### PR TITLE
Fix footer issues, allow footer to be of non-fixed height

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -11,6 +11,7 @@
 
 @import "template/page";
 @import "template/blog";
+@import "template/content-wrapper";
 @import "template/dashboard";
 @import "template/docs";
 @import "template/home";

--- a/assets/css/base/_general.scss
+++ b/assets/css/base/_general.scss
@@ -1,12 +1,15 @@
 html {
   position: relative;
+  height: 100%;
   min-height: 100%;
 }
 
 body {
   @include font-size(16, 30);
-  margin-bottom: 230px;
+  display: flex;
+  height: 100%;
   font-family: $base-font-family;
+  flex-direction: column;
 }
 
 .browserupgrade {

--- a/assets/css/template/_content-wrapper.scss
+++ b/assets/css/template/_content-wrapper.scss
@@ -1,0 +1,3 @@
+.content-wrapper {
+  flex: 1 0 auto;
+}

--- a/assets/css/template/_footer.scss
+++ b/assets/css/template/_footer.scss
@@ -1,9 +1,7 @@
 .footer {
-  position: absolute;
-  bottom: 0;
   width: 100%;
-  height: 190px;
-  overflow: scroll;
+  flex-shrink: 0;
+  margin-top: 30px;
   color: $color-white;
   background: #a4a6af;
   border-top: 1px solid #cbccd2;

--- a/lib/hexpm/web/templates/layout/footer.html.eex
+++ b/lib/hexpm/web/templates/layout/footer.html.eex
@@ -1,4 +1,5 @@
     </div>
+    </section>
 
     <div class="footer">
       <div class="footer-nav">

--- a/lib/hexpm/web/templates/layout/header.html.eex
+++ b/lib/hexpm/web/templates/layout/header.html.eex
@@ -19,6 +19,7 @@
       <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
 
+    <section class="content-wrapper">
     <nav class="navbar navbar-default">
       <div class="container">
         <div class="navbar-header">


### PR DESCRIPTION
Remove absolute positioning, forced height, and overflow:scroll from the footer to fix issues where:
- Not all content would be displayed on mobile devices
- Users would be forced to scroll footer separately on mobile
- Footer would be forced to a fixed height, limiting flow

Prior to this PR, the footer would forcibly display scrollbars at all screen sizes, which are especially visible on Windows (macOS and some others hide them system-wide). This is fixed by simply dropping the declaration and letting the content flow & the footer itself flow naturally.

This PR also fixes an issue where the forced height of the footer made mobile browsing unpleasant, as the user would be forced to scroll the footer separately from the rest of the viewport.

Lastly, we drop the absolute positioning of the footer in favour of generally letting the page flow be more natural. To compensate for the spacing that was previously applied with a margin on the body element, the footer has been given some margin-top to create spacing between it and the content area.

To ensure the footer would still remain at the end of the page regardless of content above it, we introduce a flexbox-based solution. This has been tested to work on IE11 and up, with IE10 simply not applying this positioning-related effect (thus displaying regular non-flexbox document flow).