### PR TITLE
Set content-encoding:gzip for registry files

### DIFF
--- a/lib/hexpm/repository/registry_builder.ex
+++ b/lib/hexpm/repository/registry_builder.ex
@@ -304,7 +304,7 @@ defmodule Hexpm.Repository.RegistryBuilder do
         " " <> repository_cdn_key(repository, "registry-index")
 
     meta = [{"surrogate-key", surrogate_key}]
-    opts = [cache_control: "public, max-age=600", meta: meta]
+    opts = [cache_control: "public, max-age=600", content_encoding: "gzip", meta: meta]
     index_opts = Keyword.put(opts, :meta, meta)
 
     names_object = {repository_store_key(repository, "names"), names, index_opts}


### PR DESCRIPTION
It's missing but the files are gzipped:

    curl --head https://repo.hex.pm/names
    HTTP/2 200
    date: Fri, 09 Mar 2018 18:20:47 GMT
    x-amz-id-2: Q3cU5vPuyhneVqNwCYEWQuJTvb6EBaJ4Cg+t0GgtJUMTSGs7SmM3gsOA7rmHonh7sCWOt71LxKw=
    x-amz-request-id: 7CA3160DC01987B3
    x-amz-replication-status: COMPLETED
    last-modified: Fri, 09 Mar 2018 18:13:38 GMT
    etag: "352d451d45c5b49783df72a98071cf0c"
    cache-control: public, max-age=600
    x-amz-meta-surrogate-key: registry registry-index
    x-amz-version-id: NymPrDojZzfIkBDg2LlOcchjwJvKKaYe
    content-type: application/octet-stream
    server: AmazonS3
    accept-ranges: bytes
    via: 1.1 varnish
    age: 22
    x-served-by: cache-hhn1529-HHN
    x-cache: HIT
    x-cache-hits: 1
    x-timer: S1520619647.156614,VS0,VE7
    content-length: 32844