### PR TITLE
Adds an all versions page for packages

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -24,3 +24,4 @@
 @import "template/sponsors";
 @import "template/stats";
 @import "template/user";
+@import "template/version-list";

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -43,7 +43,7 @@ defmodule Hexpm.Repository.Releases do
     |> Multi.run(:organization, fn _, _ -> {:ok, organization} end)
     |> Multi.run(:reserved_packages, fn _, _ -> {:ok, reserved_packages(organization, meta)} end)
     |> create_package(organization, package, user, meta)
-    |> create_release(package, checksum, meta)
+    |> create_release(package, user, checksum, meta)
     |> audit_publish(audit_data)
     |> refresh_package_dependants()
     |> Repo.transaction(timeout: @publish_timeout)
@@ -156,7 +156,7 @@ defmodule Hexpm.Repository.Releases do
     end)
   end
 
-  defp create_release(multi, package, checksum, meta) do
+  defp create_release(multi, package, user, checksum, meta) do
     version = meta["version"]
 
     params = %{
@@ -177,9 +177,10 @@ defmodule Hexpm.Repository.Releases do
         if release do
           %{release | package: package}
           |> Repo.preload(requirements: Release.requirements(release))
-          |> Release.update(params, checksum)
+          |> Repo.preload(:publisher)
+          |> Release.update(user, params, checksum)
         else
-          Release.build(package, params, checksum)
+          Release.build(package, user, params, checksum)
         end
 
       validate_reserved_version(changeset, reserved_packages)
@@ -202,7 +203,7 @@ defmodule Hexpm.Repository.Releases do
       |> Package.delete()
       |> repo.delete()
     else
-      :ok
+      {:ok, release.package}
     end
   end
 

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -56,7 +56,6 @@ defmodule HexpmWeb.PackageController do
     if repository in Enum.map(organizations, & &1.name) do
       organization = Organizations.get(repository)
       package = organization && Packages.get(organization, name)
-
       # Should have access even though organization does not have active billing
       if package do
         releases = Releases.all(package)

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -23,7 +23,7 @@ defmodule HexpmWeb.Endpoint do
   end
 
   plug Plug.RequestId
-  plug Plug.Logger
+  plug Logster.Plugs.Logger, excludes: [:params]
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :json, HexpmWeb.PlugParser],

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -88,6 +88,9 @@ defmodule HexpmWeb.Router do
     get "/policies/copyright", PolicyController, :copyright
     get "/policies/dispute", PolicyController, :dispute
 
+    get "/packages/:name/versions", VersionsController, :index
+    get "/packages/:repository/:name/versions", VersionsController, :index
+
     get "/packages", PackageController, :index
     get "/packages/:name", PackageController, :show
     get "/packages/:name/:version", PackageController, :show

--- a/lib/hexpm_web/templates/docs/layout.html.eex
+++ b/lib/hexpm_web/templates/docs/layout.html.eex
@@ -4,11 +4,11 @@
       <li class="sidebar-header">Mix</li>
       <li class="sidebar-item <%= selected_docs(@conn, :usage) %>"><a href="<%= Routes.docs_path(Endpoint, :usage) %>">Usage</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :publish) %>"><a href="<%= Routes.docs_path(Endpoint, :publish) %>">Publishing packages</a></li>
-      <li class="sidebar-item"><a href="https://hexdocs.pm/hex" target="_blank">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
+      <li class="sidebar-item"><a target="_blank" rel="noopener" href="https://hexdocs.pm/hex">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
       <li class="sidebar-header">Rebar</li>
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_usage) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_usage) %>">Usage</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_publish) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_publish) %>">Publishing packages</a></li>
-      <li class="sidebar-item"><a target="_blank" href="https://www.rebar3.org/v3.0/docs/hex-package-management">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
+      <li class="sidebar-item"><a target="_blank" rel="noopener" href="https://www.rebar3.org/v3.0/docs/hex-package-management">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
       <li class="sidebar-header">Hex</li>
       <li class="sidebar-item <%= selected_docs(@conn, :faq) %>"><a href="<%= Routes.docs_path(Endpoint, :faq) %>">FAQ</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :private) %>"><a href="<%= Routes.docs_path(Endpoint, :private) %>">Private packages</a></li>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -130,14 +130,8 @@ tools = Keyword.take(tools, compatible_tools)
         </ul>
 
         <%= if length(@releases)> show_latest_versions do %>
-          <ul id="older-versions" class="collapse version-dependency-list">
-            <%= render "versions.html", [package: @package, releases: Enum.drop(@releases, show_latest_versions)] %>
-          </ul>
           <p class="show-versions">
-            <span class="toggle-text" role="button" data-toggle="collapse" data-target="#older-versions" aria-expanded="false" aria-controls="versions">
-              <a>Show All Versions</a>
-              <a class="invisible">Show Recent Versions</a>
-            </span>
+            <a href="<%= path_for_releases(@package) %>">Show All Versions</a>
           </p>
         <% end %>
       </div>

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -44,6 +44,14 @@ defmodule HexpmWeb.ViewHelpers do
     end
   end
 
+  def path_for_releases(package) do
+    if package.organization.name == "hexpm" do
+      Routes.versions_path(Endpoint, :index, package)
+    else
+      Routes.versions_path(Endpoint, :index, package.organization, package)
+    end
+  end
+
   def html_url_for_package(%Package{organization_id: 1} = package) do
     Routes.package_url(Endpoint, :show, package, [])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -47,6 +47,7 @@ defmodule Hexpm.MixProject do
       {:hackney, "~> 1.7"},
       {:hex_core, "~> 0.1"},
       {:libcluster, "~> 3.0"},
+      {:logster, "~> 0.10.0"},
       {:mox, "~> 0.3.1", only: :test},
       {:phoenix_ecto, "~> 3.1"},
       {:phoenix_html, "~> 2.3"},

--- a/mix.lock
+++ b/mix.lock
@@ -23,6 +23,7 @@
   "idna": {:hex, :idna, "5.1.1", "cbc3b2fa1645113267cc59c760bafa64b2ea0334635ef06dbac8801e42f7279c", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "libcluster": {:hex, :libcluster, "3.0.3", "492e98c7f5c9a6e95b8d51f0b198cf8eab60af3b490f40b958d4bc326d11e40e", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm"},
+  "logster": {:hex, :logster, "0.10.0", "5ba89528f1b143328c2ef2050ced34e4f0c981482a1cfab94393139a9b5189b6", [:mix], [{:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:plug, "~> 1.0", [hex: :plug, repo: "hexpm", optional: false]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},

--- a/test/hexpm/repository/release_test.exs
+++ b/test/hexpm/repository/release_test.exs
@@ -8,20 +8,27 @@ defmodule Hexpm.Repository.ReleaseTest do
       insert_list(3, :package)
       |> Hexpm.Repo.preload(:organization)
 
-    %{packages: packages}
+    publisher = insert(:user)
+
+    %{publisher: publisher, packages: packages}
   end
 
-  test "create release and get", %{packages: [package, _, _]} do
+  test "create release and get", %{publisher: publisher, packages: [package, _, _]} do
     package_id = package.id
 
     assert %Release{package_id: ^package_id, version: %Version{major: 0, minor: 0, patch: 1}} =
-             Release.build(package, rel_meta(%{version: "0.0.1", app: package.name}), "")
+             Release.build(
+               package,
+               publisher,
+               rel_meta(%{version: "0.0.1", app: package.name}),
+               ""
+             )
              |> Hexpm.Repo.insert!()
 
     assert %Release{package_id: ^package_id, version: %Version{major: 0, minor: 0, patch: 1}} =
              Hexpm.Repo.get_by!(assoc(package, :releases), version: "0.0.1")
 
-    Release.build(package, rel_meta(%{version: "0.0.2", app: package.name}), "")
+    Release.build(package, publisher, rel_meta(%{version: "0.0.2", app: package.name}), "")
     |> Hexpm.Repo.insert!()
 
     assert [
@@ -30,11 +37,40 @@ defmodule Hexpm.Repository.ReleaseTest do
            ] = Release.all(package) |> Hexpm.Repo.all() |> Release.sort()
   end
 
-  test "create release with deps", %{packages: [package1, package2, package3]} do
-    Release.build(package3, rel_meta(%{version: "0.0.1", app: package3.name}), "")
+  test "create release and set its publisher", %{publisher: publisher, packages: [package, _, _]} do
+    release =
+      Release.build(
+        package,
+        publisher,
+        rel_meta(%{publisher_id: publisher.id, version: "0.0.1", app: package.name}),
+        ""
+      )
+      |> Hexpm.Repo.insert!()
+
+    assert release.publisher_id == publisher.id
+  end
+
+  test "update release and update its publisher", %{packages: [package, _, _]} do
+    old_publisher = insert(:user)
+    new_publisher = insert(:user)
+
+    release =
+      Release.build(package, old_publisher, rel_meta(%{version: "0.0.1", app: package.name}), "")
+      |> Hexpm.Repo.insert!()
+
+    updated_release = release |> Release.update(new_publisher, %{}, "") |> Hexpm.Repo.update!()
+
+    assert updated_release.publisher_id == new_publisher.id
+  end
+
+  test "create release with deps", %{
+    publisher: publisher,
+    packages: [package1, package2, package3]
+  } do
+    Release.build(package3, publisher, rel_meta(%{version: "0.0.1", app: package3.name}), "")
     |> Hexpm.Repo.insert!()
 
-    Release.build(package3, rel_meta(%{version: "0.0.2", app: package3.name}), "")
+    Release.build(package3, publisher, rel_meta(%{version: "0.0.2", app: package3.name}), "")
     |> Hexpm.Repo.insert!()
 
     meta =
@@ -46,7 +82,7 @@ defmodule Hexpm.Repository.ReleaseTest do
         version: "0.0.1"
       })
 
-    Release.build(package2, meta, "") |> Hexpm.Repo.insert!()
+    Release.build(package2, publisher, meta, "") |> Hexpm.Repo.insert!()
 
     meta =
       rel_meta(%{
@@ -58,7 +94,7 @@ defmodule Hexpm.Repository.ReleaseTest do
         version: "0.0.1"
       })
 
-    Release.build(package1, meta, "") |> Hexpm.Repo.insert!()
+    Release.build(package1, publisher, meta, "") |> Hexpm.Repo.insert!()
 
     release =
       assoc(package1, :releases)
@@ -86,18 +122,26 @@ defmodule Hexpm.Repository.ReleaseTest do
            ] = release.requirements
   end
 
-  test "create release in other repository with deps", %{packages: [_, package2, package3]} do
+  test "create release in other repository with deps", %{
+    publisher: publisher,
+    packages: [_, package2, package3]
+  } do
     organization = insert(:organization)
     package1_repo = insert(:package, organization_id: organization.id)
     package2_repo = insert(:package, organization_id: organization.id, organization: organization)
 
-    Release.build(package1_repo, rel_meta(%{version: "0.0.1", app: package1_repo.name}), "")
+    Release.build(
+      package1_repo,
+      publisher,
+      rel_meta(%{version: "0.0.1", app: package1_repo.name}),
+      ""
+    )
     |> Hexpm.Repo.insert!()
 
-    Release.build(package2, rel_meta(%{version: "0.0.1", app: package2.name}), "")
+    Release.build(package2, publisher, rel_meta(%{version: "0.0.1", app: package2.name}), "")
     |> Hexpm.Repo.insert!()
 
-    Release.build(package3, rel_meta(%{version: "0.0.1", app: package3.name}), "")
+    Release.build(package3, publisher, rel_meta(%{version: "0.0.1", app: package3.name}), "")
     |> Hexpm.Repo.insert!()
 
     meta =
@@ -123,7 +167,7 @@ defmodule Hexpm.Repository.ReleaseTest do
         version: "0.0.1"
       })
 
-    Release.build(package2_repo, meta, "") |> Hexpm.Repo.insert!()
+    Release.build(package2_repo, publisher, meta, "") |> Hexpm.Repo.insert!()
 
     release =
       assoc(package2_repo, :releases)
@@ -141,7 +185,10 @@ defmodule Hexpm.Repository.ReleaseTest do
            ] = release.requirements
   end
 
-  test "create release does not allow deps from other repositories", %{packages: [package1, _, _]} do
+  test "create release does not allow deps from other repositories", %{
+    publisher: publisher,
+    packages: [package1, _, _]
+  } do
     organization1 = insert(:organization)
     organization2 = insert(:organization)
     package1_repo = insert(:package, organization_id: organization1.id)
@@ -150,10 +197,20 @@ defmodule Hexpm.Repository.ReleaseTest do
     package3_repo =
       insert(:package, organization_id: organization2.id, organization: organization2)
 
-    Release.build(package1_repo, rel_meta(%{version: "0.0.1", app: package1_repo.name}), "")
+    Release.build(
+      package1_repo,
+      publisher,
+      rel_meta(%{version: "0.0.1", app: package1_repo.name}),
+      ""
+    )
     |> Hexpm.Repo.insert!()
 
-    Release.build(package2_repo, rel_meta(%{version: "0.0.1", app: package2_repo.name}), "")
+    Release.build(
+      package2_repo,
+      publisher,
+      rel_meta(%{version: "0.0.1", app: package2_repo.name}),
+      ""
+    )
     |> Hexpm.Repo.insert!()
 
     package1 = Repo.preload(package1, :organization)
@@ -177,7 +234,7 @@ defmodule Hexpm.Repository.ReleaseTest do
              requirements: %{
                repository: "dependencies can only belong to public repository \"hexpm\"" <> _
              }
-           } = Release.build(package1, meta, "") |> errors_on()
+           } = Release.build(package1, publisher, meta, "") |> errors_on()
 
     meta =
       rel_meta(%{
@@ -198,7 +255,7 @@ defmodule Hexpm.Repository.ReleaseTest do
              requirements: %{
                repository: "dependencies can only belong to public repository \"hexpm\"" <> _
              }
-           } = Release.build(package1, meta, "") |> errors_on()
+           } = Release.build(package1, publisher, meta, "") |> errors_on()
 
     meta =
       rel_meta(%{
@@ -216,7 +273,7 @@ defmodule Hexpm.Repository.ReleaseTest do
       })
 
     assert %{requirements: %{dependency: "package does not exist" <> _}} =
-             Release.build(package1, meta, "") |> errors_on()
+             Release.build(package1, publisher, meta, "") |> errors_on()
 
     meta =
       rel_meta(%{
@@ -233,7 +290,7 @@ defmodule Hexpm.Repository.ReleaseTest do
       })
 
     assert %{requirements: %{dependency: "package does not exist" <> _}} =
-             Release.build(package1, meta, "") |> errors_on()
+             Release.build(package1, publisher, meta, "") |> errors_on()
 
     meta =
       rel_meta(%{
@@ -251,7 +308,7 @@ defmodule Hexpm.Repository.ReleaseTest do
       })
 
     assert %{requirements: %{dependency: "package does not exist" <> _}} =
-             Release.build(package3_repo, meta, "") |> errors_on()
+             Release.build(package3_repo, publisher, meta, "") |> errors_on()
 
     meta =
       rel_meta(%{
@@ -268,12 +325,13 @@ defmodule Hexpm.Repository.ReleaseTest do
       })
 
     assert %{requirements: %{dependency: "package does not exist" <> _}} =
-             Release.build(package3_repo, meta, "") |> errors_on()
+             Release.build(package3_repo, publisher, meta, "") |> errors_on()
   end
 
-  test "validate release", %{packages: [_, package2, package3]} do
+  test "validate release", %{publisher: publisher, packages: [_, package2, package3]} do
     Release.build(
       package3,
+      publisher,
       rel_meta(%{version: "0.1.0", app: package3.name, requirements: []}),
       ""
     )
@@ -283,6 +341,7 @@ defmodule Hexpm.Repository.ReleaseTest do
 
     Release.build(
       package2,
+      publisher,
       rel_meta(%{version: "0.1.0", app: package2.name, requirements: reqs}),
       ""
     )
@@ -291,12 +350,12 @@ defmodule Hexpm.Repository.ReleaseTest do
     meta = %{"version" => "0.1.0", "requirements" => [], "build_tools" => ["mix"]}
 
     assert %{meta: %{app: "can't be blank"}} =
-             Release.build(package3, %{"meta" => meta}, "") |> errors_on()
+             Release.build(package3, publisher, %{"meta" => meta}, "") |> errors_on()
 
     meta = %{"app" => package3.name, "version" => "0.1.0", "requirements" => []}
 
     assert %{meta: %{build_tools: "can't be blank"}} =
-             Release.build(package3, %{"meta" => meta}, "") |> errors_on()
+             Release.build(package3, publisher, %{"meta" => meta}, "") |> errors_on()
 
     meta = %{
       "app" => package3.name,
@@ -306,7 +365,7 @@ defmodule Hexpm.Repository.ReleaseTest do
     }
 
     assert %{meta: %{build_tools: "can't be blank"}} =
-             Release.build(package3, %{"meta" => meta}, "") |> errors_on()
+             Release.build(package3, publisher, %{"meta" => meta}, "") |> errors_on()
 
     meta = %{
       "app" => package3.name,
@@ -317,10 +376,15 @@ defmodule Hexpm.Repository.ReleaseTest do
     }
 
     assert %{meta: %{elixir: "invalid requirement: \"== == 0.0.1\""}} =
-             Release.build(package3, %{"meta" => meta}, "") |> errors_on()
+             Release.build(package3, publisher, %{"meta" => meta}, "") |> errors_on()
 
     assert %{version: "is invalid SemVer"} =
-             Release.build(package2, rel_meta(%{version: "0.1", app: package2.name}), "")
+             Release.build(
+               package2,
+               publisher,
+               rel_meta(%{version: "0.1", app: package2.name}),
+               ""
+             )
              |> errors_on()
 
     reqs = [%{name: package3.name, app: package3.name, requirement: "~> fail", optional: false}]
@@ -328,6 +392,7 @@ defmodule Hexpm.Repository.ReleaseTest do
     assert %{requirements: %{requirement: "invalid requirement: \"~> fail\""}} =
              Release.build(
                package2,
+               publisher,
                rel_meta(%{version: "0.1.1", app: package2.name, requirements: reqs}),
                ""
              )
@@ -339,16 +404,18 @@ defmodule Hexpm.Repository.ReleaseTest do
     # assert %{requirements: "Failed to use" <> _} =
     #          Release.build(
     #            package2,
+    #            publisher,
     #            rel_meta(%{version: "0.1.1", app: package2.name, requirements: reqs}),
     #            ""
     #          )
     #          |> errors_on()
   end
 
-  test "ensure unique build tools", %{packages: [_, _, package3]} do
+  test "ensure unique build tools", %{publisher: publisher, packages: [_, _, package3]} do
     changeset =
       Release.build(
         package3,
+        publisher,
         rel_meta(%{version: "0.1.0", app: package3.name, build_tools: ["mix", "make", "make"]}),
         ""
       )
@@ -356,20 +423,25 @@ defmodule Hexpm.Repository.ReleaseTest do
     assert changeset.changes.meta.changes.build_tools == ["mix", "make"]
   end
 
-  test "release version is unique", %{packages: [package1, package2, _]} do
-    Release.build(package1, rel_meta(%{version: "0.0.1", app: package1.name}), "")
+  test "release version is unique", %{publisher: publisher, packages: [package1, package2, _]} do
+    Release.build(package1, publisher, rel_meta(%{version: "0.0.1", app: package1.name}), "")
     |> Hexpm.Repo.insert!()
 
-    Release.build(package2, rel_meta(%{version: "0.0.1", app: package2.name}), "")
+    Release.build(package2, publisher, rel_meta(%{version: "0.0.1", app: package2.name}), "")
     |> Hexpm.Repo.insert!()
 
     assert {:error, %{errors: [version: {"has already been published", _}]}} =
-             Release.build(package1, rel_meta(%{version: "0.0.1", app: package1.name}), "")
+             Release.build(
+               package1,
+               publisher,
+               rel_meta(%{version: "0.0.1", app: package1.name}),
+               ""
+             )
              |> Hexpm.Repo.insert()
   end
 
-  test "update release", %{packages: [_, package2, package3]} do
-    Release.build(package3, rel_meta(%{version: "0.0.1", app: package3.name}), "")
+  test "update release", %{publisher: publisher, packages: [_, package2, package3]} do
+    Release.build(package3, publisher, rel_meta(%{version: "0.0.1", app: package3.name}), "")
     |> Hexpm.Repo.insert!()
 
     reqs = [%{name: package3.name, app: package3.name, requirement: "~> 0.0.1", optional: false}]
@@ -377,6 +449,7 @@ defmodule Hexpm.Repository.ReleaseTest do
     release =
       Release.build(
         package2,
+        publisher,
         rel_meta(%{version: "0.0.1", app: package2.name, requirements: reqs}),
         ""
       )
@@ -390,7 +463,7 @@ defmodule Hexpm.Repository.ReleaseTest do
         ]
       })
 
-    Release.update(%{release | package: package2}, params, "") |> Hexpm.Repo.update!()
+    Release.update(%{release | package: package2}, publisher, params, "") |> Hexpm.Repo.update!()
 
     package3_id = package3.id
     package3_name = package3.name
@@ -412,9 +485,10 @@ defmodule Hexpm.Repository.ReleaseTest do
 
   @tag :skip
   test "do not allow pre-release dependencies of stable releases", %{
+    publisher: publisher,
     packages: [_, package2, package3]
   } do
-    Release.build(package3, rel_meta(%{version: "0.0.1-dev", app: package3.name}), "")
+    Release.build(package3, publisher, rel_meta(%{version: "0.0.1-dev", app: package3.name}), "")
     |> Hexpm.Repo.insert!()
 
     reqs = [
@@ -424,6 +498,7 @@ defmodule Hexpm.Repository.ReleaseTest do
     assert {:error, changeset} =
              Release.build(
                package2,
+               publisher,
                rel_meta(%{version: "0.0.1", app: package2.name, requirements: reqs}),
                ""
              )
@@ -437,15 +512,16 @@ defmodule Hexpm.Repository.ReleaseTest do
 
     Release.build(
       package2,
+      publisher,
       rel_meta(%{version: "0.0.1-dev", app: package2.name, requirements: reqs}),
       ""
     )
     |> Hexpm.Repo.insert!()
   end
 
-  test "delete release", %{packages: [_, package2, package3]} do
+  test "delete release", %{publisher: publisher, packages: [_, package2, package3]} do
     release =
-      Release.build(package3, rel_meta(%{version: "0.0.1", app: package3.name}), "")
+      Release.build(package3, publisher, rel_meta(%{version: "0.0.1", app: package3.name}), "")
       |> Hexpm.Repo.insert!()
 
     Release.delete(release) |> Hexpm.Repo.delete!()


### PR DESCRIPTION
Fixes https://github.com/hexpm/hexpm/issues/727

![screen shot 2018-12-03 at 11 00 30 am](https://user-images.githubusercontent.com/773380/49395053-a8d74980-f6f2-11e8-9f1c-3ff363617b9e.png)

URLs are:
/packages/:repo/:pkgname/versions
/packages/:pkgname/versions