### PR TITLE
Support "depends" query param

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -150,6 +150,13 @@ defmodule Hexpm.Repository.Package do
       where: fragment("?->'extra' @> ?", p.meta, ^extra))
   end
 
+  defp search_param("depends", search, query) do
+    from(p in query,
+         join: pd in Hexpm.Repository.PackageDependant,
+         on: p.id == pd.dependant_id,
+         where: pd.name == ^search)
+  end
+
   defp search_param(_, _, query) do
     query
   end

--- a/lib/hexpm/repository/package_dependant.ex
+++ b/lib/hexpm/repository/package_dependant.ex
@@ -1,0 +1,8 @@
+defmodule Hexpm.Repository.PackageDependant do
+  use Hexpm.Web, :schema
+
+  schema "package_dependants" do
+    belongs_to :package, Package, references: :package_id
+    field :name, :string
+  end
+end

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -111,7 +111,6 @@ defmodule Hexpm.Repository.Releases do
     |> Multi.run(:package, fn _ -> {:ok, package} end)
     |> Multi.update(:release, Release.retire(release, params))
     |> audit_retire(audit_data, package)
-    |> refresh_package_dependants()
     |> Repo.transaction
     |> publish_result
   end
@@ -121,7 +120,6 @@ defmodule Hexpm.Repository.Releases do
     |> Multi.run(:package, fn _ -> {:ok, package} end)
     |> Multi.update(:release, Release.unretire(release))
     |> audit_unretire(audit_data, package)
-    |> refresh_package_dependants()
     |> Repo.transaction
     |> publish_result
   end
@@ -183,12 +181,9 @@ defmodule Hexpm.Repository.Releases do
   end
 
   defp refresh_package_dependants(multi) do
-    multi
-    |> Multi.run(:refresh, fn _ ->
-      case Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDependant) do
-        :ok -> {:ok, :refresh}
-        :error -> {:error, :refresh}
-      end
+    Multi.run(multi, :refresh, fn _ ->
+      :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDependant)
+      {:ok, :refresh}
     end)
   end
 

--- a/priv/repo/migrations/20170613205641_add_package_dependants_view.exs
+++ b/priv/repo/migrations/20170613205641_add_package_dependants_view.exs
@@ -1,0 +1,22 @@
+defmodule Hexpm.Repo.Migrations.AddPackageDependantsView do
+  use Ecto.Migration
+
+  def up do
+    execute """
+      CREATE MATERIALIZED VIEW package_dependants (
+        name,
+        dependant_id) AS
+          SELECT DISTINCT p3.name AS name, p0.id AS dependant_id
+          FROM "packages" AS p0
+          INNER JOIN "releases" AS r1 ON r1."package_id" = p0."id"
+          INNER JOIN "requirements" AS r2 ON r2."release_id" = r1."id"
+          INNER JOIN "packages" AS p3 ON p3."id" = r2."dependency_id"
+    """
+
+    execute "CREATE INDEX ON package_dependants (name)"
+  end
+
+  def down do
+    execute "DROP MATERIALIZED VIEW package_dependants"
+  end
+end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -85,6 +85,26 @@ defmodule Hexpm.Repository.PackageTest do
     end
   end
 
+  test "search dependants", %{user: user, repository: repository} do
+    Package.build(repository, user, pkg_meta(%{name: "nerves", description: "Nerves package"}))
+    |> Hexpm.Repo.insert!
+    phoenix =
+      Package.build(repository, user, pkg_meta(%{name: "phoenix", description: "Web framework"}))
+      |> Hexpm.Repo.insert!
+    ecto =
+      Package.build(repository, user, pkg_meta(%{name: "ecto", description: "Database wrapper"}))
+      |> Hexpm.Repo.insert!
+    rel =
+      Hexpm.Repository.Release.build(phoenix, rel_meta(%{version: "0.0.1", app: "phoenix"}), "")
+      |> Hexpm.Repo.insert!
+    Hexpm.Repo.insert!(%Hexpm.Repository.Requirement{app: "phoenix", release: rel, dependency: ecto})
+    Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDependant)
+
+    assert ["phoenix"] = Package.all(1, 10, "depends:ecto", nil)
+                         |> Hexpm.Repo.all
+                         |> Enum.map(& &1.name)
+  end
+
   test "sort packages by downloads", %{user: user, repository: repository} do
     phoenix =
       Package.build(repository, user, pkg_meta(%{name: "phoenix", description: "Web framework"}))


### PR DESCRIPTION
* Introduce `PackageDependant` and its friends (migration, repo).
* Support `depends:<package-name>` in search query.
* Refresh view after package changes (published/reverted/retired)

Link https://github.com/hexpm/hexpm/issues/450