### PR TITLE
Show audit logs in package show page

### DIFF
--- a/assets/css/template/_package-view.scss
+++ b/assets/css/template/_package-view.scss
@@ -111,6 +111,16 @@
 .audit-logs-list {
   padding: 0;
   list-style: none;
+
+  li {
+    @include font-size(18);
+    margin: 0 0 10px;
+    overflow: hidden;
+    font-weight: 300;
+    line-height: 1.06;  // Just enough for e.g. the bottom of a "g" not to be cut off.
+    color: #000;
+    text-overflow: ellipsis;
+  }
 }
 
 .user-avatar {

--- a/assets/css/template/_package-view.scss
+++ b/assets/css/template/_package-view.scss
@@ -108,6 +108,11 @@
   }
 }
 
+.audit-logs-list {
+  padding: 0;
+  list-style: none;
+}
+
 .user-avatar {
   width: 30px;
   margin: 0 7px;

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -2,6 +2,7 @@ defmodule HexpmWeb.PackageController do
   use HexpmWeb, :controller
 
   @packages_per_page 30
+  @audit_logs_per_page 10
   @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at recently_published)
   @letters for letter <- ?A..?Z, do: <<letter>>
 
@@ -127,7 +128,7 @@ defmodule HexpmWeb.PackageController do
 
     dependants_count = Packages.count(repositories, "depends:#{package.name}")
 
-    audit_logs = AuditLogs.all_by(package, 1)
+    audit_logs = AuditLogs.all_by(package, 1, @audit_logs_per_page)
 
     render(
       conn,

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -127,6 +127,8 @@ defmodule HexpmWeb.PackageController do
 
     dependants_count = Packages.count(repositories, "depends:#{package.name}")
 
+    audit_logs = AuditLogs.all_by(package, 1)
+
     render(
       conn,
       "show.html",
@@ -141,7 +143,8 @@ defmodule HexpmWeb.PackageController do
         downloads: downloads,
         owners: owners,
         dependants: dependants,
-        dependants_count: dependants_count
+        dependants_count: dependants_count,
+        audit_logs: audit_logs
       ] ++ docs_assigns
     )
   end

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -157,7 +157,7 @@ tools = Keyword.take(tools, compatible_tools)
         <ul class="audit-logs-list">
           <%= for audit_log <- @audit_logs do %>
             <li>
-              <%= humanize_audit_log_info(audit_log) %>
+              <%= pretty_date(audit_log.inserted_at) %> <%= humanize_audit_log_info(audit_log) %>
             </li>
           <% end %>
         </ul>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -223,7 +223,7 @@ tools = Keyword.take(tools, compatible_tools)
     <% end %>
 
     <h3>Audit Logs</h3>
-    <ul>
+    <ul class="audit-logs-list">
       <%= for audit_log <- @audit_logs do %>
         <li>
           <%= humanize_audit_log_info(audit_log) %>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -221,5 +221,14 @@ tools = Keyword.take(tools, compatible_tools)
     end) %><%= if @dependants_count != 0 do %>,
     <a href="<%= Routes.package_path(Endpoint, :index, search: "depends:#{@package.name}") %>">show all...</a>
     <% end %>
+
+    <h3>Audit Logs</h3>
+    <ul>
+      <%= for audit_log <- @audit_logs do %>
+        <li>
+          <%= humanize_audit_log_info(audit_log) %>
+        </li>
+      <% end %>
+    </ul>
   </div>
 </div>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -152,7 +152,7 @@ tools = Keyword.take(tools, compatible_tools)
     </div>
 
     <div class="row">
-      <div class="col-md-6">
+      <div class="col-md-12">
         <h3>Audit Logs</h3>
         <ul class="audit-logs-list">
           <%= for audit_log <- @audit_logs do %>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -150,6 +150,19 @@ tools = Keyword.take(tools, compatible_tools)
         </ul>
       </div>
     </div>
+
+    <div class="row">
+      <div class="col-md-6">
+        <h3>Audit Logs</h3>
+        <ul class="audit-logs-list">
+          <%= for audit_log <- @audit_logs do %>
+            <li>
+              <%= humanize_audit_log_info(audit_log) %>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
   </div>
 
   <div class="col-md-3">
@@ -221,14 +234,5 @@ tools = Keyword.take(tools, compatible_tools)
     end) %><%= if @dependants_count != 0 do %>,
     <a href="<%= Routes.package_path(Endpoint, :index, search: "depends:#{@package.name}") %>">show all...</a>
     <% end %>
-
-    <h3>Audit Logs</h3>
-    <ul class="audit-logs-list">
-      <%= for audit_log <- @audit_logs do %>
-        <li>
-          <%= humanize_audit_log_info(audit_log) %>
-        </li>
-      <% end %>
-    </ul>
   </div>
 </div>

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -157,35 +157,39 @@ defmodule HexpmWeb.PackageView do
     end
   end
 
+  def pretty_date(datetime) do
+    "#{DateTime.to_date(datetime)}"
+  end
+
   def humanize_audit_log_info(%{action: "docs.publish"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Publish doc"
+    "Publish doc"
   end
 
   def humanize_audit_log_info(%{action: "docs.revert"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Revert doc"
+    "Revert doc"
   end
 
   def humanize_audit_log_info(%{action: "owner.add"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Add owner"
+    "Add owner"
   end
 
   def humanize_audit_log_info(%{action: "owner.remove"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Remove owner"
+    "Remove owner"
   end
 
   def humanize_audit_log_info(%{action: "release.publish"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Publish release"
+    "Publish release"
   end
 
   def humanize_audit_log_info(%{action: "release.revert"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Revert release"
+    "Revert release"
   end
 
   def humanize_audit_log_info(%{action: "release.retire"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Retire release"
+    "Retire release"
   end
 
   def humanize_audit_log_info(%{action: "release.unretire"} = audit_log) do
-    "#{DateTime.to_date(audit_log.inserted_at)} Unretire release"
+    "Unretire release"
   end
 end

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -156,4 +156,36 @@ defmodule HexpmWeb.PackageView do
         [content_tag(:strong, "Retired package")]
     end
   end
+
+  def humanize_audit_log_info(audit_log = %{action: "docs.publish"}) do
+    "Published documentation on #{pretty_datetime(audit_log.inserted_at)}"
+  end
+
+  def humanize_audit_log_info(audit_log = %{action: "docs.revert"}) do
+    "Reverted documentation on #{pretty_datetime(audit_log.inserted_at)}"
+  end
+
+  def humanize_audit_log_info(audit_log = %{action: "owner.add"}) do
+    "Added owner on #{pretty_datetime(audit_log.inserted_at)}"
+  end
+
+  def humanize_audit_log_info(audit_log = %{action: "owner.remove"}) do
+    "Removed owner on #{pretty_datetime(audit_log.inserted_at)}"
+  end
+
+  def humanize_audit_log_info(audit_log = %{action: "release.publish"}) do
+    "Published release on #{pretty_datetime(audit_log.inserted_at)}"
+  end
+
+  def humanize_audit_log_info(audit_log = %{action: "release.revert"}) do
+    "Reverted release on #{pretty_datetime(audit_log.inserted_at)}"
+  end
+
+  def humanize_audit_log_info(audit_log = %{action: "release.retire"}) do
+    "Retired release on #{pretty_datetime(audit_log.inserted_at)}"
+  end
+
+  def humanize_audit_log_info(audit_log = %{action: "release.unretire"}) do
+    "Unretired release on #{pretty_datetime(audit_log.inserted_at)}"
+  end
 end

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -161,6 +161,12 @@ defmodule HexpmWeb.PackageView do
     "#{DateTime.to_date(datetime)}"
   end
 
+  @doc """
+  This function turns an audit_log struct into a short description.
+
+  Please check Hexpm.Accounts.AuditLog.extract_params/2 to see all the
+  package related actions and their params structures.
+  """
   def humanize_audit_log_info(%{action: "docs.publish"} = audit_log) do
     if release_version = audit_log.params["release"]["version"] do
       "Publish documentation for release #{release_version}"

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -157,35 +157,35 @@ defmodule HexpmWeb.PackageView do
     end
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "docs.publish"}) do
+  def humanize_audit_log_info(%{action: "docs.publish"} = audit_log) do
     "Published documentation on #{pretty_datetime(audit_log.inserted_at)}"
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "docs.revert"}) do
+  def humanize_audit_log_info(%{action: "docs.revert"} = audit_log) do
     "Reverted documentation on #{pretty_datetime(audit_log.inserted_at)}"
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "owner.add"}) do
+  def humanize_audit_log_info(%{action: "owner.add"} = audit_log) do
     "Added owner on #{pretty_datetime(audit_log.inserted_at)}"
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "owner.remove"}) do
+  def humanize_audit_log_info(%{action: "owner.remove"} = audit_log) do
     "Removed owner on #{pretty_datetime(audit_log.inserted_at)}"
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "release.publish"}) do
+  def humanize_audit_log_info(%{action: "release.publish"} = audit_log) do
     "Published release on #{pretty_datetime(audit_log.inserted_at)}"
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "release.revert"}) do
+  def humanize_audit_log_info(%{action: "release.revert"} = audit_log) do
     "Reverted release on #{pretty_datetime(audit_log.inserted_at)}"
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "release.retire"}) do
+  def humanize_audit_log_info(%{action: "release.retire"} = audit_log) do
     "Retired release on #{pretty_datetime(audit_log.inserted_at)}"
   end
 
-  def humanize_audit_log_info(audit_log = %{action: "release.unretire"}) do
+  def humanize_audit_log_info(%{action: "release.unretire"} = audit_log) do
     "Unretired release on #{pretty_datetime(audit_log.inserted_at)}"
   end
 end

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -162,34 +162,72 @@ defmodule HexpmWeb.PackageView do
   end
 
   def humanize_audit_log_info(%{action: "docs.publish"} = audit_log) do
-    "Publish doc"
+    if release_version = audit_log.params["release"]["version"] do
+      "Publish documentation for release #{release_version}"
+    else
+      "Publish documentation"
+    end
   end
 
   def humanize_audit_log_info(%{action: "docs.revert"} = audit_log) do
-    "Revert doc"
+    if release_version = audit_log.params["release"]["version"] do
+      "Revert documentation for release #{release_version}"
+    else
+      "Revert documentation"
+    end
   end
 
   def humanize_audit_log_info(%{action: "owner.add"} = audit_log) do
-    "Add owner"
+    username = audit_log.params["user"]["username"]
+    level = audit_log.params["level"]
+
+    if username && level do
+      "Add #{username} as a level #{level} owner"
+    else
+      "Add owner"
+    end
   end
 
   def humanize_audit_log_info(%{action: "owner.remove"} = audit_log) do
-    "Remove owner"
+    username = audit_log.params["user"]["username"]
+    level = audit_log.params["level"]
+
+    if username && level do
+      "Remove level #{level} owner #{username}"
+    else
+      "Remove owner"
+    end
   end
 
   def humanize_audit_log_info(%{action: "release.publish"} = audit_log) do
-    "Publish release"
+    if version = audit_log.params["release"]["version"] do
+      "Publish release #{version}"
+    else
+      "Publish release"
+    end
   end
 
   def humanize_audit_log_info(%{action: "release.revert"} = audit_log) do
-    "Revert release"
+    if version = audit_log.params["release"]["version"] do
+      "Revert release #{version}"
+    else
+      "Revert release"
+    end
   end
 
   def humanize_audit_log_info(%{action: "release.retire"} = audit_log) do
-    "Retire release"
+    if version = audit_log.params["release"]["version"] do
+      "Retire release #{version}"
+    else
+      "Retire release"
+    end
   end
 
   def humanize_audit_log_info(%{action: "release.unretire"} = audit_log) do
-    "Unretire release"
+    if version = audit_log.params["release"]["version"] do
+      "Unretire release #{version}"
+    else
+      "Unretire release"
+    end
   end
 end

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -158,34 +158,34 @@ defmodule HexpmWeb.PackageView do
   end
 
   def humanize_audit_log_info(%{action: "docs.publish"} = audit_log) do
-    "Published documentation on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Publish doc"
   end
 
   def humanize_audit_log_info(%{action: "docs.revert"} = audit_log) do
-    "Reverted documentation on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Revert doc"
   end
 
   def humanize_audit_log_info(%{action: "owner.add"} = audit_log) do
-    "Added owner on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Add owner"
   end
 
   def humanize_audit_log_info(%{action: "owner.remove"} = audit_log) do
-    "Removed owner on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Remove owner"
   end
 
   def humanize_audit_log_info(%{action: "release.publish"} = audit_log) do
-    "Published release on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Publish release"
   end
 
   def humanize_audit_log_info(%{action: "release.revert"} = audit_log) do
-    "Reverted release on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Revert release"
   end
 
   def humanize_audit_log_info(%{action: "release.retire"} = audit_log) do
-    "Retired release on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Retire release"
   end
 
   def humanize_audit_log_info(%{action: "release.unretire"} = audit_log) do
-    "Unretired release on #{pretty_datetime(audit_log.inserted_at)}"
+    "#{DateTime.to_date(audit_log.inserted_at)} Unretire release"
   end
 end

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -188,6 +188,14 @@ defmodule HexpmWeb.PackageView do
     end
   end
 
+  def humanize_audit_log_info(%{action: "owner.transfer"} = audit_log) do
+    if username = audit_log.params["user"]["username"] do
+      "Transfer owner to #{username}"
+    else
+      "Transfer owner"
+    end
+  end
+
   def humanize_audit_log_info(%{action: "owner.remove"} = audit_log) do
     username = audit_log.params["user"]["username"]
     level = audit_log.params["level"]

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -122,6 +122,31 @@ defmodule HexpmWeb.PackageControllerTest do
       |> get("/packages/#{package3.name}")
       |> response(404)
     end
+
+    test "show first few audit_logs related to this package", %{package1: package} do
+      insert(:audit_log, action: "docs.publish", params: %{package: %{id: package.id}})
+      insert(:audit_log, action: "docs.revert", params: %{package: %{id: package.id}})
+      insert(:audit_log, action: "owner.add", params: %{package: %{id: package.id}})
+      insert(:audit_log, action: "owner.remove", params: %{package: %{id: package.id}})
+      insert(:audit_log, action: "release.publish", params: %{package: %{id: package.id}})
+      insert(:audit_log, action: "release.revert", params: %{package: %{id: package.id}})
+      insert(:audit_log, action: "release.retire", params: %{package: %{id: package.id}})
+      insert(:audit_log, action: "release.unretire", params: %{package: %{id: package.id}})
+
+      html_response =
+        build_conn()
+        |> get("/packages/#{package.name}")
+        |> html_response(200)
+
+      assert html_response =~ "Published documentation"
+      assert html_response =~ "Reverted documentation"
+      assert html_response =~ "Added owner"
+      assert html_response =~ "Removed owner"
+      assert html_response =~ "Published release"
+      assert html_response =~ "Reverted release"
+      assert html_response =~ "Retired release"
+      assert html_response =~ "Unretired release"
+    end
   end
 
   describe "GET /packages/:name/:version" do

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -138,14 +138,14 @@ defmodule HexpmWeb.PackageControllerTest do
         |> get("/packages/#{package.name}")
         |> html_response(200)
 
-      assert html_response =~ "Published documentation"
-      assert html_response =~ "Reverted documentation"
-      assert html_response =~ "Added owner"
-      assert html_response =~ "Removed owner"
-      assert html_response =~ "Published release"
-      assert html_response =~ "Reverted release"
-      assert html_response =~ "Retired release"
-      assert html_response =~ "Unretired release"
+      assert html_response =~ "Publish doc"
+      assert html_response =~ "Revert doc"
+      assert html_response =~ "Add owner"
+      assert html_response =~ "Remove owner"
+      assert html_response =~ "Publish release"
+      assert html_response =~ "Revert release"
+      assert html_response =~ "Retire release"
+      assert html_response =~ "Unretire release"
     end
   end
 

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -236,6 +236,24 @@ defmodule HexpmWeb.PackageViewTest do
                "Add New User as a level 2 owner"
     end
 
+    test "owner.transfer with no params" do
+      audit_log = build(:audit_log, action: "owner.transfer")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Transfer owner"
+    end
+
+    test "owner.transfer with params" do
+      audit_log =
+        build(:audit_log,
+          action: "owner.transfer",
+          params: %{"user" => %{"username" => "New Owner"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Transfer owner to New Owner"
+    end
+
     test "owner.remove with no params" do
       audit_log = build(:audit_log, action: "owner.remove")
 

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -180,4 +180,150 @@ defmodule HexpmWeb.PackageViewTest do
                "<strong>Retired package:</strong> Security issue"
     end
   end
+
+  describe "humanize_audit_log_info/1" do
+    test "docs.publish with no params" do
+      audit_log = build(:audit_log, action: "docs.publish")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Publish documentation"
+    end
+
+    test "docs.publish with params" do
+      audit_log =
+        build(:audit_log,
+          action: "docs.publish",
+          params: %{"release" => %{"version" => "1.0.2"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Publish documentation for release 1.0.2"
+    end
+
+    test "docs.revert with no params" do
+      audit_log = build(:audit_log, action: "docs.revert")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Revert documentation"
+    end
+
+    test "docs.revert with params" do
+      audit_log =
+        build(:audit_log,
+          action: "docs.revert",
+          params: %{"release" => %{"version" => "0.3.4"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Revert documentation for release 0.3.4"
+    end
+
+    test "owner.add with no params" do
+      audit_log = build(:audit_log, action: "owner.add")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Add owner"
+    end
+
+    test "owner.add with params" do
+      audit_log =
+        build(:audit_log,
+          action: "owner.add",
+          params: %{"level" => 2, "user" => %{"username" => "New User"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Add New User as a level 2 owner"
+    end
+
+    test "owner.remove with no params" do
+      audit_log = build(:audit_log, action: "owner.remove")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Remove owner"
+    end
+
+    test "owner.remove with params" do
+      audit_log =
+        build(:audit_log,
+          action: "owner.remove",
+          params: %{"level" => 3, "user" => %{"username" => "Removee"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Remove level 3 owner Removee"
+    end
+
+    test "release.publish with no params" do
+      audit_log = build(:audit_log, action: "release.publish")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Publish release"
+    end
+
+    test "release.publish with params" do
+      audit_log =
+        build(:audit_log,
+          action: "release.publish",
+          params: %{"release" => %{"version" => "10.2.8"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Publish release 10.2.8"
+    end
+
+    test "release.revert with no params" do
+      audit_log = build(:audit_log, action: "release.revert")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Revert release"
+    end
+
+    test "release.revert with params" do
+      audit_log =
+        build(:audit_log,
+          action: "release.revert",
+          params: %{"release" => %{"version" => "0.2.7"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Revert release 0.2.7"
+    end
+
+    test "release.retire with no params" do
+      audit_log = build(:audit_log, action: "release.retire")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Retire release"
+    end
+
+    test "release.retire with params" do
+      audit_log =
+        build(:audit_log,
+          action: "release.retire",
+          params: %{"release" => %{"version" => "8.3.1"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Retire release 8.3.1"
+    end
+
+    test "release.unretire with no params" do
+      audit_log = build(:audit_log, action: "release.unretire")
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Unretire release"
+    end
+
+    test "release.unretire with params" do
+      audit_log =
+        build(:audit_log,
+          action: "release.unretire",
+          params: %{"release" => %{"version" => "3.7.21"}}
+        )
+
+      assert PackageView.humanize_audit_log_info(audit_log) ==
+               "Unretire release 3.7.21"
+    end
+  end
 end


### PR DESCRIPTION
This is what it looks like for now:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/4723751/60108346-08826880-979b-11e9-8f27-6565045582fe.png">

Hi @ericmj! I'm creating this PR to get some feedback:
1. The style of this list needs to be changed. Any ideas?
2. The wording for different audit_log actions also need to be changed. Specifically, shall we provide more info for different actions? Like which owner is added for `owner.add`, etc.