### PR TITLE
Refresh materalized view concurrently

### DIFF
--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -115,8 +115,9 @@ defmodule Hexpm.RepoBase do
 
   def refresh_view(schema) do
     source = schema.__schema__(:source)
+    query = ~s(REFRESH MATERIALIZED VIEW CONCURRENTLY "#{source}")
 
-    {:ok, _} = Hexpm.Repo.query(~s(REFRESH MATERIALIZED VIEW "#{source}"), [])
+    {:ok, _} = Hexpm.Repo.query(query, [])
     :ok
   end
 

--- a/priv/repo/migrations/20181019154146_add_unique_index_to_materialized_views.exs
+++ b/priv/repo/migrations/20181019154146_add_unique_index_to_materialized_views.exs
@@ -1,0 +1,14 @@
+defmodule Hexpm.RepoBase.Migrations.AddUniqueIndexToMaterializedViews do
+  use Ecto.Migration
+
+  def change do
+    execute("DROP INDEX package_dependants_name_idx")
+    execute("CREATE UNIQUE INDEX ON package_dependants (name, dependant_id)")
+
+    execute("DROP INDEX package_downloads_package_id_idx")
+    execute("CREATE UNIQUE INDEX ON package_downloads (package_id, view)")
+
+    execute("DROP INDEX release_downloads_release_id_idx")
+    execute("CREATE UNIQUE INDEX ON release_downloads (release_id)")
+  end
+end


### PR DESCRIPTION
The same time the stats job runs (which refreshes views) we sometimes get time outs accessing the view `package_downloads`. Try running it concurrently to see if that fixes it.