### PR TITLE
Cleans up UI of retirement message on package show page

### DIFF
--- a/lib/hexpm/web/views/package_view.ex
+++ b/lib/hexpm/web/views/package_view.ex
@@ -114,27 +114,31 @@ defmodule Hexpm.Web.PackageView do
   end
 
   def retirement_message(retirement) do
+    reason = ReleaseRetirement.reason_text(retirement.reason)
     ["Retired package"] ++
       cond do
-        ReleaseRetirement.reason_text(retirement.reason) && retirement.message ->
-          ["; reason: ", ReleaseRetirement.reason_text(retirement.reason), " - ", retirement.message]
-        ReleaseRetirement.reason_text(retirement.reason) ->
-          ["; reason: ", ReleaseRetirement.reason_text(retirement.reason)]
+        reason && retirement.message ->
+          ["; reason: ", reason, " - ", retirement.message]
+        reason ->
+          ["; reason: ", reason]
         retirement.message ->
           ["; reason: ", retirement.message]
-        true -> []
+        true ->
+          []
       end
   end
 
   def retirement_html(retirement) do
+    reason = ReleaseRetirement.reason_text(retirement.reason)
     cond do
-      ReleaseRetirement.reason_text(retirement.reason) && retirement.message ->
-        [content_tag(:strong, "Retired package;"), " reason: ", ReleaseRetirement.reason_text(retirement.reason), " - ", retirement.message]
-      ReleaseRetirement.reason_text(retirement.reason) ->
-        [content_tag(:strong, "Retired package;"), " reason: ", ReleaseRetirement.reason_text(retirement.reason)]
+      reason && retirement.message ->
+        [content_tag(:strong, "Retired package;"), " reason: ", reason, " - ", retirement.message]
+      reason ->
+        [content_tag(:strong, "Retired package;"), " reason: ", reason]
       retirement.message ->
         [content_tag(:strong, "Retired package;"), " reason: ", retirement.message]
-      true -> [content_tag(:strong, "Retired package")]
+      true ->
+        [content_tag(:strong, "Retired package")]
     end
   end
 end

--- a/lib/hexpm/web/views/package_view.ex
+++ b/lib/hexpm/web/views/package_view.ex
@@ -114,12 +114,27 @@ defmodule Hexpm.Web.PackageView do
   end
 
   def retirement_message(retirement) do
-    [ReleaseRetirement.reason_text(retirement.reason)] ++
-      if(retirement.message, do: [": ", retirement.message], else: [])
+    ["Retired package"] ++
+      cond do
+        ReleaseRetirement.reason_text(retirement.reason) && retirement.message ->
+          ["; reason: ", ReleaseRetirement.reason_text(retirement.reason), " - ", retirement.message]
+        ReleaseRetirement.reason_text(retirement.reason) ->
+          ["; reason: ", ReleaseRetirement.reason_text(retirement.reason)]
+        retirement.message ->
+          ["; reason: ", retirement.message]
+        true -> []
+      end
   end
 
   def retirement_html(retirement) do
-    [content_tag(:strong, ReleaseRetirement.reason_text(retirement.reason))] ++
-      if(retirement.message, do: [": ", retirement.message], else: [])
+    cond do
+      ReleaseRetirement.reason_text(retirement.reason) && retirement.message ->
+        [content_tag(:strong, "Retired package;"), " reason: ", ReleaseRetirement.reason_text(retirement.reason), " - ", retirement.message]
+      ReleaseRetirement.reason_text(retirement.reason) ->
+        [content_tag(:strong, "Retired package;"), " reason: ", ReleaseRetirement.reason_text(retirement.reason)]
+      retirement.message ->
+        [content_tag(:strong, "Retired package;"), " reason: ", retirement.message]
+      true -> [content_tag(:strong, "Retired package")]
+    end
   end
 end

--- a/test/hexpm/web/views/package_view_test.exs
+++ b/test/hexpm/web/views/package_view_test.exs
@@ -3,6 +3,10 @@ defmodule Hexpm.Web.PackageViewTest do
 
   alias Hexpm.Web.PackageView
 
+  defp parse_html_list_to_string(html_map) do
+    Enum.map_join(html_map, fn(x) -> if is_tuple(x), do: Phoenix.HTML.safe_to_string(x), else: x end)
+  end
+
   test "show sort info" do
     assert PackageView.show_sort_info(:name) == "(Sorted by name)"
     assert PackageView.show_sort_info(:inserted_at) == "(Sorted by recently created)"
@@ -131,27 +135,23 @@ defmodule Hexpm.Web.PackageViewTest do
 
   describe "retirement_html/1" do
     test "reason is 'other', message contains text" do
-      retirement = %{reason: "other", message: "something went terribly wrong"}
-      assert PackageView.retirement_html(retirement) ==
-        [{:safe, [60, "strong", [], 62, "Retired package;", 60, 47, "strong", 62]}, " reason: ", "something went terribly wrong"]
+      retirement = PackageView.retirement_html(%{reason: "other", message: "something went terribly wrong"})
+      assert parse_html_list_to_string(retirement) == "<strong>Retired package;</strong> reason: something went terribly wrong"
     end
 
     test "reason is 'other', message is empty" do
-      retirement = %{reason: "other", message: nil}
-      assert PackageView.retirement_html(retirement) ==
-        [safe: [60, "strong", [], 62, "Retired package", 60, 47, "strong", 62]]
+      retirement = PackageView.retirement_html(%{reason: "other", message: nil})
+      assert parse_html_list_to_string(retirement) == "<strong>Retired package</strong>"
     end
 
     test "reason is not 'other', message contains text" do
-      retirement = %{reason: "security", message: "something went terribly wrong"}
-      assert PackageView.retirement_html(retirement) ==
-        [{:safe, [60, "strong", [], 62, "Retired package;", 60, 47, "strong", 62]}, " reason: ", "Security issue", " - ", "something went terribly wrong"]
+      retirement = PackageView.retirement_html(%{reason: "security", message: "something went terribly wrong"})
+      assert parse_html_list_to_string(retirement) == "<strong>Retired package;</strong> reason: Security issue - something went terribly wrong"
     end
 
     test "reason is not 'other', message is empty" do
-      retirement = %{reason: "security", message: nil}
-      assert PackageView.retirement_html(retirement) ==
-        [{:safe, [60, "strong", [], 62, "Retired package;", 60, 47, "strong", 62]}, " reason: ", "Security issue"]
+      retirement = PackageView.retirement_html(%{reason: "security", message: nil})
+      assert parse_html_list_to_string(retirement) == "<strong>Retired package;</strong> reason: Security issue"
     end
   end
 end

--- a/test/hexpm/web/views/package_view_test.exs
+++ b/test/hexpm/web/views/package_view_test.exs
@@ -107,4 +107,51 @@ defmodule Hexpm.Web.PackageViewTest do
     assert PackageView.snippet_version(:erlang_mk, version3) == "2.0.2"
   end
 
+  describe "retirement_message/1" do
+    test "reason is 'other', message contains text" do
+      retirement = %{reason: "other", message: "something went terribly wrong"}
+      assert PackageView.retirement_message(retirement) == ["Retired package", "; reason: ", "something went terribly wrong"]
+    end
+
+    test "reason is 'other', message is empty" do
+      retirement = %{reason: "other", message: nil}
+      assert PackageView.retirement_message(retirement) == ["Retired package"]
+    end
+
+    test "reason is not 'other', message contains text" do
+      retirement = %{reason: "security", message: "something went terribly wrong"}
+      assert PackageView.retirement_message(retirement) == ["Retired package", "; reason: ", "Security issue", " - ", "something went terribly wrong"]
+    end
+
+    test "reason is not 'other', message is empty" do
+      retirement = %{reason: "security", message: nil}
+      assert PackageView.retirement_message(retirement) == ["Retired package", "; reason: ", "Security issue"]
+    end
+  end
+
+  describe "retirement_html/1" do
+    test "reason is 'other', message contains text" do
+      retirement = %{reason: "other", message: "something went terribly wrong"}
+      assert PackageView.retirement_html(retirement) ==
+        [{:safe, [60, "strong", [], 62, "Retired package;", 60, 47, "strong", 62]}, " reason: ", "something went terribly wrong"]
+    end
+
+    test "reason is 'other', message is empty" do
+      retirement = %{reason: "other", message: nil}
+      assert PackageView.retirement_html(retirement) ==
+        [safe: [60, "strong", [], 62, "Retired package", 60, 47, "strong", 62]]
+    end
+
+    test "reason is not 'other', message contains text" do
+      retirement = %{reason: "security", message: "something went terribly wrong"}
+      assert PackageView.retirement_html(retirement) ==
+        [{:safe, [60, "strong", [], 62, "Retired package;", 60, 47, "strong", 62]}, " reason: ", "Security issue", " - ", "something went terribly wrong"]
+    end
+
+    test "reason is not 'other', message is empty" do
+      retirement = %{reason: "security", message: nil}
+      assert PackageView.retirement_html(retirement) ==
+        [{:safe, [60, "strong", [], 62, "Retired package;", 60, 47, "strong", 62]}, " reason: ", "Security issue"]
+    end
+  end
 end


### PR DESCRIPTION
This removes the alert box entirely if the reason is "other" and there is no message included.
It also removes the lead ": " when the reason is "other" and a message exists.