### PR TITLE
Do not set compile time dependencies on the router

### DIFF
--- a/lib/hexpm/web/controllers/api/key_controller.ex
+++ b/lib/hexpm/web/controllers/api/key_controller.ex
@@ -39,7 +39,7 @@ defmodule Hexpm.Web.API.KeyController do
     else
       case Keys.add(user, params, audit: audit_data(conn)) do
         {:ok, %{key: key}} ->
-          location = api_key_url(conn, :show, params["name"])
+          location = Routes.api_key_url(conn, :show, params["name"])
 
           conn
           |> put_resp_header("location", location)

--- a/lib/hexpm/web/controllers/api/release_controller.ex
+++ b/lib/hexpm/web/controllers/api/release_controller.ex
@@ -54,7 +54,7 @@ defmodule Hexpm.Web.API.ReleaseController do
   end
 
   defp publish_result({:ok, %{action: :insert, package: package, release: release}}, conn) do
-    location = api_release_url(conn, :show, package, release)
+    location = Routes.api_release_url(conn, :show, package, release)
 
     conn
     |> put_resp_header("location", location)

--- a/lib/hexpm/web/controllers/api/user_controller.ex
+++ b/lib/hexpm/web/controllers/api/user_controller.ex
@@ -9,7 +9,7 @@ defmodule Hexpm.Web.API.UserController do
 
     case Users.add(params, audit: audit_data(conn)) do
       {:ok, user} ->
-        location = api_user_url(conn, :show, user.username)
+        location = Routes.api_user_url(conn, :show, user.username)
 
         conn
         |> put_resp_header("location", location)

--- a/lib/hexpm/web/controllers/controller_helpers.ex
+++ b/lib/hexpm/web/controllers/controller_helpers.ex
@@ -4,6 +4,7 @@ defmodule Hexpm.Web.ControllerHelpers do
 
   alias Hexpm.Accounts.Auth
   alias Hexpm.Repository.{Packages, Releases, Repositories}
+  alias Hexpm.Web.Router.Helpers, as: Routes
 
   @max_cache_age 60
 
@@ -302,7 +303,7 @@ defmodule Hexpm.Web.ControllerHelpers do
     if logged_in?(conn) do
       conn
     else
-      redirect(conn, to: Hexpm.Web.Router.Helpers.login_path(conn, :show, return: conn.request_path))
+      redirect(conn, to: Routes.login_path(conn, :show, return: conn.request_path))
       |> halt
     end
   end

--- a/lib/hexpm/web/controllers/dashboard_controller.ex
+++ b/lib/hexpm/web/controllers/dashboard_controller.ex
@@ -4,7 +4,7 @@ defmodule Hexpm.Web.DashboardController do
   plug :requires_login
 
   def index(conn, _params) do
-    redirect(conn, to: dashboard_path(conn, :profile))
+    redirect(conn, to: Routes.dashboard_path(conn, :profile))
   end
 
   def profile(conn, _params) do
@@ -19,7 +19,7 @@ defmodule Hexpm.Web.DashboardController do
       {:ok, _user} ->
         conn
         |> put_flash(:info, "Profile updated successfully.")
-        |> redirect(to: dashboard_path(conn, :profile))
+        |> redirect(to: Routes.dashboard_path(conn, :profile))
       {:error, changeset} ->
         conn
         |> put_status(400)
@@ -39,7 +39,7 @@ defmodule Hexpm.Web.DashboardController do
       {:ok, _user} ->
         conn
         |> put_flash(:info, "Your password has been updated.")
-        |> redirect(to: dashboard_path(conn, :password))
+        |> redirect(to: Routes.dashboard_path(conn, :password))
       {:error, changeset} ->
         conn
         |> put_status(400)
@@ -59,7 +59,7 @@ defmodule Hexpm.Web.DashboardController do
         email = params["email"]["email"]
         conn
         |> put_flash(:info, "A verification email has been sent to #{email}.")
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
       {:error, changeset} ->
         conn
         |> put_status(400)
@@ -72,11 +72,11 @@ defmodule Hexpm.Web.DashboardController do
       :ok ->
         conn
         |> put_flash(:info, "Removed email #{email} from your account.")
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
       {:error, reason} ->
         conn
         |> put_flash(:error, email_error_message(reason, email))
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
     end
   end
 
@@ -85,11 +85,11 @@ defmodule Hexpm.Web.DashboardController do
       :ok ->
         conn
         |> put_flash(:info, "Your primary email was changed to #{email}.")
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
       {:error, reason} ->
         conn
         |> put_flash(:error, email_error_message(reason, email))
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
     end
   end
 
@@ -98,11 +98,11 @@ defmodule Hexpm.Web.DashboardController do
       :ok ->
         conn
         |> put_flash(:info, "Your public email was changed to #{email}.")
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
       {:error, reason} ->
         conn
         |> put_flash(:error, email_error_message(reason, email))
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
     end
   end
 
@@ -111,11 +111,11 @@ defmodule Hexpm.Web.DashboardController do
       :ok ->
         conn
         |> put_flash(:info, "A verification email has been sent to #{email}.")
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
       {:error, reason} ->
         conn
         |> put_flash(:error, email_error_message(reason, email))
-        |> redirect(to: dashboard_path(conn, :email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
     end
   end
 
@@ -132,7 +132,7 @@ defmodule Hexpm.Web.DashboardController do
         {:ok, _} ->
           conn
           |> put_flash(:info, "User #{username} has been added to the organization.")
-          |> redirect(to: dashboard_path(conn, :repository, repository))
+          |> redirect(to: Routes.dashboard_path(conn, :repository, repository))
         {:error, :unknown_user} ->
           conn
           |> put_status(400)
@@ -154,7 +154,7 @@ defmodule Hexpm.Web.DashboardController do
         :ok ->
           conn
           |> put_flash(:info, "User #{username} has been removed from the repository.")
-          |> redirect(to: dashboard_path(conn, :repository, repository))
+          |> redirect(to: Routes.dashboard_path(conn, :repository, repository))
         {:error, reason} ->
           conn
           |> put_status(400)
@@ -171,7 +171,7 @@ defmodule Hexpm.Web.DashboardController do
         {:ok, _} ->
           conn
           |> put_flash(:info, "User #{username}'s role has been changed to #{params["role"]}.")
-          |> redirect(to: dashboard_path(conn, :repository, repository))
+          |> redirect(to: Routes.dashboard_path(conn, :repository, repository))
         {:error, :unknown_user} ->
           conn
           |> put_status(400)
@@ -203,7 +203,7 @@ defmodule Hexpm.Web.DashboardController do
 
     conn
     |> put_flash(:info, "You have requested access to the organization beta. We will get back to you shortly.")
-    |> redirect(to: dashboard_path(conn, :repository_signup))
+    |> redirect(to: Routes.dashboard_path(conn, :repository_signup))
   end
 
   defp render_profile(conn, changeset) do

--- a/lib/hexpm/web/controllers/email_controller.ex
+++ b/lib/hexpm/web/controllers/email_controller.ex
@@ -12,6 +12,6 @@ defmodule Hexpm.Web.EmailController do
 
     conn
     |> put_flash(:custom_location, true)
-    |> redirect(to: page_path(Hexpm.Web.Endpoint, :index))
+    |> redirect(to: Routes.page_path(Hexpm.Web.Endpoint, :index))
   end
 end

--- a/lib/hexpm/web/controllers/login_controller.ex
+++ b/lib/hexpm/web/controllers/login_controller.ex
@@ -5,7 +5,7 @@ defmodule Hexpm.Web.LoginController do
 
   def show(conn, _params) do
     if logged_in?(conn) do
-      path = conn.params["return"] || user_path(conn, :show, conn.assigns.current_user)
+      path = conn.params["return"] || Routes.user_path(conn, :show, conn.assigns.current_user)
       redirect(conn, to: path)
     else
       render_show(conn)
@@ -15,7 +15,7 @@ defmodule Hexpm.Web.LoginController do
   def create(conn, %{"username" => username, "password" => password}) do
     case password_auth(username, password) do
       {:ok, user} ->
-        path = conn.params["return"] || user_path(conn, :show, user)
+        path = conn.params["return"] || Routes.user_path(conn, :show, user)
 
         conn
         |> configure_session(renew: true)
@@ -32,7 +32,7 @@ defmodule Hexpm.Web.LoginController do
   def delete(conn, _params) do
     conn
     |> delete_session("user_id")
-    |> redirect(to: page_path(Hexpm.Web.Endpoint, :index))
+    |> redirect(to: Routes.page_path(Hexpm.Web.Endpoint, :index))
   end
 
   defp render_show(conn) do

--- a/lib/hexpm/web/controllers/package_controller.ex
+++ b/lib/hexpm/web/controllers/package_controller.ex
@@ -100,7 +100,7 @@ defmodule Hexpm.Web.PackageController do
       title: package.name,
       description: package.meta.description,
       container: "container package-view",
-      canonical_url: package_url(conn, :show, package),
+      canonical_url: Routes.package_url(conn, :show, package),
       package: package,
       releases: releases,
       current_release: release,

--- a/lib/hexpm/web/controllers/password_controller.ex
+++ b/lib/hexpm/web/controllers/password_controller.ex
@@ -5,7 +5,7 @@ defmodule Hexpm.Web.PasswordController do
     conn
     |> put_session("reset_username", username)
     |> put_session("reset_key", key)
-    |> redirect(to: password_path(conn, :show))
+    |> redirect(to: Routes.password_path(conn, :show))
   end
 
   def show(conn, _params) do
@@ -32,12 +32,12 @@ defmodule Hexpm.Web.PasswordController do
         |> configure_session(renew: true)
         |> put_flash(:info, "Your account password has been changed to your new password.")
         |> put_flash(:custom_location, true)
-        |> redirect(to: page_path(Hexpm.Web.Endpoint, :index))
+        |> redirect(to: Routes.page_path(Hexpm.Web.Endpoint, :index))
       :error ->
         conn
         |> put_flash(:error, "Failed to change your password.")
         |> put_flash(:custom_location, true)
-        |> redirect(to: page_path(Hexpm.Web.Endpoint, :index))
+        |> redirect(to: Routes.page_path(Hexpm.Web.Endpoint, :index))
       {:error, changeset} ->
         render_show(conn, username, key, changeset)
     end

--- a/lib/hexpm/web/controllers/signup_controller.ex
+++ b/lib/hexpm/web/controllers/signup_controller.ex
@@ -11,7 +11,7 @@ defmodule Hexpm.Web.SignupController do
         conn
         |> put_flash(:info, "A confirmation email has been sent, you will have access to your account shortly.")
         |> put_flash(:custom_location, true)
-        |> redirect(to: page_path(Hexpm.Web.Endpoint, :index))
+        |> redirect(to: Routes.page_path(Hexpm.Web.Endpoint, :index))
       {:error, changeset} ->
         conn
         |> put_status(400)

--- a/lib/hexpm/web/controllers/test_controller.ex
+++ b/lib/hexpm/web/controllers/test_controller.ex
@@ -50,7 +50,7 @@ defmodule Hexpm.Web.TestController do
   end
 
   def docs_sitemap(conn, _params) do
-    Hexpm.Store.get(nil, :docs_bucket, sitemap_path(Hexpm.Web.Endpoint, :sitemap), [])
+    Hexpm.Store.get(nil, :docs_bucket, Routes.sitemap_path(Hexpm.Web.Endpoint, :sitemap), [])
     |> send_object(conn)
   end
 

--- a/lib/hexpm/web/templates/blog/index.html.eex
+++ b/lib/hexpm/web/templates/blog/index.html.eex
@@ -1,6 +1,6 @@
 <%= for post <- @posts do %>
   <div class="index-post">
-    <h3><a href="<%= blog_path(Endpoint, :show, post.slug) %>"><%= post.title %></a></h3>
+    <h3><a href="<%= Routes.blog_path(Endpoint, :show, post.slug) %>"><%= post.title %></a></h3>
     <div class="subtitle"><%= post.subtitle %></div>
     <p class="content"><%= raw post.paragraph %></p>
   </div>

--- a/lib/hexpm/web/templates/dashboard/_sidebar.html.eex
+++ b/lib/hexpm/web/templates/dashboard/_sidebar.html.eex
@@ -3,7 +3,7 @@
   <ul class="list-group">
     <%= for {id, name} <- account_settings() do %>
       <li class="list-group-item <%= selected_setting(@conn, id) %>">
-        <a href="<%= dashboard_path(Endpoint, id) %>">
+        <a href="<%= Routes.dashboard_path(Endpoint, id) %>">
           <%= name %>
         </a>
       </li>
@@ -12,20 +12,20 @@
   <div class="panel-heading">Organization settings</div>
   <%= if @current_user.repositories == [] do %>
     <div class="panel-body">
-      <small>You are not a member of any organizations. Organizations is currently in beta, fill out the <a href="<%= dashboard_path(Endpoint, :repository_signup) %>">sign up form</a> to request access.</small>
+      <small>You are not a member of any organizations. Organizations is currently in beta, fill out the <a href="<%= Routes.dashboard_path(Endpoint, :repository_signup) %>">sign up form</a> to request access.</small>
     </div>
   <% else %>
     <ul class="list-group">
       <%= for repository <- @current_user.repositories do %>
         <li class="list-group-item <%= selected_repository(@conn, repository.name) %>">
-          <a href="<%= dashboard_path(Endpoint, :repository, repository) %>">
+          <a href="<%= Routes.dashboard_path(Endpoint, :repository, repository) %>">
             <%= repository.name %>
           </a>
         </li>
       <% end %>
     </ul>
     <div class="panel-body">
-      <small>Fill out the <a href="<%= dashboard_path(Endpoint, :repository_signup) %>">sign up form</a> to request access to a new organization.</small>
+      <small>Fill out the <a href="<%= Routes.dashboard_path(Endpoint, :repository_signup) %>">sign up form</a> to request access to a new organization.</small>
     </div>
   <% end %>
 </div>

--- a/lib/hexpm/web/templates/dashboard/email.html.eex
+++ b/lib/hexpm/web/templates/dashboard/email.html.eex
@@ -26,7 +26,7 @@
               <span class="label label-success">Public</span>
             <% end %>
 
-            <%= form_tag(dashboard_path(Endpoint, :remove_email), method: :delete, class: "action") do %>
+            <%= form_tag(Routes.dashboard_path(Endpoint, :remove_email), method: :delete, class: "action") do %>
               <input type="hidden" name="email" value="<%= email.email %>">
               <button type="submit" class="btn btn-link btn-svg" <%= if email.primary do %>disabled<% end %>>
                 <%= Hexpm.Web.ViewIcons.icon(:octicon, :trashcan) %>
@@ -34,20 +34,20 @@
             <% end %>
 
             <%= if email.verified and not email.primary do %>
-              <%= form_tag(dashboard_path(Endpoint, :primary_email), class: "action") do %>
+              <%= form_tag(Routes.dashboard_path(Endpoint, :primary_email), class: "action") do %>
                 <input type="hidden" name="email" value="<%= email.email %>">
                 <button type="submit" class="btn btn-primary btn-xs">Set as primary</button>
               <% end %>
             <% end %>
             <%= if email.verified and not email.public do %>
-              <%= form_tag(dashboard_path(Endpoint, :public_email), class: "action") do %>
+              <%= form_tag(Routes.dashboard_path(Endpoint, :public_email), class: "action") do %>
                 <input type="hidden" name="email" value="<%= email.email %>">
                 <button type="submit" class="btn btn-primary btn-xs">Set as public</button>
               <% end %>
             <% end %>
 
             <%= unless email.verified do %>
-              <%= form_tag(dashboard_path(Endpoint, :resend_verify_email), class: "action") do %>
+              <%= form_tag(Routes.dashboard_path(Endpoint, :resend_verify_email), class: "action") do %>
                 <input type="hidden" name="email" value="<%= email.email %>">
                 <button type="submit" class="btn btn-link">Resend verification email</button>
               <% end %>
@@ -56,7 +56,7 @@
         <% end %>
 
         <li class="list-group-item">
-          <%= form_for @add_email_changeset, dashboard_path(Endpoint, :add_email), [method: :post], fn f -> %>
+          <%= form_for @add_email_changeset, Routes.dashboard_path(Endpoint, :add_email), [method: :post], fn f -> %>
             <%= label f, :email, "Add email address" %>
             <div class="form-group">
               <%= email_input f, :email, class: "form-control" %>

--- a/lib/hexpm/web/templates/dashboard/password.html.eex
+++ b/lib/hexpm/web/templates/dashboard/password.html.eex
@@ -9,7 +9,7 @@
     <div class="panel panel-default">
       <div class="panel-heading">Change password</div>
       <div class="panel-body">
-        <%= form_for @changeset, dashboard_path(Endpoint, :update_password), [method: :post], fn f -> %>
+        <%= form_for @changeset, Routes.dashboard_path(Endpoint, :update_password), [method: :post], fn f -> %>
           <div class="form-group">
             <%= label f, :password_current, "Current password" %>
             <%= password_input f, :password_current %>

--- a/lib/hexpm/web/templates/dashboard/profile.html.eex
+++ b/lib/hexpm/web/templates/dashboard/profile.html.eex
@@ -25,7 +25,7 @@
           </p>
         </div>
 
-        <%= form_for @changeset, dashboard_path(Endpoint, :update_profile), [method: :post], fn f -> %>
+        <%= form_for @changeset, Routes.dashboard_path(Endpoint, :update_profile), [method: :post], fn f -> %>
           <div class="form-group">
             <%= label f, :full_name %>
             <%= text_input f, :full_name %>
@@ -37,7 +37,7 @@
             <%= select f, :public_email, public_email_options(@changeset.data), value: public_email_value(@changeset.data) %>
             <%= error_tag f, :public_email %>
             <small>
-              You can add or remove email address on the <a href="<%= dashboard_path(Endpoint, :email) %>">email settings page</a>.
+              You can add or remove email address on the <a href="<%= Routes.dashboard_path(Endpoint, :email) %>">email settings page</a>.
             </small>
           </div>
 

--- a/lib/hexpm/web/templates/dashboard/repository.html.eex
+++ b/lib/hexpm/web/templates/dashboard/repository.html.eex
@@ -13,7 +13,7 @@
         <%= for repository_user <- @repository.repository_users do %>
           <li class="list-group-item clearfix">
             <img src="<%= gravatar_url(User.email(repository_user.user, :public), :small) %>" class="member-avatar">
-            <a class="member-username" href="<%= user_path(Endpoint, :show, repository_user.user) %>"><%= repository_user.user.username %></a>
+            <a class="member-username" href="<%= Routes.user_path(Endpoint, :show, repository_user.user) %>"><%= repository_user.user.username %></a>
             <div style="float: right">
               <div class="dropdown role-dropdown">
                 <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
@@ -23,7 +23,7 @@
                 <ul class="dropdown-menu dropdown-menu-right">
                   <%= for {name, id, title} <- repository_roles() do %>
                     <li>
-                      <%= form_tag dashboard_path(Endpoint, :update_repository, @repository), class: "change-role" do %>
+                      <%= form_tag Routes.dashboard_path(Endpoint, :update_repository, @repository), class: "change-role" do %>
                         <input type="hidden" name="action" value="change_role">
                         <input type="hidden" name="repository_user[username]" value="<%= repository_user.user.username %>">
                         <input type="hidden" name="repository_user[role]" value="<%= id %>">
@@ -32,7 +32,7 @@
                     </li>
                   <% end %>
                 </ul>
-                  <%= form_tag dashboard_path(Endpoint, :update_repository, @repository), class: "remove-role" do %>
+                  <%= form_tag Routes.dashboard_path(Endpoint, :update_repository, @repository), class: "remove-role" do %>
                     <input type="hidden" name="action" value="remove_member">
                     <input type="hidden" name="repository_user[username]" value="<%= repository_user.user.username %>">
                     <%= submit "Remove", class: "btn btn-danger", disabled: repository_user.user.id == @current_user.id %>
@@ -42,7 +42,7 @@
           </li>
         <% end %>
         <li class="list-group-item clearfix">
-          <%= form_for @add_member_changeset, dashboard_path(Endpoint, :update_repository, @repository), [method: :post, class: "form-inline"], fn f -> %>
+          <%= form_for @add_member_changeset, Routes.dashboard_path(Endpoint, :update_repository, @repository), [method: :post, class: "form-inline"], fn f -> %>
             <input type="hidden" name="action" value="add_member">
             <div class="form-group">
               <%= text_input f, :username, class: "form-control", style: "width: 250px", placeholder: "Username or email address", required: true %>

--- a/lib/hexpm/web/templates/dashboard/repository_signup.html.eex
+++ b/lib/hexpm/web/templates/dashboard/repository_signup.html.eex
@@ -19,7 +19,7 @@
         </p>
       </div>
       <div class="panel-body">
-        <%= form_tag dashboard_path(Endpoint, :new_repository_signup) do %>
+        <%= form_tag Routes.dashboard_path(Endpoint, :new_repository_signup) do %>
           <div class="form-group">
             <label for="name">Organization name</label>
             <input type="text" id="name" name="name" class="form-control" placeholder="Only allows lowercase letters and underscore" required pattern="[a-z]\w*" aria-describedby="name-helpblock">

--- a/lib/hexpm/web/templates/email/password_changed.html.eex
+++ b/lib/hexpm/web/templates/email/password_changed.html.eex
@@ -5,7 +5,7 @@
 </p>
 
 <p>
-  If you did not perform this change, you can reset your password by entering your email at <a href="<%= password_reset_url(Endpoint, :show) %>"><%= password_reset_url(Endpoint, :show) %></a>.
+  If you did not perform this change, you can reset your password by entering your email at <a href="<%= Routes.password_reset_url(Endpoint, :show) %>"><%= Routes.password_reset_url(Endpoint, :show) %></a>.
 </p>
 
 <p>

--- a/lib/hexpm/web/templates/email/password_reset_request.html.eex
+++ b/lib/hexpm/web/templates/email/password_reset_request.html.eex
@@ -1,5 +1,5 @@
 <%
-new_url = password_url(Endpoint, :show, username: @username, key: @key)
+new_url = Routes.password_url(Endpoint, :show, username: @username, key: @key)
 %>
 
 <p>Reset your Hex.pm password</p>

--- a/lib/hexpm/web/templates/email/repository_invite.html.eex
+++ b/lib/hexpm/web/templates/email/repository_invite.html.eex
@@ -1,8 +1,8 @@
 <p>You have been added as a member to the <strong><%= @repository %></strong> repository.</p>
 
-<p>Go check out the <a href="<%= raw dashboard_url(Endpoint, :repository, @repository) %>">repository</a>, if you do not want to join the repository you can leave it from the dashboard. You need to be logged in as <strong><%= @username %></strong> to access it.</p>
+<p>Go check out the <a href="<%= raw Routes.dashboard_url(Endpoint, :repository, @repository) %>">repository</a>, if you do not want to join the repository you can leave it from the dashboard. You need to be logged in as <strong><%= @username %></strong> to access it.</p>
 
-<p>To learn more about private packages and organizations go to the <a href="<%= raw docs_url(Endpoint, :private) %>">documentation</a>.
+<p>To learn more about private packages and organizations go to the <a href="<%= raw Routes.docs_url(Endpoint, :private) %>">documentation</a>.
 
 <p>
   --<br>

--- a/lib/hexpm/web/templates/email/repository_signup.html.eex
+++ b/lib/hexpm/web/templates/email/repository_signup.html.eex
@@ -8,5 +8,5 @@
   Username: <%= @user.username %>
   Full name: <%= @user.full_name %>
   Email: <%= User.email(@user, :primary) %>
-  Link: <a href="<%= user_url(Endpoint, :show, @user) %>"><%= user_url(Endpoint, :show, @user) %></a>
+  Link: <a href="<%= Routes.user_url(Endpoint, :show, @user) %>"><%= Routes.user_url(Endpoint, :show, @user) %></a>
 </pre>

--- a/lib/hexpm/web/templates/email/verification.html.eex
+++ b/lib/hexpm/web/templates/email/verification.html.eex
@@ -1,5 +1,5 @@
 <%
-verify_url = email_url(Endpoint, :verify, username: @username, email: @email, key: @key)
+verify_url = Routes.email_url(Endpoint, :verify, username: @username, email: @email, key: @key)
 %>
 
 <p>

--- a/lib/hexpm/web/templates/layout/footer.html.eex
+++ b/lib/hexpm/web/templates/layout/footer.html.eex
@@ -5,13 +5,13 @@
         <div class="container">
           <ul>
             <li>
-              <a href="<%= blog_path(Endpoint, :index) %>">blog</a>
+              <a href="<%= Routes.blog_path(Endpoint, :index) %>">blog</a>
             </li>
             <li>
-              <a href="<%= policy_path(Endpoint, :index) %>">policies</a>
+              <a href="<%= Routes.policy_path(Endpoint, :index) %>">policies</a>
             </li>
             <li>
-              <a href="<%= page_path(Endpoint, :sponsors) %>">sponsors</a>
+              <a href="<%= Routes.page_path(Endpoint, :sponsors) %>">sponsors</a>
             </li>
             <li>
               <a href="https://github.com/hexpm">github</a>
@@ -24,7 +24,7 @@
       </div>
     </div>
 
-    <script src="<%= static_path(Endpoint, "/js/app.js") %>"></script>
+    <script src="<%= Routes.static_path(Endpoint, "/js/app.js") %>"></script>
 
     <script>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/lib/hexpm/web/templates/layout/header.html.eex
+++ b/lib/hexpm/web/templates/layout/header.html.eex
@@ -11,8 +11,8 @@
     <%= og_tags(assigns) %>
 
     <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="/hexsearch.xml">
-    <link rel="stylesheet" href="<%= static_path(Endpoint, "/css/app.css") %>">
-    <link rel="shortcut icon" href="<%= static_path(Endpoint, "/favicon.png") %>">
+    <link rel="stylesheet" href="<%= Routes.static_path(Endpoint, "/css/app.css") %>">
+    <link rel="shortcut icon" href="<%= Routes.static_path(Endpoint, "/favicon.png") %>">
   </head>
   <body>
     <!--[if lt IE 10]>
@@ -29,12 +29,12 @@
             <span class="icon-bar"></span>
           </button>
           <a class="navbar-brand" href="/">
-            <img src="<%= static_path(Endpoint, "/images/hex.png") %>" srcset="<%= static_path(Endpoint, "/images/hex.png") %> 1x, <%= static_path(Endpoint, "/images/hex@2.png") %> 2x, <%= static_path(Endpoint, "/images/hex@3.png") %> 3x" alt="hex logo">
+            <img src="<%= Routes.static_path(Endpoint, "/images/hex.png") %>" srcset="<%= Routes.static_path(Endpoint, "/images/hex.png") %> 1x, <%= Routes.static_path(Endpoint, "/images/hex@2.png") %> 2x, <%= Routes.static_path(Endpoint, "/images/hex@3.png") %> 3x" alt="hex logo">
           </a>
         </div>
         <div id="navbar" class="navbar-collapse collapse">
           <%= if show_search?(assigns) do %>
-          <form class="navbar-form pull-left" role="search" action="<%= package_path(Endpoint, :index) %>">
+          <form class="navbar-form pull-left" role="search" action="<%= Routes.package_path(Endpoint, :index) %>">
              <div class="input-group">
                 <input placeholder="Find packages" name="search" type="text" autofocus class="form-control" value="<%= search(assigns) %>">
                 <input type="hidden" name="sort" value="recent_downloads">
@@ -49,25 +49,25 @@
           <% end %>
 
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="<%= package_path(Endpoint, :index) %>">Packages</a></li>
+            <li><a href="<%= Routes.package_path(Endpoint, :index) %>">Packages</a></li>
 
             <li class="dropdown">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation <b class="caret"></b></a>
               <ul class="dropdown-menu">
                 <li class="dropdown-header menu-dropdown-header">Mix</li>
-                <li><a href="<%= docs_path(Endpoint, :usage) %>">Usage</a></li>
-                <li><a href="<%= docs_path(Endpoint, :publish) %>">Publishing packages</a></li>
-                <li><a href="<%= docs_path(Endpoint, :tasks) %>">Tasks</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :usage) %>">Usage</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :publish) %>">Publishing packages</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :tasks) %>">Tasks</a></li>
                 <li role="separator" class="divider"></li>
                 <li class="dropdown-header menu-dropdown-header">Rebar3</li>
-                <li><a href="<%= docs_path(Endpoint, :rebar3_usage) %>">Usage</a></li>
-                <li><a href="<%= docs_path(Endpoint, :rebar3_publish) %>">Publishing packages</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :rebar3_usage) %>">Usage</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :rebar3_publish) %>">Publishing packages</a></li>
                 <li><a href="https://www.rebar3.org/v3.0/docs/hex-package-management">Tasks</a></li>
                 <li role="separator" class="divider"></li>
-                <li><a href="<%= docs_path(Endpoint, :private) %>">Private packages</a></li>
-                <li><a href="<%= policy_path(Endpoint, :index) %>">Policies</a></li>
-                <li><a href="<%= docs_path(Endpoint, :mirrors) %>">Mirrors</a></li>
-                <li><a href="<%= docs_path(Endpoint, :public_keys) %>">Public keys</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :private) %>">Private packages</a></li>
+                <li><a href="<%= Routes.policy_path(Endpoint, :index) %>">Policies</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :mirrors) %>">Mirrors</a></li>
+                <li><a href="<%= Routes.docs_path(Endpoint, :public_keys) %>">Public keys</a></li>
                 <li><a href="https://github.com/hexpm/specifications">Specifications</a></li>
               </ul>
             </li>
@@ -80,18 +80,18 @@
                   <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">
-                  <li><a href="<%= user_path(Endpoint, :show, @current_user) %>">Profile</a></li>
-                  <li><a href="<%= dashboard_path(Endpoint, :profile) %>">Dashboard</a></li>
+                  <li><a href="<%= Routes.user_path(Endpoint, :show, @current_user) %>">Profile</a></li>
+                  <li><a href="<%= Routes.dashboard_path(Endpoint, :profile) %>">Dashboard</a></li>
                   <li role="separator" class="divider"></li>
                   <li>
-                    <%= form_tag(login_path(Endpoint, :delete)) do %>
+                    <%= form_tag(Routes.login_path(Endpoint, :delete)) do %>
                       <button type="submit" class="btn btn-link">Log out</button>
                     <% end %>
                   </li>
                 </ul>
               </li>
             <% else %>
-              <li><a href="<%= login_path(Endpoint, :show) %>">Log in</a></li>
+              <li><a href="<%= Routes.login_path(Endpoint, :show) %>">Log in</a></li>
             <% end %>
 
           </ul>

--- a/lib/hexpm/web/templates/login/show.html.eex
+++ b/lib/hexpm/web/templates/login/show.html.eex
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
-    <%= form_tag(login_path(Endpoint, :create)) do %>
+    <%= form_tag(Routes.login_path(Endpoint, :create)) do %>
       <h2>Log in</h2>
 
       <div class="form-group">
@@ -10,7 +10,7 @@
 
       <div class="form-group">
         <label for="password">Password</label>
-        <span style="float: right;"><a href="<%= password_reset_path(Endpoint, :show) %>">Forgot your password?</a></span>
+        <span style="float: right;"><a href="<%= Routes.password_reset_path(Endpoint, :show) %>">Forgot your password?</a></span>
         <input type="password" class="form-control" name="password">
       </div>
 
@@ -20,7 +20,7 @@
 
       <br><br>
 
-      <p><a href="<%= signup_path(Endpoint, :show) %>">Don't have an account?</a></p>
+      <p><a href="<%= Routes.signup_path(Endpoint, :show) %>">Don't have an account?</a></p>
     <% end %>
   </div>
 </div>

--- a/lib/hexpm/web/templates/open_search/opensearch.xml.eex
+++ b/lib/hexpm/web/templates/open_search/opensearch.xml.eex
@@ -7,14 +7,14 @@
   <Language>en-us</Language>
 
   <Image height="48" width="48" type="image/x-icon">
-    <%= static_url(Endpoint, "/favicon.ico") %>
+    <%= Routes.static_url(Endpoint, "/favicon.ico") %>
   </Image>
 
   <Image height="64" width="64" type="image/png">
-     <%= static_url(Endpoint, "/images/favicon-64.png") %>
+     <%= Routes.static_url(Endpoint, "/images/favicon-64.png") %>
   </Image>
 
   <InputEncoding>utf-8</InputEncoding>
   <OutputEncoding>utf-8</OutputEncoding>
-  <Url type="text/html" method="get" template="<%= package_url(Endpoint, :index) %>?search={searchTerms}&amp;sort=recent_downloads" />
+  <Url type="text/html" method="get" template="<%= Routes.package_url(Endpoint, :index) %>?search={searchTerms}&amp;sort=recent_downloads" />
 </OpenSearchDescription>

--- a/lib/hexpm/web/templates/package/index.html.eex
+++ b/lib/hexpm/web/templates/package/index.html.eex
@@ -7,7 +7,7 @@
     <ul class="list">
       <%= for letter <- @letters do %>
       <li>
-        <a href="<%= package_path(Endpoint, :index, letter: letter) %>">
+        <a href="<%= Routes.package_path(Endpoint, :index, letter: letter) %>">
           <%= letter %>
         </a>
       </li>
@@ -52,19 +52,19 @@
         </button>
         <ul class="dropdown-menu dropdown-menu-right" role="menu">
           <li role="presentation">
-            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_name_params) %>">Name</a>
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_name_params) %>">Name</a>
           </li>
           <li role="presentation">
-            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_total_downloads_params) %>">Total Downloads</a>
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_total_downloads_params) %>">Total Downloads</a>
           </li>
           <li role="presentation">
-            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_recent_downloads_params) %>">Recent Downloads</a>
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_recent_downloads_params) %>">Recent Downloads</a>
           </li>
           <li role="presentation">
-            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_created_params) %>">Recently created</a>
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_created_params) %>">Recently created</a>
           </li>
           <li role="presentation">
-            <a role="menuitem" tabindex="-1" href="<%= package_path(Endpoint, :index, sort_updated_params) %>">Recently updated</a>
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_updated_params) %>">Recently updated</a>
           </li>
         </ul>
       </div>
@@ -105,7 +105,7 @@
   <nav class="pagination-widget">
     <ul class="pagination pagination-sm">
       <%= if paginate[:prev] do %>
-        <li><a href="<%= package_path(Endpoint, :index, prev_page_params) %>" aria-label="Previous">&laquo;</a></li>
+        <li><a href="<%= Routes.package_path(Endpoint, :index, prev_page_params) %>" aria-label="Previous">&laquo;</a></li>
       <% else %>
         <li class="disabled"><span>&laquo;</span></li>
       <% end %>
@@ -116,14 +116,14 @@
           </li>
         <% else %>
           <li>
-            <a href="<%= package_path(Endpoint, :index, params(search: @search, page: counter, sort: @sort, letter: @letter)) %>">
+            <a href="<%= Routes.package_path(Endpoint, :index, params(search: @search, page: counter, sort: @sort, letter: @letter)) %>">
               <%= counter %>
             </a>
           </li>
         <% end %>
       <% end %>
       <%= if paginate[:next] do %>
-        <li><a href="<%= package_path(Endpoint, :index, next_page_params) %>" aria-label="Next" >&raquo;</a></li>
+        <li><a href="<%= Routes.package_path(Endpoint, :index, next_page_params) %>" aria-label="Next" >&raquo;</a></li>
       <% else %>
         <li class="disabled"><span>&raquo;</span></li>
       <% end %>

--- a/lib/hexpm/web/templates/package/show.html.eex
+++ b/lib/hexpm/web/templates/package/show.html.eex
@@ -204,7 +204,7 @@ tools = Keyword.take(tools, compatible_tools)
     <ul class="owners-list">
       <%= for user <- @owners do %>
         <li>
-          <a href="<%= user_path(Endpoint, :show, user) %>">
+          <a href="<%= Routes.user_path(Endpoint, :show, user) %>">
             <img src="<%= gravatar_url(User.email(user, :public), :small) %>" class="owner-avatar"><%= user.username %>
           </a>
         </li>
@@ -215,7 +215,7 @@ tools = Keyword.take(tools, compatible_tools)
     <%= safe_join(@dependants, ", ", fn package ->
       link(package_name(package), to: path_for_package(package))
     end) %><%= if @dependants_count != 0 do %>,
-    <a href="<%= package_path(Endpoint, :index, search: "depends:#{@package.name}") %>">show all...</a>
+    <a href="<%= Routes.package_path(Endpoint, :index, search: "depends:#{@package.name}") %>">show all...</a>
     <% end %>
   </div>
 </div>

--- a/lib/hexpm/web/templates/page/_package.html.eex
+++ b/lib/hexpm/web/templates/page/_package.html.eex
@@ -1,6 +1,6 @@
 <li>
   <div class="title-container">
-    <a href="<%= package_path(Endpoint, :show, @package) %>" class="title"><%= @package %></a>
+    <a href="<%= Routes.package_path(Endpoint, :show, @package) %>" class="title"><%= @package %></a>
   </div>
   <p>
     <%= if @downloads do %>
@@ -12,7 +12,7 @@
     <%= if @inserted_at do %>
       <span class="published-at">
         <%= if @version do %>
-          <a href="<%= package_path(Endpoint, :show, @package) %>"><%= @version %></a>
+          <a href="<%= Routes.package_path(Endpoint, :show, @package) %>"><%= @version %></a>
         <% end %>
         published <%= human_relative_time_from_now(@inserted_at) %>
       </span>

--- a/lib/hexpm/web/templates/page/index.html.eex
+++ b/lib/hexpm/web/templates/page/index.html.eex
@@ -7,7 +7,7 @@
 
       <div class="row">
         <div class="col-md-8 col-md-offset-2">
-          <%= form_tag(package_path(Endpoint, :index), method: "get", role: "search") do %>
+          <%= form_tag(Routes.package_path(Endpoint, :index), method: "get", role: "search") do %>
             <div class="input-group">
               <input type="search" autofocus class="form-control" placeholder="Find packages" name="search" id="search" value="<% # search(assigns) %>" tabindex="1">
               <input type="hidden" name="sort" value="recent_downloads">
@@ -30,7 +30,7 @@
           <div class="lang-symbol"></div>
         </div>
         <div class="instructions">
-          <h3><a href="<%= docs_path(Endpoint, :usage) %>">Using with Elixir</a></h3>
+          <h3><a href="<%= Routes.docs_path(Endpoint, :usage) %>">Using with Elixir</a></h3>
           <p>
             Simply specify your Mix dependencies as two-item tuples like <code>{:plug, "~> 1.1.0"}</code> and Elixir will ask if you want to install Hex if you haven't already.
             After installed, you can run <code>$ mix local </code> to see all available Hex tasks and  <code>$ mix help TASK</code> for more information about a specific task.
@@ -46,7 +46,7 @@
           <div class="lang-symbol"></div>
         </div>
         <div class="instructions">
-          <h3><a href="<%= docs_path(Endpoint, :rebar3_usage) %>">Using with Erlang</a></h3>
+          <h3><a href="<%= Routes.docs_path(Endpoint, :rebar3_usage) %>">Using with Erlang</a></h3>
           <p>
             Download <a href="https://s3.amazonaws.com/rebar3/rebar3">rebar3</a>, put it in your <code>PATH</code> and give it executable permissions.
             Now you can specify Hex dependencies in your rebar.config like <code>{deps, [hackney]}</code>.

--- a/lib/hexpm/web/templates/page/sponsors.html.eex
+++ b/lib/hexpm/web/templates/page/sponsors.html.eex
@@ -5,7 +5,7 @@
 <div class="sponsors container">
   <div class="row">
     <div class="col-md-4 image">
-      <a href="http://pages.plataformatec.com.br/elixir-phoenix-consulting"><img src="<%= static_path(Endpoint, "/images/plataformatec.png") %>" alt="Plataformatec logo"></a>
+      <a href="http://pages.plataformatec.com.br/elixir-phoenix-consulting"><img src="<%= Routes.static_path(Endpoint, "/images/plataformatec.png") %>" alt="Plataformatec logo"></a>
     </div>
     <div class="col-md-8">
       <p>
@@ -19,7 +19,7 @@
 
   <div class="row">
     <div class="col-md-4 image">
-      <a href="https://www.fastly.com/"><img src="<%= static_path(Endpoint, "/images/fastly.png") %>" alt="Fastly logo"></a>
+      <a href="https://www.fastly.com/"><img src="<%= Routes.static_path(Endpoint, "/images/fastly.png") %>" alt="Fastly logo"></a>
     </div>
     <div class="col-md-8">
       <p>

--- a/lib/hexpm/web/templates/password/show.html.eex
+++ b/lib/hexpm/web/templates/password/show.html.eex
@@ -2,7 +2,7 @@
 
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
-    <%= form_for @changeset, password_path(Endpoint, :update), [method: :post], fn f -> %>
+    <%= form_for @changeset, Routes.password_path(Endpoint, :update), [method: :post], fn f -> %>
       <h2>Choose a new password</h2>
 
       <div class="form-group">

--- a/lib/hexpm/web/templates/password_reset/show.html.eex
+++ b/lib/hexpm/web/templates/password_reset/show.html.eex
@@ -1,6 +1,6 @@
 <div class="row">
   <div class="col-md-8 col-md-offset-2">
-    <%= form_tag(password_reset_path(Endpoint, :create)) do %>
+    <%= form_tag(Routes.password_reset_path(Endpoint, :create)) do %>
       <h2>Reset your password</h2>
 
       <div class="form-group">

--- a/lib/hexpm/web/templates/policy/index.html.eex
+++ b/lib/hexpm/web/templates/policy/index.html.eex
@@ -1,10 +1,10 @@
 <h2>Policies</h2>
 
 <ul>
-  <li><a href="<%= policy_path(Endpoint, :coc) %>">Code of Conduct</a></li>
-  <li><a href="<%= policy_path(Endpoint, :tos) %>">Terms of Service</a></li>
-  <li><a href="<%= policy_path(Endpoint, :privacy) %>">Privacy Policy</a></li>
-  <li><a href="<%= policy_path(Endpoint, :copyright) %>">Copyright Policy</a></li>
+  <li><a href="<%= Routes.policy_path(Endpoint, :coc) %>">Code of Conduct</a></li>
+  <li><a href="<%= Routes.policy_path(Endpoint, :tos) %>">Terms of Service</a></li>
+  <li><a href="<%= Routes.policy_path(Endpoint, :privacy) %>">Privacy Policy</a></li>
+  <li><a href="<%= Routes.policy_path(Endpoint, :copyright) %>">Copyright Policy</a></li>
 </ul>
 
 <p>

--- a/lib/hexpm/web/templates/signup/show.html.eex
+++ b/lib/hexpm/web/templates/signup/show.html.eex
@@ -4,7 +4,7 @@
   <div class="col-md-8 col-md-offset-2">
     <h2>Sign up</h2>
 
-    <%= form_for @changeset, signup_path(Endpoint, :create), fn f -> %>
+    <%= form_for @changeset, Routes.signup_path(Endpoint, :create), fn f -> %>
       <div class="form-group">
         <%= label f, :full_name %>
         <%= text_input f, :full_name %>
@@ -47,7 +47,7 @@
 
       <br><br>
 
-      <p><a href="<%= login_path(Endpoint, :show) %>">Already have an account?</a></p>
+      <p><a href="<%= Routes.login_path(Endpoint, :show) %>">Already have an account?</a></p>
     <% end %>
   </div>
 </div>

--- a/lib/hexpm/web/templates/sitemap/packages_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/packages_sitemap.xml.eex
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <%= for {name, updated_at} <- @packages do %>
     <url>
-      <loc>https://hex.pm<%= package_path(Endpoint, :show, name) %></loc>
+      <loc>https://hex.pm<%= Routes.package_path(Endpoint, :show, name) %></loc>
       <lastmod><%= Hexpm.Utils.binarify(updated_at) %>Z</lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>

--- a/lib/hexpm/web/views/api/index_view.ex
+++ b/lib/hexpm/web/views/api/index_view.ex
@@ -2,12 +2,12 @@ defmodule Hexpm.Web.API.IndexView do
   use Hexpm.Web, :view
 
   def render("index." <> _format, _assigns) do
-    %{packages_url: api_package_url(Endpoint, :index),
-      package_url: api_package_url(Endpoint, :show, "{name}") |> fix_placeholder(),
-      package_release_url: api_release_url(Endpoint, :show, "{name}", "{version}") |> fix_placeholder(),
-      package_owners_url: api_owner_url(Endpoint, :index, "{name}") |> fix_placeholder(),
-      keys_url: api_key_url(Endpoint, :index),
-      key_url: api_key_url(Endpoint, :show, "{name}") |> fix_placeholder(),
+    %{packages_url: Routes.api_package_url(Endpoint, :index),
+      package_url: Routes.api_package_url(Endpoint, :show, "{name}") |> fix_placeholder(),
+      package_release_url: Routes.api_release_url(Endpoint, :show, "{name}", "{version}") |> fix_placeholder(),
+      package_owners_url: Routes.api_owner_url(Endpoint, :index, "{name}") |> fix_placeholder(),
+      keys_url: Routes.api_key_url(Endpoint, :index),
+      key_url: Routes.api_key_url(Endpoint, :show, "{name}") |> fix_placeholder(),
       documentation_url: "http://docs.hexpm.apiary.io"}
   end
 

--- a/lib/hexpm/web/views/api/key_view.ex
+++ b/lib/hexpm/web/views/api/key_view.ex
@@ -21,7 +21,7 @@ defmodule Hexpm.Web.API.KeyView do
       revoked_at: key.revoked_at,
       inserted_at: key.inserted_at,
       updated_at: key.updated_at,
-      url: api_key_url(Endpoint, :show, key)
+      url: Routes.api_key_url(Endpoint, :show, key)
     }
   end
 end

--- a/lib/hexpm/web/views/api/user_view.ex
+++ b/lib/hexpm/web/views/api/user_view.ex
@@ -17,7 +17,7 @@ defmodule Hexpm.Web.API.UserView do
       full_name: user.full_name,
       handles: handles(user),
       email: User.email(user, :public),
-      url: api_user_url(Endpoint, :show, user),
+      url: Routes.api_user_url(Endpoint, :show, user),
       inserted_at: user.inserted_at,
       updated_at: user.updated_at,
     }
@@ -28,7 +28,7 @@ defmodule Hexpm.Web.API.UserView do
     %{
       username: user.username,
       email: User.email(user, :public),
-      url: api_user_url(Endpoint, :show, user),
+      url: Routes.api_user_url(Endpoint, :show, user),
     }
   end
 
@@ -40,7 +40,7 @@ defmodule Hexpm.Web.API.UserView do
 
   defp owned_packages(packages) do
     Enum.into(packages, %{}, fn package ->
-      {package.name, api_package_url(Endpoint, :show, package)}
+      {package.name, Routes.api_package_url(Endpoint, :show, package)}
     end)
   end
 end

--- a/lib/hexpm/web/views/layout_view.ex
+++ b/lib/hexpm/web/views/layout_view.ex
@@ -42,7 +42,7 @@ defmodule Hexpm.Web.LayoutView do
       tag(:meta, property: "og:title", content: Map.get(assigns, :title)),
       tag(:meta, property: "og:type", content: "website"),
       tag(:meta, property: "og:url", content: Map.get(assigns, :canonical_url)),
-      tag(:meta, property: "og:image", content: static_url(Hexpm.Web.Endpoint, "/images/favicon-160.png")),
+      tag(:meta, property: "og:image", content: Routes.static_url(Hexpm.Web.Endpoint, "/images/favicon-160.png")),
       tag(:meta, property: "og:image:width", content: "160"),
       tag(:meta, property: "og:image:height", content: "160"),
       tag(:meta, property: "og:description", content: description(assigns)),

--- a/lib/hexpm/web/views/view_helpers.ex
+++ b/lib/hexpm/web/views/view_helpers.ex
@@ -1,8 +1,8 @@
 defmodule Hexpm.Web.ViewHelpers do
   use Phoenix.HTML
   alias Hexpm.Repository.Package
-  alias Hexpm.Web.Router.Helpers
   alias Hexpm.Web.Endpoint
+  alias Hexpm.Web.Router.Helpers, as: Routes
 
   def logged_in?(assigns) do
     !!assigns[:current_user]
@@ -21,53 +21,53 @@ defmodule Hexpm.Web.ViewHelpers do
 
   def path_for_package(package) do
     if package.repository.name == "hexpm" do
-      Helpers.package_path(Endpoint, :show, package, [])
+      Routes.package_path(Endpoint, :show, package, [])
     else
-      Helpers.package_path(Endpoint, :show, package.repository, package, [])
+      Routes.package_path(Endpoint, :show, package.repository, package, [])
     end
   end
 
   def path_for_package("hexpm", package) do
-    Helpers.package_path(Endpoint, :show, package, [])
+    Routes.package_path(Endpoint, :show, package, [])
   end
   def path_for_package(repository, package) do
-    Helpers.package_path(Endpoint, :show, repository, package, [])
+    Routes.package_path(Endpoint, :show, repository, package, [])
   end
 
   def path_for_release(package, release) do
     if package.repository.name == "hexpm" do
-      Helpers.package_path(Endpoint, :show, package, release, [])
+      Routes.package_path(Endpoint, :show, package, release, [])
     else
-      Helpers.package_path(Endpoint, :show, package.repository, package, release, [])
+      Routes.package_path(Endpoint, :show, package.repository, package, release, [])
     end
   end
 
   def html_url_for_package(%Package{repository_id: 1} = package) do
-    Helpers.package_url(Endpoint, :show, package, [])
+    Routes.package_url(Endpoint, :show, package, [])
   end
   def html_url_for_package(%Package{} = package) do
-    Helpers.package_url(Endpoint, :show, package.repository, package, [])
+    Routes.package_url(Endpoint, :show, package.repository, package, [])
   end
 
   def html_url_for_release(%Package{repository_id: 1} = package, release) do
-    Helpers.package_url(Endpoint, :show, package, to_string(release.version), [])
+    Routes.package_url(Endpoint, :show, package, to_string(release.version), [])
   end
   def html_url_for_release(%Package{} = package, release) do
-    Helpers.package_url(Endpoint, :show, package.repository, package, to_string(release.version), [])
+    Routes.package_url(Endpoint, :show, package.repository, package, to_string(release.version), [])
   end
 
   def url_for_package(%Package{repository_id: 1} = package) do
-    Helpers.api_package_url(Endpoint, :show, package, [])
+    Routes.api_package_url(Endpoint, :show, package, [])
   end
   def url_for_package(package) do
-    Helpers.api_package_url(Endpoint, :show, package.repository, package, [])
+    Routes.api_package_url(Endpoint, :show, package.repository, package, [])
   end
 
   def url_for_release(%Package{repository_id: 1} = package, release) do
-    Helpers.api_release_url(Endpoint, :show, package, to_string(release.version), [])
+    Routes.api_release_url(Endpoint, :show, package, to_string(release.version), [])
   end
   def url_for_release(%Package{} = package, release) do
-    Helpers.api_release_url(Endpoint, :show, package.repository, package, to_string(release.version), [])
+    Routes.api_release_url(Endpoint, :show, package.repository, package, to_string(release.version), [])
   end
 
   def gravatar_url(nil, size) do

--- a/lib/hexpm/web/web.ex
+++ b/lib/hexpm/web/web.ex
@@ -53,9 +53,10 @@ defmodule Hexpm.Web do
       import Ecto
       import Ecto.Query, only: [from: 1, from: 2]
 
-      import Hexpm.Web.{Router.Helpers, ControllerHelpers, AuthHelpers}
+      import Hexpm.Web.{ControllerHelpers, AuthHelpers}
 
       alias Hexpm.Web.Endpoint
+      alias Hexpm.Web.Router.Helpers, as: Routes
 
       Hexpm.Web.shared()
     end
@@ -78,9 +79,10 @@ defmodule Hexpm.Web do
         select: 3, select: 4
       ]
 
-      import Hexpm.Web.{Router.Helpers, ViewHelpers, ViewIcons}
+      import Hexpm.Web.{ViewHelpers, ViewIcons}
 
       alias Hexpm.Web.Endpoint
+      alias Hexpm.Web.Router.Helpers, as: Routes
 
       Hexpm.Web.shared
     end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -21,10 +21,10 @@ defmodule Hexpm.ConnCase do
       use Phoenix.ConnTest
 
       alias Hexpm.{Fake, Repo}
+      alias Hexpm.Web.Router.Helpers, as: Routes
 
       import Ecto
       import Ecto.Query, only: [from: 2]
-      import Hexpm.Web.Router.Helpers
       import Hexpm.{Case, Factory, TestHelpers}
       import unquote(__MODULE__)
 


### PR DESCRIPTION
Ref https://github.com/phoenixframework/phoenix/issues/2530

---

I did it using following snippet (using Elixir v1.6.0-dev ~on branch https://github.com/elixir-lang/elixir/pull/6947~)  + some minor manual changes

```
mix compile && mix xref callers Hexpm.Web.Router.Helpers | while read i; do echo $i | sed -E "s/(.*):(.*): Hexpm.Web.Router.Helpers.(.*)\/[0-9]/'\2s\/\3\/Routes.\3\/g' \1/" | xargs sed -i '' ; done
```

I'm sure there's a better way to do it now :) Looking forward to eventually doing this sort of stuff with `go fix` like tool since we already have the formatter.