### PR TITLE
HEX-561: Add sort by recent downloads feature

### DIFF
--- a/assets/css/template/_package-list.scss
+++ b/assets/css/template/_package-list.scss
@@ -93,6 +93,40 @@
           font-weight: bold;
           color: $color-text-grey;
         }
+        .downloads-count-wrapper {
+          position: relative;
+          display: inline-block;
+
+          .downloads-count-desc {
+            border-bottom: 1px dotted $color-purple;
+          }
+          .tooltiptext {
+            @include font-size(14, $base-line-height);
+            visibility: hidden;
+            width: 300px;
+            background-color: $color-text-grey;
+            color: $color-white;
+            text-align: center;
+            border-radius: 4px;
+            border: #919ca2 1px solid;
+            padding: 5px 5px;
+            position: relative;
+            top: -2em;
+            text-transform: none;
+            -webkit-transition: all 0.3s ease;
+            -moz-transition: all 0.3s ease-in-out;
+            -o-transition: all 0.3s ease;
+            transition: all 0.3s ease-in-out;
+          }
+        }
+        .downloads-count-wrapper:hover .tooltiptext {
+          visibility: visible;
+          top: 1.2em;
+          -webkit-transition: all 0.2s ease;
+          -moz-transition: all 0.2s ease;
+          -o-transition: all 0.2s ease;
+          transition: all 0.2s ease;
+        }
       }
     }
   }

--- a/assets/css/template/_package-list.scss
+++ b/assets/css/template/_package-list.scss
@@ -93,6 +93,7 @@
           font-weight: bold;
           color: $color-text-grey;
         }
+        
         .downloads-count-wrapper {
           position: relative;
           display: inline-block;
@@ -100,6 +101,7 @@
           .downloads-count-desc {
             border-bottom: 1px dotted $color-purple;
           }
+
           .tooltiptext {
             @include font-size(14, $base-line-height);
             position: relative;

--- a/assets/css/template/_package-list.scss
+++ b/assets/css/template/_package-list.scss
@@ -102,19 +102,20 @@
           }
           .tooltiptext {
             @include font-size(14, $base-line-height);
+            position: relative;
             top: -2em;
-            visibility: hidden;
             width: 300px;
-            background-color: $color-text-grey;
+            padding: 5px;
             color: $color-white;
             text-align: center;
-            border-radius: 4px;
-            border: #919ca2 1px solid;
-            padding: 5px 5px;
-            position: relative;
             text-transform: none;
+            visibility: hidden;
+            background-color: $color-text-grey;
+            border: #919ca2 1px solid;
+            border-radius: 4px;
             transition: all .3s ease-in-out;
           }
+
         }
 
         .downloads-count-wrapper:hover .tooltiptext {
@@ -126,7 +127,7 @@
       }
 
     }
-    
+
   }
 
   h5 {

--- a/assets/css/template/_package-list.scss
+++ b/assets/css/template/_package-list.scss
@@ -93,7 +93,7 @@
           font-weight: bold;
           color: $color-text-grey;
         }
-        
+
         .downloads-count-wrapper {
           position: relative;
           display: inline-block;
@@ -117,7 +117,6 @@
             border-radius: 4px;
             transition: all .3s ease-in-out;
           }
-
         }
 
         .downloads-count-wrapper:hover .tooltiptext {
@@ -125,11 +124,8 @@
           visibility: visible;
           transition: all .2s ease;
         }
-
       }
-
     }
-
   }
 
   h5 {

--- a/assets/css/template/_package-list.scss
+++ b/assets/css/template/_package-list.scss
@@ -102,6 +102,7 @@
           }
           .tooltiptext {
             @include font-size(14, $base-line-height);
+            top: -2em;
             visibility: hidden;
             width: 300px;
             background-color: $color-text-grey;
@@ -111,24 +112,21 @@
             border: #919ca2 1px solid;
             padding: 5px 5px;
             position: relative;
-            top: -2em;
             text-transform: none;
-            -webkit-transition: all 0.3s ease;
-            -moz-transition: all 0.3s ease-in-out;
-            -o-transition: all 0.3s ease;
-            transition: all 0.3s ease-in-out;
+            transition: all .3s ease-in-out;
           }
         }
+
         .downloads-count-wrapper:hover .tooltiptext {
-          visibility: visible;
           top: 1.2em;
-          -webkit-transition: all 0.2s ease;
-          -moz-transition: all 0.2s ease;
-          -o-transition: all 0.2s ease;
-          transition: all 0.2s ease;
+          visibility: visible;
+          transition: all .2s ease;
         }
+
       }
+
     }
+    
   }
 
   h5 {

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -309,12 +309,20 @@ defmodule Hexpm.Repository.Package do
     from(p in query, order_by: [desc: p.updated_at])
   end
 
-  defp sort(query, :downloads) do
+  defp sort(query, :total_downloads) do
     from(p in query,
       left_join: d in PackageDownload,
       on: p.id == d.package_id and (d.view == "all" or is_nil(d.view)),
       order_by: [fragment("? DESC NULLS LAST", d.downloads)])
   end
+
+  defp sort(query, :ninety_days) do
+    from(p in query,
+      left_join: d in PackageDownload,
+      on: p.id == d.package_id and (d.view == "ninety_days" or is_nil(d.view)),
+      order_by: [fragment("? DESC NULLS LAST", d.downloads)])
+  end
+
 
   defp sort(query, nil) do
     query

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -323,7 +323,6 @@ defmodule Hexpm.Repository.Package do
       order_by: [fragment("? DESC NULLS LAST", d.downloads)])
   end
 
-
   defp sort(query, nil) do
     query
   end

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -316,10 +316,10 @@ defmodule Hexpm.Repository.Package do
       order_by: [fragment("? DESC NULLS LAST", d.downloads)])
   end
 
-  defp sort(query, :ninety_days) do
+  defp sort(query, :recent_downloads) do
     from(p in query,
       left_join: d in PackageDownload,
-      on: p.id == d.package_id and (d.view == "ninety_days" or is_nil(d.view)),
+      on: p.id == d.package_id and (d.view == "recent" or is_nil(d.view)),
       order_by: [fragment("? DESC NULLS LAST", d.downloads)])
   end
 

--- a/lib/hexpm/repository/package_download.ex
+++ b/lib/hexpm/repository/package_download.ex
@@ -37,6 +37,16 @@ defmodule Hexpm.Repository.PackageDownload do
     )
   end
 
+  def packages_and_all_download_views(packages) do
+    package_ids = Enum.map(packages, &(&1.id))
+
+    from(pd in PackageDownload,
+      join: p in assoc(pd, :package),
+      where: pd.package_id in ^package_ids,
+      select: {p.id, pd.view, coalesce(pd.downloads, 0)},
+      order_by: [desc: pd.view])
+  end
+
   def packages(packages, view) do
     package_ids = Enum.map(packages, &(&1.id))
 

--- a/lib/hexpm/repository/package_download.ex
+++ b/lib/hexpm/repository/package_download.ex
@@ -43,8 +43,7 @@ defmodule Hexpm.Repository.PackageDownload do
     from(pd in PackageDownload,
       join: p in assoc(pd, :package),
       where: pd.package_id in ^package_ids,
-      select: {p.id, pd.view, coalesce(pd.downloads, 0)},
-      order_by: [desc: pd.view])
+      select: {p.id, pd.view, coalesce(pd.downloads, 0)})
   end
 
   def packages(packages, view) do

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -94,25 +94,16 @@ defmodule Hexpm.Repository.Packages do
 
   @doc """
     Retrieves package downloads including all views available.
-    i.e day, week, month, ninety_days, all.
+    i.e day, week, recent, and all.
     The return value is a map with the following structure:
     %{ package.id => %{ view1 => numDownloads, view2 => numDownloads, ...}
-    Example: %{ 105 => %{ "all" => 1_234_567, "ninety_days" => 10_000, etc... }
+    Example: %{ 105 => %{ "all" => 1_234_567, "recent" => 10_000, etc... }
   """
   def packages_downloads_with_all_views(packages) do
     PackageDownload.packages_and_all_download_views(packages)
     |> Repo.all()
-    |> Enum.into([])
-    |> Enum.reduce(%{}, fn(package, acc) ->
-      {id, view, dls} = package
-      case Map.has_key?(acc, id) do
-        true ->
-          map = Map.get(acc, id)
-                |> Map.put(view, dls)
-          Map.update!(acc, id, fn(_) -> map end)
-        false ->
-          Map.put_new(acc, id,  %{view => dls})
-      end
+    |> Enum.reduce(%{}, fn({id, view, dls}, acc) ->
+         Map.update(acc, id, %{view => dls}, &Map.put(&1, view, dls))
     end)
   end
 

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -104,14 +104,14 @@ defmodule Hexpm.Repository.Packages do
     |> Repo.all()
     |> Enum.into([])
     |> Enum.reduce(%{}, fn(package, acc) ->
-      { id, view, dls } = package
+      {id, view, dls} = package
       case Map.has_key?(acc, id) do
         true ->
           map = Map.get(acc, id)
                 |> Map.put(view, dls)
           Map.update!(acc, id, fn(_) -> map end)
         false ->
-          Map.put_new(acc, id,  %{ view => dls })
+          Map.put_new(acc, id,  %{view => dls})
       end
     end)
   end

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -92,13 +92,6 @@ defmodule Hexpm.Repository.Packages do
     |> Enum.into(%{})
   end
 
-  @doc """
-    Retrieves package downloads including all views available.
-    i.e day, week, recent, and all.
-    The return value is a map with the following structure:
-    %{ package.id => %{ view1 => numDownloads, view2 => numDownloads, ...}
-    Example: %{ 105 => %{ "all" => 1_234_567, "recent" => 10_000, etc... }
-  """
   def packages_downloads_with_all_views(packages) do
     PackageDownload.packages_and_all_download_views(packages)
     |> Repo.all()

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -92,6 +92,30 @@ defmodule Hexpm.Repository.Packages do
     |> Enum.into(%{})
   end
 
+  @doc """
+    Retrieves package downloads including all views available.
+    i.e day, week, month, ninety_days, all.
+    The return value is a map with the following structure:
+    %{ package.id => %{ view1 => numDownloads, view2 => numDownloads, ...}
+    Example: %{ 105 => %{ "all" => 1_234_567, "ninety_days" => 10_000, etc... }
+  """
+  def packages_downloads_with_all_views(packages) do
+    PackageDownload.packages_and_all_download_views(packages)
+    |> Repo.all()
+    |> Enum.into([])
+    |> Enum.reduce(%{}, fn(package, acc) ->
+      { id, view, dls } = package
+      case Map.has_key?(acc, id) do
+        true ->
+          map = Map.get(acc, id)
+                |> Map.put(view, dls)
+          Map.update!(acc, id, fn(_) -> map end)
+        false ->
+          Map.put_new(acc, id,  %{ view => dls })
+      end
+    end)
+  end
+
   def packages_downloads(packages, view) do
     PackageDownload.packages(packages, view)
     |> Repo.all()

--- a/lib/hexpm/web/controllers/api/package_controller.ex
+++ b/lib/hexpm/web/controllers/api/package_controller.ex
@@ -4,14 +4,14 @@ defmodule Hexpm.Web.API.PackageController do
   plug :maybe_fetch_package when action in [:show]
   plug :maybe_authorize, [domain: "api", fun: &repository_access?/2] when action in [:show]
 
-  @sort_params ~w(name downloads inserted_at updated_at)
+  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
 
   def index(conn, params) do
     # TODO: Handle /repos/:repo/ and /
     repositories = Users.all_repositories(conn.assigns.current_user)
     page = Hexpm.Utils.safe_int(params["page"])
     search = Hexpm.Utils.parse_search(params["search"])
-    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "name", @sort_params)
+    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "recent_downloads", @sort_params)
     packages = Packages.search_with_versions(repositories, page, 100, search, sort)
 
     when_stale(conn, packages, [modified: false], fn conn ->

--- a/lib/hexpm/web/controllers/api/package_controller.ex
+++ b/lib/hexpm/web/controllers/api/package_controller.ex
@@ -11,7 +11,7 @@ defmodule Hexpm.Web.API.PackageController do
     repositories = Users.all_repositories(conn.assigns.current_user)
     page = Hexpm.Utils.safe_int(params["page"])
     search = Hexpm.Utils.parse_search(params["search"])
-    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "recent_downloads", @sort_params)
+    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "name", @sort_params)
     packages = Packages.search_with_versions(repositories, page, 100, search, sort)
 
     when_stale(conn, packages, [modified: false], fn conn ->

--- a/lib/hexpm/web/controllers/package_controller.ex
+++ b/lib/hexpm/web/controllers/package_controller.ex
@@ -1,12 +1,6 @@
 defmodule Hexpm.Web.PackageController do
   use Hexpm.Web, :controller
 
-  @moduledoc """
-    sort params:
-    recent_downloads is defined as the sum of a packages downloads over ninety days.
-    total_downloads is the sum of all a packages downloads.
-  """
-
   @packages_per_page 30
   @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
   @letters for letter <- ?A..?Z, do: <<letter>>
@@ -95,7 +89,7 @@ defmodule Hexpm.Web.PackageController do
 
     downloads = Packages.package_downloads(package)
     owners = Owners.all(package, [:emails])
-    dependants = Packages.search(repositories, 1, 20, "depends:#{package.name}", :total_downloads, [:name, :repository_id])
+    dependants = Packages.search(repositories, 1, 20, "depends:#{package.name}", :recent_downloads, [:name, :repository_id])
     dependants_count = Packages.count(repositories, "depends:#{package.name}")
 
     render(conn, "show.html", [

--- a/lib/hexpm/web/controllers/package_controller.ex
+++ b/lib/hexpm/web/controllers/package_controller.ex
@@ -2,7 +2,7 @@ defmodule Hexpm.Web.PackageController do
   use Hexpm.Web, :controller
 
   @packages_per_page 30
-  @sort_params ~w(name downloads inserted_at updated_at)
+  @sort_params ~w(name ninety_days total_downloads inserted_at updated_at)
   @letters for letter <- ?A..?Z, do: <<letter>>
 
   def index(conn, params) do
@@ -20,12 +20,12 @@ defmodule Hexpm.Web.PackageController do
       end
 
     repositories = Users.all_repositories(conn.assigns.current_user)
-    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "name", @sort_params)
+    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "ninety_days", @sort_params)
     page_param = Hexpm.Utils.safe_int(params["page"]) || 1
     package_count = Packages.count(repositories, filter)
     page = Hexpm.Utils.safe_page(page_param, package_count, @packages_per_page)
     packages = fetch_packages(repositories, page, @packages_per_page, filter, sort)
-    downloads = Packages.packages_downloads(packages, "all")
+    downloads = Packages.packages_downloads_with_all_views(packages)
     exact_match = exact_match(repositories, search)
 
     render(conn, "index.html", [
@@ -89,7 +89,7 @@ defmodule Hexpm.Web.PackageController do
 
     downloads = Packages.package_downloads(package)
     owners = Owners.all(package, [:emails])
-    dependants = Packages.search(repositories, 1, 20, "depends:#{package.name}", :downloads, [:name, :repository_id])
+    dependants = Packages.search(repositories, 1, 20, "depends:#{package.name}", :total_downloads, [:name, :repository_id])
     dependants_count = Packages.count(repositories, "depends:#{package.name}")
 
     render(conn, "show.html", [

--- a/lib/hexpm/web/controllers/package_controller.ex
+++ b/lib/hexpm/web/controllers/package_controller.ex
@@ -1,8 +1,14 @@
 defmodule Hexpm.Web.PackageController do
   use Hexpm.Web, :controller
 
+  @moduledoc """
+    sort params:
+    recent_downloads is defined as the sum of a packages downloads over ninety days.
+    total_downloads is the sum of all a packages downloads.
+  """
+
   @packages_per_page 30
-  @sort_params ~w(name ninety_days total_downloads inserted_at updated_at)
+  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
   @letters for letter <- ?A..?Z, do: <<letter>>
 
   def index(conn, params) do
@@ -20,7 +26,7 @@ defmodule Hexpm.Web.PackageController do
       end
 
     repositories = Users.all_repositories(conn.assigns.current_user)
-    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "ninety_days", @sort_params)
+    sort = Hexpm.Utils.safe_to_atom(params["sort"] || "recent_downloads", @sort_params)
     page_param = Hexpm.Utils.safe_int(params["page"]) || 1
     package_count = Packages.count(repositories, filter)
     page = Hexpm.Utils.safe_page(page_param, package_count, @packages_per_page)

--- a/lib/hexpm/web/templates/layout/header.html.eex
+++ b/lib/hexpm/web/templates/layout/header.html.eex
@@ -37,7 +37,7 @@
           <form class="navbar-form pull-left" role="search" action="<%= package_path(Endpoint, :index) %>">
              <div class="input-group">
                 <input placeholder="Find packages" name="search" type="text" autofocus class="form-control" value="<%= search(assigns) %>">
-                <input type="hidden" name="sort" value="ninety_days">
+                <input type="hidden" name="sort" value="recent_downloads">
 
                 <div class="input-group-btn">
                   <button type="submit" class="btn btn-search" tabindex="1">

--- a/lib/hexpm/web/templates/layout/header.html.eex
+++ b/lib/hexpm/web/templates/layout/header.html.eex
@@ -37,7 +37,7 @@
           <form class="navbar-form pull-left" role="search" action="<%= package_path(Endpoint, :index) %>">
              <div class="input-group">
                 <input placeholder="Find packages" name="search" type="text" autofocus class="form-control" value="<%= search(assigns) %>">
-                <input type="hidden" name="sort" value="downloads">
+                <input type="hidden" name="sort" value="ninety_days">
 
                 <div class="input-group-btn">
                   <button type="submit" class="btn btn-search" tabindex="1">

--- a/lib/hexpm/web/templates/open_search/opensearch.xml.eex
+++ b/lib/hexpm/web/templates/open_search/opensearch.xml.eex
@@ -16,5 +16,5 @@
 
   <InputEncoding>utf-8</InputEncoding>
   <OutputEncoding>utf-8</OutputEncoding>
-  <Url type="text/html" method="get" template="<%= package_url(Endpoint, :index) %>?search={searchTerms}&amp;sort=downloads" />
+  <Url type="text/html" method="get" template="<%= package_url(Endpoint, :index) %>?search={searchTerms}&amp;sort=ninety_days" />
 </OpenSearchDescription>

--- a/lib/hexpm/web/templates/open_search/opensearch.xml.eex
+++ b/lib/hexpm/web/templates/open_search/opensearch.xml.eex
@@ -16,5 +16,5 @@
 
   <InputEncoding>utf-8</InputEncoding>
   <OutputEncoding>utf-8</OutputEncoding>
-  <Url type="text/html" method="get" template="<%= package_url(Endpoint, :index) %>?search={searchTerms}&amp;sort=ninety_days" />
+  <Url type="text/html" method="get" template="<%= package_url(Endpoint, :index) %>?search={searchTerms}&amp;sort=recent_downloads" />
 </OpenSearchDescription>

--- a/lib/hexpm/web/templates/package/_package.html.eex
+++ b/lib/hexpm/web/templates/package/_package.html.eex
@@ -1,7 +1,10 @@
 <li>
   <div class="downloads-info">
-    <span class="download-count"><%= human_number_space(@package_downloads || 0) %></span> <br>
-    downloads
+    <span class="download-count"><%= human_number_space(display_downloads(@package_downloads, @view)|| 0) %></span> <br>
+    <div class="downloads-count-wrapper">
+      <span class="downloads-count-desc"><%= display_downloads_view_title(@view) %></span><br>
+      <span class="tooltiptext"><%= display_downloads_for_opposite_views(@package_downloads, @view) %></span>
+    </div>
   </div>
   <a href="<%= path_for_package(@package) %>"><%= package_name(@package) %></a>
   <span class="version"><%= @package.latest_version %></span>

--- a/lib/hexpm/web/templates/package/index.html.eex
+++ b/lib/hexpm/web/templates/package/index.html.eex
@@ -30,7 +30,8 @@
   page = if @page == 1, do: nil, else: @page
 
   sort_name_params = params(search: @search, page: page, sort: "name")
-  sort_downloads_params = params(search: @search, page: page, sort: "downloads")
+  sort_total_downloads_params = params(search: @search, page: page, sort: "total_downloads")
+  sort_recent_downloads_params = params(search: @search, page: page, sort: "ninety_days")
   sort_created_params = params(search: @search, page: page, sort: "inserted_at")
   sort_updated_params = params(search: @search, page: page, sort: "updated_at")
   prev_page_params = params(search: @search, page: @page-1, sort: @sort)
@@ -54,7 +55,10 @@
             <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_name_params) %>">Name</a>
           </li>
           <li role="presentation">
-            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_downloads_params) %>">Downloads</a>
+            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_total_downloads_params) %>">Total Downloads</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_recent_downloads_params) %>">Recent Downloads</a>
           </li>
           <li role="presentation">
             <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_created_params) %>">Recently created</a>
@@ -74,7 +78,7 @@
   <div class="exact-match">
     <h5>Exact Match:</h5>
     <ul>
-      <%= render "_package.html", package: @exact_match, package_downloads: @downloads[@exact_match.id] %>
+      <%= render "_package.html", package: @exact_match, package_downloads: downloads_for_package(@exact_match, @downloads), view: @sort %>
     </ul>
   </div>
 <% end %>
@@ -85,7 +89,7 @@
   <% end %>
   <ul>
     <%= for package <- @packages do %>
-      <%= render "_package.html", package: package, package_downloads: @downloads[package.id] %>
+      <%= render "_package.html", package: package, package_downloads: downloads_for_package(package, @downloads), view: @sort %>
     <% end %>
   </ul>
 </div>

--- a/lib/hexpm/web/templates/package/index.html.eex
+++ b/lib/hexpm/web/templates/package/index.html.eex
@@ -31,7 +31,7 @@
 
   sort_name_params = params(search: @search, page: page, sort: "name")
   sort_total_downloads_params = params(search: @search, page: page, sort: "total_downloads")
-  sort_recent_downloads_params = params(search: @search, page: page, sort: "ninety_days")
+  sort_recent_downloads_params = params(search: @search, page: page, sort: "recent_downloads")
   sort_created_params = params(search: @search, page: page, sort: "inserted_at")
   sort_updated_params = params(search: @search, page: page, sort: "updated_at")
   prev_page_params = params(search: @search, page: @page-1, sort: @sort)

--- a/lib/hexpm/web/templates/page/index.html.eex
+++ b/lib/hexpm/web/templates/page/index.html.eex
@@ -10,7 +10,7 @@
           <%= form_tag(package_path(Endpoint, :index), method: "get", role: "search") do %>
             <div class="input-group">
               <input type="search" autofocus class="form-control" placeholder="Find packages" name="search" id="search" value="<% # search(assigns) %>" tabindex="1">
-              <input type="hidden" name="sort" value="ninety_days">
+              <input type="hidden" name="sort" value="recent_downloads">
               <label class="sr-only" for="search">Find packages</label>
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-search" tabindex="1">

--- a/lib/hexpm/web/templates/page/index.html.eex
+++ b/lib/hexpm/web/templates/page/index.html.eex
@@ -10,7 +10,7 @@
           <%= form_tag(package_path(Endpoint, :index), method: "get", role: "search") do %>
             <div class="input-group">
               <input type="search" autofocus class="form-control" placeholder="Find packages" name="search" id="search" value="<% # search(assigns) %>" tabindex="1">
-              <input type="hidden" name="sort" value="downloads">
+              <input type="hidden" name="sort" value="ninety_days">
               <label class="sr-only" for="search">Find packages</label>
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-search" tabindex="1">

--- a/lib/hexpm/web/views/package_view.ex
+++ b/lib/hexpm/web/views/package_view.ex
@@ -15,7 +15,7 @@ defmodule Hexpm.Web.PackageView do
 
   def display_downloads(package_downloads, view) do
     case view do
-      :recent_downloads->
+      :recent_downloads ->
         Map.get(package_downloads, "recent")
       _ ->
         Map.get(package_downloads, "all")
@@ -24,7 +24,7 @@ defmodule Hexpm.Web.PackageView do
 
   def display_downloads_for_opposite_views(package_downloads, view) do
     case view do
-      :recent_downloads->
+      :recent_downloads ->
         downloads = display_downloads(package_downloads, :all) || 0
         "total downloads: #{human_number_space(downloads)}"
       _ ->
@@ -35,7 +35,7 @@ defmodule Hexpm.Web.PackageView do
 
   def display_downloads_view_title(view) do
     case view do
-      :recent_downloads-> "recent downloads"
+      :recent_downloads -> "recent downloads"
       _ -> "total downloads"
     end
   end

--- a/lib/hexpm/web/views/package_view.ex
+++ b/lib/hexpm/web/views/package_view.ex
@@ -6,17 +6,17 @@ defmodule Hexpm.Web.PackageView do
   def show_sort_info(:inserted_at), do: "(Sorted by recently created)"
   def show_sort_info(:updated_at), do: "(Sorted by recently updated)"
   def show_sort_info(:total_downloads), do: "(Sorted by total downloads)"
-  def show_sort_info(:ninety_days), do: "(Sorted by last ninety days)"
+  def show_sort_info(:recent_downloads), do: "(Sorted by recent downloads)"
   def show_sort_info(_param), do: nil
 
   def downloads_for_package(package, downloads) do
-    Map.get(downloads, package.id, %{"all" => 0, "ninety_days" => 0})
+    Map.get(downloads, package.id, %{"all" => 0, "recent" => 0})
   end
 
   def display_downloads(package_downloads, view) do
     case view do
-      :ninety_days ->
-        Map.get(package_downloads, "ninety_days")
+      :recent_downloads->
+        Map.get(package_downloads, "recent")
       _ ->
         Map.get(package_downloads, "all")
     end
@@ -24,18 +24,18 @@ defmodule Hexpm.Web.PackageView do
 
   def display_downloads_for_opposite_views(package_downloads, view) do
     case view do
-      :ninety_days ->
+      :recent_downloads->
         downloads = display_downloads(package_downloads, :all) || 0
         "total downloads: #{human_number_space(downloads)}"
       _ ->
-        downloads = display_downloads(package_downloads, :ninety_days) || 0
+        downloads = display_downloads(package_downloads, :recent_downloads) || 0
         "recent downloads: #{human_number_space(downloads)}"
     end
   end
 
   def display_downloads_view_title(view) do
     case view do
-      :ninety_days -> "recent downloads"
+      :recent_downloads-> "recent downloads"
       _ -> "total downloads"
     end
   end

--- a/lib/hexpm/web/views/package_view.ex
+++ b/lib/hexpm/web/views/package_view.ex
@@ -2,11 +2,44 @@ defmodule Hexpm.Web.PackageView do
   use Hexpm.Web, :view
 
   def show_sort_info(nil), do: "(Sorted by name)"
-  def show_sort_info("name"), do: "(Sorted by name)"
-  def show_sort_info("inserted_at"), do: "(Sorted by recently created)"
-  def show_sort_info("updated_at"), do: "(Sorted by recently updated)"
-  def show_sort_info("downloads"), do: "(Sorted by downloads)"
+  def show_sort_info(:name), do: "(Sorted by name)"
+  def show_sort_info(:inserted_at), do: "(Sorted by recently created)"
+  def show_sort_info(:updated_at), do: "(Sorted by recently updated)"
+  def show_sort_info(:total_downloads), do: "(Sorted by total downloads)"
+  def show_sort_info(:ninety_days), do: "(Sorted by last ninety days)"
   def show_sort_info(_param), do: nil
+
+  def downloads_for_package(package, downloads) do
+    Map.get(downloads, package.id, %{"all" => 0, "ninety_days" => 0})
+  end
+
+
+  def display_downloads(package_downloads, view) do
+    case view do
+      :ninety_days ->
+        Map.get(package_downloads, "ninety_days")
+      _ ->
+        Map.get(package_downloads, "all")
+    end
+  end
+
+  def display_downloads_for_opposite_views(package_downloads, view) do
+    case view do
+      :ninety_days ->
+        downloads = display_downloads(package_downloads, :all) || 0
+        "total downloads: #{human_number_space(downloads)}"
+      _ ->
+        downloads = display_downloads(package_downloads, :ninety_days) || 0
+        "recent downloads: #{human_number_space(downloads)}"
+    end
+  end
+
+  def display_downloads_view_title(view) do
+    case view do
+      :ninety_days -> "recent downloads"
+      _ -> "total downloads"
+    end
+  end
 
   def dep_snippet(:mix, package_name, release) do
     version = snippet_version(:mix, release.version)

--- a/lib/hexpm/web/views/package_view.ex
+++ b/lib/hexpm/web/views/package_view.ex
@@ -13,7 +13,6 @@ defmodule Hexpm.Web.PackageView do
     Map.get(downloads, package.id, %{"all" => 0, "ninety_days" => 0})
   end
 
-
   def display_downloads(package_downloads, view) do
     case view do
       :ninety_days ->

--- a/priv/repo/migrations/20170902072705_add_ninety_days_to_package_downloads_view.exs
+++ b/priv/repo/migrations/20170902072705_add_ninety_days_to_package_downloads_view.exs
@@ -1,0 +1,93 @@
+defmodule Hexpm.Repo.Migrations.AddNinetyDaysToPackageDownloadsView do
+  use Ecto.Migration
+
+  def up do
+    execute "DROP MATERIALIZED VIEW package_downloads"
+
+    execute """
+      CREATE MATERIALIZED VIEW package_downloads (
+        id,
+        package_id,
+        view,
+        downloads) AS
+          SELECT concat(r.package_id, v.view), r.package_id, v.view, SUM(d.downloads)
+          FROM downloads AS d
+          JOIN releases AS r ON r.id = d.release_id
+          CROSS JOIN (VALUES ('day'), ('week'), ('ninety_days'), ('all')) AS v(view)
+          WHERE CASE
+                  WHEN v.view='day'
+                    THEN d.day = current_date - interval '1 day'
+                  WHEN v.view='week'
+                    THEN d.day BETWEEN current_date - interval '7 days' AND
+                                       current_date - interval '1 day'
+                  WHEN v.view='ninety_days'
+                    THEN d.day BETWEEN current_date - interval '90 days' AND
+                                       current_date - interval '1 day'
+                  WHEN v.view='all'
+                    THEN true
+                END
+          GROUP BY r.package_id, v.view
+          UNION
+          SELECT NULL, NULL, 'day', SUM(d.downloads)
+          FROM downloads AS d
+          WHERE d.day = current_date - interval '1 day'
+          UNION
+          SELECT NULL, NULL, 'week', SUM(d.downloads)
+          FROM downloads AS d
+          WHERE d.day BETWEEN current_date - interval '7 days' AND
+                              current_date - interval '1 day'
+          UNION
+          SELECT NULL, NULL, 'ninety_days', SUM(d.downloads)
+          FROM downloads AS d
+          WHERE d.day BETWEEN current_date - interval '90 days' AND
+                              current_date - interval '1 day'
+          UNION
+          SELECT NULL, NULL, 'all', SUM(d.downloads)
+          FROM downloads AS d
+    """
+
+    execute "CREATE INDEX ON package_downloads (package_id)"
+    execute "CREATE INDEX ON package_downloads (view, downloads)"
+  end
+
+  def down do
+    execute "DROP MATERIALIZED VIEW package_downloads"
+
+    execute """
+      CREATE MATERIALIZED VIEW package_downloads (
+        id,
+        package_id,
+        view,
+        downloads) AS
+          SELECT concat(r.package_id, v.view), r.package_id, v.view, SUM(d.downloads)
+          FROM downloads AS d
+          JOIN releases AS r ON r.id = d.release_id
+          CROSS JOIN (VALUES ('day'), ('week'), ('all')) AS v(view)
+          WHERE CASE
+                  WHEN v.view='day'
+                    THEN d.day = current_date - interval '1 day'
+                  WHEN v.view='week'
+                    THEN d.day BETWEEN current_date - interval '7 days' AND
+                                       current_date - interval '1 day'
+                  WHEN v.view='all'
+                    THEN true
+                END
+          GROUP BY r.package_id, v.view
+          UNION
+          SELECT NULL, NULL, 'day', SUM(d.downloads)
+          FROM downloads AS d
+          WHERE d.day = current_date - interval '1 day'
+          UNION
+          SELECT NULL, NULL, 'week', SUM(d.downloads)
+          FROM downloads AS d
+          WHERE d.day BETWEEN current_date - interval '7 days' AND
+                              current_date - interval '1 day'
+          UNION
+          SELECT NULL, NULL, 'all', SUM(d.downloads)
+          FROM downloads AS d
+    """
+
+    execute "CREATE INDEX ON package_downloads (package_id)"
+    execute "CREATE INDEX ON package_downloads (view, downloads)"
+  end
+end

--- a/priv/repo/migrations/20170902072705_add_ninety_days_to_package_downloads_view.exs
+++ b/priv/repo/migrations/20170902072705_add_ninety_days_to_package_downloads_view.exs
@@ -13,14 +13,14 @@ defmodule Hexpm.Repo.Migrations.AddNinetyDaysToPackageDownloadsView do
           SELECT concat(r.package_id, v.view), r.package_id, v.view, SUM(d.downloads)
           FROM downloads AS d
           JOIN releases AS r ON r.id = d.release_id
-          CROSS JOIN (VALUES ('day'), ('week'), ('ninety_days'), ('all')) AS v(view)
+          CROSS JOIN (VALUES ('day'), ('week'), ('recent'), ('all')) AS v(view)
           WHERE CASE
                   WHEN v.view='day'
                     THEN d.day = current_date - interval '1 day'
                   WHEN v.view='week'
                     THEN d.day BETWEEN current_date - interval '7 days' AND
                                        current_date - interval '1 day'
-                  WHEN v.view='ninety_days'
+                  WHEN v.view='recent'
                     THEN d.day BETWEEN current_date - interval '90 days' AND
                                        current_date - interval '1 day'
                   WHEN v.view='all'
@@ -37,7 +37,7 @@ defmodule Hexpm.Repo.Migrations.AddNinetyDaysToPackageDownloadsView do
           WHERE d.day BETWEEN current_date - interval '7 days' AND
                               current_date - interval '1 day'
           UNION
-          SELECT NULL, NULL, 'ninety_days', SUM(d.downloads)
+          SELECT NULL, NULL, 'recent', SUM(d.downloads)
           FROM downloads AS d
           WHERE d.day BETWEEN current_date - interval '90 days' AND
                               current_date - interval '1 day'

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -37,12 +37,17 @@ Hexpm.Repo.transaction(fn ->
       app: "decimal",
       build_tools: ["mix"]))
 
-  insert(:release,
+  decimal_release = insert(:release,
     package: decimal,
     version: "0.1.0",
     meta: build(:release_metadata,
       app: "decimal",
       build_tools: ["mix"]))
+
+  insert(:download, release: decimal_release, downloads: 1_200_000, day: Hexpm.Utils.utc_days_ago(180))
+  insert(:download, release: decimal_release, downloads: 200_000, day: Hexpm.Utils.utc_days_ago(90))
+  insert(:download, release: decimal_release, downloads: 56_000, day: Hexpm.Utils.utc_days_ago(35))
+  insert(:download, release: decimal_release, downloads: 1_000, day: Hexpm.Utils.utc_yesterday())
 
   postgrex = insert(:package,
     name: "postgrex",
@@ -72,7 +77,7 @@ Hexpm.Repo.transaction(fn ->
       build_tools: ["mix"]),
     has_docs: true)
 
-  insert(:release,
+  postgrex_release = insert(:release,
     package: postgrex,
     version: "0.1.0",
     requirements: [build(:requirement,
@@ -82,6 +87,11 @@ Hexpm.Repo.transaction(fn ->
     meta: build(:release_metadata,
       app: "postgrex",
       build_tools: ["mix"]))
+
+  insert(:download, release: postgrex_release, downloads: 1_200_000, day: Hexpm.Utils.utc_days_ago(180))
+  insert(:download, release: postgrex_release, downloads: 200_000, day: Hexpm.Utils.utc_days_ago(90))
+  insert(:download, release: postgrex_release, downloads: 56_000, day: Hexpm.Utils.utc_days_ago(35))
+  insert(:download, release: postgrex_release, downloads: 1_000, day: Hexpm.Utils.utc_yesterday())
 
   ecto = insert(:package,
     name: "ecto",
@@ -181,6 +191,9 @@ Hexpm.Repo.transaction(fn ->
       build_tools: ["mix"]),
     has_docs: true)
 
+  insert(:download, release: rel, downloads: 1_500_000, day: Hexpm.Utils.utc_days_ago(180))
+  insert(:download, release: rel, downloads: 200_000, day: Hexpm.Utils.utc_days_ago(90))
+  insert(:download, release: rel, downloads: 56_000, day: Hexpm.Utils.utc_days_ago(35))
   insert(:download, release: rel, downloads: 42, day: Hexpm.Utils.utc_yesterday())
 
   myrepo = insert(:repository, name: "myrepo")
@@ -269,6 +282,8 @@ Hexpm.Repo.transaction(fn ->
         app: "ups",
         build_tools: ["mix"]))
 
+    insert(:download, release: rel1, downloads: div(index, 2), day: Hexpm.Utils.utc_days_ago(180))
+    insert(:download, release: rel1, downloads: div(index, 2), day: Hexpm.Utils.utc_days_ago(90))
     insert(:download, release: rel1, downloads: div(index, 2), day: Hexpm.Utils.utc_days_ago(35))
     insert(:download, release: rel2, downloads: div(index, 2), day: Hexpm.Utils.utc_yesterday())
   end)

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -124,7 +124,6 @@ defmodule Hexpm.Repository.PackageTest do
     assert [^phoenix_id, ^ecto_id] = Package.all([repository], 1, 10, nil, :total_downloads, nil) |> Repo.pluck(:id)
   end
 
-
   test "sort packages by recent downloads", %{repository: repository} do
     %{id: ecto_id} = insert(:package, repository_id: repository.id)
     %{id: phoenix_id} = insert(:package, repository_id: repository.id)

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -132,6 +132,6 @@ defmodule Hexpm.Repository.PackageTest do
 
     :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
 
-    assert [^phoenix_id, ^ecto_id] = Package.all([repository], 1, 10, nil, :ninety_days, nil) |> Repo.pluck(:id)
+    assert [^phoenix_id, ^ecto_id] = Package.all([repository], 1, 10, nil, :recent_downloads, nil) |> Repo.pluck(:id)
   end
 end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -127,11 +127,13 @@ defmodule Hexpm.Repository.PackageTest do
   test "sort packages by recent downloads", %{repository: repository} do
     %{id: ecto_id} = insert(:package, repository_id: repository.id)
     %{id: phoenix_id} = insert(:package, repository_id: repository.id)
-    insert(:release, package_id: phoenix_id, daily_downloads: [build(:download, downloads: 10)])
-    insert(:release, package_id: ecto_id, daily_downloads: [build(:download, downloads: 5)])
+    %{id: decimal_id} = insert(:package, repository_id: repository.id)
+    insert(:release, package_id: phoenix_id, daily_downloads: [build(:download, downloads: 10, day: Hexpm.Utils.utc_days_ago(91))])
+    insert(:release, package_id: decimal_id, daily_downloads: [build(:download, downloads: 10, day: Hexpm.Utils.utc_days_ago(35))])
+    insert(:release, package_id: ecto_id, daily_downloads: [build(:download, downloads: 5, day: Hexpm.Utils.utc_days_ago(10))])
 
     :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
 
-    assert [^phoenix_id, ^ecto_id] = Package.all([repository], 1, 10, nil, :recent_downloads, nil) |> Repo.pluck(:id)
+    assert [^decimal_id, ^ecto_id, ^phoenix_id] = Package.all([repository], 1, 10, nil, :recent_downloads, nil) |> Repo.pluck(:id)
   end
 end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -113,7 +113,7 @@ defmodule Hexpm.Repository.PackageTest do
     assert ["phoenix"] = Package.all([repository], 1, 10, "depends:poison depends:ecto", nil, nil) |> Repo.pluck(:name)
   end
 
-  test "sort packages by downloads", %{repository: repository} do
+  test "sort packages by total downloads", %{repository: repository} do
     %{id: ecto_id} = insert(:package, repository_id: repository.id)
     %{id: phoenix_id} = insert(:package, repository_id: repository.id)
     insert(:release, package_id: phoenix_id, daily_downloads: [build(:download, downloads: 10)])
@@ -121,6 +121,18 @@ defmodule Hexpm.Repository.PackageTest do
 
     :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
 
-    assert [^phoenix_id, ^ecto_id] = Package.all([repository], 1, 10, nil, :downloads, nil) |> Repo.pluck(:id)
+    assert [^phoenix_id, ^ecto_id] = Package.all([repository], 1, 10, nil, :total_downloads, nil) |> Repo.pluck(:id)
+  end
+
+
+  test "sort packages by recent downloads", %{repository: repository} do
+    %{id: ecto_id} = insert(:package, repository_id: repository.id)
+    %{id: phoenix_id} = insert(:package, repository_id: repository.id)
+    insert(:release, package_id: phoenix_id, daily_downloads: [build(:download, downloads: 10)])
+    insert(:release, package_id: ecto_id, daily_downloads: [build(:download, downloads: 5)])
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [^phoenix_id, ^ecto_id] = Package.all([repository], 1, 10, nil, :ninety_days, nil) |> Repo.pluck(:id)
   end
 end

--- a/test/hexpm/web/controllers/opensearch_controller_test.exs
+++ b/test/hexpm/web/controllers/opensearch_controller_test.exs
@@ -3,6 +3,6 @@ defmodule Hexpm.Web.OpenSearchControllerTest do
 
   test "opensearch" do
     conn = get build_conn(), "/hexsearch.xml"
-    assert response(conn, 200) =~ "<Url type=\"text/html\" method=\"get\" template=\"http://localhost:4001/packages?search={searchTerms}&amp;sort=downloads\" />"
+    assert response(conn, 200) =~ "<Url type=\"text/html\" method=\"get\" template=\"http://localhost:4001/packages?search={searchTerms}&amp;sort=ninety_days\" />"
   end
 end

--- a/test/hexpm/web/controllers/opensearch_controller_test.exs
+++ b/test/hexpm/web/controllers/opensearch_controller_test.exs
@@ -3,6 +3,6 @@ defmodule Hexpm.Web.OpenSearchControllerTest do
 
   test "opensearch" do
     conn = get build_conn(), "/hexsearch.xml"
-    assert response(conn, 200) =~ "<Url type=\"text/html\" method=\"get\" template=\"http://localhost:4001/packages?search={searchTerms}&amp;sort=ninety_days\" />"
+    assert response(conn, 200) =~ "<Url type=\"text/html\" method=\"get\" template=\"http://localhost:4001/packages?search={searchTerms}&amp;sort=recent_downloads\" />"
   end
 end

--- a/test/hexpm/web/views/package_view_test.exs
+++ b/test/hexpm/web/views/package_view_test.exs
@@ -8,7 +8,7 @@ defmodule Hexpm.Web.PackageViewTest do
     assert PackageView.show_sort_info(:inserted_at) == "(Sorted by recently created)"
     assert PackageView.show_sort_info(:updated_at) == "(Sorted by recently updated)"
     assert PackageView.show_sort_info(:total_downloads) == "(Sorted by total downloads)"
-    assert PackageView.show_sort_info(:ninety_days) == "(Sorted by last ninety days)"
+    assert PackageView.show_sort_info(:recent_downloads) == "(Sorted by recent downloads)"
     assert PackageView.show_sort_info(nil) == "(Sorted by name)"
   end
 

--- a/test/hexpm/web/views/package_view_test.exs
+++ b/test/hexpm/web/views/package_view_test.exs
@@ -4,10 +4,12 @@ defmodule Hexpm.Web.PackageViewTest do
   alias Hexpm.Web.PackageView
 
   test "show sort info" do
-    assert PackageView.show_sort_info("name") == "(Sorted by name)"
-    assert PackageView.show_sort_info("inserted_at") == "(Sorted by recently created)"
-    assert PackageView.show_sort_info("updated_at") == "(Sorted by recently updated)"
-    assert PackageView.show_sort_info("downloads") == "(Sorted by downloads)"
+    assert PackageView.show_sort_info(:name) == "(Sorted by name)"
+    assert PackageView.show_sort_info(:inserted_at) == "(Sorted by recently created)"
+    assert PackageView.show_sort_info(:updated_at) == "(Sorted by recently updated)"
+    assert PackageView.show_sort_info(:total_downloads) == "(Sorted by total downloads)"
+    assert PackageView.show_sort_info(:ninety_days) == "(Sorted by last ninety days)"
+    assert PackageView.show_sort_info(nil) == "(Sorted by name)"
   end
 
   test "show sort info when sort param is not available" do


### PR DESCRIPTION
Add new ninety_days view to package_downloads view
Add new migration to drop and reinsert package_downloads MATERIALIZED
VIEW
Add ninety_days sort to package.ex
Add function to query db for all views within a list of packages in
package_download.ex
Update default sorting to ninety_days in: package_controller,
layout/header.html.eex, opensearch.xml.eex, page/index.html.eex
Update OpenSearchController test to include ninety_days sort by default
change
Update :downloads atom to :total_downloads
Add tooltip to downloads info css
Update _package.html.eex template to display appropriate downloads desc
text for current sort method
Update _package.html.eex template to display a tooltip, when hovering
over downloads desc text, with either total downloads or recent
downloads depending upon sort method
Update show_sort_info functions to include sort by changes (i.e. total
downloads or ninety_days).  This update fixed a bug where the
show_sort_info wasn't displaying the text as the functions expected a
string while the actual input was coming in as an atom
Update PackageViewTest to reflect show sort info changes
Update seed.exs with inclusions of ninety_day downloads for packages:
decimal, ecto, postgrex, and ups packages
Update package_test.exs to include :total_downloads sort change