### PR TITLE
Update task docs

### DIFF
--- a/lib/hexpm/web/templates/docs/tasks.html.eex
+++ b/lib/hexpm/web/templates/docs/tasks.html.eex
@@ -268,7 +268,7 @@ and want to authenticate on a CI server or similar system
 <h3>Generate a repository autentication key</h3>
 <p>This command is useful to pre-generate keys for use with <code class="inline">mix hex.organization auth NAME --key KEY</code>
 on CI servers or similar systems. It returns the hash of the generated key that you can pass to
-<code class="inline">auth NAME --key KEY</code></p>
+<code class="inline">auth NAME --key KEY</code>. This key allows read-only access to the repository.</p>
 <pre><code>mix hex.organization key NAME</code></pre>
 <h3>List all authorized organizations</h3>
 <pre><code>mix hex.organization list</code></pre>


### PR DESCRIPTION
I didn't see anywhere that mentioned that this key allows read-only access, and prevents any write access. @ericmj confirmed in the #hex Slack channel that this is the case. This is an important security feature, and I think it would be helpful if it was documented.

Happy to alter the wording or format, just LMK.