### PR TITLE
Rename RepositoryControllerTest to OrganizationControllerTest

### DIFF
--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -1,4 +1,4 @@
-defmodule HexpmWeb.Dashboard.RepositoryControllerTest do
+defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
   use HexpmWeb.ConnCase, async: true
   use Bamboo.Test
 


### PR DESCRIPTION
I found this typo when working on #673 