### PR TITLE
Fix postgres setup instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ CREATE USER postgres;
 ALTER USER postgres PASSWORD 'postgres';
 CREATE DATABASE hex_dev;
 GRANT ALL PRIVILEGES ON DATABASE hex_dev TO postgres;
+ALTER USER postgres WITH SUPERUSER;
 ```
 
 Now you are fine to run the ecto migrations:


### PR DESCRIPTION
When running migrations for the first time I saw this error:

```
* running UP _build/dev/lib/hex_web/priv/migrations/20140323232653_add_package_downloads_view.exs
* running UP _build/dev/lib/hex_web/priv/migrations/20140510114425_add_installs_table.exs
* running UP _build/dev/lib/hex_web/priv/migrations/20140511133315_add_optional_to_requirements.exs
* running UP _build/dev/lib/hex_web/priv/migrations/20140518153329_add_checksum_to_releases.exs
* running UP _build/dev/lib/hex_web/priv/migrations/20140527204944_change_packages_index_to_trigram.exs
** (Postgrex.Error) ERROR (42501): permission denied to create extension "pg_trgm"
    (ecto) lib/ecto/adapters/postgres/worker.ex:20: Ecto.Adapters.Postgres.Worker.query!/4
    (ecto) lib/ecto/adapters/postgres.ex:337: Ecto.Adapters.Postgres.use_worker/3
    (elixir) lib/enum.ex:537: Enum."-each/2-lists^foreach/1-0-"/2
    (elixir) lib/enum.ex:537: Enum.each/2
    (ecto) lib/ecto/adapters/postgres.ex:473: anonymous fn/3 in Ecto.Adapters.Postgres.migrate_up/3
    (ecto) lib/ecto/adapters/postgres.ex:306: Ecto.Adapters.Postgres.transaction/3
    (ecto) lib/ecto/adapters/postgres.ex:472: Ecto.Adapters.Postgres.migrate_up/3
    (ecto) lib/ecto/migrator.ex:136: anonymous fn/3 in Ecto.Migrator.migrate/3
```

I updated README instructions for setting up postgres to add SUPERUSER permissions for the user.
This way we can create extensions without error.
