### PR TITLE
Set reponse time header on responses

### DIFF
--- a/lib/hex_web/api/router.ex
+++ b/lib/hex_web/api/router.ex
@@ -13,6 +13,7 @@ defmodule HexWeb.API.Router do
   alias HexWeb.API.Key
 
   plug Plugs.Format
+  plug Plugs.ResponseTime
   plug :match
   plug :dispatch
 

--- a/lib/hex_web/plugs/response_time.ex
+++ b/lib/hex_web/plugs/response_time.ex
@@ -1,0 +1,22 @@
+defmodule HexWeb.Plugs.ResponseTime do
+  use Plug.Builder
+  import Plug.Conn
+  alias HexWeb.Util
+
+  plug :put_resp_time
+
+  def call(conn, opts) do
+    put_resp_time(conn, opts)
+  end
+
+  def put_resp_time(conn, _) do
+    conn
+    |> put_private(:request_start, :os.timestamp)
+    |> register_before_send fn conn ->
+      response_time =  Util.format_response_time(conn.private[:request_start])
+
+      conn
+      |> put_resp_header("x-response-time", response_time)
+    end
+  end
+end

--- a/lib/hex_web/router.ex
+++ b/lib/hex_web/router.ex
@@ -8,6 +8,7 @@ defmodule HexWeb.Router do
     Plugs.Exception.call(conn, [fun: &super(&1, opts)])
   end
 
+  plug Plugs.ResponseTime
   plug Plugs.Forwarded
   plug HexWeb.BlockedAddress.Plug
   plug Plugs.Redirect,

--- a/lib/hex_web/util.ex
+++ b/lib/hex_web/util.ex
@@ -24,6 +24,24 @@ defmodule HexWeb.Util do
     Ecto.DateTime.from_erl(:calendar.universal_time)
   end
 
+  @doc """
+  Returns a formatted response time.
+  """
+  def format_response_time(start) do
+    time = :timer.now_diff(:os.timestamp, start)
+
+    formatted_diff(time)
+      |> Enum.join("")
+  end
+
+  @doc """
+  From Plug.Logger (https://github.com/elixir-lang/plug/blob/master/lib/plug/logger.ex#L65).
+
+  Formats microsecond (µs) time units as either µs or ms
+  """
+  defp formatted_diff(diff) when diff > 1000, do: [diff |> div(1000) |> Integer.to_string, "ms"]
+  defp formatted_diff(diff), do: [diff |> Integer.to_string, "µs"]
+
   def etag(nil), do: nil
   def etag([]),  do: nil
 

--- a/lib/hex_web/web/router.ex
+++ b/lib/hex_web/web/router.ex
@@ -11,7 +11,6 @@ defmodule HexWeb.Web.Router do
   alias HexWeb.Package
   alias HexWeb.User
 
-
   @packages 30
 
   plug :match


### PR DESCRIPTION
This is a really basic PR, which I've found quite useful for debugging while working on password resets.

Basically, it sets the header `X-Response-Time` on all responses, formatted like: `64ms`.

This is added to all requests processed by HexWeb.Router (so all requests on every router).
