### PR TITLE
Improve HTTP stale checking

### DIFF
--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -1,6 +1,9 @@
 defmodule Hexpm.Accounts.Email do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
+  @email_regex ~r"^.+@.+\..+$"
+
   schema "emails" do
     field :email, :string
     field :verified, :boolean, default: false
@@ -12,8 +15,6 @@ defmodule Hexpm.Accounts.Email do
 
     timestamps()
   end
-
-  @email_regex ~r"^.+@.+\..+$"
 
   def changeset(email, type, params, verified? \\ not Application.get_env(:hexpm, :user_confirm))
 

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -1,6 +1,7 @@
 defmodule Hexpm.Accounts.Key do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
   @derive {Phoenix.Param, key: :name}
 
   schema "keys" do

--- a/lib/hexpm/accounts/key_permission.ex
+++ b/lib/hexpm/accounts/key_permission.ex
@@ -1,12 +1,13 @@
 defmodule Hexpm.Accounts.KeyPermission do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
+  @domains ~w(api repository)
+
   embedded_schema do
     field :domain, :string
     field :resource, :string
   end
-
-  @domains ~w(api repository)
 
   def changeset(struct, user, params) do
     cast(struct, params, ~w(domain resource))

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -1,6 +1,7 @@
 defmodule Hexpm.Accounts.User do
   use Hexpm.Web, :schema
 
+  @derive {Hexpm.Web.Stale, assocs: [:emails, :owned_packages, :repositories, :keys]}
   @derive {Phoenix.Param, key: :username}
 
   schema "users" do

--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Accounts.UserHandles do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
+
   embedded_schema do
     field :twitter, :string
     field :github, :string

--- a/lib/hexpm/repository/download.ex
+++ b/lib/hexpm/repository/download.ex
@@ -1,9 +1,12 @@
 defmodule Hexpm.Repository.Download do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
+
   schema "downloads" do
     belongs_to :release, Release
     field :downloads, :integer
     field :day, :date
+    field :updated_at, :naive_datetime, virtual: true
   end
 end

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -1,5 +1,7 @@
 defmodule Hexpm.Repository.Package do
   use Hexpm.Web, :schema
+
+  @derive {Hexpm.Web.Stale, assocs: [:releases, :owners, :downloads]}
   @derive {Phoenix.Param, key: :name}
 
   schema "packages" do

--- a/lib/hexpm/repository/package_download.ex
+++ b/lib/hexpm/repository/package_download.ex
@@ -2,6 +2,7 @@ defmodule Hexpm.Repository.PackageDownload do
   use Hexpm.Web, :schema
   import Hexpm.QueryAPI, only: [coalesce: 2]
 
+  @derive Hexpm.Web.Stale
   @primary_key false
 
   schema "package_downloads" do

--- a/lib/hexpm/repository/package_metadata.ex
+++ b/lib/hexpm/repository/package_metadata.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Repository.PackageMetadata do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
+
   embedded_schema do
     field :description, :string
     field :licenses, {:array, :string}

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -67,7 +67,7 @@ defmodule Hexpm.Repository.Packages do
 
   def search_with_versions(repositories, page, packages_per_page, query, sort) do
     Package.all(repositories, page, packages_per_page, query, sort, nil)
-    |> Ecto.Query.preload(releases: ^from(r in Release, select: map(r, [:version])))
+    |> Ecto.Query.preload(releases: ^from(r in Release, select: struct(r, [:id, :version, :updated_at])))
     |> Repo.all()
     |> Enum.map(fn package -> update_in(package.releases, &Release.sort/1) end)
     |> attach_repositories(repositories)

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Repository.Release do
   use Hexpm.Web, :schema
 
+  @derive {Hexpm.Web.Stale, assocs: [:requirements, :downloads]}
+
   schema "releases" do
     field :version, Hexpm.Version
     field :checksum, :string

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -177,14 +177,29 @@ defmodule Hexpm.Repository.Release do
         from(d in query,
           group_by: date_trunc("day", d.day),
           order_by: date_trunc("day", d.day),
-          select: {date_trunc_format("day", "YYYY-MM-DD", d.day), sum(d.downloads)})
+          select: %Download{
+            day: date_trunc_format("day", "YYYY-MM-DD", d.day),
+            downloads: sum(d.downloads),
+            updated_at: max(d.day)
+          }
+        )
       "month" ->
         from(d in query,
           group_by: date_trunc("month", d.day),
           order_by: date_trunc("month", d.day),
-          select: {date_trunc_format("month", "YYYY-MM", d.day), sum(d.downloads)})
+          select:  %Download{
+            day: date_trunc_format("month", "YYYY-MM", d.day),
+            downloads: sum(d.downloads),
+            updated_at: max(d.day)
+          }
+        )
       "all" ->
-        from(d in query, select: sum(d.downloads))
+        from(d in query,
+          select: %Download{
+            downloads: sum(d.downloads),
+            updated_at: max(d.day)
+          }
+        )
     end
   end
 

--- a/lib/hexpm/repository/release_download.ex
+++ b/lib/hexpm/repository/release_download.ex
@@ -1,6 +1,7 @@
 defmodule Hexpm.Repository.ReleaseDownload do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
   @primary_key false
 
   schema "release_downloads" do

--- a/lib/hexpm/repository/release_metadata.ex
+++ b/lib/hexpm/repository/release_metadata.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Repository.ReleaseMetadata do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
+
   embedded_schema do
     field :app, :string
     field :build_tools, {:array, :string}

--- a/lib/hexpm/repository/release_retirement.ex
+++ b/lib/hexpm/repository/release_retirement.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Repository.ReleaseRetirement do
   use Hexpm.Web, :schema
 
+  @derive Hexpm.Web.Stale
+
   embedded_schema do
     field :reason, :string
     field :message, :string

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -128,9 +128,6 @@ defmodule Hexpm.Repository.Releases do
     if filter in ["day", "month"] do
       Release.downloads_by_period(package, filter)
       |> Repo.all()
-      |> Enum.map(fn {date, downloads} ->
-        [to_string(date), downloads]
-      end)
     else
       Release.downloads_by_period(package, "all")
       |> Repo.one()

--- a/lib/hexpm/repository/repository.ex
+++ b/lib/hexpm/repository/repository.ex
@@ -1,5 +1,7 @@
 defmodule Hexpm.Repository.Repository do
   use Hexpm.Web, :schema
+
+  @derive Hexpm.Web.Stale
   @derive {Phoenix.Param, key: :name}
 
   schema "repositories" do

--- a/lib/hexpm/repository/requirement.ex
+++ b/lib/hexpm/repository/requirement.ex
@@ -2,6 +2,8 @@ defmodule Hexpm.Repository.Requirement do
   use Hexpm.Web, :schema
   require Logger
 
+  @derive {Hexpm.Web.Stale, last_modified: nil}
+
   schema "requirements" do
     field :app, :string
     field :requirement, :string

--- a/lib/hexpm/web/controllers/controller_helpers.ex
+++ b/lib/hexpm/web/controllers/controller_helpers.ex
@@ -174,28 +174,24 @@ defmodule Hexpm.Web.ControllerHelpers do
     end
   end
 
-  defp etag(nil) do
-    nil
-  end
-  defp etag([]) do
-    nil
-  end
-  defp etag(models) do
-    list = Enum.map(List.wrap(models), fn model ->
-      [model.__struct__, model.id, model.updated_at]
-    end)
+  defp etag(schemas) do
+    binary =
+      schemas
+      |> List.wrap()
+      |> Enum.map(&Hexpm.Web.Stale.etag/1)
+      |> List.flatten()
+      |> :erlang.term_to_binary()
 
-    binary = :erlang.term_to_binary(list)
     :crypto.hash(:md5, binary)
     |> Base.encode16(case: :lower)
   end
 
-  def last_modified(nil), do: nil
-  def last_modified([]),  do: nil
-  def last_modified(models) do
-    Enum.map(List.wrap(models), fn model ->
-      NaiveDateTime.to_erl(model.updated_at)
-    end)
+  def last_modified(schemas) do
+    schemas
+    |> List.wrap()
+    |> Enum.map(&Hexpm.Web.Stale.last_modified/1)
+    |> List.flatten()
+    |> Enum.map(&NaiveDateTime.to_erl/1)
     |> Enum.max()
   end
 

--- a/lib/hexpm/web/controllers/controller_helpers.ex
+++ b/lib/hexpm/web/controllers/controller_helpers.ex
@@ -191,9 +191,15 @@ defmodule Hexpm.Web.ControllerHelpers do
     |> List.wrap()
     |> Enum.map(&Hexpm.Web.Stale.last_modified/1)
     |> List.flatten()
-    |> Enum.map(&NaiveDateTime.to_erl/1)
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(&time_to_erl/1)
     |> Enum.max()
   end
+
+  defp time_to_erl(%NaiveDateTime{} = datetime),
+    do: NaiveDateTime.to_erl(datetime)
+  defp time_to_erl(%Date{} = date),
+    do: {Date.to_erl(date), {0, 0, 0}}
 
   def fetch_repository(conn, _opts) do
     if repository = Repositories.get(conn.params["repository"]) do

--- a/lib/hexpm/web/stale.ex
+++ b/lib/hexpm/web/stale.ex
@@ -1,0 +1,57 @@
+defprotocol Hexpm.Web.Stale do
+  def etag(schema)
+  def last_modified(schema)
+end
+
+defimpl Hexpm.Web.Stale, for: Atom do
+  def etag(nil), do: nil
+
+  # This is not a good solution because we don't know when a missing
+  # association was modified but this is the best we have for now
+  def last_modified(nil), do: ~N[0000-01-01 00:00:00]
+end
+
+defimpl Hexpm.Web.Stale, for: Any do
+  defmacro __deriving__(module, _struct, opts) do
+    etag_keys = Keyword.get(opts, :etag, [:__struct__, :id, :updated_at])
+    last_modified_key = Keyword.get(opts, :last_modified, :updated_at)
+    assocs = Keyword.get(opts, :assocs, [])
+
+    quote do
+      defimpl Hexpm.Web.Stale, for: unquote(module) do
+        alias Hexpm.Web.Stale
+        alias Hexpm.Web.Stale.Any
+
+        def etag(schema) do
+          assocs = unquote(assocs)
+          etag_keys = unquote(etag_keys)
+          [Map.take(schema, etag_keys), Any.recurse_fields(schema, assocs, &Stale.etag/1)]
+        end
+
+        def last_modified(schema) do
+          assocs = unquote(assocs)
+          last_modified_key = unquote(last_modified_key)
+          last_modified = fetch_last_modified(schema, last_modified_key)
+          [last_modified, Any.recurse_fields(schema, assocs, &Stale.last_modified/1)]
+        end
+
+        defp fetch_last_modified(_schema, nil), do: ~N[0000-01-01 00:00:00]
+        defp fetch_last_modified(schema, key), do: Map.fetch!(schema, key)
+      end
+    end
+  end
+
+  def etag(_), do: raise("not implemented")
+  def last_modified(_), do: raise("not implemented")
+
+  def recurse_fields(schema, keys, fun) do
+    Enum.map(keys, fn key ->
+      Map.fetch!(schema, key)
+      |> recurse_field(fun)
+    end)
+  end
+
+  defp recurse_field(%Ecto.Association.NotLoaded{}, _fun), do: []
+  defp recurse_field(schemas, fun) when is_list(schemas), do: Enum.map(schemas, fun)
+  defp recurse_field(schema, fun), do: fun.(schema)
+end

--- a/lib/hexpm/web/views/api/release_view.ex
+++ b/lib/hexpm/web/views/api/release_view.ex
@@ -2,9 +2,6 @@ defmodule Hexpm.Web.API.ReleaseView do
   use Hexpm.Web, :view
   alias Hexpm.Web.API.RetirementView
 
-  def render("index." <> _, %{releases: releases}) do
-    render_many(releases, __MODULE__, "show")
-  end
   def render("show." <> _, %{release: release}) do
     render_one(release, __MODULE__, "show")
   end
@@ -28,8 +25,8 @@ defmodule Hexpm.Web.API.ReleaseView do
         build_tools: Enum.uniq(release.meta.build_tools),
         elixir: release.meta.elixir,
       },
+      downloads: downloads(release.downloads)
     }
-    |> include_if_loaded(:downloads, release.downloads, &downloads/1)
   end
 
   def render("minimal", %{release: release, package: package}) do
@@ -45,7 +42,13 @@ defmodule Hexpm.Web.API.ReleaseView do
     end)
   end
 
-  defp downloads(%Ecto.Association.NotLoaded{}), do: 0
-  defp downloads(nil), do: 0
-  defp downloads(downloads), do: downloads
+  defp downloads(%Ecto.Association.NotLoaded{}), do: nil
+  defp downloads(%Download{downloads: downloads}) do
+    downloads
+  end
+  defp downloads(downloads) when is_list(downloads) do
+    Enum.map(downloads, fn download ->
+      [download.day, download.downloads]
+    end)
+  end
 end

--- a/test/hexpm/web/controllers/api/release_controller_test.exs
+++ b/test/hexpm/web/controllers/api/release_controller_test.exs
@@ -486,6 +486,22 @@ defmodule Hexpm.Web.API.ReleaseControllerTest do
       conn = get(build_conn(), "api/packages/unknown/releases/1.2.3")
       assert conn.status == 404
     end
+
+    test "get release with requirements", %{package: package, release: release} do
+      package2 = insert(:package)
+      insert(:release, package: package2, version: "0.0.1")
+      insert(:requirement, release: release, dependency: package2, requirement: "~> 0.0.1")
+
+      result =
+        build_conn()
+        |> get("api/packages/#{package.name}/releases/#{release.version}")
+        |> json_response(200)
+
+      assert result["url"] =~ "/api/packages/#{package.name}/releases/#{release.version}"
+      assert result["html_url"] =~ "/packages/#{package.name}/#{release.version}"
+      assert result["version"] == "#{release.version}"
+      assert result["requirements"][package2.name]["requirement"] == "~> 0.0.1"
+    end
   end
 
   describe "GET /api/repos/:repository/packages/:name/releases/:version" do


### PR DESCRIPTION
Previous etag and last-modified generation did not consider child associations. With this change the generation can also be customized per schema.

To fully complete this we also need to version and timestamp the phoenix views we call.