### PR TITLE
Add :organization to dependency declaration snippet

### DIFF
--- a/lib/hexpm/web/templates/package/show.html.eex
+++ b/lib/hexpm/web/templates/package/show.html.eex
@@ -159,7 +159,7 @@ tools = Keyword.take(tools, compatible_tools)
         <div class="config-input">
           <div class="input-group">
             <input type="text" class="form-control snippet"
-              value="<%= dep_snippet(tool, @package.name, @current_release) %>"
+              value="<%= dep_snippet(tool, @package, @current_release) %>"
               onfocus="this.select();"
               readonly="readonly" id="<%= tool %>-snippet" />
             <span class="input-group-btn">

--- a/lib/hexpm/web/views/package_view.ex
+++ b/lib/hexpm/web/views/package_view.ex
@@ -40,31 +40,32 @@ defmodule Hexpm.Web.PackageView do
     end
   end
 
-  def dep_snippet(:mix, package_name, release) do
+  def dep_snippet(:mix, package, release) do
     version = snippet_version(:mix, release.version)
-    app_name = release.meta.app || package_name
+    app_name = release.meta.app || package.name
+    organization = snippet_organization(package.repository.name)
 
-    if package_name == app_name do
-      "{:#{package_name}, \"#{version}\"}"
+    if package.name == app_name do
+      "{:#{package.name}, \"#{version}\"#{organization}}"
     else
-      "{#{app_name(:mix, app_name)}, \"#{version}\", hex: :#{package_name}}"
+      "{#{app_name(:mix, app_name)}, \"#{version}\", hex: :#{package.name}#{organization}}"
     end
   end
 
-  def dep_snippet(:rebar, package_name, release) do
+  def dep_snippet(:rebar, package, release) do
     version = snippet_version(:rebar, release.version)
-    app_name = release.meta.app || package_name
+    app_name = release.meta.app || package.name
 
-    if package_name == app_name do
-      "{#{package_name}, \"#{version}\"}"
+    if package.name == app_name do
+      "{#{package.name}, \"#{version}\"}"
     else
-      "{#{app_name(:rebar, app_name)}, \"#{version}\", {pkg, #{package_name}}}"
+      "{#{app_name(:rebar, app_name)}, \"#{version}\", {pkg, #{package.name}}}"
     end
   end
 
-  def dep_snippet(:erlang_mk, package_name, release) do
+  def dep_snippet(:erlang_mk, package, release) do
     version = snippet_version(:erlang_mk, release.version)
-    "dep_#{package_name} = hex #{version}"
+    "dep_#{package.name} = hex #{version}"
   end
 
   def snippet_version(:mix, %Version{major: 0, minor: minor, patch: patch, pre: []}) do
@@ -81,6 +82,9 @@ defmodule Hexpm.Web.PackageView do
       when other in [:rebar, :erlang_mk] do
     "#{major}.#{minor}.#{patch}#{pre_snippet(pre)}"
   end
+
+  defp snippet_organization("hexpm"), do: ""
+  defp snippet_organization(repository), do: ", organization: #{inspect repository}"
 
   defp pre_snippet([]), do: ""
   defp pre_snippet(pre) do

--- a/test/hexpm/web/controllers/package_controller_test.exs
+++ b/test/hexpm/web/controllers/package_controller_test.exs
@@ -100,7 +100,7 @@ defmodule Hexpm.Web.PackageControllerTest do
         build_conn()
         |> test_login(user1)
         |> get("/packages/#{repository1.name}/#{package3.name}")
-      assert response(conn, 200) =~ escape(~s({:#{package3.name}, "~> 0.0.1"}))
+      assert response(conn, 200) =~ escape(~s({:#{package3.name}, "~> 0.0.1", organization: "#{repository1.name}"}))
     end
 
     test "dont show private package", %{user2: user2, repository1: repository1, package3: package3} do
@@ -133,7 +133,7 @@ defmodule Hexpm.Web.PackageControllerTest do
         build_conn()
         |> test_login(user1)
         |> get("/packages/#{repository1.name}/#{package3.name}/0.0.1")
-      assert response(conn, 200) =~ escape(~s({:#{package3.name}, "~> 0.0.1"}))
+      assert response(conn, 200) =~ escape(~s({:#{package3.name}, "~> 0.0.1", organization: "#{repository1.name}"}))
     end
 
     test "dont show private package", %{user2: user2, repository1: repository1, package3: package3} do

--- a/test/hexpm/web/views/package_view_test.exs
+++ b/test/hexpm/web/views/package_view_test.exs
@@ -20,53 +20,62 @@ defmodule Hexpm.Web.PackageViewTest do
     assert PackageView.show_sort_info(nil) == "(Sorted by name)"
   end
 
-  test "format simple mix dependency snippet" do
-    version = Version.parse!("1.0.0")
-    package_name   = "ecto"
-    release = %{meta: %{app: package_name}, version: version}
-    assert PackageView.dep_snippet(:mix, package_name, release) == "{:ecto, \"~> 1.0\"}"
-  end
+  describe "dep_snippet/3" do
+    test "format simple mix dependency snippet" do
+      version = Version.parse!("1.0.0")
+      package = %{name: "ecto", repository: %{name: "hexpm"}}
+      release = %{meta: %{app: package.name}, version: version}
+      assert PackageView.dep_snippet(:mix, package, release) == ~s({:ecto, "~> 1.0"})
+    end
 
-  test "format mix dependency snippet" do
-    version = Version.parse!("1.0.0")
-    package_name   = "timex"
-    release = %{meta: %{app: "extime"}, version: version}
-    assert PackageView.dep_snippet(:mix, package_name, release) == "{:extime, \"~> 1.0\", hex: :timex}"
-  end
+    test "format mix dependency snippet" do
+      version = Version.parse!("1.0.0")
+      package = %{name: "timex", repository: %{name: "hexpm"}}
+      release = %{meta: %{app: "extime"}, version: version}
+      assert PackageView.dep_snippet(:mix, package, release) == ~s({:extime, "~> 1.0", hex: :timex})
+    end
 
-  test "format simple rebar dependency snippet" do
-    version = Version.parse!("1.0.0")
-    package_name   = "rebar"
-    release = %{meta: %{app: package_name}, version: version}
-    assert PackageView.dep_snippet(:rebar, package_name, release) == "{rebar, \"1.0.0\"}"
-  end
+    test "format private mix dependency snippet" do
+      version = Version.parse!("1.0.0")
+      package = %{name: "ecto", repository: %{name: "private"}}
+      release = %{meta: %{app: package.name}, version: version}
+      assert PackageView.dep_snippet(:mix, package, release) == ~s({:ecto, "~> 1.0", organization: "private"})
+    end
 
-  test "format rebar dependency snippet" do
-    version = Version.parse!("1.0.1")
-    package_name   = "rebar"
-    release = %{meta: %{app: "erlang_mk"}, version: version}
-    assert PackageView.dep_snippet(:rebar, package_name, release) == "{erlang_mk, \"1.0.1\", {pkg, rebar}}"
-  end
+    test "format simple rebar dependency snippet" do
+      version = Version.parse!("1.0.0")
+      package = %{name: "rebar"}
+      release = %{meta: %{app: package.name}, version: version}
+      assert PackageView.dep_snippet(:rebar, package, release) == ~s({rebar, "1.0.0"})
+    end
 
-  test "format erlang.mk dependency snippet" do
-    version = Version.parse!("1.0.4")
-    package_name   = "cowboy"
-    release = %{meta: %{app: package_name}, version: version}
-    assert PackageView.dep_snippet(:erlang_mk, package_name, release) == "dep_cowboy = hex 1.0.4"
-  end
+    test "format rebar dependency snippet" do
+      version = Version.parse!("1.0.1")
+      package = %{name: "rebar"}
+      release = %{meta: %{app: "erlang_mk"}, version: version}
+      assert PackageView.dep_snippet(:rebar, package, release) == ~s({erlang_mk, "1.0.1", {pkg, rebar}})
+    end
 
-  test "escape mix application name" do
-    version = Version.parse!("1.0.0")
-    package_name   = "lfe_app"
-    release = %{meta: %{app: "lfe-app"}, version: version}
-    assert PackageView.dep_snippet(:mix, package_name, release) == "{:\"lfe-app\", \"~> 1.0\", hex: :lfe_app}"
-  end
+    test "format erlang.mk dependency snippet" do
+      version = Version.parse!("1.0.4")
+      package = %{name: "cowboy"}
+      release = %{meta: %{app: package.name}, version: version}
+      assert PackageView.dep_snippet(:erlang_mk, package, release) == "dep_cowboy = hex 1.0.4"
+    end
 
-  test "escape rebar application name" do
-    version = Version.parse!("1.0.1")
-    package_name   = "lfe_app"
-    release = %{meta: %{app: "lfe-app"}, version: version}
-    assert PackageView.dep_snippet(:rebar, package_name, release) == "{'lfe-app', \"1.0.1\", {pkg, lfe_app}}"
+    test "escape mix application name" do
+      version = Version.parse!("1.0.0")
+      package = %{name: "lfe_app", repository: %{name: "hexpm"}}
+      release = %{meta: %{app: "lfe-app"}, version: version}
+      assert PackageView.dep_snippet(:mix, package, release) == ~s({:"lfe-app", "~> 1.0", hex: :lfe_app})
+    end
+
+    test "escape rebar application name" do
+      version = Version.parse!("1.0.1")
+      package = %{name: "lfe_app"}
+      release = %{meta: %{app: "lfe-app"}, version: version}
+      assert PackageView.dep_snippet(:rebar, package, release) == ~s({'lfe-app', "1.0.1", {pkg, lfe_app}})
+    end
   end
 
   test "mix config version" do


### PR DESCRIPTION
Closes #564

![zrzut ekranu 2017-09-09 o 01 59 40](https://user-images.githubusercontent.com/76071/30234925-90fb159c-9502-11e7-9e06-4e11ba8413c9.png)

Wondering if we should widen the right sidebar, but if people are just copy-pasting the snippet it probably doesn't matter that not everything is shown there.