### PR TITLE
[#651] Applies new design for error page

### DIFF
--- a/assets/css/template/_error.scss
+++ b/assets/css/template/_error.scss
@@ -3,9 +3,16 @@
   margin-bottom: 100px;
 
   h1 {
-    margin-bottom: 30px;
-    font-size: 140px;
+    font-size: 300px;
     font-weight: bold;
+    line-height: 280px;
+    color: #5c676d;
+    text-align: center;
+
+    @media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
+      font-size: 150px;
+      line-height: 150px;
+    }
   }
 
   .letter_1 {
@@ -20,8 +27,30 @@
     color: #89b551;
   }
 
+  .call-to-action {
+    display: block;
+    font-size: 70px;
+    font-weight: bold;
+    line-height: 100px;
+    color: #000;
+    text-align: center;
+
+    @media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
+      font-size: 50px;
+      line-height: 100px;
+    }
+  }
+
   .message {
-    font-size: 100px;
-    color: $color-text-grey;
+    display: block;
+    font-size: 30px;
+    font-weight: 100;
+    color: #4b4b4c;
+    text-align: center;
+
+    @media only screen and (min-device-width : 320px) and (max-device-width : 480px) {
+      font-size: 30px;
+      line-height: 40px;
+    }
   }
 }

--- a/lib/hexpm/web/templates/error/all.html.eex
+++ b/lib/hexpm/web/templates/error/all.html.eex
@@ -1,4 +1,5 @@
-<%= render(Hexpm.Web.LayoutView, "header.html", assigns) %>
-<h1><%= @status %></h1>
-<span class="message"><%= @message %></span>
+<%= render(Hexpm.Web.LayoutView, "simple-header.html", assigns) %>
+  <h1><%= @status %></h1>
+  <span class="call-to-action">Whoops!</span>
+  <span class="message"><%= @message %></span>
 <%= render(Hexpm.Web.LayoutView, "footer.html", assigns) %>

--- a/lib/hexpm/web/templates/layout/simple-header.html.eex
+++ b/lib/hexpm/web/templates/layout/simple-header.html.eex
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en" prefix="og: http://ogp.me/ns#">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="<%= description(assigns) %>">
+
+    <title><%= title(assigns) %></title>
+
+    <%= og_tags(assigns) %>
+
+    <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="/hexsearch.xml">
+    <link rel="stylesheet" href="<%= Routes.static_path(Endpoint, "/css/app.css") %>">
+    <link rel="shortcut icon" href="<%= Routes.static_path(Endpoint, "/favicon.png") %>">
+  </head>
+  <body>
+    <!--[if lt IE 10]>
+      <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+    <![endif]-->
+
+    <nav class="navbar navbar-default navbar-fixed-top">
+      <div class="container">
+        <div class="navbar-header">
+          <a class="navbar-brand" href="/">
+            <img src="<%= Routes.static_path(Endpoint, "/images/hex.png") %>" srcset="<%= Routes.static_path(Endpoint, "/images/hex.png") %> 1x, <%= Routes.static_path(Endpoint, "/images/hex@2.png") %> 2x, <%= Routes.static_path(Endpoint, "/images/hex@3.png") %> 3x" alt="hex logo">
+          </a>
+        </div>
+      </div>
+    </nav>
+
+    <div class="<%= container_class(assigns) %>">


### PR DESCRIPTION
Fixes #651

General Mobile view:
<img width="413" alt="screen shot 2018-04-14 at 11 41 10 am" src="https://user-images.githubusercontent.com/301291/38771483-d926396a-3fd8-11e8-8bad-5ffe790b2286.png">
Fixes #651

Desktop + Tablet view
<img width="1920" alt="screen shot 2018-04-14 at 11 41 28 am" src="https://user-images.githubusercontent.com/301291/38771487-e6113f08-3fd8-11e8-91a2-5665f8667e1a.png">
