### PR TITLE
Add api/users/me endpoint

### DIFF
--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -16,7 +16,7 @@ defmodule Hexpm.Accounts.Auth do
       from(k in Key,
            where: k.secret_first == ^first,
            join: u in assoc(k, :user),
-           preload: [user: {u, [:emails, :repositories]}])
+           preload: [user: {u, [:owned_packages, :emails, :repositories]}])
       |> Hexpm.Repo.one()
 
     case result do
@@ -36,7 +36,7 @@ defmodule Hexpm.Accounts.Auth do
   end
 
   def password_auth(username_or_email, password) do
-    user = Users.get(username_or_email, [:emails, :repositories])
+    user = Users.get(username_or_email, [:owned_packages, :emails, :repositories])
     if user && Comeonin.Bcrypt.checkpw(password, user.password) do
       {:ok, {user, nil, find_email(user, username_or_email)}}
     else

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -25,6 +25,8 @@ defmodule Hexpm.Accounts.User do
 
   @username_regex ~r"^[a-z0-9_\-\.\(\)]+$"
 
+  @reserved_names ~w(me hex hexpm elixir erlang otp)
+
   defp changeset(user, :create, params, confirmed?) do
     cast(user, params, ~w(username full_name password))
     |> validate_required(~w(username password)a)
@@ -32,6 +34,7 @@ defmodule Hexpm.Accounts.User do
     |> update_change(:username, &String.downcase/1)
     |> validate_length(:username, min: 3)
     |> validate_format(:username, @username_regex)
+    |> validate_exclusion(:username, @reserved_names)
     |> unique_constraint(:username, name: "users_username_idx")
     |> validate_length(:password, min: 7)
     |> validate_confirmation(:password, message: "does not match password")

--- a/lib/hexpm/web/controllers/api/user_controller.ex
+++ b/lib/hexpm/web/controllers/api/user_controller.ex
@@ -2,6 +2,7 @@ defmodule Hexpm.Web.API.UserController do
   use Hexpm.Web, :controller
 
   plug :authorize, [domain: :api] when action in [:test]
+  plug :authorize, [domain: :api] when action in [:me]
 
   def create(conn, params) do
     params = email_param(params)
@@ -18,6 +19,16 @@ defmodule Hexpm.Web.API.UserController do
       {:error, changeset} ->
         validation_failed(conn, changeset)
     end
+  end
+
+  def me(conn, _params) do
+    user = conn.assigns.current_user
+
+    when_stale(conn, user, fn conn ->
+      conn
+      |> api_cache(:private)
+      |> render(:show, user: user)
+    end)
   end
 
   def show(conn, %{"name" => username}) do

--- a/lib/hexpm/web/controllers/auth_helpers.ex
+++ b/lib/hexpm/web/controllers/auth_helpers.ex
@@ -57,7 +57,7 @@ defmodule Hexpm.Web.AuthHelpers do
       {:error, :basic} ->
         unauthorized(conn, "invalid username and password combination")
       {:error, :key} ->
-        unauthorized(conn, "invalid username and API key combination")
+        unauthorized(conn, "invalid API key")
       {:error, :unconfirmed} ->
         forbidden(conn, "email not verified")
       {:error, :revoked_key} ->

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -132,6 +132,7 @@ defmodule Hexpm.Web.Router do
     get "/", IndexController, :index
 
     post "/users", UserController, :create
+    get "/users/me", UserController, :me
     get "/users/:name", UserController, :show
     get "/users/:name/test", UserController, :test
     post "/users/:name/reset", UserController, :reset

--- a/test/hexpm/web/controllers/api/user_controller_test.exs
+++ b/test/hexpm/web/controllers/api/user_controller_test.exs
@@ -58,6 +58,29 @@ defmodule Hexpm.Web.API.UserControllerTest do
     end
   end
 
+  describe "GET /api/users/me" do
+    test "get current user" do
+      user = insert(:user)
+
+      body =
+        build_conn()
+        |> put_req_header("authorization", key_for(user))
+        |> get("api/users/me")
+        |> json_response(200)
+
+      assert body["username"] == user.username
+      assert body["email"] == hd(user.emails).email
+      refute body["emails"]
+      refute body["password"]
+    end
+
+    test "return 401 if not authenticated" do
+      build_conn()
+      |> get("api/users/me")
+      |> json_response(401)
+    end
+  end
+
   describe "GET /api/users/:name" do
     test "get user" do
       user = insert(:user)


### PR DESCRIPTION
Reserves the "me" username to ensure there are no conflicts.

This is needed because we no longer to store usernames on the Hex
client.