### PR TITLE
Use MixProject instead of Mixfile in mix.exs files

### DIFF
--- a/lib/hexpm/web/templates/docs/publish.html.md
+++ b/lib/hexpm/web/templates/docs/publish.html.md
@@ -76,7 +76,7 @@ Only Hex packages will be included as dependencies of the package, for example G
 #### Example mix.exs file
 
 ```elixir
-defmodule Postgrex.Mixfile do
+defmodule Postgrex.MixProject do
   use Mix.Project
 
   def project() do

--- a/lib/hexpm/web/templates/docs/usage.html.md
+++ b/lib/hexpm/web/templates/docs/usage.html.md
@@ -13,7 +13,7 @@ Hex integrates with Mix's dependency handling. Dependencies are defined in Mix's
 The version requirement specify which versions of the package you allow. The formats accepted for the requirement are documented in the [Version module](https://hexdocs.pm/elixir/Version.html). Below is an example `mix.exs` file.
 
 ```elixir
-defmodule MyProject.Mixfile do
+defmodule MyProject.MixProject do
   use Mix.Project
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Hexpm.Mixfile do
+defmodule Hexpm.MixProject do
   use Mix.Project
 
   def project do


### PR DESCRIPTION
Mix renames the module in `mix.exs` file from `Mixfile` to `MixProject`.

This pull request updates the name.

Reference: https://github.com/elixir-lang/elixir/commit/c6a0edcd32359eca284ff0166d19a6dc979ee954