### PR TITLE
Add ability to copy Mixfile entry to clipboard

### DIFF
--- a/lib/hex_web/web/templates/package.html.eex
+++ b/lib/hex_web/web/templates/package.html.eex
@@ -4,6 +4,10 @@
     <%= if @current_release do %>
       <small><%= @current_release.version %></small>
     <% end %>
+
+    <span class="form-inline pull-right">
+      <input type="text" class="form-control input-sm" value='{:<%= @package.name %>, "~> <%= Enum.fetch!(@releases, 0).version %>"}' onfocus="this.select();" onmouseup="return false;" />
+    </span>
   </h2>
 </div>
 


### PR DESCRIPTION
This PR adds an input on the opposite side of the package title/version header containing an the latest `{package, version}` entry to go into the Mixfile. When the box is clicked, the contents is hilighted to be easily copied.

This behavior is seen on [RubyGems](http://rubygems.org/gems/rails) under the **Gemfile** section.

:pineapple: :banana: 

![screen shot 2014-10-04 at 4 15 11 pm](https://cloud.githubusercontent.com/assets/860934/4514787/d4c15c44-4b8d-11e4-92d3-f5ced884fcfa.png)
![screen shot 2014-10-04 at 4 15 24 pm](https://cloud.githubusercontent.com/assets/860934/4514788/d9d4b000-4b8d-11e4-87e8-2f9e149cb38e.png)
