### PR TITLE
Move date formatting to the client side

### DIFF
--- a/lib/hex_web/web/templates.ex
+++ b/lib/hex_web/web/templates.ex
@@ -39,44 +39,4 @@ defmodule HexWeb.Web.Templates do
     EEx.function_from_file(:def, :"template_#{name}", file, args,
                            engine: HexWeb.Web.HTML.Engine)
   end)
-
-  def human_relative_time_from_now(date) do
-    ts = date |> Ecto.DateTime.to_erl |> :calendar.datetime_to_gregorian_seconds
-    diff = :calendar.datetime_to_gregorian_seconds(:calendar.universal_time) - ts
-    rel_from_now(:calendar.seconds_to_daystime(diff))
-  end
-
-  defp rel_from_now({0, {0, 0, sec}}) when sec < 30,
-    do: "about now"
-  defp rel_from_now({0, {0, min, _}}) when min < 2,
-    do: "1 minute ago"
-  defp rel_from_now({0, {0, min, _}}),
-    do: "#{min} minutes ago"
-  defp rel_from_now({0, {1, _, _}}),
-    do: "1 hour ago"
-  defp rel_from_now({0, {hour, _, _}}) when hour < 24,
-    do: "#{hour} hours ago"
-  defp rel_from_now({1, {_, _, _}}),
-    do: "1 day ago"
-  defp rel_from_now({day, {_, _, _}}) when day < 0,
-    do: "about now"
-  defp rel_from_now({day, {_, _, _}}),
-    do: "#{day} days ago"
-
-  defp pretty_date(%Ecto.DateTime{year: year, month: month, day: day}) do
-    "#{pretty_month(month)} #{day}, #{year}"
-  end
-
-  defp pretty_month(1),  do: "January"
-  defp pretty_month(2),  do: "February"
-  defp pretty_month(3),  do: "March"
-  defp pretty_month(4),  do: "April"
-  defp pretty_month(5),  do: "May"
-  defp pretty_month(6),  do: "June"
-  defp pretty_month(7),  do: "July"
-  defp pretty_month(8),  do: "August"
-  defp pretty_month(9),  do: "September"
-  defp pretty_month(10), do: "October"
-  defp pretty_month(11), do: "November"
-  defp pretty_month(12), do: "December"
 end

--- a/lib/hex_web/web/templates/index.html.eex
+++ b/lib/hex_web/web/templates/index.html.eex
@@ -63,7 +63,13 @@
     <p>
       <%= for { package, created_at } <- @package_new do %>
         <div class="row">
-          <div class="col-xs-5 text-right"><%= human_relative_time_from_now(created_at) %></div>
+			<div class="col-xs-5 text-right">
+			  <%= if time = created_at |> Ecto.DateTime.to_erl |> Timex.Date.from do %>
+				<time datetime="<%= time |> Timex.DateFormat.format!("{ISO}") %>" type="relative">
+					<%= time |> Timex.DateFormat.format!("{Mfull} {D}, {YYYY}") %>
+				</time>
+			  <% end %>
+			</div>
           <div class="col-xs-7"><a href="/packages/<%= package %>"><%= package %></a></div>
         </div>
       <% end %>

--- a/lib/hex_web/web/templates/main.html.eex
+++ b/lib/hex_web/web/templates/main.html.eex
@@ -69,7 +69,8 @@
       </div>
     </div>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.0/jquery.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/moment.js/2.8.2/moment.min.js"></script>
     <script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
 
     <script>
@@ -79,8 +80,17 @@
       })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
       ga('create', 'UA-49056880-1', 'auto');
-      ga('send', 'pageview');
+	  ga('send', 'pageview');
 
+	  Array.prototype.slice.call(document.querySelectorAll('time')).map(function(i){
+	      if(i.attributes['type'].value == "relative") {
+	          i.innerText = moment(i.attributes['datetime'].value).fromNow();
+	      } else if(i.attributes['type'].value == "standard") {
+	          i.innerText = moment(i.attributes['datetime'].value).format("MMMM Do, YYYY");
+	      } else {
+	          throw new Error('invalid time type attribute');
+	      }
+	  });
     </script>
   </body>
 </html>

--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -76,7 +76,13 @@ links = Enum.to_list(@package.meta["links"] || [])
       <%= for release <- @releases do %>
         <li>
           <a href="/packages/<%= @package.name %>/<%= release.version %>"><strong><%= release.version %></strong></a>
-          <span class="text-muted"><%= pretty_date(release.created_at) %></span>
+		  <span class="text-muted">
+			<%= if time = release.created_at |> Ecto.DateTime.to_erl |> Timex.Date.from do %>
+			  <time datetime="<%= time |> Timex.DateFormat.format!("{ISO}") %>" type="standard">
+				<%= time |> Timex.DateFormat.format!("{Mfull} {D}, {YYYY}") %>
+			  </time>
+			<% end %>
+		  </span>
         </li>
       <% end %>
     </ul>

--- a/mix.exs
+++ b/mix.exs
@@ -16,17 +16,18 @@ defmodule HexWeb.Mixfile do
   end
 
   defp deps do
-    [{:plug,      github: "elixir-lang/plug"},
-     {:ecto,      github: "elixir-lang/ecto"},
-     {:jazz,      github: "meh/jazz"},
-     {:bcrypt,    github: "opscode/erlang-bcrypt"},
-     {:mini_s3,   github: "ericmj/mini_s3", branch: "hex-fixes"},
-     {:cowboy,    github: "ninenines/cowboy", override: true},
-     {:cowlib,    github: "ninenines/cowlib", override: true},
-     {:ranch,     github: "ninenines/ranch", override: true},
-     {:poolboy,   github: "devinus/poolboy", override: true},
-     {:postgrex,  github: "ericmj/postgrex", override: true},
-     {:decimal,   github: "ericmj/decimal", override: true},
-     {:earmark,   github: "pragdave/earmark", only: :dev}]
+    [{:plug,           github: "elixir-lang/plug"},
+     {:ecto,           github: "elixir-lang/ecto"},
+     {:jazz,           github: "meh/jazz"},
+     {:bcrypt,         github: "opscode/erlang-bcrypt"},
+     {:mini_s3,        github: "ericmj/mini_s3", branch: "hex-fixes"},
+     {:timex,          github: "bitwalker/timex", override: true},
+     {:cowboy,         github: "ninenines/cowboy", override: true},
+     {:cowlib,         github: "ninenines/cowlib", override: true},
+     {:ranch,          github: "ninenines/ranch", override: true},
+     {:poolboy,        github: "devinus/poolboy", override: true},
+     {:postgrex,       github: "ericmj/postgrex", override: true},
+     {:decimal,        github: "ericmj/decimal", override: true},
+     {:earmark,        github: "pragdave/earmark", only: :dev}]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -12,4 +12,5 @@
   "plug": {:git, "git://github.com/elixir-lang/plug.git", "fb5010ae9a3bc19c99da74cb4eaca755427ad557", []},
   "poolboy": {:git, "git://github.com/devinus/poolboy.git", "17d1582533af5c076117e2e1270f4b43faa02f12", []},
   "postgrex": {:git, "git://github.com/ericmj/postgrex.git", "76426a317eab5dfeb4efd33713e63e29b1b04835", []},
-  "ranch": {:git, "git://github.com/ninenines/ranch.git", "adf1822defc2b7cfdc7aca112adabfa1d614043c", []}}
+  "ranch": {:git, "git://github.com/ninenines/ranch.git", "adf1822defc2b7cfdc7aca112adabfa1d614043c", []},
+  "timex": {:git, "git://github.com/bitwalker/timex.git", "40bc77db79e01a14730d0c48edc3df74b31c30e1", []}}


### PR DESCRIPTION
This PR moves the majority of date formatting (relative and standard) to the client side using moment, taking a _tiny_ bit of load off, but most importantly, removing unrequired code.

No new unit tests have been added, as they aren't required, but all the existing tests still pass.

If moment is unavailable, or the browser does not support it, it simply falls back to `{Mfull} {D}, {YYYY}` (eg. August 31, 2014).

I've added the dependency `Timex` by @bitwalker to generate both ISO-8601 dates (for Moment) and `{Mfull} {D}, {YYYY}` dates (for a fallback)
