### PR TITLE
snake_case validation for package name

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -59,7 +59,7 @@ defmodule Hexpm.Repository.Package do
     |> cast_embed(:meta, required: true)
     |> validate_required(:name)
     |> validate_length(:name, min: 2)
-    |> validate_format(:name, ~r"^[a-z]\w*$")
+    |> validate_format(:name, ~r/^[a-z](_?([a-z]|\d)+)+$/)
     |> validate_exclusion(:name, @reserved_names)
   end
 

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -51,6 +51,7 @@ defmodule Hexpm.Repository.Package do
 
   defp changeset(package, :create, params) do
     changeset(package, :update, params)
+    |> validate_format(:name, ~r/^[a-z](_?([a-z]|\d)+)+$/)
     |> unique_constraint(:name, name: "packages_repository_id_name_index")
   end
 
@@ -59,7 +60,7 @@ defmodule Hexpm.Repository.Package do
     |> cast_embed(:meta, required: true)
     |> validate_required(:name)
     |> validate_length(:name, min: 2)
-    |> validate_format(:name, ~r/^[a-z](_?([a-z]|\d)+)+$/)
+    |> validate_format(:name, ~r"^[a-z]\w*$")
     |> validate_exclusion(:name, @reserved_names)
   end
 


### PR DESCRIPTION
At [issue](https://github.com/hexpm/hex/issues/425) I find useful to have snake_case validation of package name.

This regex extra cover such cases:
❌ my_
❌ my_package_
❌ my__package
✅ my
✅ my_package123
✅ my_package_123


