### PR TITLE
Fix TravisCI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - mix archive.install http://s3.hex.pm/installs/hex.ez --force
   - mix deps.get
   - MIX_ENV=test mix deps.compile
-  - MIX_ENV=test mix ecto.create HexWeb.Repo
+  - MIX_ENV=test mix ecto.create HexWeb.Repo --no-start
 script:
   - mix test --include integration
 env:


### PR DESCRIPTION
Don't start the application on Ecto commands, as `HexWeb.BlockedAddress.reload` tries to access the non-existent database and crashes before the database can be created.
