### PR TITLE
Add multiple password reset tokens

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -5,6 +5,7 @@ alias Hexpm.{
   Accounts.Key,
   Accounts.KeyPermission,
   Accounts.Keys,
+  Accounts.PasswordReset,
   Accounts.Session,
   Accounts.User,
   Accounts.UserHandles,

--- a/lib/hexpm/accounts/password_reset.ex
+++ b/lib/hexpm/accounts/password_reset.ex
@@ -3,17 +3,24 @@ defmodule Hexpm.Accounts.PasswordReset do
 
   schema "password_resets" do
     field :key, :string
+    field :primary_email, :string
     belongs_to :user, User
 
     timestamps(updated_at: false)
   end
 
-  def changeset(reset) do
-    change(reset, %{key: Auth.gen_key()})
+  def changeset(reset, user) do
+    change(reset, %{
+      key: Auth.gen_key(),
+      primary_email: User.email(user, :primary)
+    })
   end
 
-  def can_reset?(reset, key) do
-    !!(reset.key && Hexpm.Utils.secure_check(reset.key, key) &&
-         Hexpm.Utils.within_last_day(reset.inserted_at))
+  def can_reset?(reset, primary_email, key) do
+    valid_email? = primary_email == reset.primary_email
+    valid_key? = !!(reset.key && Hexpm.Utils.secure_check(reset.key, key))
+    within_time? = Hexpm.Utils.within_last_day?(reset.inserted_at)
+
+    valid_email? and valid_key? and within_time?
   end
 end

--- a/lib/hexpm/accounts/password_reset.ex
+++ b/lib/hexpm/accounts/password_reset.ex
@@ -1,0 +1,19 @@
+defmodule Hexpm.Accounts.PasswordReset do
+  use Hexpm.Web, :schema
+
+  schema "password_resets" do
+    field :key, :string
+    belongs_to :user, User
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(reset) do
+    change(reset, %{key: Auth.gen_key()})
+  end
+
+  def can_reset?(reset, key) do
+    !!(reset.key && Hexpm.Utils.secure_check(reset.key, key) &&
+         Hexpm.Utils.within_last_day(reset.inserted_at))
+  end
+end

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -10,9 +10,6 @@ defmodule Hexpm.Accounts.User do
     field :password, :string
     timestamps()
 
-    field :reset_key, :string
-    field :reset_expiry, :naive_datetime
-
     embeds_one :handles, UserHandles, on_replace: :delete
 
     has_many :emails, Email
@@ -22,6 +19,7 @@ defmodule Hexpm.Accounts.User do
     has_many :repositories, through: [:repository_users, :repository]
     has_many :keys, Key
     has_many :audit_logs, AuditLog
+    has_many :password_resets, PasswordReset
   end
 
   @username_regex ~r"^[a-z0-9_\-\.]+$"
@@ -71,32 +69,8 @@ defmodule Hexpm.Accounts.User do
     |> update_change(:password, &Auth.gen_password/1)
   end
 
-  def init_password_reset(user) do
-    key = Auth.gen_key()
-    change(user, %{reset_key: key, reset_expiry: NaiveDateTime.utc_now()})
-  end
-
-  def disable_password_reset(user) do
-    change(user, %{reset_key: nil, reset_expiry: nil})
-  end
-
-  def password_reset?(nil, _key), do: false
-
-  def password_reset?(user, key) do
-    !!(user.reset_key && Hexpm.Utils.secure_check(user.reset_key, key) &&
-         Hexpm.Utils.within_last_day(user.reset_expiry))
-  end
-
-  def password_reset(user, params, revoke_all_keys \\ true) do
-    multi =
-      Multi.new()
-      |> Multi.update(:password, update_password_no_check(user, params))
-      |> Multi.update(:reset, disable_password_reset(user))
-      |> Multi.delete_all(:reset_sessions, Session.by_user(user))
-
-    if revoke_all_keys,
-      do: Multi.update_all(multi, :keys, Key.revoke_all(user), []),
-      else: multi
+  def can_reset_password?(user, key) do
+    Enum.any?(user.password_resets, &PasswordReset.can_reset?(&1, key))
   end
 
   def email(user, :primary), do: user.emails |> Enum.find(& &1.primary) |> email()

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -70,7 +70,11 @@ defmodule Hexpm.Accounts.User do
   end
 
   def can_reset_password?(user, key) do
-    Enum.any?(user.password_resets, &PasswordReset.can_reset?(&1, key))
+    primary_email = email(user, :primary)
+
+    Enum.any?(user.password_resets, fn reset ->
+      PasswordReset.can_reset?(reset, primary_email, key)
+    end)
   end
 
   def email(user, :primary), do: user.emails |> Enum.find(& &1.primary) |> email()

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -30,12 +30,12 @@ defmodule Hexpm.Emails do
     |> render("verification.html")
   end
 
-  def password_reset_request(user) do
+  def password_reset_request(user, reset) do
     email()
     |> email_to(user)
     |> subject("Hex.pm - Password reset request")
     |> assign(:username, user.username)
-    |> assign(:key, user.reset_key)
+    |> assign(:key, reset.key)
     |> render("password_reset_request.html")
   end
 

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -110,9 +110,9 @@ defmodule Hexpm.Utils do
   @doc """
   Determine if a given timestamp is less than a day (86400 seconds) old
   """
-  def within_last_day(nil), do: false
+  def within_last_day?(nil), do: false
 
-  def within_last_day(a) do
+  def within_last_day?(a) do
     diff = diff(NaiveDateTime.to_erl(a), :calendar.universal_time())
 
     diff < 24 * 60 * 60

--- a/lib/hexpm/web/controllers/password_controller.ex
+++ b/lib/hexpm/web/controllers/password_controller.ex
@@ -52,7 +52,9 @@ defmodule Hexpm.Web.PasswordController do
         |> redirect(to: Routes.page_path(Hexpm.Web.Endpoint, :index))
 
       {:error, changeset} ->
-        render_show(conn, username, key, changeset)
+        conn
+        |> put_status(400)
+        |> render_show(username, key, changeset)
     end
   end
 

--- a/lib/hexpm/web/web.ex
+++ b/lib/hexpm/web/web.ex
@@ -111,6 +111,7 @@ defmodule Hexpm.Web do
         Accounts.Key,
         Accounts.KeyPermission,
         Accounts.Keys,
+        Accounts.PasswordReset,
         Accounts.Session,
         Accounts.User,
         Accounts.UserHandles,

--- a/priv/repo/migrations/20180609210018_add_password_resets.exs
+++ b/priv/repo/migrations/20180609210018_add_password_resets.exs
@@ -4,6 +4,7 @@ defmodule Hexpm.Repo.Migrations.AddPasswordResets do
   def change do
     create table(:password_resets) do
       add(:key, :string, null: false)
+      add(:primary_email, :string, null: false)
       add(:user_id, references(:users))
 
       timestamps(updated_at: false)
@@ -11,12 +12,13 @@ defmodule Hexpm.Repo.Migrations.AddPasswordResets do
 
     create(index(:password_resets, [:user_id]))
 
-    execute """
-    INSERT INTO password_resets (key, user_id, inserted_at)
-      SELECT reset_key, id, reset_expiry
+    execute("""
+    INSERT INTO password_resets (key, primary_email, user_id, inserted_at)
+      SELECT users.reset_key, emails.email, users.id, users.reset_expiry
         FROM users
-        WHERE reset_key IS NOT NULL
-    """
+        JOIN emails ON users.id = emails.user_id
+        WHERE users.reset_key IS NOT NULL AND emails.primary
+    """)
 
     alter table(:users) do
       remove(:reset_key)

--- a/priv/repo/migrations/20180609210018_add_password_resets.exs
+++ b/priv/repo/migrations/20180609210018_add_password_resets.exs
@@ -1,0 +1,26 @@
+defmodule Hexpm.Repo.Migrations.AddPasswordResets do
+  use Ecto.Migration
+
+  def change do
+    create table(:password_resets) do
+      add(:key, :string, null: false)
+      add(:user_id, references(:users))
+
+      timestamps(updated_at: false)
+    end
+
+    create(index(:password_resets, [:user_id]))
+
+    execute """
+    INSERT INTO password_resets (key, user_id, inserted_at)
+      SELECT reset_key, id, reset_expiry
+        FROM users
+        WHERE reset_key IS NOT NULL
+    """
+
+    alter table(:users) do
+      remove(:reset_key)
+      remove(:reset_expiry)
+    end
+  end
+end

--- a/test/hexpm/web/controllers/password_controller_test.exs
+++ b/test/hexpm/web/controllers/password_controller_test.exs
@@ -1,6 +1,6 @@
 defmodule Hexpm.Web.PasswordControllerTest do
   use Hexpm.ConnCase
-  alias Hexpm.Accounts.{Auth, Session, User, Users}
+  alias Hexpm.Accounts.{Auth, User, Users}
   alias Hexpm.Repo
 
   setup do
@@ -39,9 +39,6 @@ defmodule Hexpm.Web.PasswordControllerTest do
       assert {:ok, {%User{username: ^username}, _, _, :password}} =
                Auth.password_auth(username, "hunter42")
 
-      Repo.insert!(Session.build(%{"user_id" => c.user.id}))
-      Repo.insert!(Session.build(%{"user_id" => c.user.id}))
-
       # initiate password reset (usually done via api)
       Users.password_reset_init(username, audit: audit_data(c.user))
 
@@ -69,6 +66,50 @@ defmodule Hexpm.Web.PasswordControllerTest do
                Auth.password_auth(username, "abcd1234")
 
       refute last_session().data["user_id"]
+    end
+
+    test "do not allow changing password with wrong key", c do
+      username = c.user.username
+      Users.password_reset_init(username, audit: audit_data(c.user))
+      user = Repo.preload(c.user, :password_resets)
+
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("password/new", %{
+          "user" => %{
+            "username" => user.username,
+            "key" => "WRONG",
+            "password" => "abcd1234",
+            "password_confirmation" => "abcd1234"
+          }
+        })
+
+      response(conn, 302)
+      assert get_flash(conn, :error) == "Failed to change your password."
+    end
+
+    test "do not allow changing password with changed primary email", c do
+      username = c.user.username
+      Users.password_reset_init(username, audit: audit_data(c.user))
+      user = Repo.preload(c.user, :password_resets)
+      Repo.delete!(hd(c.user.emails))
+      insert(:email, user: user)
+
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("password/new", %{
+          "user" => %{
+            "username" => user.username,
+            "key" => hd(user.password_resets).key,
+            "password" => "abcd1234",
+            "password_confirmation" => "abcd1234"
+          }
+        })
+
+      response(conn, 302)
+      assert get_flash(conn, :error) == "Failed to change your password."
     end
   end
 end

--- a/test/hexpm/web/controllers/password_reset_controller_test.exs
+++ b/test/hexpm/web/controllers/password_reset_controller_test.exs
@@ -17,11 +17,22 @@ defmodule Hexpm.Web.PasswordResetControllerTest do
     conn = post(build_conn(), "password/reset", %{"username" => c.user.username})
     assert response(conn, 200) =~ "Reset your password"
 
+    # initiate second reset request
+    conn = post(build_conn(), "password/reset", %{"username" => c.user.username})
+    assert response(conn, 200) =~ "Reset your password"
+
+    user =
+      Hexpm.Repo.get_by!(User, username: c.user.username)
+      |> Hexpm.Repo.preload([:emails, :password_resets])
+
+    assert [reset1, reset2] = user.password_resets
+
     # check email was sent with correct token
-    user = Hexpm.Repo.get_by!(User, username: c.user.username) |> Hexpm.Repo.preload(:emails)
-    assert_delivered_email(Hexpm.Emails.password_reset_request(user))
+    assert_delivered_email(Hexpm.Emails.password_reset_request(user, reset1))
+    assert_delivered_email(Hexpm.Emails.password_reset_request(user, reset2))
 
     # check reset will succeed
-    assert User.password_reset?(user, user.reset_key) == true
+    assert User.can_reset_password?(user, reset1.key)
+    assert User.can_reset_password?(user, reset2.key)
   end
 end


### PR DESCRIPTION
This disallows an attacker from preventing a user from resetting their password by constantly regenerating the reset key.