### PR TITLE
Move description to top of page

### DIFF
--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -5,6 +5,9 @@
       <small><%= @current_release.version %></small>
     <% end %>
   </h2>
+  <%= if description = @package.meta["description"] do %>
+    <span class="description"><%= description %></span>
+  <% end %>
 </div>
 
 <%
@@ -98,9 +101,3 @@ links = Enum.to_list(@package.meta["links"] || [])
     </ul>
   </div>
 </div>
-
-<div style="margin: 10px 0; border-top: 1px solid #eee"></div>
-
-<%= if description = @package.meta["description"] do %>
-  <pre class="description"><%= description %></pre>
-<% end %>


### PR DESCRIPTION
This PR moves package descriptions to the top of the page, below the package title/latest version, but above it's corresponding line break. It also changes the description to a `span` instead of a `pre` block, making it fit into the page a bit more.

The main reasoning behind this is to be able to to read the description without having to scroll to the bottom of the page.

:mushroom: :lemon: 

**tl;dr**

![screen shot 2014-10-04 at 1 22 22 pm](https://cloud.githubusercontent.com/assets/860934/4514545/a69394d0-4b75-11e4-828b-376c28129e27.png)
