### PR TITLE
fixed spelling in plugs.ex

### DIFF
--- a/lib/hexpm_web/plugs.ex
+++ b/lib/hexpm_web/plugs.ex
@@ -67,7 +67,7 @@ defmodule HexpmWeb.Plugs do
 
       [] ->
         if Application.get_env(:hexpm, :user_agent_req) do
-          ControllerHelpers.render_error(conn, 400, message: "User-Agent header is requried")
+          ControllerHelpers.render_error(conn, 400, message: "User-Agent header is required")
         else
           assign(conn, :user_agent, "missing")
         end


### PR DESCRIPTION
Fixed the spelling of the word "required" in the error when no User-Agent header is passed.