### PR TITLE
Add basic number spacing

### DIFF
--- a/lib/hex_web/web/templates.ex
+++ b/lib/hex_web/web/templates.ex
@@ -40,6 +40,14 @@ defmodule HexWeb.Web.Templates do
                            engine: HexWeb.Web.HTML.Engine)
   end)
 
+  def human_number_space(n) when is_binary(n) do
+    Regex.replace(~r/\B(?=(\d{3})+(?!\d))/, n, " ")
+  end
+
+  def human_number_space(n) when is_integer(n) do
+    human_number_space(Integer.to_string(n))
+  end
+
   def human_relative_time_from_now(date) do
     ts = date |> Ecto.DateTime.to_erl |> :calendar.datetime_to_gregorian_seconds
     diff = :calendar.datetime_to_gregorian_seconds(:calendar.universal_time) - ts

--- a/lib/hex_web/web/templates/index.html.eex
+++ b/lib/hex_web/web/templates/index.html.eex
@@ -23,23 +23,23 @@
     <h3>Statistics</h3>
     <p>
       <div class="row">
-        <div class="col-xs-3 text-right"><%= @num_packages %></div>
+        <div class="col-xs-3 text-right"><%= human_number_space @num_packages %></div>
         <div class="col-xs-9">packages</div>
       </div>
       <div class="row">
-        <div class="col-xs-3 text-right"><%= @num_releases %></div>
+        <div class="col-xs-3 text-right"><%= human_number_space @num_releases %></div>
         <div class="col-xs-9">package versions</div>
       </div>
       <div class="row">
-        <div class="col-xs-3 text-right"><%= @total[:day] %></div>
+        <div class="col-xs-3 text-right"><%= human_number_space @total[:day] %></div>
         <div class="col-xs-9">downloads yesterday</div>
       </div>
       <div class="row">
-        <div class="col-xs-3 text-right"><%= @total[:week] %></div>
+        <div class="col-xs-3 text-right"><%= human_number_space @total[:week] %></div>
         <div class="col-xs-9">downloads last seven days</div>
       </div>
       <div class="row">
-        <div class="col-xs-3 text-right"><%= @total[:all] %></div>
+        <div class="col-xs-3 text-right"><%= human_number_space @total[:all] %></div>
         <div class="col-xs-9">downloads all time</div>
       </div>
     </p>
@@ -49,7 +49,7 @@
     <p>
       <%= for { package, downloads } <- @package_top do %>
       <div class="row">
-        <div class="col-xs-3 text-right"><%= downloads %></div>
+        <div class="col-xs-3 text-right"><%= human_number_space downloads %></div>
         <div class="col-xs-9"><a href="/packages/<%= package %>"><%= package %></a></div>
       </div>
       <% end %>

--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -45,19 +45,19 @@ links = Enum.to_list(@package.meta["links"] || [])
       </div>
       <div class="panel-body">
         <div class="row">
-          <div class="col-xs-4 text-right"><%= @release_downloads || 0 %></div>
+          <div class="col-xs-4 text-right"><%= human_number_space @release_downloads || 0 %></div>
           <div class="col-xs-8 text-muted">this version</div>
         </div>
         <div class="row">
-          <div class="col-xs-4 text-right"><%= @downloads[:day] || 0 %></div>
+          <div class="col-xs-4 text-right"><%= human_number_space @downloads[:day] || 0 %></div>
           <div class="col-xs-8 text-muted">yesterday</div>
         </div>
         <div class="row">
-          <div class="col-xs-4 text-right"><%= @downloads[:week] || 0 %></div>
+          <div class="col-xs-4 text-right"><%= human_number_space @downloads[:week] || 0 %></div>
           <div class="col-xs-8 text-muted">last seven days</div>
         </div>
         <div class="row">
-          <div class="col-xs-4 text-right"><%= @downloads[:all] || 0 %></div>
+          <div class="col-xs-4 text-right"><%= human_number_space @downloads[:all] || 0 %></div>
           <div class="col-xs-8 text-muted">all time</div>
         </div>
       </div>


### PR DESCRIPTION
This PR adds date spacing for every three numbers (e.g. `9876` -> `9 876`). This makes larger numbers easier to read.

:green_apple:  
