### PR TITLE
Store release publisher

### DIFF
--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -31,7 +31,7 @@ defmodule Hexpm.Repository.Release do
   end
 
   defp changeset(release, :update, params, package, checksum) do
-    cast(release, params, ~w(version)a)
+    cast(release, params, ~w(version publisher_id)a)
     |> cast_embed(:meta, required: true)
     |> validate_version(:version)
     |> validate_editable(:update, false)

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -12,7 +12,7 @@ defmodule Hexpm.Repository.Release do
     timestamps()
 
     belongs_to :package, Package
-    belongs_to :publisher, User
+    belongs_to(:publisher, User, on_replace: :nilify)
     has_many :requirements, Requirement, on_replace: :delete
     has_many :daily_downloads, Download
     has_one :downloads, ReleaseDownload
@@ -21,8 +21,8 @@ defmodule Hexpm.Repository.Release do
     embeds_one :retirement, ReleaseRetirement, on_replace: :delete
   end
 
-  defp changeset(release, :create, params, package, checksum) do
-    changeset(release, :update, params, package, checksum)
+  defp changeset(release, :create, params, package, publisher, checksum) do
+    changeset(release, :update, params, package, publisher, checksum)
     |> unique_constraint(
       :version,
       name: "releases_package_id_version_key",
@@ -30,22 +30,23 @@ defmodule Hexpm.Repository.Release do
     )
   end
 
-  defp changeset(release, :update, params, package, checksum) do
-    cast(release, params, ~w(version publisher_id)a)
+  defp changeset(release, :update, params, package, publisher, checksum) do
+    cast(release, params, ~w(version)a)
     |> cast_embed(:meta, required: true)
     |> validate_version(:version)
     |> validate_editable(:update, false)
     |> put_change(:checksum, String.upcase(checksum))
+    |> put_assoc(:publisher, publisher)
     |> Requirement.build_all(package)
   end
 
-  def build(package, params, checksum) do
+  def build(package, publisher, params, checksum) do
     build_assoc(package, :releases)
-    |> changeset(:create, params, package, checksum)
+    |> changeset(:create, params, package, publisher, checksum)
   end
 
-  def update(release, params, checksum) do
-    changeset(release, :update, params, release.package, checksum)
+  def update(release, publisher, params, checksum) do
+    changeset(release, :update, params, release.package, publisher, checksum)
   end
 
   def delete(release, opts \\ []) do

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -12,6 +12,7 @@ defmodule Hexpm.Repository.Release do
     timestamps()
 
     belongs_to :package, Package
+    belongs_to :publisher, User
     has_many :requirements, Requirement, on_replace: :delete
     has_many :daily_downloads, Download
     has_one :downloads, ReleaseDownload

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -163,8 +163,7 @@ defmodule Hexpm.Repository.Releases do
       "app" => meta["app"],
       "version" => version,
       "requirements" => normalize_requirements(meta["requirements"]),
-      "meta" => meta,
-      "publisher_id" => user.id
+      "meta" => meta
     }
 
     release = package && Repo.get_by(assoc(package, :releases), version: version)
@@ -178,9 +177,10 @@ defmodule Hexpm.Repository.Releases do
         if release do
           %{release | package: package}
           |> Repo.preload(requirements: Release.requirements(release))
-          |> Release.update(params, checksum)
+          |> Repo.preload(:publisher)
+          |> Release.update(user, params, checksum)
         else
-          Release.build(package, params, checksum)
+          Release.build(package, user, params, checksum)
         end
 
       validate_reserved_version(changeset, reserved_packages)

--- a/priv/repo/migrations/20181129040911_add_publisher_id_to_releases.exs
+++ b/priv/repo/migrations/20181129040911_add_publisher_id_to_releases.exs
@@ -1,0 +1,11 @@
+defmodule Hexpm.RepoBase.Migrations.AddPublisherIdToReleases do
+  use Ecto.Migration
+
+  def change do
+    alter table(:releases) do
+      add(:publisher_id, references(:users))
+    end
+
+    create(index(:releases, [:publisher_id]))
+  end
+end

--- a/priv/repo/migrations/20181129040911_add_publisher_id_to_releases.exs
+++ b/priv/repo/migrations/20181129040911_add_publisher_id_to_releases.exs
@@ -5,7 +5,5 @@ defmodule Hexpm.RepoBase.Migrations.AddPublisherIdToReleases do
     alter table(:releases) do
       add(:publisher_id, references(:users))
     end
-
-    create(index(:releases, [:publisher_id]))
   end
 end

--- a/test/hexpm/repository/release_test.exs
+++ b/test/hexpm/repository/release_test.exs
@@ -30,6 +30,38 @@ defmodule Hexpm.Repository.ReleaseTest do
            ] = Release.all(package) |> Hexpm.Repo.all() |> Release.sort()
   end
 
+  test "create release and set its publisher", %{packages: [package, _, _]} do
+    publisher = insert(:user)
+    publisher_id = publisher.id
+
+    assert %Release{publisher_id: ^publisher_id} =
+             Release.build(
+               package,
+               rel_meta(%{publisher_id: publisher.id, version: "0.0.1", app: package.name}),
+               ""
+             )
+             |> Hexpm.Repo.insert!()
+  end
+
+  test "update release and update its publisher", %{packages: [package, _, _]} do
+    old_publisher = insert(:user)
+    new_publisher = insert(:user)
+    new_publisher_id = new_publisher.id
+
+    release =
+      Release.build(
+        package,
+        rel_meta(%{publisher_id: old_publisher.id, version: "0.0.1", app: package.name}),
+        ""
+      )
+      |> Hexpm.Repo.insert!()
+
+    updated_release =
+      release |> Release.update(%{publisher_id: new_publisher.id}, "") |> Hexpm.Repo.update!()
+
+    assert %Release{publisher_id: ^new_publisher_id} = updated_release
+  end
+
   test "create release with deps", %{packages: [package1, package2, package3]} do
     Release.build(package3, rel_meta(%{version: "0.0.1", app: package3.name}), "")
     |> Hexpm.Repo.insert!()

--- a/test/hexpm/repository/release_test.exs
+++ b/test/hexpm/repository/release_test.exs
@@ -32,21 +32,21 @@ defmodule Hexpm.Repository.ReleaseTest do
 
   test "create release and set its publisher", %{packages: [package, _, _]} do
     publisher = insert(:user)
-    publisher_id = publisher.id
 
-    assert %Release{publisher_id: ^publisher_id} =
-             Release.build(
-               package,
-               rel_meta(%{publisher_id: publisher.id, version: "0.0.1", app: package.name}),
-               ""
-             )
-             |> Hexpm.Repo.insert!()
+    release =
+      Release.build(
+        package,
+        rel_meta(%{publisher_id: publisher.id, version: "0.0.1", app: package.name}),
+        ""
+      )
+      |> Hexpm.Repo.insert!()
+
+    assert release.publisher_id == publisher.id
   end
 
   test "update release and update its publisher", %{packages: [package, _, _]} do
     old_publisher = insert(:user)
     new_publisher = insert(:user)
-    new_publisher_id = new_publisher.id
 
     release =
       Release.build(
@@ -59,7 +59,7 @@ defmodule Hexpm.Repository.ReleaseTest do
     updated_release =
       release |> Release.update(%{publisher_id: new_publisher.id}, "") |> Hexpm.Repo.update!()
 
-    assert %Release{publisher_id: ^new_publisher_id} = updated_release
+    assert updated_release.publisher_id == new_publisher.id
   end
 
   test "create release with deps", %{packages: [package1, package2, package3]} do

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -49,15 +49,7 @@ defmodule Hexpm.Repository.ReleasesTest do
       audit = audit_data(user)
 
       {:ok, %{release: release}} =
-        Releases.publish(
-          organization,
-          nil,
-          user,
-          "BODY",
-          meta,
-          "00",
-          audit: audit
-        )
+        Releases.publish(organization, nil, user, "BODY", meta, "00", audit: audit)
 
       assert release.publisher_id == user.id
     end

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -42,6 +42,26 @@ defmodule Hexpm.Repository.ReleasesTest do
                )
     end
 
+    test "sets release.publisher to user when publish a new release" do
+      organization = insert(:organization)
+      user = insert(:user)
+      meta = default_meta(Fake.sequence(:package), "0.1.0")
+      audit = audit_data(user)
+
+      {:ok, %{release: release}} =
+        Releases.publish(
+          organization,
+          nil,
+          user,
+          "BODY",
+          meta,
+          "00",
+          audit: audit
+        )
+
+      assert release.publisher_id == user.id
+    end
+
     test "cant publish reserved package name", %{user: user} do
       Repo.insert_all("reserved_packages", [
         %{"organization_id" => 1, "name" => "reserved_name"}


### PR DESCRIPTION
First step of #753 

In this PR, I did following things:
1. Add `belongs_to publisher` relationship to `Release` schema
2. Update `Releases.publish/7` and related changeset functions to set/update `publisher` every time a release gets touched

A few questions:
1. Is it okay to just `cast :publisher_id` in the update changeset? I chose this impl over `put_assoc` because it's much more simpler and it doesn't require us to add `user` as arguments to `changeset/5`
2. Do we need to allow updating `publisher_id` after a release is created? If not, I'll move `cast :publisher_id` to create changeset.
3. Do I need to add migration script to backfill the `publisher_id` column now? Or I can do that after all the tasks in #753 are done?
4. Also, do we need to add `validate_required :publisher_id` to Release changesets? I chose not to do it because it caused several test cases in `ReleaseTest` to fail. And since we fully control how `params["publisher_id"]` gets passed in, the value of this validation seems to be little.