### PR TITLE
Fix an issue with downloads counts in the API

### DIFF
--- a/lib/hexpm/web/views/api/package_view.ex
+++ b/lib/hexpm/web/views/api/package_view.ex
@@ -31,4 +31,7 @@ defmodule Hexpm.Web.API.PackageView do
   defp group_downloads(%{downloads: downloads} = package) do
     Map.put(package, :downloads, Enum.reduce(downloads, %{}, &Map.merge(&1, &2)))
   end
+  defp group_downloads(package) do
+    package
+  end
 end

--- a/lib/hexpm/web/views/api/package_view.ex
+++ b/lib/hexpm/web/views/api/package_view.ex
@@ -27,7 +27,7 @@ defmodule Hexpm.Web.API.PackageView do
     |> include_if_loaded(:owners, package.owners, UserView, "minimal.json")
     |> group_downloads()
   end
-  
+
   defp group_downloads(%{downloads: downloads} = package) do
     Map.put(package, :downloads, Enum.reduce(downloads, %{}, &Map.merge(&1, &2)))
   end

--- a/lib/hexpm/web/views/api/package_view.ex
+++ b/lib/hexpm/web/views/api/package_view.ex
@@ -25,5 +25,10 @@ defmodule Hexpm.Web.API.PackageView do
     |> include_if_loaded(:releases, package.releases, ReleaseView, "minimal.json", package: package)
     |> include_if_loaded(:downloads, package.downloads, DownloadView, "show.json")
     |> include_if_loaded(:owners, package.owners, UserView, "minimal.json")
+    |> group_downloads()
+  end
+  
+  defp group_downloads(%{downloads: downloads} = package) do
+    Map.put(package, :downloads, Enum.reduce(downloads, %{}, &Map.merge(&1, &2)))
   end
 end


### PR DESCRIPTION
This fixes #524.

Looks like it was caused by some refactoring, so this just merges after the fact to keep the neatened pipeline above.