### PR TITLE
Add repository to /api/users/me endpoint

### DIFF
--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -17,10 +17,7 @@ defmodule Hexpm.Accounts.Users do
   end
 
   def put_repositories(user) do
-    repositories =
-      user.repositories
-      |> Map.new(&{&1.id, &1})
-      |> Map.put(1, Repository.hexpm())
+    repositories = Map.new(user.repositories, &{&1.id, &1})
     %{user | owned_packages: Enum.map(user.owned_packages, &%{&1 | repository: repositories[&1.repository_id]})}
   end
 

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -17,7 +17,10 @@ defmodule Hexpm.Accounts.Users do
   end
 
   def put_repositories(user) do
-    repositories = Map.new(user.repositories, &{&1.id, &1})
+    repositories =
+      user.repositories
+      |> Map.new(&{&1.id, &1})
+      |> Map.put(1, Repository.hexpm())
     %{user | owned_packages: Enum.map(user.owned_packages, &%{&1 | repository: repositories[&1.repository_id]})}
   end
 

--- a/lib/hexpm/web/views/api/user_view.ex
+++ b/lib/hexpm/web/views/api/user_view.ex
@@ -58,11 +58,15 @@ defmodule Hexpm.Web.API.UserView do
     Enum.map(packages, fn package ->
       %{
         name: package.name,
+        repository: repository_name(package),
         url: url_for_package(package),
         html_url: html_url_for_package(package)
       }
     end)
   end
+
+  defp repository_name(%Package{repository_id: 1}), do: "hexpm"
+  defp repository_name(%Package{repository: %{name: name}}), do: name
 
   defp organizations(user) do
     Enum.map(user.repository_users, fn ru ->

--- a/lib/hexpm/web/views/api/user_view.ex
+++ b/lib/hexpm/web/views/api/user_view.ex
@@ -58,15 +58,12 @@ defmodule Hexpm.Web.API.UserView do
     Enum.map(packages, fn package ->
       %{
         name: package.name,
-        repository: repository_name(package),
+        repository: package.repository.name,
         url: url_for_package(package),
         html_url: html_url_for_package(package)
       }
     end)
   end
-
-  defp repository_name(%Package{repository_id: 1}), do: "hexpm"
-  defp repository_name(%Package{repository: %{name: name}}), do: name
 
   defp organizations(user) do
     Enum.map(user.repository_users, fn ru ->

--- a/lib/hexpm/web/views/api/user_view.ex
+++ b/lib/hexpm/web/views/api/user_view.ex
@@ -58,12 +58,15 @@ defmodule Hexpm.Web.API.UserView do
     Enum.map(packages, fn package ->
       %{
         name: package.name,
-        repository: package.repository.name,
+        repository: repository_name(package),
         url: url_for_package(package),
         html_url: html_url_for_package(package)
       }
     end)
   end
+
+  defp repository_name(%Package{repository_id: 1}), do: "hexpm"
+  defp repository_name(%Package{repository: %{name: name}}), do: name
 
   defp organizations(user) do
     Enum.map(user.repository_users, fn ru ->

--- a/test/hexpm/web/controllers/api/user_controller_test.exs
+++ b/test/hexpm/web/controllers/api/user_controller_test.exs
@@ -80,8 +80,10 @@ defmodule Hexpm.Web.API.UserControllerTest do
       assert [json1, json2] = body["packages"]
       assert json1["url"] =~ "/api/packages/#{package1.name}"
       assert json1["html_url"] =~ "/packages/#{package1.name}"
+      assert json1["repository"] =~ "hexpm"
       assert json2["url"] =~ "/api/repos/#{repository.name}/packages/#{package2.name}"
       assert json2["html_url"] =~ "/packages/#{repository.name}/#{package2.name}"
+      assert json2["repository"] =~ repository.name
 
       # TODO: deprecated
       assert Enum.count(body["owned_packages"]) == 2


### PR DESCRIPTION
Need it for `mix hex.owner packages` to display `<repo>/<name>` for private packages.

1. Need also to add it to http api spec, this would be an optional field
2. I wonder if we should call it `repository` or maybe `organization`.