### PR TITLE
Make timestamps DateTime instead of NaiveDateTime

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -61,7 +61,7 @@ defmodule Hexpm.Accounts.AuditLog do
 
   def audit_many(multi, {user, user_agent}, action, list, opts \\ []) do
     fields = AuditLog.__schema__(:fields) -- [:id]
-    extra = %{inserted_at: NaiveDateTime.utc_now()}
+    extra = %{inserted_at: DateTime.utc_now()}
 
     entries =
       Enum.map(list, fn entry ->

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -11,7 +11,7 @@ defmodule Hexpm.Accounts.Email do
     field :public, :boolean, default: false
     field :gravatar, :boolean, default: false
     field :verification_key, :string
-    field :verification_expiry, :naive_datetime
+    field :verification_expiry, :utc_datetime
 
     belongs_to :user, User
 
@@ -37,13 +37,13 @@ defmodule Hexpm.Accounts.Email do
     |> unique_constraint(:email, name: "emails_email_user_key")
     |> put_change(:verified, verified?)
     |> put_change(:verification_key, Auth.gen_key())
-    |> put_change(:verification_expiry, NaiveDateTime.utc_now())
+    |> put_change(:verification_expiry, DateTime.utc_now())
   end
 
   def verification(email) do
     change(email, %{
       verification_key: Auth.gen_key(),
-      verification_expiry: NaiveDateTime.utc_now()
+      verification_expiry: DateTime.utc_now()
     })
   end
 

--- a/lib/hexpm/repository/download.ex
+++ b/lib/hexpm/repository/download.ex
@@ -7,6 +7,6 @@ defmodule Hexpm.Repository.Download do
     belongs_to :release, Release
     field :downloads, :integer
     field :day, :date
-    field :updated_at, :naive_datetime, virtual: true
+    field :updated_at, :utc_datetime, virtual: true
   end
 end

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -7,7 +7,7 @@ defmodule Hexpm.Repository.Package do
 
   schema "packages" do
     field :name, :string
-    field :docs_updated_at, :naive_datetime
+    field :docs_updated_at, :utc_datetime
     field :latest_version, Hexpm.Version, virtual: true
     timestamps()
 

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -68,7 +68,7 @@ defmodule Hexpm.Repository.Releases do
 
     Assets.push_docs_tarball(release, body)
 
-    now = NaiveDateTime.utc_now()
+    now = DateTime.utc_now()
     release_changeset = Ecto.Changeset.change(release, has_docs: true)
     package_changeset = Ecto.Changeset.change(release.package, docs_updated_at: now)
 
@@ -95,7 +95,7 @@ defmodule Hexpm.Repository.Releases do
   end
 
   def revert_docs(release, audit: audit_data) do
-    now = NaiveDateTime.utc_now()
+    now = DateTime.utc_now()
     release_changeset = Ecto.Changeset.change(release, has_docs: false)
     package_changeset = Ecto.Changeset.change(release.package, docs_updated_at: now)
 

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -216,8 +216,11 @@ defmodule Hexpm.Utils do
   def binarify(list, opts) when is_list(list), do: for(elem <- list, do: binarify(elem, opts))
   def binarify(%Version{} = version, _opts), do: to_string(version)
 
-  def binarify(%NaiveDateTime{} = dt, _opts),
-    do: dt |> Map.put(:microsecond, {0, 0}) |> NaiveDateTime.to_iso8601()
+  def binarify(%DateTime{} = dt, _opts),
+    do: dt |> Map.put(:microsecond, {0, 0}) |> DateTime.to_iso8601()
+
+  def binarify(%NaiveDateTime{} = ndt, _opts),
+    do: ndt |> Map.put(:microsecond, {0, 0}) |> NaiveDateTime.to_iso8601()
 
   def binarify(%{__struct__: atom}, _opts) when is_atom(atom),
     do: raise("not able to binarify %#{inspect(atom)}{}")

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -217,10 +217,10 @@ defmodule Hexpm.Utils do
   def binarify(%Version{} = version, _opts), do: to_string(version)
 
   def binarify(%DateTime{} = dt, _opts),
-    do: dt |> Map.put(:microsecond, {0, 0}) |> DateTime.to_iso8601()
+    do: dt |> DateTime.truncate(:second) |> DateTime.to_iso8601()
 
   def binarify(%NaiveDateTime{} = ndt, _opts),
-    do: ndt |> Map.put(:microsecond, {0, 0}) |> NaiveDateTime.to_iso8601()
+    do: ndt |> NaiveDateTime.truncate(:second) |> NaiveDateTime.to_iso8601()
 
   def binarify(%{__struct__: atom}, _opts) when is_atom(atom),
     do: raise("not able to binarify %#{inspect(atom)}{}")

--- a/lib/hexpm/web/controllers/auth_helpers.ex
+++ b/lib/hexpm/web/controllers/auth_helpers.ex
@@ -143,7 +143,7 @@ defmodule Hexpm.Web.AuthHelpers do
   defp usage_info(%{remote_ip: remote_ip} = conn) do
     %{
       ip: remote_ip,
-      used_at: NaiveDateTime.utc_now(),
+      used_at: DateTime.utc_now(),
       user_agent: get_req_header(conn, "user-agent")
     }
   end

--- a/lib/hexpm/web/controllers/controller_helpers.ex
+++ b/lib/hexpm/web/controllers/controller_helpers.ex
@@ -209,6 +209,7 @@ defmodule Hexpm.Web.ControllerHelpers do
   end
 
   defp time_to_erl(%NaiveDateTime{} = datetime), do: NaiveDateTime.to_erl(datetime)
+  defp time_to_erl(%DateTime{} = datetime), do: NaiveDateTime.to_erl(datetime)
   defp time_to_erl(%Date{} = date), do: {Date.to_erl(date), {0, 0, 0}}
 
   def fetch_repository(conn, _opts) do

--- a/lib/hexpm/web/session.ex
+++ b/lib/hexpm/web/session.ex
@@ -31,7 +31,7 @@ defmodule Hexpm.Web.Session do
       Session.by_id(id),
       set: [
         data: data,
-        updated_at: NaiveDateTime.utc_now()
+        updated_at: DateTime.utc_now()
       ]
     )
 

--- a/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/docs_sitemap.xml.eex
@@ -6,7 +6,7 @@
   <%= for {name, docs_updated_at} <- @packages do %>
     <url>
       <loc><%= Hexpm.Utils.docs_html_url(Organization.hexpm(), %Package{name: name}, nil) %></loc>
-      <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %>Z</lastmod>
+      <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %></lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>
     </url>

--- a/lib/hexpm/web/templates/sitemap/packages_sitemap.xml.eex
+++ b/lib/hexpm/web/templates/sitemap/packages_sitemap.xml.eex
@@ -6,7 +6,7 @@
   <%= for {name, updated_at} <- @packages do %>
     <url>
       <loc>https://hex.pm<%= Routes.package_path(Endpoint, :show, name) %></loc>
-      <lastmod><%= Hexpm.Utils.binarify(updated_at) %>Z</lastmod>
+      <lastmod><%= Hexpm.Utils.binarify(updated_at) %></lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>
     </url>

--- a/lib/hexpm/web/views/dashboard/organization_view.ex
+++ b/lib/hexpm/web/views/dashboard/organization_view.ex
@@ -145,8 +145,8 @@ defmodule Hexpm.Web.Dashboard.OrganizationView do
     end
   end
 
-  def payment_date(date) do
-    date |> NaiveDateTime.from_iso8601!() |> pretty_datetime()
+  def payment_date(iso_8601_datetime_string) do
+    iso_8601_datetime_string |> NaiveDateTime.from_iso8601!() |> pretty_datetime()
   end
 
   defp money(integer) when is_integer(integer) and integer >= 0 do

--- a/lib/hexpm/web/views/view_helpers.ex
+++ b/lib/hexpm/web/views/view_helpers.ex
@@ -279,7 +279,7 @@ defmodule Hexpm.Web.ViewHelpers do
   defp rel_from_now({day, {_, _, _}}) when day < 0, do: "about now"
   defp rel_from_now({day, {_, _, _}}), do: "#{day} days ago"
 
-  def pretty_datetime(%NaiveDateTime{year: year, month: month, day: day}) do
+  def pretty_datetime(%{year: year, month: month, day: day}) do
     "#{pretty_month(month)} #{day}, #{year}"
   end
 

--- a/lib/hexpm/web/web.ex
+++ b/lib/hexpm/web/web.ex
@@ -19,6 +19,7 @@ defmodule Hexpm.Web do
   def schema() do
     quote do
       use Ecto.Schema
+      @timestamps_opts [type: :utc_datetime, usec: true]
 
       import Ecto
       import Ecto.Changeset

--- a/scripts/allow_republish.exs
+++ b/scripts/allow_republish.exs
@@ -27,5 +27,5 @@ unless release do
   System.halt(1)
 end
 
-Ecto.Changeset.change(release, %{inserted_at: NaiveDateTime.utc_now()})
+Ecto.Changeset.change(release, %{inserted_at: DateTime.utc_now()})
 |> Hexpm.Repo.update!()

--- a/test/hexpm/accounts/auth_test.exs
+++ b/test/hexpm/accounts/auth_test.exs
@@ -37,7 +37,7 @@ defmodule Hexpm.Accounts.AuthTest do
 
     test "stores key usage information when used", %{user: user} do
       key = insert(:key, user: user)
-      timestamp = NaiveDateTime.utc_now()
+      timestamp = DateTime.utc_now()
 
       usage_info = %{
         used_at: timestamp,

--- a/test/hexpm/web/controllers/api/key_controller_test.exs
+++ b/test/hexpm/web/controllers/api/key_controller_test.exs
@@ -38,6 +38,8 @@ defmodule Hexpm.Web.API.KeyControllerTest do
       assert a["url"] =~ "/api/keys/computer"
       assert a["authing_key"]
       assert b["name"] == "macbook"
+      # inserted_at ISO8601 datetime string should include a Z to indicate UTC
+      assert String.slice(b["inserted_at"], -1, 1) == "Z"
       assert b["secret"] == nil
       assert b["url"] =~ "/api/keys/macbook"
       refute b["authing_key"]

--- a/test/hexpm/web/controllers/api/package_controller_test.exs
+++ b/test/hexpm/web/controllers/api/package_controller_test.exs
@@ -150,6 +150,9 @@ defmodule Hexpm.Web.API.PackageControllerTest do
       conn = get(build_conn(), "api/packages/#{package1.name}")
       result = json_response(conn, 200)
       assert result["name"] == package1.name
+      assert result["inserted_at"] == "2030-01-01T00:00:00.000000Z"
+      # updated_at ISO8601 datetime string should include a Z to indicate UTC
+      assert String.slice(result["updated_at"], -1, 1) == "Z"
       assert result["url"] =~ "/api/packages/#{package1.name}"
       assert result["html_url"] =~ "/packages/#{package1.name}"
       assert result["docs_html_url"] =~ "/#{package1.name}"

--- a/test/hexpm/web/controllers/email_verification_controller_test.exs
+++ b/test/hexpm/web/controllers/email_verification_controller_test.exs
@@ -10,7 +10,7 @@ defmodule Hexpm.Web.EmailVerificationControllerTest do
           :email,
           verified: false,
           verification_key: Hexpm.Accounts.Auth.gen_key(),
-          verification_expiry: NaiveDateTime.utc_now()
+          verification_expiry: DateTime.utc_now()
         )
 
       user = insert(:user, emails: [email])

--- a/test/hexpm/web/controllers/page_controller_test.exs
+++ b/test/hexpm/web/controllers/page_controller_test.exs
@@ -46,8 +46,8 @@ defmodule Hexpm.Web.PageControllerTest do
     assert Enum.count(conn.assigns.package_new) == 3
 
     assert [
-             {^package1_name, %NaiveDateTime{}, %Hexpm.Repository.PackageMetadata{}, 7},
-             {^package2_name, %NaiveDateTime{}, %Hexpm.Repository.PackageMetadata{}, 2}
+             {^package1_name, %DateTime{}, %Hexpm.Repository.PackageMetadata{}, 7},
+             {^package2_name, %DateTime{}, %Hexpm.Repository.PackageMetadata{}, 2}
            ] = conn.assigns.package_top
   end
 end


### PR DESCRIPTION
Make timestamps DateTime instead of NaiveDateTime. We know they are in UTC so they should be UTC DateTime, not NaiveDateTime. Avoids manually adding a Z when communicating with the
outside world.

Closes #697