### PR TITLE
List User API keys on the web

### DIFF
--- a/assets/css/template/_dashboard.scss
+++ b/assets/css/template/_dashboard.scss
@@ -10,9 +10,19 @@
   margin-top: 20px;
 }
 
-table, th, td {
-  border: 1px solid black;
+table {
   padding: 15px;
+  border: 1px solid #000000;
+}
+
+th {
+  padding: 15px;
+  border: 1px solid #000000;
+}
+
+td {
+  padding: 15px;
+  border: 1px solid #000000;
 }
 
 .dashboard .sidebar .list-group-item {

--- a/assets/css/template/_dashboard.scss
+++ b/assets/css/template/_dashboard.scss
@@ -10,18 +10,6 @@
   margin-top: 20px;
 }
 
-table {
-  padding: 15px;
-}
-
-th {
-  padding: 15px;
-}
-
-td {
-  padding: 15px;
-}
-
 .dashboard .sidebar .list-group-item {
   font-weight: 400;
 

--- a/assets/css/template/_dashboard.scss
+++ b/assets/css/template/_dashboard.scss
@@ -12,17 +12,17 @@
 
 table {
   padding: 15px;
-  border: 1px solid #000000;
+  border: 1px solid #000;
 }
 
 th {
   padding: 15px;
-  border: 1px solid #000000;
+  border: 1px solid #000;
 }
 
 td {
   padding: 15px;
-  border: 1px solid #000000;
+  border: 1px solid #000;
 }
 
 .dashboard .sidebar .list-group-item {

--- a/assets/css/template/_dashboard.scss
+++ b/assets/css/template/_dashboard.scss
@@ -12,17 +12,14 @@
 
 table {
   padding: 15px;
-  border: 1px solid #000;
 }
 
 th {
   padding: 15px;
-  border: 1px solid #000;
 }
 
 td {
   padding: 15px;
-  border: 1px solid #000;
 }
 
 .dashboard .sidebar .list-group-item {

--- a/assets/css/template/_dashboard.scss
+++ b/assets/css/template/_dashboard.scss
@@ -10,6 +10,11 @@
   margin-top: 20px;
 }
 
+table, th, td {
+  border: 1px solid black;
+  padding: 15px;
+}
+
 .dashboard .sidebar .list-group-item {
   font-weight: 400;
 

--- a/lib/hexpm/web/controllers/dashboard_controller.ex
+++ b/lib/hexpm/web/controllers/dashboard_controller.ex
@@ -32,8 +32,7 @@ defmodule Hexpm.Web.DashboardController do
     user = conn.assigns.current_user
     keys = Keys.all(user)
 
-    conn
-    |> render_keys(keys)
+    render_keys(conn, keys)
   end
 
   def password(conn, _params) do

--- a/lib/hexpm/web/controllers/dashboard_controller.ex
+++ b/lib/hexpm/web/controllers/dashboard_controller.ex
@@ -28,6 +28,14 @@ defmodule Hexpm.Web.DashboardController do
     end
   end
 
+  def keys(conn, _params) do
+    user = conn.assigns.current_user
+    keys = Keys.all(user)
+
+    conn
+    |> render_keys(keys)
+  end
+
   def password(conn, _params) do
     user = conn.assigns.current_user
     render_password(conn, User.update_password(user, %{}))
@@ -407,6 +415,16 @@ defmodule Hexpm.Web.DashboardController do
       title: "Dashboard - Public profile",
       container: "container page dashboard",
       changeset: changeset
+    )
+  end
+
+  defp render_keys(conn, keys) do
+    render(
+      conn,
+      "keys.html",
+      title: "Dashboard - User API keys",
+      container: "container page dashboard",
+      keys: keys
     )
   end
 

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -89,6 +89,7 @@ defmodule Hexpm.Web.Router do
     get "/dashboard/repos/:dashboard_repo/invoices/:id", DashboardController, :show_invoice
     get "/dashboard/repo-signup", DashboardController, :new_repository
     post "/dashboard/repo-signup", DashboardController, :create_repository
+    get "/dashboard/keys", DashboardController, :keys
 
     get "/docs/usage", DocsController, :usage
     get "/docs/rebar3_usage", DocsController, :rebar3_usage

--- a/lib/hexpm/web/templates/dashboard/keys.html.eex
+++ b/lib/hexpm/web/templates/dashboard/keys.html.eex
@@ -1,0 +1,25 @@
+<div class="row">
+  <div class="col-sm-3">
+    <%= render "_sidebar.html", assigns %>
+  </div>
+  <div class="col-sm-9 email">
+    <div class="panel panel-default">
+      <div class="panel-heading">API Keys</div>
+      <div class="panel-body">
+        <p>API keys are used to authenticate and authorize clients to interact with the server. </p>
+        <br/>
+        <table>
+          <tr>
+            <th>Key Name</th>
+          </tr>
+          <%= for key <- @keys do %>
+            <tr>
+              <td><%= key.name %></td>
+            </tr>
+          <% end %>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+

--- a/lib/hexpm/web/templates/dashboard/keys.html.eex
+++ b/lib/hexpm/web/templates/dashboard/keys.html.eex
@@ -8,7 +8,7 @@
       <div class="panel-body">
         <p>API keys are used to authenticate and authorize clients to interact with the server. </p>
         <br/>
-        <table class="table-condensed table-bordered">
+        <table class="table table-striped">
           <tr>
             <th>Key Name</th>
           </tr>

--- a/lib/hexpm/web/templates/dashboard/keys.html.eex
+++ b/lib/hexpm/web/templates/dashboard/keys.html.eex
@@ -8,7 +8,7 @@
       <div class="panel-body">
         <p>API keys are used to authenticate and authorize clients to interact with the server. </p>
         <br/>
-        <table>
+        <table class="table-bordered">
           <tr>
             <th>Key Name</th>
           </tr>

--- a/lib/hexpm/web/templates/dashboard/keys.html.eex
+++ b/lib/hexpm/web/templates/dashboard/keys.html.eex
@@ -8,7 +8,7 @@
       <div class="panel-body">
         <p>API keys are used to authenticate and authorize clients to interact with the server. </p>
         <br/>
-        <table class="table-bordered">
+        <table class="table-condensed table-bordered">
           <tr>
             <th>Key Name</th>
           </tr>

--- a/lib/hexpm/web/views/dashboard_view.ex
+++ b/lib/hexpm/web/views/dashboard_view.ex
@@ -5,7 +5,8 @@ defmodule Hexpm.Web.DashboardView do
     [
       profile: "Profile",
       password: "Password",
-      email: "Email"
+      email: "Email",
+      keys: "API Keys"
     ]
   end
 

--- a/test/hexpm/web/controllers/dashboard_controller_test.exs
+++ b/test/hexpm/web/controllers/dashboard_controller_test.exs
@@ -139,6 +139,15 @@ defmodule Hexpm.Web.DashboardControllerTest do
     assert_delivered_email(Hexpm.Emails.password_changed(c.user))
   end
 
+  test "Show user API keys", c do
+    conn =
+      build_conn()
+      |> test_login(c.user)
+      |> get("dashboard/keys")
+
+      assert response(conn, 200) =~ "API Keys"
+  end
+
   test "update password invalid current password", c do
     conn =
       build_conn()

--- a/test/hexpm/web/controllers/dashboard_controller_test.exs
+++ b/test/hexpm/web/controllers/dashboard_controller_test.exs
@@ -145,7 +145,7 @@ defmodule Hexpm.Web.DashboardControllerTest do
       |> test_login(c.user)
       |> get("dashboard/keys")
 
-      assert response(conn, 200) =~ "API Keys"
+    assert response(conn, 200) =~ "API Keys"
   end
 
   test "update password invalid current password", c do


### PR DESCRIPTION
This PR addresses one part of the requirement specified as part of [this issue](https://github.com/hexpm/hexpm/issues/668). Kindly review, Thank you.


Screenshot of how the PR related changes look on the `/dashboard/keys` page:

<img width="1149" alt="screen shot 2018-05-05 at 4 55 55 am" src="https://user-images.githubusercontent.com/655963/39656859-bf55c4b2-5020-11e8-840d-12b4081f362c.png">

