### PR TITLE
Serve hexdocs sitemap

### DIFF
--- a/lib/hexpm/repository/sitemaps.ex
+++ b/lib/hexpm/repository/sitemaps.ex
@@ -14,10 +14,13 @@ defmodule Hexpm.Repository.Sitemaps do
   def packages_with_docs() do
     from(
       p in Package,
+      join: r in assoc(p, :releases),
       order_by: p.name,
       where: p.organization_id == 1,
       where: not is_nil(p.docs_updated_at),
-      select: {p.name, p.docs_updated_at}
+      where: r.has_docs,
+      select: {p.name, p.docs_updated_at},
+      distinct: true
     )
     |> Repo.all()
   end

--- a/lib/hexpm_web/controllers/sitemap_controller.ex
+++ b/lib/hexpm_web/controllers/sitemap_controller.ex
@@ -1,10 +1,17 @@
 defmodule HexpmWeb.SitemapController do
   use HexpmWeb, :controller
 
-  def sitemap(conn, _params) do
+  def main(conn, _params) do
     conn
     |> put_resp_content_type("text/xml")
     |> put_resp_header("cache-control", "public, max-age=300")
     |> render("packages_sitemap.xml", packages: Sitemaps.packages())
+  end
+
+  def docs(conn, _params) do
+    conn
+    |> put_resp_content_type("text/xml")
+    |> put_resp_header("cache-control", "public, max-age=300")
+    |> render("docs_sitemap.xml", packages: Sitemaps.packages_with_docs())
   end
 end

--- a/lib/hexpm_web/controllers/test_controller.ex
+++ b/lib/hexpm_web/controllers/test_controller.ex
@@ -67,7 +67,7 @@ defmodule HexpmWeb.TestController do
   end
 
   def docs_sitemap(conn, _params) do
-    Hexpm.Store.get(nil, :docs_bucket, Routes.sitemap_path(HexpmWeb.Endpoint, :sitemap), [])
+    Hexpm.Store.get(nil, :docs_bucket, "sitemap.xml", [])
     |> send_object(conn)
   end
 

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -138,7 +138,8 @@ defmodule HexpmWeb.Router do
   end
 
   scope "/", HexpmWeb do
-    get "/sitemap.xml", SitemapController, :sitemap
+    get "/sitemap.xml", SitemapController, :main
+    get "/docs_sitemap.xml", SitemapController, :docs
     get "/hexsearch.xml", OpenSearchController, :opensearch
     get "/installs/hex.ez", InstallController, :archive
   end

--- a/test/fixtures/docs_sitemap.xml
+++ b/test/fixtures/docs_sitemap.xml
@@ -3,12 +3,10 @@
     xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-  <%= for {name, updated_at} <- @packages do %>
     <url>
-      <loc><%= Routes.package_url(Endpoint, :show, name) %></loc>
-      <lastmod><%= Hexpm.Utils.binarify(updated_at) %></lastmod>
+      <loc>http://localhost:5002/{package}/</loc>
+      <lastmod>2014-04-17T14:00:00Z</lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>
     </url>
-  <% end %>
 </urlset>

--- a/test/fixtures/packages_sitemap.xml
+++ b/test/fixtures/packages_sitemap.xml
@@ -4,7 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
     <url>
-      <loc>https://hex.pm/packages/{package}</loc>
+      <loc>http://localhost:5000/packages/{package}</loc>
       <lastmod>2014-04-17T14:00:00Z</lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>

--- a/test/hexpm_web/controllers/sitemap_controller_test.exs
+++ b/test/hexpm_web/controllers/sitemap_controller_test.exs
@@ -2,13 +2,22 @@ defmodule HexpmWeb.SitemapControllerTest do
   use HexpmWeb.ConnCase, async: true
 
   setup do
-    package = insert(:package, updated_at: ~N[2014-04-17 14:00:00.000])
+    time = ~N[2014-04-17 14:00:00.000]
+    package = insert(:package, updated_at: time, docs_updated_at: time)
+    insert(:release, package: package, version: "0.1.0", has_docs: true)
+
     %{package: package}
   end
 
   test "GET /sitemap.xml", %{package: package} do
     conn = get(build_conn(), "/sitemap.xml")
-    sitemap = read_fixture("sitemap.xml") |> String.replace("{package}", package.name)
+    sitemap = read_fixture("packages_sitemap.xml") |> String.replace("{package}", package.name)
+    assert response(conn, 200) == sitemap
+  end
+
+  test "GET /docs_sitemap.xml", %{package: package} do
+    conn = get(build_conn(), "/docs_sitemap.xml")
+    sitemap = read_fixture("docs_sitemap.xml") |> String.replace("{package}", package.name)
     assert response(conn, 200) == sitemap
   end
 end


### PR DESCRIPTION
Hexdocs service will use this as source when pushing the sitemap to the
bucket.