### PR TITLE
Updated Elixir Buildpack for v1.0.0-rc1

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,3 +1,3 @@
-elixir_version=0.15.1
+elixir_version=1.0.0-rc1
 erlang_version=17.2
 hex_source=(http://s3.hex.pm/installs/hex.ez)


### PR DESCRIPTION
As the title explains, this updates the Elixir buildpack for v1.0.0-rc1, stopping builds from breaking while looking for `nil?` and `Record.record?`.

:strawberry: 
