### PR TITLE
Fixes ‘Show All Versions’/‘Show Recent Versions’ text when toggled.

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -29,7 +29,7 @@ export default class App {
 
     // Package: toggle text in "All Versions / Recent Version" buttons
     $(".show-versions .invisible").removeClass("invisible").toggle()
-    $(".show-versions .toggle-text").click((event) => $(event.target).find("a").toggle())
+    $(".show-versions .toggle-text").click((event) => $(event.target).parent().find("a").toggle())
 
     // Highlight syntax
     hljs.initHighlightingOnLoad()


### PR DESCRIPTION
This fixes the toggle between 'Show All Versions' and 'Show Recent Versions', which doesn't appear to be working currently.
![screen recording 2017-09-16 at 09 10 am](https://user-images.githubusercontent.com/1095055/30521892-91ec2b66-9b84-11e7-824b-eeb477541e29.gif)


