### PR TITLE
Fix navbar layout on Firefox for Android

### DIFF
--- a/assets/css/template/_navbar.scss
+++ b/assets/css/template/_navbar.scss
@@ -125,6 +125,6 @@
 }
 
 .navbar-brand {
-  height: auto;
   max-width: 100px;
+  height: auto;
 }

--- a/assets/css/template/_navbar.scss
+++ b/assets/css/template/_navbar.scss
@@ -125,6 +125,6 @@
 }
 
 .navbar-brand {
-  max-width: 100px;
+  max-width: 120px;
   height: auto;
 }

--- a/assets/css/template/_navbar.scss
+++ b/assets/css/template/_navbar.scss
@@ -123,3 +123,8 @@
 .navbar-toggle {
   margin-top: 20px;
 }
+
+.navbar-brand {
+  height: auto;
+  max-width: 100px;
+}


### PR DESCRIPTION
Fix layout issue ( #596 ) encountered with the latest version of Firefox for Android. 

More precisely, this commit sets explicit sizing for the logo element, preventing it from breaking the float-based layout when Firefox sets an incorrectly large width for the logo element.

Additionally, this commit fixes a small vertical misalignment of the logo that is visible on both iOS and Android based devices. By explicitly setting the logo element height to auto, we ensure that the navbar is correctly sized based on the real logo height (or more specifically, the link wrapper around the logo). This is essentially a few pixels of visible change, most prevalent when the navigation dropdown is toggled open.

This has been tested on various mobile- and desktop devices (Chrome, Firefox, Safari on Android & iOS, and same for desktop) with no regressions of any kind.