### PR TITLE
#754 AuditLogs.all_by/1

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -186,7 +186,7 @@ defmodule Hexpm.Accounts.AuditLog do
 
   def all_by(%Hexpm.Repository.Package{} = package) do
     from(l in AuditLog,
-      where: fragment("? -> 'package' ->> 'id' = ?", l.params, ^to_string(package.id))
+      where: fragment("(? -> 'package' ->> 'id')::integer", l.params) == ^package.id
     )
   end
 

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -189,10 +189,10 @@ defmodule Hexpm.Accounts.AuditLog do
   end
 
   def all_by(%Hexpm.Accounts.Organization{} = organization) do
-    from(l in AuditLog, where: l.organization_id == ^organization.id)
+    Ecto.assoc(organization, :audit_logs)
   end
 
   def all_by(%Hexpm.Accounts.User{} = user) do
-    from(l in AuditLog, where: l.user_id == ^user.id)
+    Ecto.assoc(user, :audit_logs)
   end
 end

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -185,7 +185,9 @@ defmodule Hexpm.Accounts.AuditLog do
   defp multi_key(action), do: :"log.#{action}"
 
   def all_by(%Hexpm.Repository.Package{} = package) do
-    from(l in AuditLog, where: fragment("? @> ?", l.params, ^%{package: %{id: package.id}}))
+    from(l in AuditLog,
+      where: fragment("? -> 'package' ->> 'id' = ?", l.params, ^to_string(package.id))
+    )
   end
 
   def all_by(%Hexpm.Accounts.Organization{} = organization) do

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -183,4 +183,16 @@ defmodule Hexpm.Accounts.AuditLog do
   defp fields(%UserHandles{}), do: [:github, :twitter, :freenode]
 
   defp multi_key(action), do: :"log.#{action}"
+
+  def all_by(%Hexpm.Repository.Package{} = package) do
+    from(l in AuditLog, where: fragment("? @> ?", l.params, ^%{package: %{id: package.id}}))
+  end
+
+  def all_by(%Hexpm.Accounts.Organization{} = organization) do
+    from(l in AuditLog, where: l.organization_id == ^organization.id)
+  end
+
+  def all_by(%Hexpm.Accounts.User{} = user) do
+    from(l in AuditLog, where: l.user_id == ^user.id)
+  end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -1,0 +1,3 @@
+defmodule Hexpm.Accounts.AuditLogs do
+  use HexpmWeb, :context
+end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -4,19 +4,17 @@ defmodule Hexpm.Accounts.AuditLogs do
   alias Hexpm.Accounts.AuditLog
 
   def all_by(%Hexpm.Repository.Package{} = package) do
-    from(l in AuditLog,
-      where: fragment("? @> ?", l.params, ^%{package: %{id: package.id}})
-    )
+    AuditLog.all_by(package)
     |> Repo.all()
   end
 
   def all_by(%Hexpm.Accounts.Organization{} = organization) do
-    from(l in AuditLog, where: l.organization_id == ^organization.id)
+    AuditLog.all_by(organization)
     |> Repo.all()
   end
 
   def all_by(%Hexpm.Accounts.User{} = user) do
-    from(l in AuditLog, where: l.user_id == ^user.id)
+    AuditLog.all_by(user)
     |> Repo.all()
   end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -1,3 +1,10 @@
 defmodule Hexpm.Accounts.AuditLogs do
   use HexpmWeb, :context
+
+  alias Hexpm.Accounts.AuditLog
+
+  def all_by(user) do
+    from(l in AuditLog, where: l.user_id == ^user.id)
+    |> Repo.all()
+  end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -3,18 +3,8 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   alias Hexpm.Accounts.AuditLog
 
-  def all_by(%Hexpm.Repository.Package{} = package) do
-    AuditLog.all_by(package)
-    |> Repo.all()
-  end
-
-  def all_by(%Hexpm.Accounts.Organization{} = organization) do
-    AuditLog.all_by(organization)
-    |> Repo.all()
-  end
-
-  def all_by(%Hexpm.Accounts.User{} = user) do
-    AuditLog.all_by(user)
+  def all_by(schema) do
+    AuditLog.all_by(schema)
     |> Repo.all()
   end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -3,8 +3,16 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   alias Hexpm.Accounts.AuditLog
 
+  @audit_logs_per_page 10
+
   def all_by(schema) do
     AuditLog.all_by(schema)
+    |> Repo.all()
+  end
+
+  def all_by(schema, page) do
+    AuditLog.all_by(schema)
+    |> Hexpm.Utils.paginate(page, @audit_logs_per_page)
     |> Repo.all()
   end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -3,6 +3,11 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   alias Hexpm.Accounts.AuditLog
 
+  def all_by(%Hexpm.Accounts.Organization{} = organization) do
+    from(l in AuditLog, where: l.organization_id == ^organization.id)
+    |> Repo.all()
+  end
+
   def all_by(user) do
     from(l in AuditLog, where: l.user_id == ^user.id)
     |> Repo.all()

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -3,6 +3,13 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   alias Hexpm.Accounts.AuditLog
 
+  def all_by(%Hexpm.Repository.Package{} = package) do
+    from(l in AuditLog,
+      where: fragment("? @> ?", l.params, ^%{package: %{id: package.id}})
+    )
+    |> Repo.all()
+  end
+
   def all_by(%Hexpm.Accounts.Organization{} = organization) do
     from(l in AuditLog, where: l.organization_id == ^organization.id)
     |> Repo.all()

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -8,7 +8,7 @@ defmodule Hexpm.Accounts.AuditLogs do
     |> Repo.all()
   end
 
-  def all_by(user) do
+  def all_by(%Hexpm.Accounts.User{} = user) do
     from(l in AuditLog, where: l.user_id == ^user.id)
     |> Repo.all()
   end

--- a/lib/hexpm/factory.ex
+++ b/lib/hexpm/factory.ex
@@ -57,10 +57,8 @@ defmodule Hexpm.Factory do
 
   def audit_log_factory() do
     %Hexpm.Accounts.AuditLog{
-      action: "NOTE: this is the default value set in Hexpm.Factory.audit_log_factory/0",
-      params: %{
-        notice: "NOTE: this is the default value set in Hexpm.Factory.audit_log_factory/0"
-      }
+      action: "",
+      params: %{}
     }
   end
 

--- a/lib/hexpm/factory.ex
+++ b/lib/hexpm/factory.ex
@@ -55,6 +55,15 @@ defmodule Hexpm.Factory do
     }
   end
 
+  def audit_log_factory() do
+    %Hexpm.Accounts.AuditLog{
+      action: "NOTE: this is the default value set in Hexpm.Factory.audit_log_factory/0",
+      params: %{
+        notice: "NOTE: this is the default value set in Hexpm.Factory.audit_log_factory/0"
+      }
+    }
+  end
+
   def repository_factory() do
     name = Fake.sequence(:package)
 

--- a/priv/repo/migrations/20190618121721_add_index_to_audit_logs_params_package_id.exs
+++ b/priv/repo/migrations/20190618121721_add_index_to_audit_logs_params_package_id.exs
@@ -1,0 +1,13 @@
+defmodule Hexpm.RepoBase.Migrations.AddIndexToAuditLogsParamsPackageId do
+  use Ecto.Migration
+
+  def change do
+    create(
+      index(
+        :audit_logs,
+        ["((params -> 'package' ->> 'id')::integer)"],
+        name: "audit_logs_params_package_id_index"
+      )
+    )
+  end
+end

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -1,0 +1,3 @@
+defmodule Hexpm.Accounts.AuditLogsTest do
+  use Hexpm.DataCase, async: true
+end

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -1,3 +1,23 @@
 defmodule Hexpm.Accounts.AuditLogsTest do
   use Hexpm.DataCase, async: true
+
+  alias Hexpm.Accounts.AuditLogs
+
+  describe "all_by(user)" do
+    test "returns audit_logs belong to this user" do
+      this_user = insert(:user)
+      audit_log = insert(:audit_log, user: this_user)
+
+      assert [audit_log_fetched] = AuditLogs.all_by(this_user)
+      assert audit_log_fetched.id == audit_log.id
+    end
+
+    test "does not return audit_logs that do not belong to this user" do
+      this_user = insert(:user)
+      other_user = insert(:user)
+      _audit_log = insert(:audit_log, user: other_user)
+
+      assert [] = AuditLogs.all_by(this_user)
+    end
+  end
 end

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -63,4 +63,25 @@ defmodule Hexpm.Accounts.AuditLogsTest do
       assert [] = AuditLogs.all_by(this_package)
     end
   end
+
+  describe "all_by(user, page)" do
+    test "returns 10 audit logs per page" do
+      user = insert(:user)
+      insert_list(11, :audit_log, user: user)
+
+      results = AuditLogs.all_by(user, 1)
+
+      assert length(results) == 10
+    end
+
+    test "returns audit_logs in page 2" do
+      user = insert(:user)
+      # NOTE: the order is desc: :inserted_at by default,
+      # so we insert audit_log in second page first
+      insert(:audit_log, action: "test.second.page", user: user)
+      insert_list(10, :audit_log, action: "test.first.page", user: user)
+
+      assert [%{action: "test.second.page"}] = AuditLogs.all_by(user, 2)
+    end
+  end
 end

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -20,4 +20,22 @@ defmodule Hexpm.Accounts.AuditLogsTest do
       assert [] = AuditLogs.all_by(this_user)
     end
   end
+
+  describe "all_by(organization)" do
+    test "returns audit_logs belong to this organization" do
+      this_org = insert(:organization)
+      audit_log = insert(:audit_log, organization: this_org)
+
+      assert [audit_log_fetched] = AuditLogs.all_by(this_org)
+      assert audit_log_fetched.id == audit_log.id
+    end
+
+    test "does not return audit_logs that do not belong to this organization" do
+      this_org = insert(:organization)
+      other_org = insert(:organization)
+      _audit_log = insert(:audit_log, organization: other_org)
+
+      assert [] = AuditLogs.all_by(this_org)
+    end
+  end
 end

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -38,4 +38,22 @@ defmodule Hexpm.Accounts.AuditLogsTest do
       assert [] = AuditLogs.all_by(this_org)
     end
   end
+
+  describe "all_by(package)" do
+    test "returns audit_logs that have are created for this package" do
+      this_package = insert(:package)
+      audit_log = insert(:audit_log, params: %{package: %{id: this_package.id}})
+
+      assert [audit_log_fetched] = AuditLogs.all_by(this_package)
+      assert audit_log_fetched.id == audit_log.id
+    end
+
+    test "does not return audit_logs that are NOT created for this package" do
+      this_package = insert(:package)
+      other_package = insert(:package)
+      _audit_log = insert(:audit_log, params: %{package: %{id: other_package.id}})
+
+      assert [] = AuditLogs.all_by(this_package)
+    end
+  end
 end

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -55,5 +55,12 @@ defmodule Hexpm.Accounts.AuditLogsTest do
 
       assert [] = AuditLogs.all_by(this_package)
     end
+
+    test "does not return audit_logs that do not have package in params" do
+      this_package = insert(:package)
+      _audit_log = insert(:audit_log, params: %{})
+
+      assert [] = AuditLogs.all_by(this_package)
+    end
   end
 end


### PR DESCRIPTION
As I mentioned in https://github.com/hexpm/hexpm/issues/754#issuecomment-498665175, this PR:
1. Add a module called `Hexpm.Accounts.AuditLogs` as the Context storing AuditLog related functions
2. Add a public function `AuditLogs.all_by/1` that can query audit logs for different structs (User/Package/Organization)
    1. For `User`, query by `belongs_to :user` relationship
    2. For `Organization`, query by `belongs_to :organization` relationship
    3. For `Package`, query by `params` which contains the `package_id`