### PR TITLE
Improve CDN caching

### DIFF
--- a/lib/hexpm/repository/assets.ex
+++ b/lib/hexpm/repository/assets.ex
@@ -1,9 +1,14 @@
 defmodule Hexpm.Repository.Assets do
+  alias Hexpm.Accounts.Organization
+
   def push_release(release, body) do
-    opts = [
-      cache_control: "public, max-age=604800",
-      meta: [{"surrogate-key", tarball_cdn_key(release)}]
+    meta = [
+      {"surrogate-key", tarball_cdn_key(release)},
+      {"surrogate-control", "public, max-age=604800"}
     ]
+
+    cache_control = tarball_cache_control(release.package.organization)
+    opts = [cache_control: cache_control, meta: meta]
 
     Hexpm.Store.put(nil, :s3_bucket, tarball_store_key(release), body, opts)
     Hexpm.CDN.purge_key(:fastly_hexrepo, tarball_cdn_key(release))
@@ -29,7 +34,7 @@ defmodule Hexpm.Repository.Assets do
     opts = [
       acl: :public_read,
       content_type: "text/xml",
-      cache_control: "public, max-age=300",
+      cache_control: "public, max-age=3600",
       meta: [{"surrogate-key", "sitemap"}]
     ]
 
@@ -102,13 +107,13 @@ defmodule Hexpm.Repository.Assets do
   end
 
   defp put_docs_tarball(release, body) do
-    surrogate_key = {"surrogate-key", docs_cdn_key(release)}
-    surrogate_control = {"surrogate-control", "max-age=604800"}
-
-    opts = [
-      cache_control: "public, max-age=3600",
-      meta: [surrogate_key, surrogate_control]
+    meta = [
+      {"surrogate-key", docs_cdn_key(release)},
+      {"surrogate-control", "public, max-age=604800"}
     ]
+
+    cache_control = docs_cache_control(release.package.organization)
+    opts = [cache_control: cache_control, meta: meta]
 
     Hexpm.Store.put(nil, :s3_bucket, docs_store_key(release), body, opts)
   end
@@ -198,6 +203,12 @@ defmodule Hexpm.Repository.Assets do
       "" -> []
     end
   end
+
+  defp tarball_cache_control(%Organization{id: 1}), do: "public, max-age=604800"
+  defp tarball_cache_control(%Organization{}), do: "private, max-age=86400"
+
+  defp docs_cache_control(%Organization{id: 1}), do: "public, max-age=86400"
+  defp docs_cache_control(%Organization{}), do: "private, max-age=86400"
 
   def tarball_cdn_key(release) do
     "tarballs/#{repository_cdn_key(release)}#{release.package.name}-#{release.version}"

--- a/lib/hexpm/repository/registry_builder.ex
+++ b/lib/hexpm/repository/registry_builder.ex
@@ -321,7 +321,7 @@ defmodule Hexpm.Repository.RegistryBuilder do
           organization_cdn_key(organization, "registry") <>
             " " <> organization_cdn_key(organization, "registry-package", name)
 
-        meta = [{"surrogate-key", surrogate_key}]
+        meta = [{"surrogate-key", surrogate_key}, {"surrogate-control", "public, max-age=604800"}]
         opts = Keyword.put(opts, :meta, meta)
         {organization_store_key(organization, "packages/#{name}"), contents, opts}
       end)
@@ -329,8 +329,8 @@ defmodule Hexpm.Repository.RegistryBuilder do
     package_objects ++ [names_object, versions_object]
   end
 
-  defp cache_control(%Organization{id: 1}), do: "public, max-age=600"
-  defp cache_control(%Organization{}), do: "private, max-age=600"
+  defp cache_control(%Organization{id: 1}), do: "public, max-age=3600"
+  defp cache_control(%Organization{}), do: "private, max-age=3600"
 
   defp package_tuples(packages, releases) do
     Enum.reduce(releases, %{}, fn {_, vsn, pkg_id, _, _, _}, map ->


### PR DESCRIPTION
* Set surrogate-control headers for bucket assets.
* Increase some object max-ages.

This should generally improve caching on Fastly, specially edge node caching.