### PR TITLE
Fix failed tests due to audit logs per page change

### DIFF
--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -3,7 +3,7 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   alias Hexpm.Accounts.AuditLog
 
-  @audit_logs_per_page 100
+  @default_per_page 100
 
   def all_by(schema) do
     AuditLog.all_by(schema)
@@ -12,7 +12,7 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   def all_by(schema, page) do
     AuditLog.all_by(schema)
-    |> Hexpm.Utils.paginate(page, @audit_logs_per_page)
+    |> Hexpm.Utils.paginate(page, @default_per_page)
     |> Repo.all()
   end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -10,9 +10,9 @@ defmodule Hexpm.Accounts.AuditLogs do
     |> Repo.all()
   end
 
-  def all_by(schema, page) do
+  def all_by(schema, page, per_page \\ @default_per_page) do
     AuditLog.all_by(schema)
-    |> Hexpm.Utils.paginate(page, @default_per_page)
+    |> Hexpm.Utils.paginate(page, per_page)
     |> Repo.all()
   end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -3,14 +3,12 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   alias Hexpm.Accounts.AuditLog
 
-  @default_per_page 100
-
   def all_by(schema) do
     AuditLog.all_by(schema)
     |> Repo.all()
   end
 
-  def all_by(schema, page, per_page \\ @default_per_page) do
+  def all_by(schema, page, per_page) do
     AuditLog.all_by(schema)
     |> Hexpm.Utils.paginate(page, per_page)
     |> Repo.all()

--- a/lib/hexpm_web/controllers/api/organization_controller.ex
+++ b/lib/hexpm_web/controllers/api/organization_controller.ex
@@ -52,7 +52,7 @@ defmodule HexpmWeb.API.OrganizationController do
 
   def audit_logs(conn, params) do
     organization = conn.assigns.organization
-    audit_logs = AuditLogs.all_by(organization, Hexpm.Utils.safe_int(params["page"]))
+    audit_logs = AuditLogs.all_by(organization, Hexpm.Utils.safe_int(params["page"]), 100)
 
     render(conn, :audit_logs, audit_logs: audit_logs)
   end

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -46,7 +46,7 @@ defmodule HexpmWeb.API.PackageController do
 
   def audit_logs(conn, params) do
     if package = conn.assigns.package do
-      audit_logs = AuditLogs.all_by(package, Hexpm.Utils.safe_int(params["page"]))
+      audit_logs = AuditLogs.all_by(package, Hexpm.Utils.safe_int(params["page"]), 100)
 
       render(conn, :audit_logs, audit_logs: audit_logs)
     else

--- a/lib/hexpm_web/controllers/api/user_controller.ex
+++ b/lib/hexpm_web/controllers/api/user_controller.ex
@@ -38,7 +38,7 @@ defmodule HexpmWeb.API.UserController do
 
   def audit_logs(conn, params) do
     if user = conn.assigns.current_user do
-      audit_logs = AuditLogs.all_by(user, Hexpm.Utils.safe_int(params["page"]))
+      audit_logs = AuditLogs.all_by(user, Hexpm.Utils.safe_int(params["page"]), 100)
 
       render(conn, :audit_logs, audit_logs: audit_logs)
     else

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -64,24 +64,24 @@ defmodule Hexpm.Accounts.AuditLogsTest do
     end
   end
 
-  describe "all_by(user, page)" do
+  describe "all_by(user, page, per_page)" do
     test "returns 10 audit logs per page" do
       user = insert(:user)
       insert_list(11, :audit_log, user: user)
 
-      results = AuditLogs.all_by(user, 1)
+      results = AuditLogs.all_by(user, 1, 10)
 
       assert length(results) == 10
     end
 
-    test "returns audit_logs in page 2" do
+    test "returns audit_logs in page 2 with 10 audit logs per page" do
       user = insert(:user)
       # NOTE: the order is desc: :inserted_at by default,
       # so we insert audit_log in second page first
       insert(:audit_log, action: "test.second.page", user: user)
       insert_list(10, :audit_log, action: "test.first.page", user: user)
 
-      assert [%{action: "test.second.page"}] = AuditLogs.all_by(user, 2)
+      assert [%{action: "test.second.page"}] = AuditLogs.all_by(user, 2, 10)
     end
   end
 end

--- a/test/hexpm_web/controllers/api/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_controller_test.exs
@@ -124,19 +124,5 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
 
       assert [%{"action" => "organization.test"}] = json_response(conn, :ok)
     end
-
-    test "returns the second page of audit_logs related to this organization when params page is 2",
-         %{user1: user1, organization: organization} do
-      insert(:organization_user, organization: organization, user: user1, role: "read")
-      insert(:audit_log, action: "organization.test", organization: organization)
-      insert_list(10, :audit_log, organization: organization)
-
-      conn =
-        build_conn()
-        |> put_req_header("authorization", key_for(user1))
-        |> get("api/orgs/#{organization.name}/audit_logs?page=2")
-
-      assert [%{"action" => "organization.test"}] = json_response(conn, :ok)
-    end
   end
 end

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -252,18 +252,5 @@ defmodule HexpmWeb.API.PackageControllerTest do
 
       assert [%{"action" => "test.package.audit_logs"}] = json_response(conn, :ok)
     end
-
-    test "returns the second page of audit_logs related to this package when params page is 2", %{
-      package1: package
-    } do
-      insert(:audit_log, action: "package.second.page", params: %{package: %{id: package.id}})
-      insert_list(10, :audit_log, params: %{package: %{id: package.id}})
-
-      conn =
-        build_conn()
-        |> get("/api/packages/HexpmWeb.API.PackageControllerTest/audit_logs?page=2")
-
-      assert [%{"action" => "package.second.page"}] = json_response(conn, :ok)
-    end
   end
 end

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -145,18 +145,6 @@ defmodule HexpmWeb.API.UserControllerTest do
                |> json_response(200)
     end
 
-    test "returns the second page of audit_logs created by this user when params page is 2" do
-      user = insert(:user)
-      insert(:audit_log, user: user, action: "test.user")
-      insert_list(10, :audit_log, user: user)
-
-      assert [%{"action" => "test.user"}] =
-               build_conn()
-               |> put_req_header("authorization", key_for(user))
-               |> get("/api/users/me/audit_logs?page=2")
-               |> json_response(200)
-    end
-
     test "returns 401 if not authenticated" do
       build_conn()
       |> get("/api/users/me/audit_logs")


### PR DESCRIPTION
These tests were broken due to https://github.com/hexpm/hexpm/pull/821/commits/b2d4482aa39f9008d9aa680c737ff41476fedea1 (Increase audit logs page size from 10 to 100).

These failures were actually covered in the CI pipeline, see: https://travis-ci.org/hexpm/hexpm/jobs/554187170#L782. But I didn't notice them because of `hex` test failures. Sorry about that.

This PR removes some failing tests and changes `AuditLogs.all_by/2` to `AuditLogs.all_by/3` by adding a `per_page` parameter, meanwhile, it removed the default per_page attribute.