### PR TITLE
Add private repository authentication

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -3,6 +3,7 @@ alias Hexpm.{
   Accounts.AuditLog,
   Accounts.Email,
   Accounts.Key,
+  Accounts.KeyPermission,
   Accounts.Keys,
   Accounts.Session,
   Accounts.User,

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,5 +1,7 @@
 use Mix.Config
 
+pool_size = String.to_integer(System.get_env("HEX_POOL_SIZE") || "20")
+
 config :hexpm,
   cookie_sign_salt: System.get_env("HEX_COOKIE_SIGNING_SALT"),
   cookie_encr_salt: System.get_env("HEX_COOKIE_ENCRYPTION_SALT")
@@ -14,8 +16,8 @@ config :hexpm, Hexpm.Web.Endpoint,
 config :hexpm, Hexpm.Repo,
   adapter: Ecto.Adapters.Postgres,
   url: {:system, "DATABASE_URL"},
-  pool_size: 20,
-  queue_size: 20 * 5,
+  pool_size: pool_size,
+  queue_size: pool_size * 5,
   ssl: true
 
 config :comeonin,

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -75,19 +75,24 @@ defmodule Hexpm.Accounts.AuditLog do
 
   defp serialize(%Package{} = package) do
     package
-    |> do_serialize
+    |> do_serialize()
     |> Map.put(:meta, serialize(package.meta))
   end
   defp serialize(%Release{} = release) do
     release
-    |> do_serialize
+    |> do_serialize()
     |> Map.put(:meta, serialize(release.meta))
     |> Map.put(:retirement, serialize(release.retirement))
   end
   defp serialize(%User{} = user) do
     user
-    |> do_serialize
+    |> do_serialize()
     |> Map.put(:handles, serialize(user.handles))
+  end
+  defp serialize(%Key{} = key) do
+    key
+    |> do_serialize()
+    |> Map.put(:permissions, Enum.map(key.permissions, &serialize/1))
   end
   defp serialize(nil),
     do: nil
@@ -97,6 +102,7 @@ defmodule Hexpm.Accounts.AuditLog do
   defp do_serialize(schema), do: Map.take(schema, fields(schema))
 
   defp fields(%Key{}), do: [:id, :name]
+  defp fields(%KeyPermission{}), do: [:resource, :domain]
   defp fields(%Package{}), do: [:id, :name]
   defp fields(%Release{}), do: [:id, :version, :checksum, :has_docs, :package_id]
   defp fields(%User{}), do: [:id, :username]

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -115,7 +115,7 @@ defmodule Hexpm.Accounts.Key do
   end
 
   def verify_permissions?(_key, nil, _resource) do
-    true
+    false
   end
   def verify_permissions?(key, :api, _resource) do
     Enum.any?(key.permissions, &(&1.domain == "api"))

--- a/lib/hexpm/accounts/key_permission.ex
+++ b/lib/hexpm/accounts/key_permission.ex
@@ -1,0 +1,24 @@
+defmodule Hexpm.Accounts.KeyPermission do
+  use Hexpm.Web, :schema
+
+  embedded_schema do
+    field :domain, :string
+    field :resource, :string
+  end
+
+  @domains ~w(api repository)
+
+  def changeset(struct, params) do
+    cast(struct, params, ~w(domain resource))
+    |> validate_inclusion(:domain, @domains)
+    |> validate_required_resource()
+  end
+
+  defp validate_required_resource(changeset) do
+    if get_change(changeset, :domain) == "repository" do
+      validate_required(changeset, :resource)
+    else
+      changeset
+    end
+  end
+end

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -95,8 +95,8 @@ defmodule Hexpm.Accounts.User do
     else: multi
   end
 
-  def email(user, :primary), do: user.emails |> Enum.find(& &1.primary) |> email
-  def email(user, :public), do: user.emails |> Enum.find(& &1.public) |> email
+  def email(user, :primary), do: user.emails |> Enum.find(& &1.primary) |> email()
+  def email(user, :public), do: user.emails |> Enum.find(& &1.public) |> email()
 
   defp email(nil), do: nil
   defp email(email), do: email.email

--- a/lib/hexpm/ecto/changeset.ex
+++ b/lib/hexpm/ecto/changeset.ex
@@ -1,6 +1,6 @@
-defmodule Hexpm.Validation do
+defmodule Hexpm.Changeset do
   @moduledoc """
-  Ecto validation helpers.
+  Ecto changeset helpers.
   """
 
   import Ecto.Changeset
@@ -84,4 +84,12 @@ defmodule Hexpm.Validation do
   defp default_hash(nil), do: @default_password
   defp default_hash(""), do: @default_password
   defp default_hash(password), do: password
+
+  def put_default_embed(changeset, key, value) do
+    if get_change(changeset, key) do
+      changeset
+    else
+      put_embed(changeset, key, value)
+    end
+  end
 end

--- a/lib/hexpm/web/controllers/api/auth_controller.ex
+++ b/lib/hexpm/web/controllers/api/auth_controller.ex
@@ -1,0 +1,41 @@
+defmodule Hexpm.Web.API.AuthController do
+  use Hexpm.Web, :controller
+
+  plug :authorize
+
+  def show(conn, params) do
+    key = conn.assigns.key
+    user = conn.assigns.user
+    domain = params["domain"]
+    resource = params["resource"]
+
+    if domain do
+      domain = domain_to_atom(domain)
+      if Key.verify_permissions?(key, domain, resource) and verify?(user, domain, resource) do
+        send_resp(conn, 204, "")
+      else
+        send_resp(conn, 403, "")
+      end
+    else
+      send_resp(conn, 204, "")
+    end
+  end
+
+  defp verify?(_user, :api, _repository) do
+    true
+  end
+  defp verify?(user, :repository, name) do
+    if repository = Repositories.get(name) do
+      Repositories.access?(repository, user)
+    else
+      false
+    end
+  end
+  defp verify?(_user, _domain, _repository) do
+    false
+  end
+
+  defp domain_to_atom("api"), do: :api
+  defp domain_to_atom("repository"), do: :repository
+  defp domain_to_atom(_other), do: nil
+end

--- a/lib/hexpm/web/controllers/api/auth_controller.ex
+++ b/lib/hexpm/web/controllers/api/auth_controller.ex
@@ -1,12 +1,12 @@
 defmodule Hexpm.Web.API.AuthController do
   use Hexpm.Web, :controller
 
+  plug :required_params, ["domain"]
   plug :authorize
 
-  def show(conn, params) do
+  def show(conn, %{"domain" => domain} = params) do
     key = conn.assigns.key
     user = conn.assigns.user
-    domain = params["domain"]
     resource = params["resource"]
 
     if domain do

--- a/lib/hexpm/web/controllers/api/auth_controller.ex
+++ b/lib/hexpm/web/controllers/api/auth_controller.ex
@@ -8,16 +8,16 @@ defmodule Hexpm.Web.API.AuthController do
     key = conn.assigns.key
     user = conn.assigns.user
     resource = params["resource"]
+    domain = domain_to_atom(domain)
 
-    if domain do
-      domain = domain_to_atom(domain)
-      if Key.verify_permissions?(key, domain, resource) and verify?(user, domain, resource) do
+    if Key.verify_permissions?(key, domain, resource) do
+      if verify?(user, domain, resource) do
         send_resp(conn, 204, "")
       else
-        send_resp(conn, 403, "")
+        error(conn, {:error, :auth})
       end
     else
-      send_resp(conn, 204, "")
+      error(conn, {:error, :domain})
     end
   end
 

--- a/lib/hexpm/web/controllers/api/docs_controller.ex
+++ b/lib/hexpm/web/controllers/api/docs_controller.ex
@@ -2,7 +2,7 @@ defmodule Hexpm.Web.API.DocsController do
   use Hexpm.Web, :controller
 
   plug :fetch_release
-  plug :authorize, [fun: &package_owner?/2] when action != :show
+  plug :authorize, [fun: &package_owner?/2, domain: :api] when action != :show
 
   def show(conn, _params) do
     package = conn.assigns.package

--- a/lib/hexpm/web/controllers/api/key_controller.ex
+++ b/lib/hexpm/web/controllers/api/key_controller.ex
@@ -1,8 +1,8 @@
 defmodule Hexpm.Web.API.KeyController do
   use Hexpm.Web, :controller
 
-  plug :authorize when action != :create
-  plug :authorize, [only_basic: true, allow_unconfirmed: true] when action == :create
+  plug :authorize, [domain: :api] when action != :create
+  plug :authorize, [domain: :api, only_basic: true, allow_unconfirmed: true] when action == :create
 
   def index(conn, _params) do
     user = conn.assigns.user

--- a/lib/hexpm/web/controllers/api/owner_controller.ex
+++ b/lib/hexpm/web/controllers/api/owner_controller.ex
@@ -2,7 +2,7 @@ defmodule Hexpm.Web.API.OwnerController do
   use Hexpm.Web, :controller
 
   plug :fetch_package
-  plug :authorize, [fun: &package_owner?/2] when action in [:create, :delete]
+  plug :authorize, [domain: :api, fun: &package_owner?/2] when action in [:create, :delete]
 
   def index(conn, _params) do
     owners =

--- a/lib/hexpm/web/controllers/api/release_controller.ex
+++ b/lib/hexpm/web/controllers/api/release_controller.ex
@@ -3,8 +3,8 @@ defmodule Hexpm.Web.API.ReleaseController do
 
   plug :fetch_release when action in [:show, :delete]
   plug :maybe_fetch_package when action in [:create]
-  plug :authorize, [fun: &package_owner?/2] when action in [:delete]
-  plug :authorize, [fun: &maybe_package_owner?/2] when action in [:create]
+  plug :authorize, [domain: :api, fun: &package_owner?/2] when action in [:delete]
+  plug :authorize, [domain: :api, fun: &maybe_package_owner?/2] when action in [:create]
 
   def create(conn, %{"body" => body}) do
     handle_tarball(conn, conn.assigns.repository, conn.assigns.package, conn.assigns.user, body)

--- a/lib/hexpm/web/controllers/api/repository_controller.ex
+++ b/lib/hexpm/web/controllers/api/repository_controller.ex
@@ -2,8 +2,8 @@ defmodule Hexpm.Web.API.RepositoryController do
   use Hexpm.Web, :controller
 
   plug :fetch_repository when action in [:show]
-  plug :maybe_authorize when action in [:index]
-  plug :maybe_authorize, [fun: &repository_access?/2] when action in [:show]
+  plug :maybe_authorize, [domain: :api] when action in [:index]
+  plug :maybe_authorize, [domain: :api, fun: &repository_access?/2] when action in [:show]
 
   def index(conn, _params) do
     repositories = Repositories.all_public() ++ all_by_user(conn.assigns.user)

--- a/lib/hexpm/web/controllers/api/retirement_controller.ex
+++ b/lib/hexpm/web/controllers/api/retirement_controller.ex
@@ -2,7 +2,7 @@ defmodule Hexpm.Web.API.RetirementController do
   use Hexpm.Web, :controller
 
   plug :fetch_release when action in [:create, :delete]
-  plug :authorize, [fun: &package_owner?/2] when action in [:create, :delete]
+  plug :authorize, [domain: :api, fun: &package_owner?/2] when action in [:create, :delete]
 
   def create(conn, params) do
     package = conn.assigns.package

--- a/lib/hexpm/web/controllers/api/user_controller.ex
+++ b/lib/hexpm/web/controllers/api/user_controller.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Web.API.UserController do
   use Hexpm.Web, :controller
 
-  plug :authorize when action in [:test]
+  plug :authorize, [domain: :api] when action in [:test]
 
   def create(conn, params) do
     params = email_param(params)

--- a/lib/hexpm/web/controllers/controller_helpers.ex
+++ b/lib/hexpm/web/controllers/controller_helpers.ex
@@ -120,15 +120,19 @@ defmodule Hexpm.Web.ControllerHelpers do
     end
   end
 
-  defp put_etag(conn, nil),
-    do: conn
-  defp put_etag(conn, etag),
-    do: put_resp_header(conn, "etag", etag)
+  defp put_etag(conn, nil) do
+    conn
+  end
+  defp put_etag(conn, etag) do
+    put_resp_header(conn, "etag", etag)
+  end
 
-  defp put_last_modified(conn, nil),
-    do: conn
-  defp put_last_modified(conn, modified),
-    do: put_resp_header(conn, "last-modified", :cowboy_clock.rfc1123(modified))
+  defp put_last_modified(conn, nil) do
+    conn
+  end
+  defp put_last_modified(conn, modified) do
+    put_resp_header(conn, "last-modified", :cowboy_clock.rfc1123(modified))
+  end
 
   defp fresh?(conn, opts) do
     not expired?(conn, opts)
@@ -166,8 +170,12 @@ defmodule Hexpm.Web.ControllerHelpers do
     end
   end
 
-  defp etag(nil), do: nil
-  defp etag([]),  do: nil
+  defp etag(nil) do
+    nil
+  end
+  defp etag([]) do
+    nil
+  end
   defp etag(models) do
     list = Enum.map(List.wrap(models), fn model ->
       [model.__struct__, model.id, model.updated_at]
@@ -191,7 +199,7 @@ defmodule Hexpm.Web.ControllerHelpers do
     if repository = Repositories.get(conn.params["repository"]) do
       assign(conn, :repository, repository)
     else
-      conn |> not_found |> halt
+      conn |> not_found() |> halt()
     end
   end
 
@@ -204,7 +212,7 @@ defmodule Hexpm.Web.ControllerHelpers do
         assign(conn, :package, nil)
       end
     else
-      conn |> not_found |> halt
+      conn |> not_found() |> halt()
     end
   end
 
@@ -217,10 +225,10 @@ defmodule Hexpm.Web.ControllerHelpers do
         |> assign(:repository, repository)
         |> assign(:package, package)
       else
-        conn |> not_found |> halt
+        conn |> not_found() |> halt()
       end
     else
-      conn |> not_found |> halt
+      conn |> not_found() |> halt()
     end
   end
 
@@ -235,10 +243,22 @@ defmodule Hexpm.Web.ControllerHelpers do
         |> assign(:package, package)
         |> assign(:release, release)
       else
-        conn |> not_found |> halt
+        conn |> not_found() |> halt()
       end
     else
-      conn |> not_found |> halt
+      conn |> not_found() |> halt()
+    end
+  end
+
+  def required_params(conn, required_param_names) do
+    remaining = required_param_names -- Map.keys(conn.params)
+
+    if remaining == [] do
+      conn
+    else
+      names = Enum.map_join(remaining, ", ", &inspect/1)
+      message = "missing required parameters: #{names}"
+      render_error(conn, 400, message: message)
     end
   end
 

--- a/lib/hexpm/web/controllers/email_controller.ex
+++ b/lib/hexpm/web/controllers/email_controller.ex
@@ -1,8 +1,6 @@
 defmodule Hexpm.Web.EmailController do
   use Hexpm.Web, :controller
 
-  # TODO: Sign in user after verification
-
   def verify(conn, %{"username" => username, "email" => email, "key" => key}) do
     success = Users.verify_email(username, email, key) == :ok
     conn =

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -117,7 +117,7 @@ defmodule Hexpm.Web.Router do
   scope "/api", Hexpm.Web.API, as: :api do
     pipe_through :upload
 
-    for prefix <- ["/", "/repositories/:repository"] do
+    for prefix <- ["/", "/repos/:repository"] do
       scope prefix do
         post "/packages/:name/releases", ReleaseController, :create
         post "/packages/:name/releases/:version/docs", DocsController,    :create
@@ -135,10 +135,10 @@ defmodule Hexpm.Web.Router do
     get "/users/:name/test", UserController, :test
     post "/users/:name/reset", UserController, :reset
 
-    get "/repositories", RepositoryController, :index
-    get "/repositories/:repository", RepositoryController, :show
+    get "/repos", RepositoryController, :index
+    get "/repos/:repository", RepositoryController, :show
 
-    for prefix <- ["/", "/repositories/:repository"] do
+    for prefix <- ["/", "/repos/:repository"] do
       scope prefix do
         get "/packages", PackageController, :index
         get "/packages/:name", PackageController, :show

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -164,5 +164,7 @@ defmodule Hexpm.Web.Router do
     post "/keys", KeyController, :create
     delete "/keys", KeyController, :delete_all
     delete "/keys/:name", KeyController, :delete
+
+    get "/auth", AuthController, :show
   end
 end

--- a/lib/hexpm/web/views/api/key_permission_view.ex
+++ b/lib/hexpm/web/views/api/key_permission_view.ex
@@ -1,0 +1,14 @@
+defmodule Hexpm.Web.API.KeyPermissionView do
+  use Hexpm.Web, :view
+
+  def render("show." <> _, %{key_permission: key_permission}) do
+    render_one(key_permission, __MODULE__, "show")
+  end
+
+  def render("show", %{key_permission: key_permission}) do
+    %{
+      domain: key_permission.domain,
+      resource: key_permission.resource
+    }
+  end
+end

--- a/lib/hexpm/web/views/api/key_view.ex
+++ b/lib/hexpm/web/views/api/key_view.ex
@@ -1,5 +1,6 @@
 defmodule Hexpm.Web.API.KeyView do
   use Hexpm.Web, :view
+  alias Hexpm.Web.API.KeyPermissionView
 
   def render("index." <> _, %{keys: keys, authing_key: authing_key}) do
     render_many(keys, __MODULE__, "show", authing_key: authing_key)
@@ -16,6 +17,7 @@ defmodule Hexpm.Web.API.KeyView do
       name: key.name,
       authing_key: !!(authing_key && key.id == authing_key.id),
       secret: key.user_secret,
+      permissions: render_many(key.permissions, KeyPermissionView, "show.json"),
       revoked_at: key.revoked_at,
       inserted_at: key.inserted_at,
       updated_at: key.updated_at,

--- a/lib/hexpm/web/web.ex
+++ b/lib/hexpm/web/web.ex
@@ -23,7 +23,7 @@ defmodule Hexpm.Web do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query, only: [from: 1, from: 2]
-      import Hexpm.Validation
+      import Hexpm.Changeset
 
       alias Ecto.Multi
 
@@ -100,6 +100,7 @@ defmodule Hexpm.Web do
         Accounts.Auth,
         Accounts.Email,
         Accounts.Key,
+        Accounts.KeyPermission,
         Accounts.Keys,
         Accounts.Session,
         Accounts.User,

--- a/priv/repo/migrations/20170702160756_add_permissions_to_keys.exs
+++ b/priv/repo/migrations/20170702160756_add_permissions_to_keys.exs
@@ -1,0 +1,17 @@
+defmodule Hexpm.Repo.Migrations.AddPermissionsToKeys do
+  use Ecto.Migration
+
+  def up do
+    alter table(:keys) do
+      add :permissions, {:array, :jsonb}, null: false, default: fragment("ARRAY[json_build_object('id', uuid_generate_v4(), 'policy', 'api')]")
+    end
+
+    execute "ALTER TABLE keys ALTER permissions DROP DEFAULT"
+  end
+
+  def down do
+    alter table(:keys) do
+      remove :permissions
+    end
+  end
+end

--- a/test/hexpm/web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm/web/controllers/api/auth_controller_test.exs
@@ -1,0 +1,131 @@
+defmodule Hexpm.Web.API.AuthControllerTest do
+  use Hexpm.ConnCase, async: true
+
+  setup do
+    owned_repo = insert(:repository, public: false)
+    unowned_repo = insert(:repository, public: false)
+    user = insert(:user)
+    insert(:repository_user, repository: owned_repo, user: user)
+
+    full_key = insert(:key, user: user, permissions: [
+      build(:key_permission, domain: "api"),
+      build(:key_permission, domain: "repository", resource: owned_repo.name)
+    ])
+    api_key = insert(:key, user: user, permissions: [build(:key_permission, domain: "api")])
+    repo_key = insert(:key, user: user, permissions: [build(:key_permission, domain: "repository", resource: owned_repo.name)])
+    unowned_repo_key = insert(:key, user: user, permissions: [build(:key_permission, domain: "repository", resource: unowned_repo.name)])
+
+    {:ok, [
+      owned_repo: owned_repo,
+      unowned_repo: unowned_repo,
+      user: user,
+      full_key: full_key,
+      api_key: api_key,
+      repo_key: repo_key,
+      unowned_repo_key: unowned_repo_key,
+    ]}
+  end
+
+  describe "GET /api/auth" do
+    test "without key" do
+      build_conn()
+      |> get("api/auth")
+      |> response(401)
+    end
+
+    test "with invalid key" do
+      build_conn()
+      |> put_req_header("authorization", "ABC")
+      |> get("api/auth")
+      |> response(401)
+    end
+
+    test "authenticate full key", %{full_key: key, owned_repo: owned_repo, unowned_repo: unowned_repo} do
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: owned_repo.name)
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: unowned_repo.name)
+      |> response(403)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: "BADREPO")
+      |> response(403)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository")
+      |> response(403)
+    end
+
+    test "authenticate api key", %{api_key: key} do
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: "myrepo")
+      |> response(403)
+    end
+
+    test "authenticate repo key", %{repo_key: key, owned_repo: owned_repo, unowned_repo: unowned_repo} do
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api")
+      |> response(403)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository")
+      |> response(403)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: owned_repo.name)
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: unowned_repo.name)
+      |> response(403)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: "BADREPO")
+      |> response(403)
+    end
+
+    test "authenticate repo key against repo without access permissions", %{unowned_repo_key: key, unowned_repo: unowned_repo} do
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "repository", resource: unowned_repo.name)
+      |> response(403)
+    end
+  end
+end

--- a/test/hexpm/web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm/web/controllers/api/auth_controller_test.exs
@@ -29,22 +29,23 @@ defmodule Hexpm.Web.API.AuthControllerTest do
   describe "GET /api/auth" do
     test "without key" do
       build_conn()
-      |> get("api/auth")
+      |> get("api/auth", domain: "api")
       |> response(401)
     end
 
     test "with invalid key" do
       build_conn()
       |> put_req_header("authorization", "ABC")
-      |> get("api/auth")
+      |> get("api/auth", domain: "api")
       |> response(401)
     end
 
-    test "authenticate full key", %{full_key: key, owned_repo: owned_repo, unowned_repo: unowned_repo} do
+    test "without domain returns 400", %{full_key: key} do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth")
-      |> response(204)
+      |> response(400)
+    end
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)

--- a/test/hexpm/web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm/web/controllers/api/auth_controller_test.exs
@@ -47,6 +47,7 @@ defmodule Hexpm.Web.API.AuthControllerTest do
       |> response(400)
     end
 
+    test "authenticate full key", %{full_key: key, owned_repo: owned_repo, unowned_repo: unowned_repo} do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "api")
@@ -60,25 +61,20 @@ defmodule Hexpm.Web.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository", resource: unowned_repo.name)
-      |> response(403)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository", resource: "BADREPO")
-      |> response(403)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository")
-      |> response(403)
+      |> response(401)
     end
 
     test "authenticate api key", %{api_key: key} do
-      build_conn()
-      |> put_req_header("authorization", key.user_secret)
-      |> get("api/auth")
-      |> response(204)
-
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "api")
@@ -87,24 +83,19 @@ defmodule Hexpm.Web.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository", resource: "myrepo")
-      |> response(403)
+      |> response(401)
     end
 
     test "authenticate repo key", %{repo_key: key, owned_repo: owned_repo, unowned_repo: unowned_repo} do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
-      |> get("api/auth")
-      |> response(204)
-
-      build_conn()
-      |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "api")
-      |> response(403)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository")
-      |> response(403)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -114,12 +105,12 @@ defmodule Hexpm.Web.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository", resource: unowned_repo.name)
-      |> response(403)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository", resource: "BADREPO")
-      |> response(403)
+      |> response(401)
     end
 
     test "authenticate repo key against repo without access permissions", %{unowned_repo_key: key, unowned_repo: unowned_repo} do

--- a/test/hexpm/web/controllers/api/repository_controller_test.exs
+++ b/test/hexpm/web/controllers/api/repository_controller_test.exs
@@ -6,13 +6,13 @@ defmodule Hexpm.Web.API.RepositoryControllerTest do
     repository1 = insert(:repository, public: true)
     repository2 = insert(:repository, public: false)
     insert(:repository, public: false)
-    insert(:repostory_user, user: user, repository: repository2)
+    insert(:repository_user, user: user, repository: repository2)
     %{user: user, repository1: repository1, repository2: repository2}
   end
 
-  describe "GET /api/repositories" do
+  describe "GET /api/repos" do
     test "not authorized" do
-      conn = get build_conn(), "api/repositories"
+      conn = get build_conn(), "api/repos"
       result = json_response(conn, 200)
       assert length(result) == 2
     end
@@ -21,19 +21,19 @@ defmodule Hexpm.Web.API.RepositoryControllerTest do
       result =
         build_conn()
         |> put_req_header("authorization", key_for(user))
-        |> get("api/repositories")
+        |> get("api/repos")
         |> json_response(200)
       assert length(result) == 3
     end
   end
 
-  describe "GET /api/repositories/:repository" do
+  describe "GET /api/repos/:repository" do
     test "not authorized", %{repository1: repository1, repository2: repository2} do
-      conn = get build_conn(), "api/repositories/#{repository1.name}"
+      conn = get build_conn(), "api/repos/#{repository1.name}"
       result = json_response(conn, 200)
       assert result["name"] == repository1.name
 
-      conn = get build_conn(), "api/repositories/#{repository2.name}"
+      conn = get build_conn(), "api/repos/#{repository2.name}"
       response(conn, 403)
     end
 
@@ -41,7 +41,7 @@ defmodule Hexpm.Web.API.RepositoryControllerTest do
       result =
         build_conn()
         |> put_req_header("authorization", key_for(user))
-        |> get("api/repositories/#{repository2.name}")
+        |> get("api/repos/#{repository2.name}")
         |> json_response(200)
       assert result["name"] == repository2.name
     end

--- a/test/hexpm/web/controllers/api/user_controller_test.exs
+++ b/test/hexpm/web/controllers/api/user_controller_test.exs
@@ -111,30 +111,4 @@ defmodule Hexpm.Web.API.UserControllerTest do
       assert conn.status == 401
     end
   end
-
-  # TODO
-  # NOTE: Also test for website sign up controller
-  # test "recreate unconfirmed user" do
-  #   # first
-  #   body = %{username: "name", email: "email@mail.com", password: "passpass"}
-  #   conn = build_conn()
-  #          |> put_req_header("content-type", "application/json")
-  #          |> post("api/users", Poison.encode!(body))
-  #
-  #   assert json_response(conn, 201)["url"] =~ "/api/users/name"
-  #
-  #   user = Hexpm.Repo.get_by!(User, username: "name")
-  #   assert user.email == "email@mail.com"
-  #
-  #   # recreate
-  #   body = %{username: "name", email: "other_email@mail.com", password: "other_pass"}
-  #   conn = build_conn()
-  #          |> put_req_header("content-type", "application/json")
-  #          |> post("api/users", Poison.encode!(body))
-  #
-  #   assert json_response(conn, 201)["url"] =~ "/api/users/name"
-  #
-  #   user = Hexpm.Repo.get_by!(User, username: "name")
-  #   assert user.email == "other_email@mail.com"
-  # end
 end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -10,23 +10,26 @@ defmodule Hexpm.Case do
 
   def create_user(username, email, password, confirmed? \\ true) do
     Hexpm.Accounts.User.build(%{username: username, password: password, emails: [%{email: email}]}, confirmed?)
-    |> Hexpm.Repo.insert!
+    |> Hexpm.Repo.insert!()
   end
 
-  def key_for(username) when is_binary(username) do
+  def key_for(user, type \\ :api)
+
+  def key_for(username, type) when is_binary(username) do
     Hexpm.Repo.get_by!(Hexpm.Accounts.User, username: username)
-    |> key_for
+    |> key_for(type)
   end
 
-  def key_for(user) do
-    key = user
-          |> Hexpm.Accounts.Key.build(%{name: "any_key_name"})
-          |> Hexpm.Repo.insert!
+  def key_for(user, _type) do
+    key =
+      user
+      |> Hexpm.Accounts.Key.build(%{name: "any_key_name"})
+      |> Hexpm.Repo.insert!
     key.user_secret
   end
 
   def read_fixture(path) do
     Path.join([__DIR__, "..", "fixtures", path])
-    |> File.read!
+    |> File.read!()
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -29,8 +29,13 @@ defmodule Hexpm.Factory do
       name: Fake.random(:username),
       secret_first: first,
       secret_second: second,
-      user_secret: user_secret
+      user_secret: user_secret,
+      permissions: [build(:key_permission, domain: "api")]
     }
+  end
+
+  def key_permission_factory() do
+    %Hexpm.Accounts.KeyPermission{}
   end
 
   def user_handles_factory() do
@@ -63,7 +68,7 @@ defmodule Hexpm.Factory do
     %Hexpm.Repository.PackageOwner{}
   end
 
-  def repostory_user_factory() do
+  def repository_user_factory() do
     %Hexpm.Repository.RepositoryUser{
       role: "read"
     }

--- a/test/support/fake.ex
+++ b/test/support/fake.ex
@@ -50,7 +50,9 @@ defmodule Hexpm.Fake do
   end)
 
   defp load_file(name) do
-    # TODO: Shuffle based on ex_unit seed
+    # TODO: Wait for 1.5.0
+    # seed = ExUnit.configuration()[:seed]
+    # :rand.seed(:exrop, {seed, seed, seed})
 
     path = Path.join([__DIR__, "..", "fake", "#{name}.txt"])
     objects =


### PR DESCRIPTION
Adds permissions to API keys. A permission has a domain (`api` or `repository`) and an optional resource, currently only used for repository names. A key with `domain: :api` has permissions to the full API and a key with `domain: :repository, resource: "myrepo"` has permissions to the repository "myrepo". Note that permissions does not necessarily give access, for example the user may not have read access for "myrepo" and no user has access to the full API.

Also note that repositories are not stored on the application server so the repository (in our case our Fastly CDN) has to make requests against `/api/auth` to verify user access to repositories, see 62a8b4c.