### PR TITLE
Implement gravatar email without public address

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -67,6 +67,7 @@ defmodule Hexpm.Accounts.AuditLog do
   defp extract_params("email.remove", email), do: serialize(email)
   defp extract_params("email.primary", {old_email, new_email}), do: %{old_email: serialize(old_email), new_email: serialize(new_email)}
   defp extract_params("email.public", {old_email, new_email}), do: %{old_email: serialize(old_email), new_email: serialize(new_email)}
+  defp extract_params("email.gravatar", {old_email, new_email}), do: %{old_email: serialize(old_email), new_email: serialize(new_email)}
   defp extract_params("user.create", user), do: serialize(user)
   defp extract_params("user.update", user), do: serialize(user)
   defp extract_params("password.reset.init", nil), do: %{}
@@ -109,7 +110,7 @@ defmodule Hexpm.Accounts.AuditLog do
   defp fields(%PackageMetadata{}), do: [:description, :licenses, :links, :maintainers, :extra]
   defp fields(%ReleaseMetadata{}), do: [:app, :build_tools, :elixir]
   defp fields(%ReleaseRetirement{}), do: [:status, :message]
-  defp fields(%Email{}), do: [:email, :primary, :public, :primary]
+  defp fields(%Email{}), do: [:email, :primary, :public, :primary, :gravatar]
   defp fields(%UserHandles{}), do: [:github, :twitter, :freenode]
 
   defp multi_key(action), do: :"log.#{action}"

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -50,16 +50,8 @@ defmodule Hexpm.Accounts.Email do
     |> unique_constraint(:email, name: "emails_email_key", message: "already in use")
   end
 
-  def toggle_primary(email, flag) do
-    change(email, %{primary: flag})
-  end
-
-  def toggle_public(email, flag) do
-    change(email, %{public: flag})
-  end
-
-  def toggle_gravatar(email, flag) do
-    change(email, %{gravatar: flag})
+  def toggle_flag(email, flag, value) do
+    change(email, %{flag => value})
   end
 
   def order_emails(emails) do

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -9,6 +9,7 @@ defmodule Hexpm.Accounts.Email do
     field :verified, :boolean, default: false
     field :primary, :boolean, default: false
     field :public, :boolean, default: false
+    field :gravatar, :boolean, default: false
     field :verification_key, :string
 
     belongs_to :user, User
@@ -55,6 +56,10 @@ defmodule Hexpm.Accounts.Email do
 
   def toggle_public(email, flag) do
     change(email, %{public: flag})
+  end
+
+  def toggle_gravatar(email, flag) do
+    change(email, %{gravatar: flag})
   end
 
   def order_emails(emails) do

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -101,6 +101,7 @@ defmodule Hexpm.Accounts.User do
 
   def email(user, :primary), do: user.emails |> Enum.find(& &1.primary) |> email()
   def email(user, :public), do: user.emails |> Enum.find(& &1.public) |> email()
+  def email(user, :gravatar), do: user.emails |> Enum.find(&(&1.gravatar)) |> email()
 
   defp email(nil), do: nil
   defp email(email), do: email.email

--- a/lib/hexpm/web/controllers/dashboard_controller.ex
+++ b/lib/hexpm/web/controllers/dashboard_controller.ex
@@ -106,6 +106,19 @@ defmodule Hexpm.Web.DashboardController do
     end
   end
 
+  def gravatar_email(conn, %{"email" => email} = params) do
+    case Users.gravatar_email(conn.assigns.current_user, params, audit: audit_data(conn)) do
+      :ok ->
+        conn
+        |> put_flash(:info, "Your gravatar email was changed to #{email}.")
+        |> redirect(to: Routes.dashboard_path(conn, :email))
+      {:error, reason} ->
+        conn
+        |> put_flash(:error, email_error_message(reason, email))
+        |> redirect(to: Routes.dashboard_path(conn, :email))
+    end
+  end
+
   def resend_verify_email(conn, %{"email" => email} = params) do
     case Users.resend_verify_email(conn.assigns.current_user, params) do
       :ok ->

--- a/lib/hexpm/web/controllers/user_controller.ex
+++ b/lib/hexpm/web/controllers/user_controller.ex
@@ -11,13 +11,15 @@ defmodule Hexpm.Web.UserController do
         |> Packages.attach_versions()
         |> Enum.sort_by(&[repository_sort(&1.repository), &1.name])
       public_email = User.email(user, :public)
+      gravatar_email = User.email(user, :gravatar)
 
       render(conn, "show.html", [
         title: user.username,
         container: "container page user",
         user: user,
         packages: packages,
-        public_email: public_email
+        public_email: public_email,
+        gravatar_email: gravatar_email
       ])
     else
       not_found(conn)

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -74,6 +74,7 @@ defmodule Hexpm.Web.Router do
     post "/dashboard/email/primary", DashboardController, :primary_email
     post "/dashboard/email/public", DashboardController, :public_email
     post "/dashboard/email/resend", DashboardController, :resend_verify_email
+    post "/dashboard/email/gravatar", DashboardController, :gravatar_email
     get "/dashboard/repos/:dashboard_repo", DashboardController, :repository
     post "/dashboard/repos/:dashboard_repo", DashboardController, :update_repository
     get "/dashboard/signup", DashboardController, :repository_signup

--- a/lib/hexpm/web/templates/dashboard/email.html.eex
+++ b/lib/hexpm/web/templates/dashboard/email.html.eex
@@ -25,6 +25,9 @@
             <%= if email.public do %>
               <span class="label label-success">Public</span>
             <% end %>
+            <%= if email.gravatar do %>
+              <span class="label label-success">Gravatar</span>
+            <% end %>
 
             <%= form_tag(Routes.dashboard_path(Endpoint, :remove_email), method: :delete, class: "action") do %>
               <input type="hidden" name="email" value="<%= email.email %>">
@@ -39,10 +42,18 @@
                 <button type="submit" class="btn btn-primary btn-xs">Set as primary</button>
               <% end %>
             <% end %>
+
             <%= if email.verified and not email.public do %>
               <%= form_tag(Routes.dashboard_path(Endpoint, :public_email), class: "action") do %>
                 <input type="hidden" name="email" value="<%= email.email %>">
                 <button type="submit" class="btn btn-primary btn-xs">Set as public</button>
+              <% end %>
+            <% end %>
+
+            <%= if email.verified and not email.gravatar do %>
+              <%= form_tag(Routes.dashboard_path(Endpoint, :gravatar_email), class: "action") do %>
+                <input type="hidden" name="email" value="<%= email.email %>">
+                <button type="submit" class="btn btn-primary btn-xs">Set as gravatar</button>
               <% end %>
             <% end %>
 

--- a/lib/hexpm/web/templates/dashboard/profile.html.eex
+++ b/lib/hexpm/web/templates/dashboard/profile.html.eex
@@ -41,6 +41,12 @@
             </small>
           </div>
 
+          <div class="form-group">
+            <%= label f, :gravatar_email %>
+            <%= select f, :gravatar_email, gravatar_email_options(@changeset.data), value: gravatar_email_value(@changeset.data) %>
+            <%= error_tag f, :gravatar_email %>
+          </div>
+
           <%= inputs_for f, :handles, fn f -> %>
             <div class="form-group">
               <%= label f, :twitter %>

--- a/lib/hexpm/web/templates/dashboard/profile.html.eex
+++ b/lib/hexpm/web/templates/dashboard/profile.html.eex
@@ -11,15 +11,15 @@
       <div class="panel-body">
         <div class="form-group">
           <label>Profile picture</label>
-          <img src="<%= gravatar_url(User.email(@current_user, :public), :large) %>">
+          <img src="<%= gravatar_url(User.email(@current_user, :gravatar), :large) %>">
           <p>
             <small>
-              <%= if User.email(@current_user, :public) do %>
-                Gravatar is used to display your profile picture, we use your public email address as the Gravatar email.
-                Go to <a href="https://en.gravatar.com/emails/">Gravatar</a> to change the image.
+              <%= if User.email(@current_user, :gravatar) do %>
+                Gravatar is used to display your profile picture. You can choose your Gravatar email below or
+                go to <a href="https://en.gravatar.com/emails/">Gravatar</a> to change the image.
               <% else %>
                 <a href="https://en.gravatar.com/">Gravatar</a> is used to display your profile picture.
-                Choose a public email address below to show your avatar on your profile.
+                Choose a Gravatar email address below to show your avatar on your profile.
               <% end %>
             </small>
           </p>

--- a/lib/hexpm/web/templates/dashboard/repository.html.eex
+++ b/lib/hexpm/web/templates/dashboard/repository.html.eex
@@ -12,7 +12,7 @@
       <ul class="list-group clearfix">
         <%= for repository_user <- @repository.repository_users do %>
           <li class="list-group-item clearfix">
-            <img src="<%= gravatar_url(User.email(repository_user.user, :public), :small) %>" class="member-avatar">
+            <img src="<%= gravatar_url(User.email(repository_user.user, :gravatar), :small) %>" class="member-avatar">
             <a class="member-username" href="<%= Routes.user_path(Endpoint, :show, repository_user.user) %>"><%= repository_user.user.username %></a>
             <div style="float: right">
               <div class="dropdown role-dropdown">

--- a/lib/hexpm/web/templates/layout/header.html.eex
+++ b/lib/hexpm/web/templates/layout/header.html.eex
@@ -76,7 +76,7 @@
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                   <%= @current_user.username %>
-                  <img src="<%= gravatar_url(User.email(@current_user, :public), :small) %>" class="navbar-avatar">
+                  <img src="<%= gravatar_url(User.email(@current_user, :gravatar), :small) %>" class="navbar-avatar">
                   <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">

--- a/lib/hexpm/web/templates/package/show.html.eex
+++ b/lib/hexpm/web/templates/package/show.html.eex
@@ -205,7 +205,7 @@ tools = Keyword.take(tools, compatible_tools)
       <%= for user <- @owners do %>
         <li>
           <a href="<%= Routes.user_path(Endpoint, :show, user) %>">
-            <img src="<%= gravatar_url(User.email(user, :public), :small) %>" class="owner-avatar"><%= user.username %>
+            <img src="<%= gravatar_url(User.email(user, :gravatar), :small) %>" class="owner-avatar"><%= user.username %>
           </a>
         </li>
       <% end %>

--- a/lib/hexpm/web/templates/user/show.html.eex
+++ b/lib/hexpm/web/templates/user/show.html.eex
@@ -18,7 +18,7 @@
   </div>
 
   <div class="col-md-3">
-    <img src="<%= gravatar_url(@public_email, :large) %>" class="avatar">
+    <img src="<%= gravatar_url(@gravatar_email, :large) %>" class="avatar">
 
     <h4><%= @user.full_name %></h4>
     <ul class="user-profile-list">

--- a/lib/hexpm/web/views/dashboard_view.ex
+++ b/lib/hexpm/web/views/dashboard_view.ex
@@ -35,6 +35,19 @@ defmodule Hexpm.Web.DashboardView do
     User.email(user, :public) || "none"
   end
 
+  def gravatar_email_options(user) do
+    emails =
+      user.emails
+      |> Enum.filter(&(&1.verified))
+      |> Enum.map(&{&1.email, &1.email})
+
+    [{"Don't show an avatar", "none"}] ++ emails
+  end
+
+  def gravatar_email_value(user) do
+    User.email(user, :gravatar) || "none"
+  end
+
   defp repository_roles_selector() do
     Enum.map(repository_roles(), fn {name, id, _title} ->
       {name, id}

--- a/priv/repo/migrations/20171201141936_add_gravatar_to_emails.exs
+++ b/priv/repo/migrations/20171201141936_add_gravatar_to_emails.exs
@@ -1,0 +1,21 @@
+defmodule Hexpm.Repo.Migrations.AddGravatarToEmails do
+  use Ecto.Migration
+
+  def up do
+    alter table(:emails) do
+      add :gravatar, :boolean, default: false, null: false
+    end
+
+    execute """
+      UPDATE emails
+      SET gravatar = true
+      WHERE public
+    """
+  end
+
+  def down do
+    alter table(:emails) do
+      remove :gravatar
+    end
+  end
+end

--- a/test/hexpm/web/controllers/dashboard_controller_test.exs
+++ b/test/hexpm/web/controllers/dashboard_controller_test.exs
@@ -310,7 +310,7 @@ defmodule Hexpm.Web.DashboardControllerTest do
 
   test "unknown email cannot be gravatar email", c do
     email = Enum.find(c.user.emails, &(&1.email == "eric@mail.com"))
-    Hexpm.Accounts.Email.toggle_gravatar(email, true) |> Hexpm.Repo.update
+    Hexpm.Accounts.Email.toggle_flag(email, :gravatar, true) |> Hexpm.Repo.update
     conn =
       build_conn()
       |> test_login(c.user)

--- a/test/hexpm/web/controllers/dashboard_controller_test.exs
+++ b/test/hexpm/web/controllers/dashboard_controller_test.exs
@@ -310,7 +310,7 @@ defmodule Hexpm.Web.DashboardControllerTest do
 
   test "unknown email cannot be gravatar email", c do
     email = Enum.find(c.user.emails, &(&1.email == "eric@mail.com"))
-    Hexpm.Accounts.Email.toggle_flag(email, :gravatar, true) |> Hexpm.Repo.update
+    Hexpm.Accounts.Email.toggle_flag(email, :gravatar, true) |> Hexpm.Repo.update!
     conn =
       build_conn()
       |> test_login(c.user)

--- a/test/hexpm/web/views/dashboard_view_test.exs
+++ b/test/hexpm/web/views/dashboard_view_test.exs
@@ -1,0 +1,42 @@
+defmodule Hexpm.Web.DashboardViewTest do
+  use Hexpm.ConnCase, async: true
+
+  alias Hexpm.Web.DashboardView
+
+  test "shows verified emails as gravatar options" do
+    verified_email = build(:email, email: "verified@mail.com", verified: true)
+    unverified_email = build(:email, email: "unverified@mail.com", verified: false)
+    user = %{
+      emails: [verified_email, unverified_email]
+    }
+
+    emails = DashboardView.gravatar_email_options(user)
+
+    assert emails == [
+      {"Don't show an avatar", "none"},
+      {"verified@mail.com", "verified@mail.com"}
+    ]
+  end
+
+  test "returns gravatar email as value" do
+    gravatar_email = build(:email, gravatar: true)
+    other_email = build(:email, gravatar: false)
+    user = %{
+      emails: [gravatar_email, other_email]
+    }
+
+    email = DashboardView.gravatar_email_value(user)
+
+    assert email == gravatar_email.email
+  end
+
+  test "returns 'none' if gravatar email is not set" do
+    user = %{
+      emails: [build(:email, gravatar: false)]
+    }
+
+    email = DashboardView.gravatar_email_value(user)
+
+    assert email == "none"
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,7 +18,8 @@ defmodule Hexpm.Factory do
       email: Fake.sequence(:email),
       verified: true,
       primary: true,
-      public: true
+      public: true,
+      gravatar: true
     }
   end
 


### PR DESCRIPTION
This PR implements  #586. 

I am quite new to elixir and hexpm project, so it is quite possible that some things can be implemented in better way. 

Emails table migration sets user's primary email as her Gravatar email. Is that correct? I know that at the moment public email is used, but based on db schema multiple public emails can exist per users, so it's harder to write generic migration using public email. I would welcome any suggestion how to solve that.

If you have any questions, please don't hesitate to ask. :smile: 