### PR TITLE
Begin redesign, new theme and search box

### DIFF
--- a/lib/hex_web/web/templates/main.html.eex
+++ b/lib/hex_web/web/templates/main.html.eex
@@ -3,9 +3,9 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/static/main.css?<%= asset_id %>" rel="stylesheet">
-    <title><%= if @title, do: "#{@title} | " %>hex.pm</title>
+    <link href="//maxcdn.bootstrapcdn.com/bootswatch/3.2.0/lumen/bootstrap.min.css" rel="stylesheet">
+	<link href="/static/main.css?<%= asset_id %>" rel="stylesheet">
+	<title><%= if @title, do: "#{@title} | " %>hex.pm</title>
     <link rel="alternate" type="application/rss+xml" title="RSS - New Packages" href="/feeds/new-packages.rss" />
   </head>
   <body>
@@ -18,7 +18,9 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="navbar-brand" href="/">Hex.pm</a>
+		  <a class="navbar-brand" href="/">
+			  <span style="font-size: 24px;">⬢</span>&nbsp;Hex
+		  </a>
        </div>
         <div class="collapse navbar-collapse">
           <ul class="nav navbar-nav">
@@ -31,13 +33,13 @@
                 <li><a href="/docs/tasks">Mix tasks</a></li>
               </ul>
             </li>
-          </ul>
-          <form class="navbar-form navbar-right" role="search" action="/packages" method="get">
-            <div class="form-group">
-              <label class="sr-only" for="inputSearchPackages">Search packages</label>
-              <input type="search" class="form-control" id="inputSearchPackages" placeholder="Search packages" name="search" value="<%= @search %>">
+		</ul>
+   		 <form class="navbar-form navbar-right" role="search" action="/packages" method="get">
+            <div class="input-group">
+				<input type="search" class="form-control" id="inputSearchPackages" placeholder="Search packages" name="search" value="<%= @search %>">
+				<label class="sr-only" for="inputSearchPackages">Search packages</label>
+				<span class="input-group-btn"><button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span></button></span>
             </div>
-            <button type="submit" class="btn btn-default">Go</button>
           </form>
         </div>
       </div>
@@ -85,3 +87,4 @@
     </script>
   </body>
 </html>
+

--- a/priv/static/main.css
+++ b/priv/static/main.css
@@ -20,6 +20,13 @@
   }
 }
 
+@media (min-width: 768px) {
+  .navbar-nav > li > a {
+    padding-top: 17px;
+    padding-bottom: 15px;
+  }
+}
+
 html {
   position: relative;
   min-height: 100%;


### PR DESCRIPTION
This PR begins the redesign of Hex.pm by doing the following:
1. Changes Bootstrap theme to [Lumen by Bootswatch](http://bootswatch.com/lumen/)
2. Connects search box to search button
3. Changes logo to a ⬢.

I'm not sure whether we should use the unicode hexagon (⬢) or an image for the title in the navbar.

Thoughts? :+1: or :-1:?

tl;dr:
![screen shot 2014-10-01 at 4 56 51 pm](https://cloud.githubusercontent.com/assets/860934/4471344/2701a8e0-4938-11e4-9e91-4809545a6c39.png)
![screen shot 2014-10-01 at 4 58 34 pm](https://cloud.githubusercontent.com/assets/860934/4471352/6a97591a-4938-11e4-9e45-d793a3f2cbec.png)

**to...**
![screen shot 2014-10-01 at 4 56 33 pm](https://cloud.githubusercontent.com/assets/860934/4471346/2c97c096-4938-11e4-96b7-e35add580ea5.png)
![screen shot 2014-10-01 at 4 58 49 pm](https://cloud.githubusercontent.com/assets/860934/4471356/701abcce-4938-11e4-8075-2debbb3e1e33.png)
