### PR TITLE
Use configurable hex docs URL instead of hardcoded one

### DIFF
--- a/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <%= for {name, docs_updated_at} <- @packages do %>
     <url>
-      <loc>https://hexdocs.pm/<%= name %>/</loc>
+      <loc><%= raw Hexpm.Utils.docs_url([name]) %></loc>
       <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %>Z</lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>


### PR DESCRIPTION
Without this change it's not possible to setup local version of hex.pm and hexdocs.pm