### PR TITLE
Validate version before attempting to cast

### DIFF
--- a/test/hexpm/repository/release_test.exs
+++ b/test/hexpm/repository/release_test.exs
@@ -483,7 +483,10 @@ defmodule Hexpm.Repository.ReleaseTest do
            ] = release.requirements
   end
 
-  test "update release fails with invalid version", %{publisher: publisher, packages: [_, package2, package3]} do
+  test "update release fails with invalid version", %{
+    publisher: publisher,
+    packages: [_, package2, package3]
+  } do
     Release.build(package3, publisher, rel_meta(%{version: "0.0.1", app: package3.name}), "")
     |> Hexpm.Repo.insert!()
 
@@ -501,11 +504,11 @@ defmodule Hexpm.Repository.ReleaseTest do
     params =
       params(%{
         app: package2.name,
-        version: "1.0",
+        version: "1.0"
       })
 
-      assert %Ecto.Changeset{} = error =  Release.update(%{release | package: package2}, publisher, params, "") 
-      assert [version: {"is invalid SemVer", _}] = error.errors
+    changeset = Release.update(%{release | package: package2}, publisher, params, "")
+    assert [version: {"is invalid SemVer", _}] = changeset.errors
   end
 
   @tag :skip

--- a/test/hexpm/repository/release_test.exs
+++ b/test/hexpm/repository/release_test.exs
@@ -483,6 +483,31 @@ defmodule Hexpm.Repository.ReleaseTest do
            ] = release.requirements
   end
 
+  test "update release fails with invalid version", %{publisher: publisher, packages: [_, package2, package3]} do
+    Release.build(package3, publisher, rel_meta(%{version: "0.0.1", app: package3.name}), "")
+    |> Hexpm.Repo.insert!()
+
+    reqs = [%{name: package3.name, app: package3.name, requirement: "~> 0.0.1", optional: false}]
+
+    release =
+      Release.build(
+        package2,
+        publisher,
+        rel_meta(%{version: "0.0.1", app: package2.name, requirements: reqs}),
+        ""
+      )
+      |> Hexpm.Repo.insert!()
+
+    params =
+      params(%{
+        app: package2.name,
+        version: "1.0",
+      })
+
+      assert %Ecto.Changeset{} = error =  Release.update(%{release | package: package2}, publisher, params, "") 
+      assert [version: {"is invalid SemVer", _}] = error.errors
+  end
+
   @tag :skip
   test "do not allow pre-release dependencies of stable releases", %{
     publisher: publisher,

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -98,6 +98,28 @@ defmodule Hexpm.Repository.ReleasesTest do
 
       assert %{version: "is reserved"} = errors_on(changeset)
     end
+
+    test "cant publish using non-semantic version", %{package: package, user: user} do
+      Repo.insert_all("reserved_packages", [
+        %{"organization_id" => 1, "name" => package.name, "version" => "0.2.0"}
+      ])
+
+      meta = default_meta(package.name, "0.2")
+      audit = audit_data(user)
+
+      assert {:error, :version, changeset, _} =
+               Releases.publish(
+                 Organization.hexpm(),
+                 package,
+                 user,
+                 "BODY",
+                 meta,
+                 "CHECKSUM",
+                 audit: audit
+               )
+
+      assert %{version: "is invalid SemVer"} = errors_on(changeset)
+    end
   end
 
   describe "revert/3" do

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -66,6 +66,21 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
       assert Hexpm.Repo.get_by(Package, name: package.name).meta.description == "awesomeness"
     end
 
+    test "update package fails when version is invalid", %{user: user, package: package} do
+      meta = %{name: package.name, version: "1.0-dev", description: "not-so-awesome"}
+
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put_req_header("authorization", key_for(user))
+        |> post("api/packages/#{package.name}/releases", create_tar(meta, []))
+
+      assert conn.status == 422
+      result = json_response(conn, 422)
+      assert result["message"] =~ "Validation error" 
+      assert result["errors"] == %{"version" => "is invalid SemVer"}
+    end
+
     test "create release checks if package name is correct", %{user: user, package: package} do
       meta = %{name: Fake.sequence(:package), version: "0.1.0", description: "description"}
 


### PR DESCRIPTION
This PR resolves the issue of the api returning a 500 in the case of a non-semantic version supplied for creation or update. 