### PR TITLE
Validate dependants when deleting package

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -70,6 +70,15 @@ defmodule Hexpm.Repository.Package do
     |> put_first_owner(user, organization)
   end
 
+  def delete(package) do
+    foreign_key_constraint(
+      change(package),
+      :name,
+      name: "requirements_dependency_id_fkey",
+      message: "you cannot delete this package because other packages depend on it"
+    )
+  end
+
   defp put_first_owner(changeset, %User{id: id}, _organization) do
     put_assoc(changeset, :package_owners, [%PackageOwner{user_id: id}])
   end

--- a/test/hexpm_web/controllers/api/docs_controller_test.exs
+++ b/test/hexpm_web/controllers/api/docs_controller_test.exs
@@ -107,8 +107,7 @@ defmodule HexpmWeb.API.DocsControllerTest do
       refute Hexpm.Repo.get_by(assoc(package, :releases), version: "0.0.1").has_docs
       refute Hexpm.Store.get(nil, :s3_bucket, "docs/#{package.name}-0.0.1.tar.gz", [])
 
-      [%{action: "docs.publish"}, log] =
-        Hexpm.Repo.all(from(al in AuditLog, order_by: al.id))
+      [%{action: "docs.publish"}, log] = Hexpm.Repo.all(from(al in AuditLog, order_by: al.id))
 
       assert log.user_id == user.id
       assert log.action == "docs.revert"


### PR DESCRIPTION
Present a validation message for the user instead of raising an error when deleting a package that has dependencies on it.