### PR TITLE
Dropping maintainers from rebar3 publishing

### DIFF
--- a/lib/hexpm_web/templates/docs/rebar3_publish.html.md
+++ b/lib/hexpm_web/templates/docs/rebar3_publish.html.md
@@ -96,9 +96,8 @@ Only Hex packages may be used as dependencies of the package. It is not possible
                    erlware_commons,
                    bbmustache,
                    providers]},
-
    {licenses, ["Apache"]},
-   {links, [{"Github", "https://github.com/erlware/relx"}]}]}.
+   {links, [{"GitHub", "https://github.com/erlware/relx"}]}]}.
 
 ```
 

--- a/lib/hexpm_web/templates/docs/rebar3_publish.html.md
+++ b/lib/hexpm_web/templates/docs/rebar3_publish.html.md
@@ -96,8 +96,7 @@ Only Hex packages may be used as dependencies of the package. It is not possible
                    erlware_commons,
                    bbmustache,
                    providers]},
-   {maintainers, ["Eric Merritt", "Tristan Sloughter",
-                  "Jordan Wilberding"]},
+
    {licenses, ["Apache"]},
    {links, [{"Github", "https://github.com/erlware/relx"}]}]}.
 


### PR DESCRIPTION
The field is deprecated anyway.