### PR TITLE
Clarify wording re non-Hex dependencies

### DIFF
--- a/lib/hexpm/web/templates/docs/publish.html.md
+++ b/lib/hexpm/web/templates/docs/publish.html.md
@@ -69,7 +69,7 @@ Consult the [ExDoc documentation](https://github.com/elixir-lang/ex_doc#using-ex
 
 A dependency defined with no SCM (`:git` or `:path`) will be automatically treated as a Hex dependency. See the [Usage guide](/docs/usage) for more details.
 
-Only Hex packages will be included as dependencies of the package, for example Git dependencies will not be included. Additionally, only production dependencies will be included, just like how Mix will only fetch production dependencies when fetching the dependencies of your dependencies. Dependencies will be treated as production dependencies when they are defined with no `:only` property or with `only: :prod`.
+Only Hex packages may be used as dependencies of the package. It is not possible to upload packages with Git dependencies. Additionally, only production dependencies will be included, just like how Mix will only fetch production dependencies when fetching the dependencies of your dependencies. Dependencies will be treated as production dependencies when they are defined with no `:only` property or with `only: :prod`.
 
 <a id="example-mix-exs-file"></a>
 

--- a/lib/hexpm/web/templates/docs/rebar3_publish.html.md
+++ b/lib/hexpm/web/templates/docs/rebar3_publish.html.md
@@ -65,7 +65,7 @@ You can also add any of the following to the list of application attributes:
 
 A dependency defined with no SCM (`git` or `hg`) will be automatically treated as a Hex dependency. See the [Usage guide](/docs/rebar3_usage) for more details.
 
-Only Hex packages will be included as dependencies of the package, for example Git dependencies will not be included. Additionally, only `default` dependencies will be included, just like how rebar3 will only fetch `default` dependencies when fetching the dependencies of your dependencies.
+Only Hex packages may be used as dependencies of the package. It is not possible to upload packages with Git dependencies. Additionally, only `default` dependencies will be included, just like how rebar3 will only fetch `default` dependencies when fetching the dependencies of your dependencies.
 
 <a id="example-rebar-config-file"></a>
 


### PR DESCRIPTION
The previous wording could be read as if the non-Hex dependencies would merely not be linked on Hex, but in reality they are simply not allowed.