### PR TITLE
Reject requests with null byte in URL

### DIFF
--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -9,6 +9,7 @@ defmodule Hexpm.Web.Router do
     plug :fetch_session
     plug :fetch_flash
     plug :protect_from_forgery
+    plug Hexpm.Web.Plugs.Attack
     plug :put_secure_browser_headers
     plug :web_user_agent
     plug :login

--- a/test/hexpm/web/plugs/attack_test.exs
+++ b/test/hexpm/web/plugs/attack_test.exs
@@ -118,6 +118,11 @@ defmodule Hexpm.Web.Plugs.AttackTest do
     end
   end
 
+  test "reject malformed query string", %{user: user} do
+    conn = request_user(user, "/%00")
+    assert conn.status == 400
+  end
+
   defp request_ip(remote_ip) do
     conn(:get, "/")
     |> Map.put(:remote_ip, remote_ip)
@@ -125,8 +130,8 @@ defmodule Hexpm.Web.Plugs.AttackTest do
     |> Hello.call(:index)
   end
 
-  defp request_user(user) do
-    conn(:get, "/")
+  defp request_user(user, path \\ "/") do
+    conn(:get, path)
     |> Map.put(:remote_ip, {10, 0, 0, 1})
     |> assign(:current_user, user)
     |> Hello.call(:index)


### PR DESCRIPTION
This is a best effort fix for requests we get once in a while. Not 100% bulletproof, e.g.: it'll still fail for POST requests but these haven't come up yet.

Also, see: https://github.com/elixir-ecto/ecto/issues/2057