### PR TITLE
[WIP] Remove existing unverified user with matching username on signup

### DIFF
--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -95,6 +95,11 @@ defmodule Hexpm.Accounts.User do
     else: multi
   end
 
+  def has_no_verified_emails?(nil), do: false
+  def has_no_verified_emails?(user) do
+    Enum.all?(user.emails, &(not &1.verified))
+  end
+
   def email(user, :primary), do: user.emails |> Enum.find(& &1.primary) |> email
   def email(user, :public), do: user.emails |> Enum.find(& &1.public) |> email
 

--- a/test/hexpm/web/controllers/signup_controller_test.exs
+++ b/test/hexpm/web/controllers/signup_controller_test.exs
@@ -21,6 +21,17 @@ defmodule Hexpm.Web.SignupControllerTest do
     assert user.full_name == "José"
   end
 
+  test "create user when existing, unverified one exists" do
+    create_user("jose", "jose@example.com", "secret123", false)
+
+    conn = post(build_conn(), "signup", %{user: %{username: "jose", emails: [%{email: "jose@mail.com"}], password: "hunter42", full_name: "José"}})
+
+    assert redirected_to(conn) == "/"
+    user = Users.get("jose")
+    assert user.username == "jose"
+    assert user.full_name == "José"
+  end
+
   test "create user invalid" do
     conn = post(build_conn(), "signup", %{user: %{username: "eric", emails: [%{email: "jose@mail.com"}], password: "hunter42", full_name: "José"}})
     assert response(conn, 400) =~ "Sign up"


### PR DESCRIPTION
Closes #513 

As discussed in #513, this PR adds a check for existing user with matching username and no verified email. If user meeting those conditions is found, he is deleted before proceeding with the new user creation.

Because `User.build/1` has no side effects, I've moved the call outside multi to avoid calling it twice.