### PR TITLE
#753 show publisher on package page

### DIFF
--- a/assets/css/template/_package-view.scss
+++ b/assets/css/template/_package-view.scss
@@ -108,7 +108,7 @@
   }
 }
 
-.owner-avatar {
+.user-avatar {
   width: 30px;
   margin: 0 7px;
   border-radius: 5px;

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -85,7 +85,7 @@ defmodule HexpmWeb.PackageController do
 
   defp package(conn, organizations, package, releases, release, type) do
     organization = package.organization
-    release = Releases.preload(release, [:requirements, :downloads])
+    release = Releases.preload(release, [:requirements, :downloads, :publisher])
     latest_release_with_docs = Enum.find(releases, & &1.has_docs)
 
     docs_assigns =

--- a/lib/hexpm_web/templates/package/_user.html.eex
+++ b/lib/hexpm_web/templates/package/_user.html.eex
@@ -1,0 +1,3 @@
+<a href="<%= Routes.user_path(Endpoint, :show, @user) %>">
+  <img src="<%= gravatar_url(User.email(@user, :gravatar), :small) %>" class="owner-avatar"><%= @user.username %>
+</a>

--- a/lib/hexpm_web/templates/package/_user.html.eex
+++ b/lib/hexpm_web/templates/package/_user.html.eex
@@ -1,3 +1,3 @@
 <a href="<%= Routes.user_path(Endpoint, :show, @user) %>">
-  <img src="<%= gravatar_url(User.email(@user, :gravatar), :small) %>" class="owner-avatar"><%= @user.username %>
+  <img src="<%= gravatar_url(User.email(@user, :gravatar), :small) %>" class="user-avatar"><%= @user.username %>
 </a>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -205,18 +205,14 @@ tools = Keyword.take(tools, compatible_tools)
     <ul class="owners-list">
       <%= for owner <- @owners do %>
         <li>
-          <a href="<%= Routes.user_path(Endpoint, :show, owner.user) %>">
-            <img src="<%= gravatar_url(User.email(owner.user, :gravatar), :small) %>" class="owner-avatar"><%= owner.user.username %>
-          </a>
+          <%= render "_user.html", user: owner.user %>
         </li>
       <% end %>
     </ul>
 
     <%= if @current_release.publisher do %>
       <h3>Publisher</h3>
-      <a href="<%= Routes.user_path(Endpoint, :show, @current_release.publisher) %>">
-        <img src="<%= gravatar_url(User.email(@current_release.publisher, :gravatar), :small) %>" class="owner-avatar"><%= @current_release.publisher.username %>
-      </a>
+      <%= render "_user.html", user: @current_release.publisher %>
     <% end %>
 
     <h3>Dependents (<%= @dependants_count %>)</h3>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -212,6 +212,13 @@ tools = Keyword.take(tools, compatible_tools)
       <% end %>
     </ul>
 
+    <%= if @current_release.publisher do %>
+      <h3>Publisher</h3>
+      <a href="<%= Routes.user_path(Endpoint, :show, @current_release.publisher) %>">
+        <img src="<%= gravatar_url(User.email(@current_release.publisher, :gravatar), :small) %>" class="owner-avatar"><%= @current_release.publisher.username %>
+      </a>
+    <% end %>
+
     <h3>Dependents (<%= @dependants_count %>)</h3>
     <%= safe_join(@dependants, ", ", fn package ->
       link(package_name(package), to: path_for_package(package))

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -130,6 +130,19 @@ defmodule HexpmWeb.PackageControllerTest do
       assert response(conn, 200) =~ escape(~s({:#{package1.name}, "~> 0.0.1"}))
     end
 
+    test "show publisher info", %{package1: package1} do
+      insert(
+        :release,
+        package: package1,
+        publisher: build(:user, username: "Publisher"),
+        version: "0.1.0",
+        meta: build(:release_metadata, app: package1.name)
+      )
+
+      conn = get(build_conn(), "/packages/#{package1.name}/0.1.0")
+      assert response(conn, 200) =~ "Publisher"
+    end
+
     test "show package from other repository", %{
       user1: user1,
       organization1: organization1,

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -131,16 +131,17 @@ defmodule HexpmWeb.PackageControllerTest do
     end
 
     test "show publisher info", %{package1: package1} do
-      insert(
-        :release,
-        package: package1,
-        publisher: build(:user, username: "Publisher"),
-        version: "0.1.0",
-        meta: build(:release_metadata, app: package1.name)
-      )
+      release =
+        insert(
+          :release,
+          package: package1,
+          publisher: build(:user),
+          version: "0.1.0",
+          meta: build(:release_metadata, app: package1.name)
+        )
 
       conn = get(build_conn(), "/packages/#{package1.name}/0.1.0")
-      assert response(conn, 200) =~ "Publisher"
+      assert response(conn, 200) =~ release.publisher.username
     end
 
     test "show package from other repository", %{


### PR DESCRIPTION
See also https://github.com/hexpm/hexpm/issues/753#issuecomment-450448194

Here is how it looks on my local:
<img width="1552" alt="screen shot 2019-01-02 at 9 01 04 pm" src="https://user-images.githubusercontent.com/4723751/50593359-0b2e9000-0ed3-11e9-80f5-61a82addb8ea.png">


BTW, Do I need to update `seeds.exs` to add publisher to every release?