### PR TITLE
Configurable docs html url

### DIFF
--- a/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <%= for {name, docs_updated_at} <- @packages do %>
     <url>
-      <loc><%= raw Hexpm.Utils.docs_url([name]) %></loc>
+      <loc><%= raw Hexpm.Utils.docs_html_url([name]) %></loc>
       <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %>Z</lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>

--- a/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <%= for {name, docs_updated_at} <- @packages do %>
     <url>
-      <loc><%= raw Hexpm.Utils.docs_html_url([name]) %></loc>
+      <loc><%= Hexpm.Utils.docs_html_url([name]) %></loc>
       <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %>Z</lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>

--- a/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <%= for {name, docs_updated_at} <- @packages do %>
     <url>
-      <loc>https://hexdocs.pm/<%= name %>/</loc>
+      <loc><%= raw Hexpm.Utils.docs_url([name]) %></loc>
       <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %>Z</lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>

--- a/test/hexpm/web/controllers/api/docs_controller_test.exs
+++ b/test/hexpm/web/controllers/api/docs_controller_test.exs
@@ -35,7 +35,7 @@ defmodule Hexpm.Web.API.DocsControllerTest do
 
       assert path("docs/#{package.name}/index.html") == "package v0.0.1"
       assert path("docs/#{package.name}/0.0.1/index.html") == "package v0.0.1"
-      assert path("docs/sitemap.xml") =~ "https://hexdocs.pm/#{package.name}"
+      assert path("docs/sitemap.xml") =~ Hexpm.Utils.docs_html_url([package.name])
     end
 
     test "update main docs", %{user: user} do


### PR DESCRIPTION
Without this change it's not possible to setup local version of hex.pm and hexdocs.pm