### PR TITLE
fix broken github links

### DIFF
--- a/lib/hexpm/web/templates/policy/coc.html.md
+++ b/lib/hexpm/web/templates/policy/coc.html.md
@@ -86,7 +86,7 @@ You are also encouraged to contact us if you are curious about something that mi
 
 ### Changes
 
-This is a living document and may be updated from time to time. Please refer to the [git history](https://github.com/hexpm/hexpm/blob/master/web/templates/policy/coc.html.md) for this document to view the changes.
+This is a living document and may be updated from time to time. Please refer to the [git history](https://github.com/hexpm/hexpm/blob/master/lib/hexpm/web/templates/policy/coc.html.md) for this document to view the changes.
 
 ### Credit and License
 

--- a/lib/hexpm/web/templates/policy/index.html.eex
+++ b/lib/hexpm/web/templates/policy/index.html.eex
@@ -12,5 +12,5 @@
 </p>
 
 <p>
-  These documents are updated from time to time. See the <a href="https://github.com/hexpm/hexpm/tree/master/web/templates/policy">git history</a> for the changes.
+  These documents are updated from time to time. See the <a href="https://github.com/hexpm/hexpm/tree/master/lib/hexpm/web/templates/policy">git history</a> for the changes.
 </p>

--- a/lib/hexpm/web/templates/policy/privacy.html.md
+++ b/lib/hexpm/web/templates/policy/privacy.html.md
@@ -54,7 +54,7 @@ Any questions about this Privacy Policy should be addressed to <support@hex.pm>.
 
 ### Changes
 
-Although most changes are likely to be minor, hex.pm may change its Privacy Policy from time to time, and at hex.pm's sole discretion. The detailed history of changes can be found in the [git repository](https://github.com/hexpm/hexpm/blob/master/web/templates/policy/privacy.html.md) history for this document.
+Although most changes are likely to be minor, hex.pm may change its Privacy Policy from time to time, and at hex.pm's sole discretion. The detailed history of changes can be found in the [git repository](https://github.com/hexpm/hexpm/blob/master/lib/hexpm/web/templates/policy/privacy.html.md) history for this document.
 
 Hex.pm encourages visitors to frequently check this page for any changes to its Privacy Policy. Your continued use of the hex.pm websites and the repository after any change in this Privacy Policy will constitute your acceptance of such change.
 

--- a/lib/hexpm/web/templates/policy/tos.html.md
+++ b/lib/hexpm/web/templates/policy/tos.html.md
@@ -68,4 +68,4 @@ The failure of Hex to enforce any right or provision of these Terms will not be 
 
 If Hex makes changes to these Terms we will post a notice on the hex.pm website and notify you by email. New features, tools or resources added to the Services will be subject to the Terms. By continuing to use the Services you are agreeing to the Terms as it is subject to the changes.
 
-The detailed history of changes to these Terms can be found in the [git repository](https://github.com/hexpm/hexpm/blob/master/web/templates/policy/tos.html.md) history for this document.
+The detailed history of changes to these Terms can be found in the [git repository](https://github.com/hexpm/hexpm/blob/master/lib/hexpm/web/templates/policy/tos.html.md) history for this document.


### PR DESCRIPTION
Some links to the github repository were broken when the code was moved in order to adopt the phoenix 1.3 directory structure.