### PR TITLE
Update `credo.exs` for Credo 0.7.x

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -45,7 +45,7 @@
         {Credo.Check.Readability.ModuleAttributeNames},
         {Credo.Check.Readability.ModuleDoc, false},
         {Credo.Check.Readability.ModuleNames},
-        {Credo.Check.Readability.NoParenthesesWhenZeroArity, false},
+        {Credo.Check.Readability.ParenthesesOnZeroArityDefs, false},
         {Credo.Check.Readability.ParenthesesInCondition},
         {Credo.Check.Readability.PredicateFunctionNames},
         {Credo.Check.Readability.TrailingBlankLine},


### PR DESCRIPTION
* `NoParenthesesWhenZeroArity` was renamed to `ParenthesesOnZeroArityDefs`.

https://github.com/rrrene/credo/blob/master/CHANGELOG.md#070