### PR TITLE
#754 Add AuditLogs API Endpoints

### DIFF
--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -3,7 +3,7 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   alias Hexpm.Accounts.AuditLog
 
-  @audit_logs_per_page 10
+  @audit_logs_per_page 100
 
   def all_by(schema) do
     AuditLog.all_by(schema)

--- a/lib/hexpm_web/controllers/api/organization_controller.ex
+++ b/lib/hexpm_web/controllers/api/organization_controller.ex
@@ -54,8 +54,7 @@ defmodule HexpmWeb.API.OrganizationController do
     organization = conn.assigns.organization
     audit_logs = AuditLogs.all_by(organization, Hexpm.Utils.safe_int(params["page"]))
 
-    conn
-    |> render(:audit_logs, audit_logs: audit_logs)
+    render(conn, :audit_logs, audit_logs: audit_logs)
   end
 
   defp current_organization(nil), do: []

--- a/lib/hexpm_web/controllers/api/organization_controller.ex
+++ b/lib/hexpm_web/controllers/api/organization_controller.ex
@@ -10,7 +10,7 @@ defmodule HexpmWeb.API.OrganizationController do
 
   plug :authorize,
        [domain: "api", resource: "read", fun: &organization_access/2]
-       when action == :show
+       when action in [:show, :audit_logs]
 
   plug :authorize,
        [domain: "api", resource: "write", fun: &organization_access_write/2]

--- a/lib/hexpm_web/controllers/api/organization_controller.ex
+++ b/lib/hexpm_web/controllers/api/organization_controller.ex
@@ -50,6 +50,14 @@ defmodule HexpmWeb.API.OrganizationController do
     end
   end
 
+  def audit_logs(conn, params) do
+    organization = conn.assigns.organization
+    audit_logs = AuditLogs.all_by(organization, Hexpm.Utils.safe_int(params["page"]))
+
+    conn
+    |> render(:audit_logs, audit_logs: audit_logs)
+  end
+
   defp current_organization(nil), do: []
   defp current_organization(organization), do: [organization]
 end

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -48,8 +48,7 @@ defmodule HexpmWeb.API.PackageController do
     if package = conn.assigns.package do
       audit_logs = AuditLogs.all_by(package, Hexpm.Utils.safe_int(params["page"]))
 
-      conn
-      |> render(:audit_logs, audit_logs: audit_logs)
+      render(conn, :audit_logs, audit_logs: audit_logs)
     else
       not_found(conn)
     end

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -2,7 +2,7 @@ defmodule HexpmWeb.API.PackageController do
   use HexpmWeb, :controller
 
   plug :fetch_repository when action in [:index]
-  plug :maybe_fetch_package when action in [:show]
+  plug :maybe_fetch_package when action in [:show, :audit_logs]
 
   plug :maybe_authorize,
        [domain: "api", resource: "read", fun: &maybe_repository_access/2]
@@ -39,6 +39,17 @@ defmodule HexpmWeb.API.PackageController do
         |> api_cache(:public)
         |> render(:show, package: package)
       end)
+    else
+      not_found(conn)
+    end
+  end
+
+  def audit_logs(conn, params) do
+    if package = conn.assigns.package do
+      audit_logs = AuditLogs.all_by(package, Hexpm.Utils.safe_int(params["page"]))
+
+      conn
+      |> render(:audit_logs, audit_logs: audit_logs)
     else
       not_found(conn)
     end

--- a/lib/hexpm_web/controllers/api/user_controller.ex
+++ b/lib/hexpm_web/controllers/api/user_controller.ex
@@ -2,7 +2,7 @@ defmodule HexpmWeb.API.UserController do
   use HexpmWeb, :controller
 
   plug :authorize, [domain: "api", resource: "read"] when action in [:test]
-  plug :authorize, [domain: "api", resource: "read"] when action in [:me]
+  plug :authorize, [domain: "api", resource: "read"] when action in [:me, :audit_logs]
 
   def create(conn, params) do
     params = email_param(params)
@@ -31,6 +31,16 @@ defmodule HexpmWeb.API.UserController do
         |> api_cache(:private)
         |> render(:me, user: user)
       end)
+    else
+      not_found(conn)
+    end
+  end
+
+  def audit_logs(conn, params) do
+    if user = conn.assigns.current_user do
+      audit_logs = AuditLogs.all_by(user, Hexpm.Utils.safe_int(params["page"]))
+
+      render(conn, :audit_logs, audit_logs: audit_logs)
     else
       not_found(conn)
     end

--- a/lib/hexpm_web/controllers/api/user_controller.ex
+++ b/lib/hexpm_web/controllers/api/user_controller.ex
@@ -53,10 +53,9 @@ defmodule HexpmWeb.API.UserController do
     end
   end
 
-  def audit_logs(conn, %{"name" => name}) do
+  def audit_logs(conn, params = %{"name" => name}) do
     user = Users.public_get(name)
-    # TODO: audit_logs pagination
-    audit_logs = AuditLogs.all_by(user)
+    audit_logs = AuditLogs.all_by(user, Hexpm.Utils.safe_int(params["page"]))
 
     conn
     |> render(:audit_logs, audit_logs: audit_logs)

--- a/lib/hexpm_web/controllers/api/user_controller.ex
+++ b/lib/hexpm_web/controllers/api/user_controller.ex
@@ -53,6 +53,15 @@ defmodule HexpmWeb.API.UserController do
     end
   end
 
+  def audit_logs(conn, %{"name" => name}) do
+    user = Users.public_get(name)
+    # TODO: audit_logs pagination
+    audit_logs = AuditLogs.all_by(user)
+
+    conn
+    |> render(:audit_logs, audit_logs: audit_logs)
+  end
+
   def test(conn, params) do
     show(conn, params)
   end

--- a/lib/hexpm_web/controllers/api/user_controller.ex
+++ b/lib/hexpm_web/controllers/api/user_controller.ex
@@ -53,14 +53,6 @@ defmodule HexpmWeb.API.UserController do
     end
   end
 
-  def audit_logs(conn, params = %{"name" => name}) do
-    user = Users.public_get(name)
-    audit_logs = AuditLogs.all_by(user, Hexpm.Utils.safe_int(params["page"]))
-
-    conn
-    |> render(:audit_logs, audit_logs: audit_logs)
-  end
-
   def test(conn, params) do
     show(conn, params)
   end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -171,6 +171,7 @@ defmodule HexpmWeb.Router do
     post "/users", UserController, :create
     get "/users/me", UserController, :me
     get "/users/:name", UserController, :show
+    get "/users/:name/audit_logs", UserController, :audit_logs
     # NOTE: Deprecated (2018-05-21)
     get "/users/:name/test", UserController, :test
     post "/users/:name/reset", UserController, :reset

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -171,7 +171,6 @@ defmodule HexpmWeb.Router do
     post "/users", UserController, :create
     get "/users/me", UserController, :me
     get "/users/:name", UserController, :show
-    get "/users/:name/audit_logs", UserController, :audit_logs
     # NOTE: Deprecated (2018-05-21)
     get "/users/:name/test", UserController, :test
     post "/users/:name/reset", UserController, :reset

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -179,6 +179,7 @@ defmodule HexpmWeb.Router do
     get "/orgs", OrganizationController, :index
     get "/orgs/:organization", OrganizationController, :show
     post "/orgs/:organization", OrganizationController, :update
+    get "/orgs/:organization/audit_logs", OrganizationController, :audit_logs
 
     get "/orgs/:organization/members", OrganizationUserController, :index
     post "/orgs/:organization/members", OrganizationUserController, :create

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -170,6 +170,7 @@ defmodule HexpmWeb.Router do
 
     post "/users", UserController, :create
     get "/users/me", UserController, :me
+    get "/users/me/audit_logs", UserController, :audit_logs
     get "/users/:name", UserController, :show
     # NOTE: Deprecated (2018-05-21)
     get "/users/:name/test", UserController, :test

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -193,6 +193,7 @@ defmodule HexpmWeb.Router do
       scope prefix do
         get "/packages", PackageController, :index
         get "/packages/:name", PackageController, :show
+        get "/packages/:name/audit_logs", PackageController, :audit_logs
 
         get "/packages/:name/releases/:version", ReleaseController, :show
         delete "/packages/:name/releases/:version", ReleaseController, :delete

--- a/lib/hexpm_web/views/api/audit_log_view.ex
+++ b/lib/hexpm_web/views/api/audit_log_view.ex
@@ -1,0 +1,7 @@
+defmodule HexpmWeb.API.AuditLogView do
+  use HexpmWeb, :view
+
+  def render("show", %{audit_log: audit_log}) do
+    Map.take(audit_log, [:action, :user_agent, :params])
+  end
+end

--- a/lib/hexpm_web/views/api/organization_view.ex
+++ b/lib/hexpm_web/views/api/organization_view.ex
@@ -23,4 +23,8 @@ defmodule HexpmWeb.API.OrganizationView do
     }
     |> include_if_loaded(:users, organization.organization_users, OrganizationUserView, "show")
   end
+
+  def render("audit_logs." <> _, %{audit_logs: audit_logs}) do
+    render_many(audit_logs, HexpmWeb.API.AuditLogView, "show")
+  end
 end

--- a/lib/hexpm_web/views/api/package_view.ex
+++ b/lib/hexpm_web/views/api/package_view.ex
@@ -10,6 +10,10 @@ defmodule HexpmWeb.API.PackageView do
     render_one(package, __MODULE__, "show")
   end
 
+  def render("audit_logs." <> _, %{audit_logs: audit_logs}) do
+    render_many(audit_logs, HexpmWeb.API.AuditLogView, "show")
+  end
+
   def render("show", %{package: package}) do
     %{
       repository: package.repository.name,

--- a/lib/hexpm_web/views/api/user_view.ex
+++ b/lib/hexpm_web/views/api/user_view.ex
@@ -17,6 +17,10 @@ defmodule HexpmWeb.API.UserView do
     render_one(user, __MODULE__, "minimal")
   end
 
+  def render("audit_logs." <> _, %{audit_logs: audit_logs}) do
+    render_many(audit_logs, HexpmWeb.API.AuditLogView, "show")
+  end
+
   def render("show", %{user: user}) do
     %{
       username: user.username,

--- a/lib/hexpm_web/web.ex
+++ b/lib/hexpm_web/web.ex
@@ -110,6 +110,7 @@ defmodule HexpmWeb do
     quote do
       alias Hexpm.{
         Accounts.AuditLog,
+        Accounts.AuditLogs,
         Accounts.Auth,
         Accounts.Email,
         Accounts.Key,

--- a/test/hexpm_web/controllers/api/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_controller_test.exs
@@ -116,11 +116,7 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
         |> put_req_header("authorization", key_for(user1))
         |> get("api/orgs/#{organization.name}/audit_logs")
 
-      assert [
-               %{
-                 "action" => "organization.test"
-               }
-             ] = json_response(conn, :ok)
+      assert [%{"action" => "organization.test"}] = json_response(conn, :ok)
     end
 
     test "returns the second page of audit_logs related to this organization when params page is 2",
@@ -135,11 +131,7 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
         |> put_req_header("authorization", key_for(user1))
         |> get("api/orgs/#{organization.name}/audit_logs?page=2")
 
-      assert [
-               %{
-                 "action" => "organization.test"
-               }
-             ] = json_response(conn, :ok)
+      assert [%{"action" => "organization.test"}] = json_response(conn, :ok)
     end
   end
 end

--- a/test/hexpm_web/controllers/api/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_controller_test.exs
@@ -103,4 +103,43 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
       assert result["errors"] == "number of seats cannot be less than number of members"
     end
   end
+
+  describe "GET /api/orgs/:organization/audit_logs" do
+    test "returns the first page of audit_logs related to this organization when params page is not specified",
+         %{user1: user1, organization: organization} do
+      insert(:organization_user, organization: organization, user: user1, role: "read")
+
+      insert(:audit_log, action: "organization.test", organization: organization)
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key_for(user1))
+        |> get("api/orgs/#{organization.name}/audit_logs")
+
+      assert [
+               %{
+                 "action" => "organization.test"
+               }
+             ] = json_response(conn, :ok)
+    end
+
+    test "returns the second page of audit_logs related to this organization when params page is 2",
+         %{user1: user1, organization: organization} do
+      insert(:organization_user, organization: organization, user: user1, role: "read")
+
+      insert(:audit_log, action: "organization.test", organization: organization)
+      insert_list(10, :audit_log, organization: organization)
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key_for(user1))
+        |> get("api/orgs/#{organization.name}/audit_logs?page=2")
+
+      assert [
+               %{
+                 "action" => "organization.test"
+               }
+             ] = json_response(conn, :ok)
+    end
+  end
 end

--- a/test/hexpm_web/controllers/api/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_controller_test.exs
@@ -115,7 +115,6 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
     test "returns the first page of audit_logs related to this organization when params page is not specified",
          %{user1: user1, organization: organization} do
       insert(:organization_user, organization: organization, user: user1, role: "read")
-
       insert(:audit_log, action: "organization.test", organization: organization)
 
       conn =
@@ -129,7 +128,6 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
     test "returns the second page of audit_logs related to this organization when params page is 2",
          %{user1: user1, organization: organization} do
       insert(:organization_user, organization: organization, user: user1, role: "read")
-
       insert(:audit_log, action: "organization.test", organization: organization)
       insert_list(10, :audit_log, organization: organization)
 

--- a/test/hexpm_web/controllers/api/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_controller_test.exs
@@ -105,6 +105,13 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
   end
 
   describe "GET /api/orgs/:organization/audit_logs" do
+    test "returns 403 FORBIDDEN when unauthorized", %{user1: user1, organization: organization} do
+      build_conn()
+      |> put_req_header("authorization", key_for(user1))
+      |> get("api/orgs/#{organization.name}/audit_logs")
+      |> response(403)
+    end
+
     test "returns the first page of audit_logs related to this organization when params page is not specified",
          %{user1: user1, organization: organization} do
       insert(:organization_user, organization: organization, user: user1, role: "read")

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -237,4 +237,43 @@ defmodule HexpmWeb.API.PackageControllerTest do
              }
     end
   end
+
+  describe "GET /api/packages/:name/audit_logs" do
+    # TODO: add test cases for
+    # /api/repos/:repository/packages/:name/audit_logs as well?
+    test "returns the first page of audit_logs related to this package when params page is not specified",
+         %{package1: package} do
+      insert(:audit_log,
+        action: "test.package.audit_logs",
+        params: %{package: %{id: package.id}}
+      )
+
+      conn =
+        build_conn()
+        |> get("/api/packages/HexpmWeb.API.PackageControllerTest/audit_logs")
+
+      assert [
+               %{
+                 "action" => "test.package.audit_logs"
+               }
+             ] = json_response(conn, :ok)
+    end
+
+    test "returns the second page of audit_logs related to this package when params page is 2", %{
+      package1: package
+    } do
+      insert(:audit_log, action: "package.second.page", params: %{package: %{id: package.id}})
+      insert_list(10, :audit_log, params: %{package: %{id: package.id}})
+
+      conn =
+        build_conn()
+        |> get("/api/packages/HexpmWeb.API.PackageControllerTest/audit_logs?page=2")
+
+      assert [
+               %{
+                 "action" => "package.second.page"
+               }
+             ] = json_response(conn, :ok)
+    end
+  end
 end

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -252,11 +252,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
         build_conn()
         |> get("/api/packages/HexpmWeb.API.PackageControllerTest/audit_logs")
 
-      assert [
-               %{
-                 "action" => "test.package.audit_logs"
-               }
-             ] = json_response(conn, :ok)
+      assert [%{"action" => "test.package.audit_logs"}] = json_response(conn, :ok)
     end
 
     test "returns the second page of audit_logs related to this package when params page is 2", %{
@@ -269,11 +265,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
         build_conn()
         |> get("/api/packages/HexpmWeb.API.PackageControllerTest/audit_logs?page=2")
 
-      assert [
-               %{
-                 "action" => "package.second.page"
-               }
-             ] = json_response(conn, :ok)
+      assert [%{"action" => "package.second.page"}] = json_response(conn, :ok)
     end
   end
 end

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -239,8 +239,6 @@ defmodule HexpmWeb.API.PackageControllerTest do
   end
 
   describe "GET /api/packages/:name/audit_logs" do
-    # TODO: add test cases for
-    # /api/repos/:repository/packages/:name/audit_logs as well?
     test "returns the first page of audit_logs related to this package when params page is not specified",
          %{package1: package} do
       insert(:audit_log,

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -227,6 +227,22 @@ defmodule HexpmWeb.API.UserControllerTest do
                }
              ] = json_response(conn, :ok)
     end
+
+    test "returns the second page of audit_logs when params page is 2" do
+      user = insert(:user, username: "tester")
+      insert(:audit_log, user: user, action: "test.second.page")
+      insert_list(10, :audit_log, user: user)
+
+      conn =
+        build_conn()
+        |> get("/api/users/tester/audit_logs?page=2")
+
+      assert [
+               %{
+                 "action" => "test.second.page"
+               }
+             ] = json_response(conn, :ok)
+    end
   end
 
   describe "POST /api/users/:name/reset" do

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -210,33 +210,6 @@ defmodule HexpmWeb.API.UserControllerTest do
     end
   end
 
-  describe "GET /api/users/:name/audit_logs" do
-    test "returns the first page of audit_logs for this user" do
-      insert(:audit_log,
-        user: insert(:user, username: "tester"),
-        action: "test.action"
-      )
-
-      conn =
-        build_conn()
-        |> get("/api/users/tester/audit_logs")
-
-      assert [%{"action" => "test.action"}] = json_response(conn, :ok)
-    end
-
-    test "returns the second page of audit_logs when params page is 2" do
-      user = insert(:user, username: "tester")
-      insert(:audit_log, user: user, action: "test.second.page")
-      insert_list(10, :audit_log, user: user)
-
-      conn =
-        build_conn()
-        |> get("/api/users/tester/audit_logs?page=2")
-
-      assert [%{"action" => "test.second.page"}] = json_response(conn, :ok)
-    end
-  end
-
   describe "POST /api/users/:name/reset" do
     test "email is sent with reset_token when password is reset" do
       user = insert(:user)

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -210,6 +210,25 @@ defmodule HexpmWeb.API.UserControllerTest do
     end
   end
 
+  describe "GET /api/users/:name/audit_logs" do
+    test "returns the first page of audit_logs for this user" do
+      insert(:audit_log,
+        user: insert(:user, username: "tester"),
+        action: "test.action"
+      )
+
+      conn =
+        build_conn()
+        |> get("/api/users/tester/audit_logs")
+
+      assert [
+               %{
+                 "action" => "test.action"
+               }
+             ] = json_response(conn, :ok)
+    end
+  end
+
   describe "POST /api/users/:name/reset" do
     test "email is sent with reset_token when password is reset" do
       user = insert(:user)

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -221,11 +221,7 @@ defmodule HexpmWeb.API.UserControllerTest do
         build_conn()
         |> get("/api/users/tester/audit_logs")
 
-      assert [
-               %{
-                 "action" => "test.action"
-               }
-             ] = json_response(conn, :ok)
+      assert [%{"action" => "test.action"}] = json_response(conn, :ok)
     end
 
     test "returns the second page of audit_logs when params page is 2" do
@@ -237,11 +233,7 @@ defmodule HexpmWeb.API.UserControllerTest do
         build_conn()
         |> get("/api/users/tester/audit_logs?page=2")
 
-      assert [
-               %{
-                 "action" => "test.second.page"
-               }
-             ] = json_response(conn, :ok)
+      assert [%{"action" => "test.second.page"}] = json_response(conn, :ok)
     end
   end
 

--- a/test/hexpm_web/views/api/audit_log_view_test.exs
+++ b/test/hexpm_web/views/api/audit_log_view_test.exs
@@ -1,0 +1,27 @@
+defmodule HexpmWeb.API.AuditLogViewTest do
+  use HexpmWeb.ConnCase, async: true
+
+  alias HexpmWeb.API.AuditLogView
+
+  describe "render/2 show" do
+    test "includes action" do
+      audit_log = build(:audit_log, action: "test.action")
+
+      assert %{action: "test.action"} = AuditLogView.render("show", %{audit_log: audit_log})
+    end
+
+    test "includes user_agent" do
+      audit_log = build(:audit_log, user_agent: "Test User Agent")
+
+      assert %{user_agent: "Test User Agent"} =
+               AuditLogView.render("show", %{audit_log: audit_log})
+    end
+
+    test "includes params" do
+      audit_log = build(:audit_log, params: %{test_key: "test_value"})
+
+      assert %{params: %{test_key: "test_value"}} =
+               AuditLogView.render("show", %{audit_log: audit_log})
+    end
+  end
+end


### PR DESCRIPTION
This PR adds three API endpoints for audit logs:
1. [X] `/api/users/:username/audit_logs?page=1`
2. [x] `/api/packages/:name/audit_logs?page=1`
3. [x] `/api/orgs/:name/audit_logs?page=1`

See also #754, #817 for previous discussions