### PR TITLE
Make docs_updated_at DateTime instead of NaiveDateTime

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -7,7 +7,7 @@ defmodule Hexpm.Repository.Package do
 
   schema "packages" do
     field :name, :string
-    field :docs_updated_at, :naive_datetime
+    field :docs_updated_at, :utc_datetime
     field :latest_version, Hexpm.Version, virtual: true
     timestamps()
 

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -68,7 +68,7 @@ defmodule Hexpm.Repository.Releases do
 
     Assets.push_docs_tarball(release, body)
 
-    now = NaiveDateTime.utc_now()
+    now = DateTime.utc_now()
     release_changeset = Ecto.Changeset.change(release, has_docs: true)
     package_changeset = Ecto.Changeset.change(release.package, docs_updated_at: now)
 
@@ -95,7 +95,7 @@ defmodule Hexpm.Repository.Releases do
   end
 
   def revert_docs(release, audit: audit_data) do
-    now = NaiveDateTime.utc_now()
+    now = DateTime.utc_now()
     release_changeset = Ecto.Changeset.change(release, has_docs: false)
     package_changeset = Ecto.Changeset.change(release.package, docs_updated_at: now)
 

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -216,8 +216,11 @@ defmodule Hexpm.Utils do
   def binarify(list, opts) when is_list(list), do: for(elem <- list, do: binarify(elem, opts))
   def binarify(%Version{} = version, _opts), do: to_string(version)
 
-  def binarify(%NaiveDateTime{} = dt, _opts),
-    do: dt |> Map.put(:microsecond, {0, 0}) |> NaiveDateTime.to_iso8601()
+  def binarify(%DateTime{} = dt, _opts),
+    do: dt |> Map.put(:microsecond, {0, 0}) |> DateTime.to_iso8601()
+
+  def binarify(%NaiveDateTime{} = ndt, _opts),
+    do: ndt |> Map.put(:microsecond, {0, 0}) |> NaiveDateTime.to_iso8601()
 
   def binarify(%{__struct__: atom}, _opts) when is_atom(atom),
     do: raise("not able to binarify %#{inspect(atom)}{}")

--- a/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
@@ -6,7 +6,7 @@
   <%= for {name, docs_updated_at} <- @packages do %>
     <url>
       <loc><%= Hexpm.Utils.docs_html_url(Organization.hexpm(), %Package{name: name}, nil) %></loc>
-      <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %>Z</lastmod>
+      <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %></lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>
     </url>


### PR DESCRIPTION
We know docs_updated_at is in UTC so it should be a UTC DateTime, not NaiveDateTime. Avoids manually adding a "Z" to ISO 8601 datetime strings when communicating with the outside world.

Related to https://github.com/hexpm/hexpm/issues/697

The existing tests pass unchanged, but no manual tests have been made.