### PR TITLE
Add "Recently released" filter to Packages list

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -352,12 +352,13 @@ defmodule Hexpm.Repository.Package do
     from(p in query, order_by: [desc: p.updated_at])
   end
 
-  defp sort(query, :recently_released) do
+  defp sort(query, :recently_published) do
     from(
       p in query,
-      left_join: r in Release,
+      join: r in Release,
       on: p.id == r.package_id,
-      order_by: [desc: r.inserted_at]
+      group_by: p.id,
+      order_by: [desc: max(r.inserted_at), desc: p.id]
     )
   end
 

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -352,6 +352,15 @@ defmodule Hexpm.Repository.Package do
     from(p in query, order_by: [desc: p.updated_at])
   end
 
+  defp sort(query, :recently_released) do
+    from(
+      p in query,
+      left_join: r in Release,
+      on: p.id == r.package_id,
+      order_by: [desc: r.inserted_at]
+    )
+  end
+
   defp sort(query, :total_downloads) do
     from(
       p in query,

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -2,7 +2,7 @@ defmodule HexpmWeb.PackageController do
   use HexpmWeb, :controller
 
   @packages_per_page 30
-  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at recently_released)
+  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at recently_published)
   @letters for letter <- ?A..?Z, do: <<letter>>
 
   def index(conn, params) do

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -2,7 +2,7 @@ defmodule HexpmWeb.PackageController do
   use HexpmWeb, :controller
 
   @packages_per_page 30
-  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
+  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at recently_released)
   @letters for letter <- ?A..?Z, do: <<letter>>
 
   def index(conn, params) do

--- a/lib/hexpm_web/templates/package/index.html.eex
+++ b/lib/hexpm_web/templates/package/index.html.eex
@@ -34,6 +34,7 @@
   sort_recent_downloads_params = params(search: @search, page: page, sort: "recent_downloads")
   sort_created_params = params(search: @search, page: page, sort: "inserted_at")
   sort_updated_params = params(search: @search, page: page, sort: "updated_at")
+  sort_recently_released_params = params(search: @search, page: page, sort: "recently_released")
   prev_page_params = params(search: @search, page: @page-1, sort: @sort, letter: @letter)
   next_page_params = params(search: @search, page: @page+1, sort: @sort, letter: @letter)
   %>
@@ -64,6 +65,9 @@
           </li>
           <li role="presentation">
             <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_updated_params) %>">Recently updated</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_recently_released_params) %>">Recently released</a>
           </li>
         </ul>
       </div>

--- a/lib/hexpm_web/templates/package/index.html.eex
+++ b/lib/hexpm_web/templates/package/index.html.eex
@@ -34,7 +34,7 @@
   sort_recent_downloads_params = params(search: @search, page: page, sort: "recent_downloads")
   sort_created_params = params(search: @search, page: page, sort: "inserted_at")
   sort_updated_params = params(search: @search, page: page, sort: "updated_at")
-  sort_recently_released_params = params(search: @search, page: page, sort: "recently_released")
+  sort_recently_published_params = params(search: @search, page: page, sort: "recently_published")
   prev_page_params = params(search: @search, page: @page-1, sort: @sort, letter: @letter)
   next_page_params = params(search: @search, page: @page+1, sort: @sort, letter: @letter)
   %>
@@ -67,7 +67,7 @@
             <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_updated_params) %>">Recently updated</a>
           </li>
           <li role="presentation">
-            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_recently_released_params) %>">Recently released</a>
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_recently_published_params) %>">Recently published</a>
           </li>
         </ul>
       </div>

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -7,6 +7,7 @@ defmodule HexpmWeb.PackageView do
   def show_sort_info(:updated_at), do: "Sort: Recently updated"
   def show_sort_info(:total_downloads), do: "Sort: Total downloads"
   def show_sort_info(:recent_downloads), do: "Sort: Recent downloads"
+  def show_sort_info(:recently_released), do: "Sort: Recently released"
   def show_sort_info(_param), do: nil
 
   def downloads_for_package(package, downloads) do

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -7,7 +7,7 @@ defmodule HexpmWeb.PackageView do
   def show_sort_info(:updated_at), do: "Sort: Recently updated"
   def show_sort_info(:total_downloads), do: "Sort: Total downloads"
   def show_sort_info(:recent_downloads), do: "Sort: Recent downloads"
-  def show_sort_info(:recently_released), do: "Sort: Recently released"
+  def show_sort_info(:recently_published), do: "Sort: Recently published"
   def show_sort_info(_param), do: nil
 
   def downloads_for_package(package, downloads) do

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -223,4 +223,21 @@ defmodule Hexpm.Repository.PackageTest do
              |> Repo.all()
              |> Enum.map(& &1.id)
   end
+
+  test "sort packages by recent releases", %{organization: organization} do
+    %{id: ecto_id} = insert(:package, organization_id: organization.id)
+    %{id: phoenix_id} = insert(:package, organization_id: organization.id)
+    %{id: decimal_id} = insert(:package, organization_id: organization.id)
+
+    insert(:release, package_id: phoenix_id)
+    insert(:release, package_id: decimal_id)
+    insert(:release, package_id: ecto_id)
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [ecto_id, decimal_id, phoenix_id] ==
+             Package.all([organization], 1, 10, nil, :recently_released, nil)
+             |> Repo.all()
+             |> Enum.map(& &1.id)
+  end
 end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -229,14 +229,13 @@ defmodule Hexpm.Repository.PackageTest do
     %{id: phoenix_id} = insert(:package, organization_id: organization.id)
     %{id: decimal_id} = insert(:package, organization_id: organization.id)
 
-    insert(:release, package_id: phoenix_id)
-    insert(:release, package_id: decimal_id)
-    insert(:release, package_id: ecto_id)
+    insert(:release, package_id: decimal_id, version: "0.0.1")
+    insert(:release, package_id: phoenix_id, version: "0.0.1")
+    insert(:release, package_id: ecto_id, version: "0.0.1")
+    insert(:release, package_id: decimal_id, version: "0.0.2")
 
-    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
-
-    assert [ecto_id, decimal_id, phoenix_id] ==
-             Package.all([organization], 1, 10, nil, :recently_released, nil)
+    assert [decimal_id, ecto_id, phoenix_id] ==
+             Package.all([organization], 1, 10, nil, :recently_published, nil)
              |> Repo.all()
              |> Enum.map(& &1.id)
   end

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -15,7 +15,7 @@ defmodule HexpmWeb.PackageViewTest do
     assert PackageView.show_sort_info(:updated_at) == "Sort: Recently updated"
     assert PackageView.show_sort_info(:total_downloads) == "Sort: Total downloads"
     assert PackageView.show_sort_info(:recent_downloads) == "Sort: Recent downloads"
-    assert PackageView.show_sort_info(:recently_released) == "Sort: Recently released"
+    assert PackageView.show_sort_info(:recently_published) == "Sort: Recently published"
     assert PackageView.show_sort_info(nil) == "Sort: Name"
   end
 

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -15,6 +15,7 @@ defmodule HexpmWeb.PackageViewTest do
     assert PackageView.show_sort_info(:updated_at) == "Sort: Recently updated"
     assert PackageView.show_sort_info(:total_downloads) == "Sort: Total downloads"
     assert PackageView.show_sort_info(:recent_downloads) == "Sort: Recent downloads"
+    assert PackageView.show_sort_info(:recently_released) == "Sort: Recently released"
     assert PackageView.show_sort_info(nil) == "Sort: Name"
   end
 


### PR DESCRIPTION
Solves #769 

Although in #769 "Last recently released" was suggested, I dropped the "Last" to keep the filters naming consistent with the rest. You can see the look n feel in the screenshots below.

The query string in the URL is `/packages?sort=recently_released`, but I am open to any suggestions if you feel it can be improved.

Screenshots:
<img width="1064" alt="screen shot 2018-12-20 at 15 04 24" src="https://user-images.githubusercontent.com/854173/50289274-a736b100-0468-11e9-9748-41e38491072e.png">
<img width="1051" alt="screen shot 2018-12-20 at 15 04 30" src="https://user-images.githubusercontent.com/854173/50289283-ab62ce80-0468-11e9-9de0-d745bd01aaac.png">
