### PR TITLE
Log the port that Cowboy starts on

### DIFF
--- a/lib/hex_web.ex
+++ b/lib/hex_web.ex
@@ -1,3 +1,5 @@
+require Logger
+
 defmodule HexWeb do
   use Application
 
@@ -11,6 +13,7 @@ defmodule HexWeb do
     config(opts[:port])
     File.mkdir_p!("tmp")
 
+    Logger.info "Starting Cowboy on port #{opts[:port]}"
     Plug.Adapters.Cowboy.http(HexWeb.Router, [], opts)
     HexWeb.Supervisor.start_link
   end


### PR DESCRIPTION
Before it wasn't clear:

```
hex_web[master]% foreman start
12:00:26 web.1  | started with pid 59220
12:00:28 web.1  | [Porcelain]: goon executable not found
12:00:28 web.1  | [Porcelain]: falling back to the basic driver
12:00:28 web.1  |
```

After:

```
hex_web[add_log_for_port]% foreman start
11:59:37 web.1  | started with pid 58891
11:59:38 web.1  | [Porcelain]: goon executable not found
11:59:38 web.1  | [Porcelain]: falling back to the basic driver
11:59:38 web.1  |
11:59:38 web.1  | 2014-10-11 11:59:38.617 [info] Starting Cowboy on port 5000
```
