### PR TITLE
Update mix.exs file

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,6 @@ defmodule Hexpm.MixProject do
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
-  defp elixirc_paths(:dev), do: ["lib", "test/support/fake.ex", "test/support/factory.ex"]
   defp elixirc_paths(_), do: ["lib"]
 
   defp xref() do


### PR DESCRIPTION
Due to the fake.ex and factory.ex files were both moved to the `lib/hexpm` folder, can we just remove this line?