### PR TITLE
New Feature: API supports number of downloads per release (with filters)

### DIFF
--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -155,6 +155,34 @@ defmodule Hexpm.Repository.Release do
       select: {p.name, r.version, r.inserted_at, p.meta}
     )
   end
+
+  def downloads_by(release_id, filter) do
+    case filter do
+      :by_day ->
+        from(d in Download,
+          where: d.release_id == ^release_id,
+          group_by: fragment("date_trunc('day', ?)", d.day),
+          order_by: fragment("date_trunc('day', ?)", d.day),
+          select: {fragment("to_char(date_trunc('day', ?), 'YYYY-MM-DD')", d.day), fragment("sum(?)", d.downloads)})
+      :by_week ->
+        from(d in Download,
+          where: d.release_id == ^release_id,
+          group_by: fragment("date_trunc('week', ?)",  d.day), # d.day,
+          order_by: fragment("date_trunc('week', ?)",  d.day), # d.day,
+          select: {fragment("to_char(date_trunc('week', ?), 'YYYY-MM-DD')", d.day), fragment("sum(?)", d.downloads)})
+      :by_month ->
+        from(d in Download,
+          where: d.release_id == ^release_id,
+          group_by: fragment("date_trunc('month', ?)",  d.day), # d.day,
+          order_by: fragment("date_trunc('month', ?)",  d.day), # d.day,
+          select: {fragment("to_char(date_trunc('month', ?), 'YYYY-MM')", d.day), fragment("sum(?)", d.downloads)})
+      _ ->
+        from(d in Download,
+          where: d.release_id == ^release_id,
+          select: fragment("sum(?)", d.downloads))
+    end
+  end
+
 end
 
 defimpl Phoenix.Param, for: Hexpm.Repository.Release do

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -156,20 +156,20 @@ defmodule Hexpm.Repository.Release do
     )
   end
 
-  defmacro date_trunc(period, expr) do
+  defmacrop date_trunc(period, expr) do
     quote do
       fragment("date_trunc(?, ?)", unquote(period), unquote(expr))
     end
   end
-  defmacro date_trunc_format(period, format, expr) do
+
+  defmacrop date_trunc_format(period, format, expr) do
     quote do
       fragment("to_char(date_trunc(?, ?), ?)", unquote(period), unquote(expr), unquote(format))
     end
   end
 
   def downloads_by_period(release_id, filter) do
-    query = from(d in Download,
-      where: d.release_id == ^release_id)
+    query = from(d in Download, where: d.release_id == ^release_id)
     case filter do
       "day" ->
         from(d in query,
@@ -182,8 +182,7 @@ defmodule Hexpm.Repository.Release do
           order_by: date_trunc("month", d.day),
           select: {date_trunc_format("month", "YYYY-MM", d.day), sum(d.downloads)})
       "all" ->
-        from(d in query,
-          select: sum(d.downloads))
+        from(d in query, select: sum(d.downloads))
     end
   end
 

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -33,10 +33,9 @@ defmodule Hexpm.Repository.Releases do
     |> Enum.into(%{})
   end
 
-  def preload(release) do
-    Repo.preload(release,
-      requirements: Release.requirements(release),
-      downloads: ReleaseDownload.release(release))
+  def preload(release, keys) do
+    preload = Enum.map(keys, &preload_field(release, &1))
+    Repo.preload(release, preload)
   end
 
   def publish(repository, package, user, body, meta, checksum, [audit: audit_data]) do
@@ -125,16 +124,17 @@ defmodule Hexpm.Repository.Releases do
     |> publish_result(nil)
   end
 
-  def downloads_by(package, :all) do
-    Release.downloads_by(package, :all)
-    |> Repo.one()
-  end
-  def downloads_by(package, filter) when filter in [:by_day, :by_week, :by_month] do
-    Release.downloads_by(package, filter)
-    |> Repo.all()
-    |> Enum.map(fn {date, downloads} ->
-      [to_string(date), downloads]
-    end)
+  def downloads_by_period(package, filter) do
+    if filter in ["day", "month"] do
+      Release.downloads_by_period(package, filter)
+      |>  Repo.all()
+      |> Enum.map(fn {date, downloads} ->
+        [to_string(date), downloads]
+      end)
+    else
+      Release.downloads_by_period(package, "all")
+      |> Repo.one()
+    end
   end
 
   defp publish_result({:ok, %{repository: repository, package: package, release: release} = result}, body) do
@@ -231,4 +231,7 @@ defmodule Hexpm.Repository.Releases do
     end)
   end
   defp normalize_requirements(requirements), do: requirements
+
+  defp preload_field(release, :requirements), do: {:requirements, Release.requirements(release)}
+  defp preload_field(release, :downloads), do: {:downloads, ReleaseDownload.release(release)}
 end

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -127,7 +127,7 @@ defmodule Hexpm.Repository.Releases do
   def downloads_by_period(package, filter) do
     if filter in ["day", "month"] do
       Release.downloads_by_period(package, filter)
-      |>  Repo.all()
+      |> Repo.all()
       |> Enum.map(fn {date, downloads} ->
         [to_string(date), downloads]
       end)

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -125,6 +125,18 @@ defmodule Hexpm.Repository.Releases do
     |> publish_result(nil)
   end
 
+  def downloads_by(package, :all) do
+    Release.downloads_by(package, :all)
+    |> Repo.one()
+  end
+  def downloads_by(package, filter) when filter in [:by_day, :by_week, :by_month] do
+    Release.downloads_by(package, filter)
+    |> Repo.all()
+    |> Enum.map(fn {date, downloads} ->
+      [to_string(date), downloads]
+    end)
+  end
+
   defp publish_result({:ok, %{repository: repository, package: package, release: release} = result}, body) do
     package = %{package | repository: repository}
     release = %{release | package: package}

--- a/lib/hexpm/web/controllers/api/release_controller.ex
+++ b/lib/hexpm/web/controllers/api/release_controller.ex
@@ -1,10 +1,10 @@
 defmodule Hexpm.Web.API.ReleaseController do
   use Hexpm.Web, :controller
 
-  plug :maybe_fetch_release when action in [:show, :show_downloads]
+  plug :maybe_fetch_release when action in [:show]
   plug :fetch_release when action in [:delete]
   plug :maybe_fetch_package when action in [:create]
-  plug :maybe_authorize, [domain: "api", fun: &repository_access?/2] when action in [:show, :show_downloads]
+  plug :maybe_authorize, [domain: "api", fun: &repository_access?/2] when action in [:show]
   plug :authorize, [domain: "api", fun: &package_owner?/2] when action in [:delete]
   plug :authorize, [domain: "api", fun: &maybe_package_owner?/2] when action in [:create]
 

--- a/lib/hexpm/web/controllers/package_controller.ex
+++ b/lib/hexpm/web/controllers/package_controller.ex
@@ -72,7 +72,7 @@ defmodule Hexpm.Web.PackageController do
   end
 
   defp package(conn, repositories, package, releases, release, type) do
-    release = Releases.preload(release)
+    release = Releases.preload(release, [:requirements, :downloads])
     latest_release_with_docs = Enum.find(releases, & &1.has_docs)
 
     docs_assigns =

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -171,9 +171,6 @@ defmodule Hexpm.Web.Router do
         get "/packages/:name/releases/:version/docs", DocsController, :show
         delete "/packages/:name/releases/:version/docs", DocsController, :delete
 
-        get "/packages/:name/releases/:version/downloads", ReleaseController, :show_downloads
-        get "/packages/:name/releases/:version/downloads/:filter", ReleaseController, :show_downloads
-
         get "/packages/:name/owners", OwnerController, :index
         get "/packages/:name/owners/:email", OwnerController, :show
         put "/packages/:name/owners/:email", OwnerController, :create

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -171,6 +171,9 @@ defmodule Hexpm.Web.Router do
         get "/packages/:name/releases/:version/docs", DocsController, :show
         delete "/packages/:name/releases/:version/docs", DocsController, :delete
 
+        get "/packages/:name/releases/:version/downloads", ReleaseController, :show_downloads
+        get "/packages/:name/releases/:version/downloads/:filter", ReleaseController, :show_downloads
+
         get "/packages/:name/owners", OwnerController, :index
         get "/packages/:name/owners/:email", OwnerController, :show
         put "/packages/:name/owners/:email", OwnerController, :create

--- a/lib/hexpm/web/views/api/release_view.ex
+++ b/lib/hexpm/web/views/api/release_view.ex
@@ -11,6 +11,9 @@ defmodule Hexpm.Web.API.ReleaseView do
   def render("minimal." <> _, %{release: release, package: package}) do
     render_one(release, __MODULE__, "minimal", %{package: package})
   end
+  def render("show_downloads." <> _, %{release: release, package: package, downloads: downloads}) do
+    %{name: package.name, version: release.version, downloads: downloads}
+  end
 
   def render("show", %{release: release}) do
     %{

--- a/lib/hexpm/web/views/api/release_view.ex
+++ b/lib/hexpm/web/views/api/release_view.ex
@@ -11,9 +11,6 @@ defmodule Hexpm.Web.API.ReleaseView do
   def render("minimal." <> _, %{release: release, package: package}) do
     render_one(release, __MODULE__, "minimal", %{package: package})
   end
-  def render("show_downloads." <> _, %{release: release, package: package, downloads: downloads}) do
-    %{name: package.name, version: release.version, downloads: downloads}
-  end
 
   def render("show", %{release: release}) do
     %{
@@ -50,5 +47,5 @@ defmodule Hexpm.Web.API.ReleaseView do
 
   defp downloads(%Ecto.Association.NotLoaded{}), do: 0
   defp downloads(nil), do: 0
-  defp downloads(downloads), do: downloads.downloads
+  defp downloads(downloads), do: downloads
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -193,7 +193,9 @@ Hexpm.Repo.transaction(fn ->
 
   insert(:download, release: rel, downloads: 1_500_000, day: Hexpm.Utils.utc_days_ago(180))
   insert(:download, release: rel, downloads: 200_000, day: Hexpm.Utils.utc_days_ago(90))
+  insert(:download, release: rel, downloads: 1, day: Hexpm.Utils.utc_days_ago(45))
   insert(:download, release: rel, downloads: 56_000, day: Hexpm.Utils.utc_days_ago(35))
+  insert(:download, release: rel, downloads: 1, day: Hexpm.Utils.utc_days_ago(2))
   insert(:download, release: rel, downloads: 42, day: Hexpm.Utils.utc_yesterday())
 
   myrepo = insert(:repository, name: "myrepo")


### PR DESCRIPTION
Hi,

First time trying to add some functionality to hex.pm. So, please, suggest me anything to improve my way to contribute.

This pull request comes with the functionality to query the API by release (package-release) and get the downloads filtered by day, by week, by month or all of them (`all` like what you get when querying the release).

Use case: I want to get the downloads of every version of my package, how hard/easy it is the adoption of a new version, if someone continues using X version, etc.

Example querying the API of hexpm with the database after executing `priv/repo/seeds.exs`:
```
GET http://localhost:4000/api/packages/ecto/releases/0.2.0/downloads/by_day
{"version":"0.2.0","name":"ecto","downloads":[["2017-03-24",1500000],["2017-06-22",200000],["2017-08-06",1],["2017-08-16",56000],["2017-09-18",1],["2017-09-19",42]]}

GET http://localhost:4000/api/packages/ecto/releases/0.2.0/downloads/by_week
{"version":"0.2.0","name":"ecto","downloads":[["2017-03-20",1500000],["2017-06-19",200000],["2017-07-31",1],["2017-08-14",56000],["2017-09-18",43]]}

GET http://localhost:4000/api/packages/ecto/releases/0.2.0/downloads/by_month
{"version":"0.2.0","name":"ecto","downloads":[["2017-03",1500000],["2017-06",200000],["2017-08",56001],["2017-09",43]]}

GET http://localhost:4000/api/packages/ecto/releases/0.2.0/downloads/all
{"version":"0.2.0","name":"ecto","downloads":1756044}
```

I was thinking a lot where and how to modify hexpm, so, I tried to simplify it as much as possible. 

Also, I had some doubts, like:
- Should I provide this API feature only to authenticated users? (I choose public)
- Is there any trick to reduce the function downloads_by in release.ex (I tried many things but I cannot build "date_trunc('day', ?)" with 'day' dynamically because it comes inside a `fragment`). So my way was to use `case do`.
- I didn't use the `maybe_authorize` but I added `show_downloads`. 
- I don't know how to use the `when_stale` in my case (controller). 
- Also, I define a new render function for my case. I decided to show the name and version of the package although the query contains it.
- Finally, I decided to be flexible with `/downloads`, `/downloads/.*` and `/downloads/all`, being in any case `all`. This could be removed and just support `/downloads/all` and you can clean a few lines. But I don't know if you like to have the parent always (`/downloads`) if you have something inside (`/downloads/:filter`).

As you can see I provide some tests. The only "tricky" test is the filter by week, because it depends upon the LOCALE of the system where it is tested (I think). I mean, it could start with mondays or sundays, etc. So, I just check if it has the number of elements (3 different weeks in my test).

Thanks, and please, If I have to change something give me the guidelines because it is something new for me. For example, I tried to do a pull request to you trying to give you a new branch and you will decide how to integrate in your master, but I cannot select it.

This feature comes from my question to Hex Support (email 25 June, 2017) and Eric Meadows-Jönsson answered me that they will be happy if I contribute to this repository with this feature because nobody is working on it.

Thanks again.