### PR TITLE
Do not allow pre-release requirements for stable releases

### DIFF
--- a/lib/hexpm/ecto/validation.ex
+++ b/lib/hexpm/ecto/validation.ex
@@ -26,7 +26,7 @@ defmodule Hexpm.Validation do
     end)
   end
 
-  def validate_requirement(changeset, field) do
+  def validate_requirement(changeset, field, opts) do
     validate_change(changeset, field, fn key, req ->
       cond do
         is_nil(req) ->
@@ -34,6 +34,8 @@ defmodule Hexpm.Validation do
           [{key, {"invalid requirement: #{inspect req}, use \">= 0.0.0\" instead", []}}]
         not valid_requirement?(req) ->
           [{key, {"invalid requirement: #{inspect req}", []}}]
+        String.contains?(req, "-") and not Keyword.fetch!(opts, :pre) ->
+          [{key, {"invalid requirement: #{inspect req}, unstable requirements are not allowed for stable releases", []}}]
         true ->
           []
       end

--- a/lib/hexpm/repository/release_metadata.ex
+++ b/lib/hexpm/repository/release_metadata.ex
@@ -12,6 +12,6 @@ defmodule Hexpm.Repository.ReleaseMetadata do
     |> validate_required(~w(app build_tools)a)
     |> validate_list_required(:build_tools)
     |> update_change(:build_tools, &Enum.uniq/1)
-    |> validate_requirement(:elixir)
+    |> validate_requirement(:elixir, pre: true)
   end
 end

--- a/lib/hexpm/repository/requirement.ex
+++ b/lib/hexpm/repository/requirement.ex
@@ -14,50 +14,54 @@ defmodule Hexpm.Repository.Requirement do
     belongs_to :dependency, Package
   end
 
-  def changeset(requirement, params, dependencies) do
+  def changeset(requirement, params, dependencies, release_changeset) do
     cast(requirement, params, ~w(name app requirement optional))
     |> put_assoc(:dependency, dependencies[params["name"]])
     |> validate_required(~w(name app requirement optional)a)
     |> validate_required(:dependency, message: "package does not exist")
-    |> validate_requirement(:requirement)
+    |> validate_requirement(:requirement, pre: get_field(release_changeset, :version).pre != [])
   end
 
   # TODO: Raise validation error if field is not set
   def build_all(release_changeset) do
     dependencies = preload_dependencies(release_changeset.params["requirements"])
 
-    release_changeset =
-      release_changeset
-      |> cast_assoc(:requirements, with: &changeset(&1, &2, dependencies))
+    release_changeset = cast_assoc(
+      release_changeset,
+      :requirements,
+      with: &changeset(&1, &2, dependencies, release_changeset)
+    )
 
     if release_changeset.valid? do
       requirements =
         get_change(release_changeset, :requirements, [])
-        |> Enum.map(&Ecto.Changeset.apply_changes/1)
+        |> Enum.map(&apply_changes/1)
 
-      build_tools = get_field(release_changeset, :meta).build_tools
-
-      {time, result} = :timer.tc(fn ->
-        case Resolver.run(requirements, build_tools) do
-          :ok ->
-            release_changeset
-          {:error, reason} ->
-            release_changeset = update_in(release_changeset.changes.requirements, fn req_changesets ->
-              Enum.map(req_changesets, fn req_changeset ->
-                add_error(req_changeset, :requirement, reason)
-              end)
-            end)
-            %{release_changeset | valid?: false}
-        end
-      end)
-
-      Logger.warn "DEPENDENCY_RESOLUTION_COMPLETED (#{div time, 1000}ms)"
-      result
+      validate_resolver(release_changeset, requirements)
     else
       release_changeset
     end
 
     # TODO: Remap requirements errors to hex http spec
+  end
+
+  defp validate_resolver(release_changeset, requirements) do
+    build_tools = get_field(release_changeset, :meta).build_tools
+
+    {time, release_changeset} = :timer.tc(fn ->
+      case Resolver.run(requirements, build_tools) do
+        :ok ->
+          release_changeset
+        {:error, reason} ->
+          release_changeset = update_in(release_changeset.changes.requirements, fn req_changesets ->
+            Enum.map(req_changesets, &add_error(&1, :requirement, reason))
+          end)
+          %{release_changeset | valid?: false}
+      end
+    end)
+
+    Logger.warn "DEPENDENCY_RESOLUTION_COMPLETED (#{div time, 1000}ms)"
+    release_changeset
   end
 
   defp preload_dependencies(requirements)  do


### PR DESCRIPTION
This validation already exists on the client, make sure we are consistent on the backend.