### PR TITLE
Feat add package download api controller

### DIFF
--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -53,7 +53,8 @@ defmodule Hexpm.Repository.Packages do
             :inserted_at,
             :updated_at,
             :retirement,
-            :has_docs
+            :has_docs,
+            :id
           ])
       )
 
@@ -64,6 +65,28 @@ defmodule Hexpm.Repository.Packages do
       ])
 
     update_in(package.releases, &Release.sort/1)
+  end
+
+  def releases(package) do
+    package
+    |> preload()
+    |> Map.get(:releases)
+  end
+
+  def downloads(package) do
+    release_ids =
+      package
+      |> releases()
+      |> Enum.map(& &1.id)
+
+    Repo.all(
+      from(
+        d in Download,
+        where: d.release_id in ^release_ids,
+        select: struct(d, [:downloads, :day]),
+        order_by: [desc: d.id]
+      )
+    )
   end
 
   def attach_versions(packages) do

--- a/lib/hexpm/web/controllers/api/package_download_controller.ex
+++ b/lib/hexpm/web/controllers/api/package_download_controller.ex
@@ -15,8 +15,8 @@ defmodule Hexpm.Web.API.PackageDownloadController do
     if package = conn.assigns.package do
       when_stale(conn, package, fn conn ->
         package = Packages.preload(package)
-        owners = Enum.map(Owners.all(package, user: :emails), & &1.user)
-        package = %{package | owners: owners}
+        downloads = Packages.downloads(package)
+        package = %{package | downloads: downloads}
 
         conn
         |> api_cache(:public)

--- a/lib/hexpm/web/controllers/api/package_download_controller.ex
+++ b/lib/hexpm/web/controllers/api/package_download_controller.ex
@@ -1,0 +1,29 @@
+defmodule Hexpm.Web.API.PackageDownloadController do
+  use Hexpm.Web, :controller
+
+  plug :maybe_fetch_package when action in [:show]
+
+  plug :maybe_authorize,
+       [domain: "api", resource: "read", fun: &maybe_organization_access/2]
+       when action in [:index]
+
+  plug :maybe_authorize,
+       [domain: "api", resource: "read", fun: &organization_access/2]
+       when action in [:show]
+
+  def show(conn, _params) do
+    if package = conn.assigns.package do
+      when_stale(conn, package, fn conn ->
+        package = Packages.preload(package)
+        owners = Enum.map(Owners.all(package, user: :emails), & &1.user)
+        package = %{package | owners: owners}
+
+        conn
+        |> api_cache(:public)
+        |> render(:show, package_download: package)
+      end)
+    else
+      not_found(conn)
+    end
+  end
+end

--- a/lib/hexpm/web/router.ex
+++ b/lib/hexpm/web/router.ex
@@ -181,6 +181,8 @@ defmodule Hexpm.Web.Router do
         get "/packages", PackageController, :index
         get "/packages/:name", PackageController, :show
 
+        get "/packages/:name/downloads", PackageDownloadController, :show
+
         get "/packages/:name/releases/:version", ReleaseController, :show
         delete "/packages/:name/releases/:version", ReleaseController, :delete
 

--- a/lib/hexpm/web/views/api/package_download_view.ex
+++ b/lib/hexpm/web/views/api/package_download_view.ex
@@ -30,7 +30,7 @@ defmodule Hexpm.Web.API.PackageDownloadView do
 
   defp downloads(downloads) when is_list(downloads) do
     Enum.map(downloads, fn download ->
-      [download.day, download.downloads]
+      %{download.day => download.downloads}
     end)
   end
 

--- a/lib/hexpm/web/views/api/package_download_view.ex
+++ b/lib/hexpm/web/views/api/package_download_view.ex
@@ -1,0 +1,29 @@
+defmodule Hexpm.Web.API.PackageDownloadView do
+  use Hexpm.Web, :view
+
+  def render("index." <> _, %{package_download: packages}) do
+    render_many(packages, __MODULE__, "show")
+  end
+
+  def render("show." <> _, %{package_download: package}) do
+    render_one(package, __MODULE__, "show")
+  end
+
+  def render("show", %{package_download: package}) do
+    %{
+      repository: package.organization.name,
+      name: package.name,
+      inserted_at: package.inserted_at,
+      updated_at: package.updated_at,
+      url: url_for_package(package),
+      html_url: html_url_for_package(package),
+      docs_html_url: docs_html_url_for_package(package),
+      meta: %{
+        description: package.meta.description,
+        licenses: package.meta.licenses || [],
+        links: package.meta.links || %{},
+        maintainers: package.meta.maintainers || []
+      }
+    }
+  end
+end

--- a/lib/hexpm/web/views/api/package_download_view.ex
+++ b/lib/hexpm/web/views/api/package_download_view.ex
@@ -23,7 +23,18 @@ defmodule Hexpm.Web.API.PackageDownloadView do
         licenses: package.meta.licenses || [],
         links: package.meta.links || %{},
         maintainers: package.meta.maintainers || []
-      }
+      },
+      downloads: downloads(package.downloads)
     }
+  end
+
+  defp downloads(downloads) when is_list(downloads) do
+    Enum.map(downloads, fn download ->
+      [download.day, download.downloads]
+    end)
+  end
+
+  defp downloads(_) do
+    []
   end
 end

--- a/test/hexpm/web/controllers/api/package_download_controller_test.exs
+++ b/test/hexpm/web/controllers/api/package_download_controller_test.exs
@@ -1,0 +1,118 @@
+defmodule Hexpm.Web.API.PackageDownloadControllerTest do
+  use Hexpm.ConnCase, async: true
+
+  setup do
+    user = insert(:user)
+    unauthorized_user = insert(:user)
+    organization = insert(:organization)
+
+    package1 =
+      insert(
+        :package,
+        name: "Hexpm.Web.API.PackageControllerTest",
+        inserted_at: ~N[2030-01-01 00:00:00]
+      )
+
+    package2 = insert(:package, updated_at: ~N[2030-01-01 00:00:00])
+
+    package3 =
+      insert(:package, organization_id: organization.id, updated_at: ~N[2030-01-01 00:00:00])
+
+    package4 = insert(:package)
+    insert(:release, package: package1, version: "0.0.1", has_docs: true)
+    insert(:release, package: package3, version: "0.0.1")
+
+    insert(
+      :release,
+      package: package4,
+      version: "0.0.1",
+      retirement: %{reason: "other", message: "not backward compatible"}
+    )
+
+    insert(:release, package: package4, version: "1.0.0")
+    insert(:organization_user, organization: organization, user: user)
+
+    %{
+      package1: package1,
+      package2: package2,
+      package3: package3,
+      package4: package4,
+      organization: organization,
+      user: user,
+      unauthorized_user: unauthorized_user
+    }
+  end
+
+  describe "GET /api/packages/:name/downloads" do
+    test "get package downloads", %{package1: package1} do
+      conn = get(build_conn(), "api/packages/#{package1.name}/downloads")
+      result = json_response(conn, 200)
+      assert result["name"] == package1.name
+      assert result["inserted_at"] == "2030-01-01T00:00:00.000000Z"
+      assert String.slice(result["updated_at"], -1, 1) == "Z"
+      assert result["url"] =~ "/api/packages/#{package1.name}"
+      assert result["html_url"] =~ "/packages/#{package1.name}"
+      assert result["docs_html_url"] =~ "/#{package1.name}"
+    end
+
+    test "get package downloads for non namespaced private organization", %{
+      user: user,
+      package3: package3
+    } do
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> get("api/packages/#{package3.name}/downloads")
+      |> json_response(404)
+    end
+
+    test "get package downloads for unauthenticated private organization", %{
+      organization: organization,
+      package3: package3
+    } do
+      build_conn()
+      |> get("api/repos/#{organization.name}/packages/#{package3.name}/downloads")
+      |> json_response(403)
+    end
+
+    test "get package downloads returns 403 for unknown organization", %{package1: package1} do
+      build_conn()
+      |> get("api/repos/UNKNOWN_REPOSITORY/packages/#{package1.name}/downloads")
+      |> json_response(403)
+    end
+
+    test "get package downloads returns 403 for unknown package if you are not authorized", %{
+      organization: organization
+    } do
+      build_conn()
+      |> get("api/repos/#{organization.name}/packages/UNKNOWN_PACKAGE/downloads")
+      |> json_response(403)
+    end
+
+    test "get package downloads returns 404 for unknown package if you are authorized", %{
+      user: user,
+      organization: organization
+    } do
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> get("api/repos/#{organization.name}/packages/UNKNOWN_PACKAGE/downloads")
+      |> json_response(404)
+    end
+
+    test "get package downloads for authenticated private organization", %{
+      user: user,
+      organization: organization,
+      package3: package3
+    } do
+      result =
+        build_conn()
+        |> put_req_header("authorization", key_for(user))
+        |> get("api/repos/#{organization.name}/packages/#{package3.name}/downloads")
+        |> json_response(200)
+
+      assert result["name"] == package3.name
+      assert result["repository"] == organization.name
+      assert result["url"] =~ "/api/repos/#{organization.name}/packages/#{package3.name}"
+      assert result["html_url"] =~ "/packages/#{organization.name}/#{package3.name}"
+    end
+  end
+end

--- a/test/hexpm/web/controllers/api/package_download_controller_test.exs
+++ b/test/hexpm/web/controllers/api/package_download_controller_test.exs
@@ -75,9 +75,9 @@ defmodule Hexpm.Web.API.PackageDownloadControllerTest do
       result = json_response(conn, 200)
 
       assert result["downloads"] == [
-               ["#{days_ago_92}", 0],
-               ["#{days_ago_11}", 317],
-               ["#{days_ago_10}", 12]
+               %{"#{days_ago_92}" => 0},
+               %{"#{days_ago_11}" => 317},
+               %{"#{days_ago_10}" => 12}
              ]
     end
 


### PR DESCRIPTION
## Proposal: add package download api that takes the name of the package and exposes the daily downloads 

The reason for this feature is that in that way it would be possible to fetch and use this data to built stats around each package with an external client (or even via CLI)

This PR adds a new endpoint to the api `GET /api/packages/:name/downloads` that takes the name of a package and returns a package object that has a key `downloads`. The key `downloads` is a list of objects where the key is the `date` and the value is the `number of downloads` as integer. 

I am happy to discuss changes and different implementations of this feature as I would consider that PR just a proposal for now

Thank you for the amazing job on this repo!