### PR TITLE
Use SPDX license identifiers

### DIFF
--- a/lib/hexpm_web/templates/docs/publish.html.md
+++ b/lib/hexpm_web/templates/docs/publish.html.md
@@ -45,7 +45,7 @@ Under the `:package` property are some additional configuration options:
   <dt><code>:organization</code></dt>
   <dd>The organization the package belongs to. The package will be published to the organization repository, defaults to the global <code>"hexpm"</code> repository.</dd>
   <dt><code>:licenses</code></dt>
-  <dd>A list of licenses the project is licensed under. This attribute is required.</dd>
+  <dd>A list of licenses the project is licensed under. This attribute is required. It is recommended to use <a href="https://spdx.org/licenses/">SPDX License identifier</a>.</dd>
   <dt><code>:links</code></dt>
   <dd>A map where the key is a link name and the value is the link URL. Optional but highly recommended.</dd>
   <dt><code>:files</code></dt>
@@ -124,7 +124,7 @@ defmodule Postgrex.MixProject do
       # These are the default files included in the package
       files: ~w(lib priv .formatter.exs mix.exs README* readme* LICENSE*
                 license* CHANGELOG* changelog* src),
-      licenses: ["Apache 2.0"],
+      licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/elixir-ecto/postgrex"}
     ]
   end

--- a/lib/hexpm_web/templates/docs/rebar3_publish.html.md
+++ b/lib/hexpm_web/templates/docs/rebar3_publish.html.md
@@ -96,7 +96,7 @@ Only Hex packages may be used as dependencies of the package. It is not possible
                    erlware_commons,
                    bbmustache,
                    providers]},
-   {licenses, ["Apache"]},
+   {licenses, ["Apache-2.0"]},
    {links, [{"GitHub", "https://github.com/erlware/relx"}]}]}.
 
 ```

--- a/lib/hexpm_web/templates/policy/coc.html.md
+++ b/lib/hexpm_web/templates/policy/coc.html.md
@@ -52,7 +52,7 @@ Packages must contain some functionality. "Squatting", that is, publishing an em
 
 Packages must not contain illegal or infringing content. You should only publish packages or other materials to the Service if you have the right to do so. This includes complying with all software license agreements or other intellectual property restrictions. For example, redistributing an MIT-licensed module with the copyright notice removed, would not be allowed. You will be responsible for any violation of laws or others’ intellectual property rights.
 
-Packages must have a license that allows any users access to the package and it's contents for use as a dependency in their project. The license may impose sensible restrictions on how the package can be used or add requirements to the project using it. Examples of licenses that can be used is (but not limited to): MIT, Apache, BSD, GPL, WTFPL and Unlicense.
+Packages must specify a license under which users can access and use the package and its contents as a dependency in their project. The license may impose sensible restrictions on how the package can be used or add requirements to the project using it. Examples of licenses that can be used is (but not limited to): MIT, Apache-2.0, BSD-3-Clause, GPL-3.0-or-later, WTFPL and Unlicense. See [Open Source Initiative](https://opensource.org/) and [SPDX License List](https://spdx.org/licenses/).
 
 Packages must not be malware. For example, a package which is designed to maliciously exploit or damage computer systems, is not allowed. However, an explicitly documented penetration testing library designed to be used for white-hat security research would most likely be fine.
 

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -59,7 +59,7 @@ Hexpm.Repo.transaction(fn ->
       meta:
         build(
           :package_metadata,
-          licenses: ["Apache 2.0", "MIT"],
+          licenses: ["Apache-2.0", "MIT"],
           links: %{
             "Github" => "http://example.com/github",
             "Documentation" => "http://example.com/documentation"
@@ -139,7 +139,7 @@ Hexpm.Repo.transaction(fn ->
       meta:
         build(
           :package_metadata,
-          licenses: ["Apache 2.0"],
+          licenses: ["Apache-2.0"],
           links: %{"Github" => "http://example.com/github"},
           description: lorem
         )
@@ -544,7 +544,7 @@ Hexpm.Repo.transaction(fn ->
       meta:
         build(
           :package_metadata,
-          licenses: ["Apache 2.0"],
+          licenses: ["Apache-2.0"],
           links: %{"Github" => "http://example.com/github"},
           description: lorem,
           extra: %{"foo" => %{"bar" => "baz"}, "key" => "value 1"}
@@ -576,7 +576,7 @@ Hexpm.Repo.transaction(fn ->
         meta:
           build(
             :package_metadata,
-            licenses: ["Apache 2.0"],
+            licenses: ["Apache-2.0"],
             links: %{"Github" => "http://example.com/github"},
             description: lorem,
             extra: %{"list" => ["a", "b", "c"], "foo" => %{"bar" => "baz"}, "key" => "value"}

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -39,7 +39,7 @@ defmodule Hexpm.Repository.PackageTest do
     Package.update(package, %{
       "meta" => %{
         "description" => "updated",
-        "licenses" => ["Apache"]
+        "licenses" => ["Apache-2.0"]
       }
     })
     |> Hexpm.Repo.update!()
@@ -141,7 +141,7 @@ defmodule Hexpm.Repository.PackageTest do
 
   test "search extra metadata", %{user: user, repository: repository} do
     meta = %{
-      "licenses" => ["apache", "BSD"],
+      "licenses" => ["Apache-2.0", "BSD-3-Clause"],
       "links" => %{"github" => "https://github.com", "docs" => "https://hexdocs.pm"},
       "description" => "description",
       "extra" => %{"foo" => %{"bar" => "baz"}, "list" => ["a", 1]}

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -6,7 +6,7 @@ defmodule Hexpm.TestHelpers do
       meta
       |> Map.put_new(:app, meta[:name])
       |> Map.put_new(:build_tools, ["mix"])
-      |> Map.put_new(:licenses, ["Apache"])
+      |> Map.put_new(:licenses, ["Apache-2.0"])
       |> Map.put_new(:requirements, %{})
 
     contents_path = Path.join(@tmp, "#{meta[:name]}-#{meta[:version]}-contents.tar.gz")
@@ -42,7 +42,7 @@ defmodule Hexpm.TestHelpers do
 
   def pkg_meta(meta) do
     params = params(meta)
-    meta = Map.put_new(params, "licenses", ["Apache"])
+    meta = Map.put_new(params, "licenses", ["Apache-2.0"])
     Map.put(params, "meta", meta)
   end
 


### PR DESCRIPTION
Related: #746 

## Changes

Web pages

- https://hex.pm/docs/publish
- https://hex.pm/policies/codeofconduct

All tests/seeds to use SPDX license identifiers