### PR TITLE
Toggle JSON prettify with query parameter

### DIFF
--- a/lib/hex_web/api/util.ex
+++ b/lib/hex_web/api/util.ex
@@ -7,6 +7,7 @@ defmodule HexWeb.API.Util do
   import Plug.Conn
   alias HexWeb.User
   alias HexWeb.API.Key
+  import HexWeb.Util, only: [parse_integer: 2]
 
   @max_age 60
 
@@ -109,7 +110,15 @@ defmodule HexWeb.API.Util do
         body = HexWeb.API.ElixirFormat.encode(body)
         content_type = "application/vnd.hex+elixir"
       format when format == :json or fallback ->
-        body = Jazz.encode!(body, pretty: true)
+        conn = conn |> fetch_params
+        case conn.params["pp"] |> parse_integer(1) do
+          1 ->
+            body = Jazz.encode!(body, pretty: true)
+          0 ->
+            body = Jazz.encode!(body, pretty: false)
+          _ ->
+            body = Jazz.encode!(body, pretty: true)
+        end
         content_type = "application/json"
       _ ->
         raise Plug.Parsers.UnsupportedMediaTypeError


### PR DESCRIPTION
This PR does exactly as the title says. It allows you to attach the query parameter `pp` to JSON requests, which is an integer `0` or `1`, that allows you to explicitly enable or disable pretty printing. The default is still to pretty print by default. JSON prettifying was added in #27
