### PR TITLE
Add read/write API keys

### DIFF
--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -126,8 +126,11 @@ defmodule Hexpm.Accounts.Key do
     end
   end
 
-  def verify_permissions?(key, "api", _resource) do
-    Enum.any?(key.permissions, &(&1.domain == "api"))
+  def verify_permissions?(key, "api", resource) do
+    Enum.any?(key.permissions, fn permission ->
+      permission.domain == "api" and
+        (is_nil(permission.resource) or permission.resource == resource)
+    end)
   end
 
   def verify_permissions?(key, "repository", resource) do

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -132,7 +132,7 @@ defmodule Hexpm.Accounts.Key do
         (is_nil(permission.resource) or permission.resource == resource)
     end)
   end
-  
+
   def verify_permissions?(key, "repositories", _resource) do
     Enum.any?(key.permissions, &(&1.domain == "repositories"))
   end

--- a/lib/hexpm/accounts/key_permission.ex
+++ b/lib/hexpm/accounts/key_permission.ex
@@ -33,12 +33,11 @@ defmodule Hexpm.Accounts.KeyPermission do
 
   defp validate_resource(changeset) do
     validate_change(changeset, :resource, fn _, resource ->
-      domain = get_change(changeset, :domain)
-
-      cond do
-        !domain -> []
-        domain in ["api", "repositories"] and is_nil(resource) -> []
-        domain == "repository" and is_binary(resource) -> []
+      case get_change(changeset, :domain) do
+        nil -> []
+        "api" when resource in [nil, "read", "write"] -> []
+        "repository" when is_binary(resource) -> []
+        "repositories" when is_nil(resource) -> []
         true -> [resource: "invalid resource for given domain"]
       end
     end)

--- a/lib/hexpm/web/controllers/api/docs_controller.ex
+++ b/lib/hexpm/web/controllers/api/docs_controller.ex
@@ -2,11 +2,17 @@ defmodule Hexpm.Web.API.DocsController do
   use Hexpm.Web, :controller
 
   plug :fetch_release
-  plug :maybe_authorize, [domain: "api", fun: &repository_access/2] when action in [:show]
-  plug :authorize, [domain: "api", fun: &package_owner/2] when action in [:create, :delete]
+
+  plug :maybe_authorize,
+       [
+         domain: "api",
+         resource: "read",
+         fun: [&repository_access/2, &repository_billing_active/2]
+       ]
+       when action in [:show]
 
   plug :authorize,
-       [domain: "api", fun: &repository_billing_active/2]
+       [domain: "api", resource: "write", fun: [&package_owner/2, &repository_billing_active/2]]
        when action in [:create, :delete]
 
   def show(conn, _params) do

--- a/lib/hexpm/web/controllers/api/key_controller.ex
+++ b/lib/hexpm/web/controllers/api/key_controller.ex
@@ -1,9 +1,14 @@
 defmodule Hexpm.Web.API.KeyController do
   use Hexpm.Web, :controller
 
-  plug :authorize, [domain: "api"] when action != :create
-  plug :authorize, [domain: "api", allow_unconfirmed: true] when action == :create
+  plug :authorize,
+       [domain: "api", resource: "write", allow_unconfirmed: true]
+       when action == :create
 
+  plug :authorize, [domain: "api", resource: "write"] when action in [:delete, :delete_all]
+  plug :authorize, [domain: "api", resource: "read"] when action in [:index, :show]
+
+  # TODO: Add filtering on domain and resource
   def index(conn, _params) do
     user = conn.assigns.current_user
     authing_key = conn.assigns.key

--- a/lib/hexpm/web/controllers/api/owner_controller.ex
+++ b/lib/hexpm/web/controllers/api/owner_controller.ex
@@ -2,11 +2,18 @@ defmodule Hexpm.Web.API.OwnerController do
   use Hexpm.Web, :controller
 
   plug :maybe_fetch_package
-  plug :authorize, [domain: "api", fun: &repository_access/2] when action in [:index, :show]
-  plug :authorize, [domain: "api", fun: &maybe_package_owner/2] when action in [:create, :delete]
 
   plug :authorize,
-       [domain: "api", fun: &repository_billing_active/2] when action in [:create, :delete]
+       [domain: "api", resource: "read", fun: &repository_access/2]
+       when action in [:index, :show]
+
+  plug :authorize,
+       [
+         domain: "api",
+         resource: "write",
+         fun: [&maybe_package_owner/2, &repository_billing_active/2]
+       ]
+       when action in [:create, :delete]
 
   def index(conn, _params) do
     if package = conn.assigns.package do

--- a/lib/hexpm/web/controllers/api/package_controller.ex
+++ b/lib/hexpm/web/controllers/api/package_controller.ex
@@ -3,8 +3,14 @@ defmodule Hexpm.Web.API.PackageController do
 
   plug :fetch_repository when action in [:index]
   plug :maybe_fetch_package when action in [:show]
-  plug :maybe_authorize, [domain: "api", fun: &maybe_repository_access/2] when action in [:index]
-  plug :maybe_authorize, [domain: "api", fun: &repository_access/2] when action in [:show]
+
+  plug :maybe_authorize,
+       [domain: "api", resource: "read", fun: &maybe_repository_access/2]
+       when action in [:index]
+
+  plug :maybe_authorize,
+       [domain: "api", resource: "read", fun: &repository_access/2]
+       when action in [:show]
 
   @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
 

--- a/lib/hexpm/web/controllers/api/repository_controller.ex
+++ b/lib/hexpm/web/controllers/api/repository_controller.ex
@@ -2,8 +2,11 @@ defmodule Hexpm.Web.API.RepositoryController do
   use Hexpm.Web, :controller
 
   plug :fetch_repository when action in [:show]
-  plug :maybe_authorize, [domain: "api"] when action in [:index]
-  plug :maybe_authorize, [domain: "api", fun: &repository_access/2] when action in [:show]
+  plug :maybe_authorize, [domain: "api", resource: "read"] when action in [:index]
+
+  plug :maybe_authorize,
+       [domain: "api", resource: "read", fun: &repository_access/2]
+       when action in [:show]
 
   def index(conn, _params) do
     repositories = Repositories.all_public() ++ all_by_user(conn.assigns.current_user)

--- a/lib/hexpm/web/controllers/api/retirement_controller.ex
+++ b/lib/hexpm/web/controllers/api/retirement_controller.ex
@@ -2,7 +2,10 @@ defmodule Hexpm.Web.API.RetirementController do
   use Hexpm.Web, :controller
 
   plug :maybe_fetch_release when action in [:create, :delete]
-  plug :authorize, [domain: "api", fun: &maybe_package_owner/2] when action in [:create, :delete]
+
+  plug :authorize,
+       [domain: "api", resource: "write", fun: &maybe_package_owner/2]
+       when action in [:create, :delete]
 
   def create(conn, params) do
     package = conn.assigns.package

--- a/lib/hexpm/web/controllers/api/user_controller.ex
+++ b/lib/hexpm/web/controllers/api/user_controller.ex
@@ -1,8 +1,8 @@
 defmodule Hexpm.Web.API.UserController do
   use Hexpm.Web, :controller
 
-  plug :authorize, [domain: "api"] when action in [:test]
-  plug :authorize, [domain: "api"] when action in [:me]
+  plug :authorize, [domain: "api", resource: "read"] when action in [:test]
+  plug :authorize, [domain: "api", resource: "read"] when action in [:me]
 
   def create(conn, params) do
     params = email_param(params)

--- a/test/hexpm/web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm/web/controllers/api/auth_controller_test.exs
@@ -109,7 +109,47 @@ defmodule Hexpm.Web.API.AuthControllerTest do
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api", resource: "read")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api", resource: "write")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
       |> get("api/auth", domain: "repository", resource: "myrepo")
+      |> response(401)
+    end
+
+    test "authenticate read api key", %{user: user} do
+      permission = build(:key_permission, domain: "api", resource: "read")
+      key = insert(:key, user: user, permissions: [permission])
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api", resource: "read")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api", resource: "write")
+      |> response(401)
+    end
+
+    test "authenticate write api key", %{user: user} do
+      permission = build(:key_permission, domain: "api", resource: "write")
+      key = insert(:key, user: user, permissions: [permission])
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api", resource: "write")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> get("api/auth", domain: "api", resource: "read")
       |> response(401)
     end
 


### PR DESCRIPTION
This is in preparation for authentication improvements in the Hex client. Currently we have one encrypted API key and one unencrypted repository key for each organization. This has some downsides, you have to input your local password when running tasks such as `mix hex.search` and `mix hex.docs fetch`. You also have to reauthenticate when you are added to a new organization and we generate lots of keys if you are member of many organizations.

To solve these problems we will store two keys on the client when authenticating. One encrypted key with `api:write` and `api:read` permission and one unencrypted key with permissions `api:read` and `repositories`.

The `repositories` key is already implemented, this PR adds the final requirements on the server to start on the client.