### PR TITLE
Add audit log for the rest billing "write" actions

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -171,6 +171,12 @@ defmodule Hexpm.Accounts.AuditLog do
       plan_id: params["plan_id"]
     }
 
+  defp extract_params("billing.pay_invoice", {organization, invoice_id}),
+    do: %{
+      organization: serialize(organization),
+      invoice_id: invoice_id
+    }
+
   defp serialize(%Key{} = key) do
     key
     |> do_serialize()

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -152,6 +152,16 @@ defmodule Hexpm.Accounts.AuditLog do
       quantity: params["quantity"]
     }
 
+  defp extract_params("billing.update", {organization, params}),
+    do: %{
+      organization: serialize(organization),
+      email: params["email"],
+      person: params["person"],
+      company: params["company"],
+      token: params["token"],
+      quantity: params["quantity"]
+    }
+
   defp serialize(%Key{} = key) do
     key
     |> do_serialize()

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -142,6 +142,9 @@ defmodule Hexpm.Accounts.AuditLog do
   defp extract_params("password.reset.finish", nil), do: %{}
   defp extract_params("password.update", nil), do: %{}
 
+  defp extract_params("billing.cancel", {organization, _pramas}),
+    do: %{organization: serialize(organization)}
+
   defp extract_params("billing.create", {organization, params}),
     do: %{
       organization: serialize(organization),

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -142,7 +142,7 @@ defmodule Hexpm.Accounts.AuditLog do
   defp extract_params("password.reset.finish", nil), do: %{}
   defp extract_params("password.update", nil), do: %{}
 
-  defp extract_params("billing.cancel", {organization, _pramas}),
+  defp extract_params("billing.cancel", {organization, _params}),
     do: %{organization: serialize(organization)}
 
   defp extract_params("billing.create", {organization, params}),

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -165,6 +165,12 @@ defmodule Hexpm.Accounts.AuditLog do
       quantity: params["quantity"]
     }
 
+  defp extract_params("billing.change_plan", {organization, params}),
+    do: %{
+      organization: serialize(organization),
+      plan_id: params["plan_id"]
+    }
+
   defp serialize(%Key{} = key) do
     key
     |> do_serialize()

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -54,4 +54,12 @@ defmodule Hexpm.Billing do
         {:error, reason}
     end
   end
+
+  def change_plan(organization_name, params,
+        audit: %{audit_data: audit_data, organization: organization}
+      ) do
+    impl().change_plan(organization_name, params)
+    Repo.insert!(audit(audit_data, "billing.change_plan", {organization, params}))
+    :ok
+  end
 end

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -25,6 +25,12 @@ defmodule Hexpm.Billing do
   def pay_invoice(id), do: impl().pay_invoice(id)
   def report(), do: impl().report()
 
+  def cancel(params, audit: %{audit_data: audit_data, organization: organization}) do
+    result = impl().cancel(params)
+    Repo.insert!(audit(audit_data, "billing.cancel", {organization, params}))
+    result
+  end
+
   def create(params, audit: %{audit_data: audit_data, organization: organization}) do
     case impl().create(params) do
       {:ok, result} ->

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -36,8 +36,8 @@ defmodule Hexpm.Billing do
     end
   end
 
-  def update(organization, params, audit: audit) do
-    case impl().update(organization, params) do
+  def update(organization_name, params, audit: audit) do
+    case impl().update(organization_name, params) do
       {:ok, result} ->
         Repo.insert!(audit(audit.audit_data, "billing.update", {audit.organization, params}))
         {:ok, result}

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -62,4 +62,15 @@ defmodule Hexpm.Billing do
     Repo.insert!(audit(audit_data, "billing.change_plan", {organization, params}))
     :ok
   end
+
+  def pay_invoice(id, audit: %{audit_data: audit_data, organization: organization}) do
+    case impl().pay_invoice(id) do
+      :ok ->
+        Repo.insert!(audit(audit_data, "billing.pay_invoice", {organization, id}))
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
 end

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -36,10 +36,12 @@ defmodule Hexpm.Billing do
     end
   end
 
-  def update(organization_name, params, audit: audit) do
+  def update(organization_name, params,
+        audit: %{audit_data: audit_data, organization: organization}
+      ) do
     case impl().update(organization_name, params) do
       {:ok, result} ->
-        Repo.insert!(audit(audit.audit_data, "billing.update", {audit.organization, params}))
+        Repo.insert!(audit(audit_data, "billing.update", {organization, params}))
         {:ok, result}
 
       {:error, reason} ->

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -35,4 +35,15 @@ defmodule Hexpm.Billing do
         {:error, reason}
     end
   end
+
+  def update(organization, params, audit: audit) do
+    with {:update, {:ok, result}} <- {:update, impl().update(organization, params)},
+         {:audit, {:ok, _audit_log}} <-
+           {:audit,
+            Repo.insert(audit(audit.audit_data, "billing.update", {audit.organization, params}))} do
+      {:ok, result}
+    else
+      {:update, {:error, reason}} -> {:error, reason}
+    end
+  end
 end

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -37,13 +37,13 @@ defmodule Hexpm.Billing do
   end
 
   def update(organization, params, audit: audit) do
-    with {:update, {:ok, result}} <- {:update, impl().update(organization, params)},
-         {:audit, {:ok, _audit_log}} <-
-           {:audit,
-            Repo.insert(audit(audit.audit_data, "billing.update", {audit.organization, params}))} do
-      {:ok, result}
-    else
-      {:update, {:error, reason}} -> {:error, reason}
+    case impl().update(organization, params) do
+      {:ok, result} ->
+        Repo.insert!(audit(audit.audit_data, "billing.update", {audit.organization, params}))
+        {:ok, result}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 end

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -137,7 +137,11 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
   def cancel_billing(conn, %{"dashboard_org" => organization}) do
     access_organization(conn, organization, "admin", fn organization ->
-      customer = Hexpm.Billing.cancel(organization.name)
+      customer =
+        Hexpm.Billing.cancel(organization.name,
+          audit: %{audit_data: audit_data(conn), organization: organization}
+        )
+
       message = cancel_message(customer["subscription"]["current_period_end"])
 
       conn

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -232,7 +232,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       seats = current_seats + add_seats
 
       if seats >= user_count do
-        {:ok, _customer} = Hexpm.Billing.update(organization.name, %{"quantity" => seats})
+        {:ok, _customer} =
+          Hexpm.Billing.update(organization.name, %{"quantity" => seats},
+            audit: %{audit_data: audit_data(conn), organization: organization}
+          )
 
         conn
         |> put_flash(:info, "The number of open seats have been increased.")
@@ -252,7 +255,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       seats = String.to_integer(params["seats"])
 
       if seats >= user_count do
-        {:ok, _customer} = Hexpm.Billing.update(organization.name, %{"quantity" => seats})
+        {:ok, _customer} =
+          Hexpm.Billing.update(organization.name, %{"quantity" => seats},
+            audit: %{audit_data: audit_data(conn), organization: organization}
+          )
 
         conn
         |> put_flash(:info, "The number of open seats have been reduced.")

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -215,8 +215,6 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
         conn,
         organization,
         params,
-        # TODO: call fun.(customer_params, audit: audit_data(conn)) in
-        # update_billing/4 directly after Hexpm.Billing.update/2 is added
         &Hexpm.Billing.create(&1,
           audit: %{audit_data: audit_data(conn), organization: organization}
         )

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -195,7 +195,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
         conn,
         organization,
         params,
-        &Hexpm.Billing.update(organization.name, &1)
+        &Hexpm.Billing.update(organization.name, &1,
+          audit: %{audit_data: audit_data(conn), organization: organization}
+        )
       )
     end)
   end

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -175,7 +175,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       invoice_ids = Enum.map(customer["invoices"], & &1["id"])
 
       if id in invoice_ids do
-        case Hexpm.Billing.pay_invoice(id) do
+        case Hexpm.Billing.pay_invoice(id,
+               audit: %{audit_data: audit_data(conn), organization: organization}
+             ) do
           :ok ->
             conn
             |> put_flash(:info, "Invoice paid.")

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -278,7 +278,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
   def change_plan(conn, %{"dashboard_org" => organization} = params) do
     access_organization(conn, organization, "admin", fn organization ->
-      Hexpm.Billing.change_plan(organization.name, %{"plan_id" => params["plan_id"]})
+      Hexpm.Billing.change_plan(organization.name, %{"plan_id" => params["plan_id"]},
+        audit: %{audit_data: audit_data(conn), organization: organization}
+      )
 
       conn
       |> put_flash(:info, "You have switched to the #{plan_name(params["plan_id"])} plan.")

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -137,10 +137,8 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
   def cancel_billing(conn, %{"dashboard_org" => organization}) do
     access_organization(conn, organization, "admin", fn organization ->
-      customer =
-        Hexpm.Billing.cancel(organization.name,
-          audit: %{audit_data: audit_data(conn), organization: organization}
-        )
+      audit = %{audit_data: audit_data(conn), organization: organization}
+      customer = Hexpm.Billing.cancel(organization.name, audit: audit)
 
       message = cancel_message(customer["subscription"]["current_period_end"])
 
@@ -174,10 +172,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       customer = Hexpm.Billing.get(organization.name)
       invoice_ids = Enum.map(customer["invoices"], & &1["id"])
 
+      audit = %{audit_data: audit_data(conn), organization: organization}
+
       if id in invoice_ids do
-        case Hexpm.Billing.pay_invoice(id,
-               audit: %{audit_data: audit_data(conn), organization: organization}
-             ) do
+        case Hexpm.Billing.pay_invoice(id, audit: audit) do
           :ok ->
             conn
             |> put_flash(:info, "Invoice paid.")
@@ -197,13 +195,13 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
   def update_billing(conn, %{"dashboard_org" => organization} = params) do
     access_organization(conn, organization, "admin", fn organization ->
+      audit = %{audit_data: audit_data(conn), organization: organization}
+
       update_billing(
         conn,
         organization,
         params,
-        &Hexpm.Billing.update(organization.name, &1,
-          audit: %{audit_data: audit_data(conn), organization: organization}
-        )
+        &Hexpm.Billing.update(organization.name, &1, audit: audit)
       )
     end)
   end
@@ -217,14 +215,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
         |> Map.put("token", organization.name)
         |> Map.put("quantity", user_count)
 
-      update_billing(
-        conn,
-        organization,
-        params,
-        &Hexpm.Billing.create(&1,
-          audit: %{audit_data: audit_data(conn), organization: organization}
-        )
-      )
+      audit = %{audit_data: audit_data(conn), organization: organization}
+
+      update_billing(conn, organization, params, &Hexpm.Billing.create(&1, audit: audit))
     end)
   end
 
@@ -238,10 +231,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       seats = current_seats + add_seats
 
       if seats >= user_count do
+        audit = %{audit_data: audit_data(conn), organization: organization}
+
         {:ok, _customer} =
-          Hexpm.Billing.update(organization.name, %{"quantity" => seats},
-            audit: %{audit_data: audit_data(conn), organization: organization}
-          )
+          Hexpm.Billing.update(organization.name, %{"quantity" => seats}, audit: audit)
 
         conn
         |> put_flash(:info, "The number of open seats have been increased.")
@@ -261,10 +254,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       seats = String.to_integer(params["seats"])
 
       if seats >= user_count do
+        audit = %{audit_data: audit_data(conn), organization: organization}
+
         {:ok, _customer} =
-          Hexpm.Billing.update(organization.name, %{"quantity" => seats},
-            audit: %{audit_data: audit_data(conn), organization: organization}
-          )
+          Hexpm.Billing.update(organization.name, %{"quantity" => seats}, audit: audit)
 
         conn
         |> put_flash(:info, "The number of open seats have been reduced.")
@@ -280,9 +273,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
   def change_plan(conn, %{"dashboard_org" => organization} = params) do
     access_organization(conn, organization, "admin", fn organization ->
-      Hexpm.Billing.change_plan(organization.name, %{"plan_id" => params["plan_id"]},
-        audit: %{audit_data: audit_data(conn), organization: organization}
-      )
+      audit = %{audit_data: audit_data(conn), organization: organization}
+
+      Hexpm.Billing.change_plan(organization.name, %{"plan_id" => params["plan_id"]}, audit: audit)
 
       conn
       |> put_flash(:info, "You have switched to the #{plan_name(params["plan_id"])} plan.")

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -81,6 +81,36 @@ defmodule Hexpm.Accounts.AuditLogTest do
 
       assert %AuditLog{action: "docs.revert"} = audit_log
     end
+
+    test "billing.update", %{user: user} do
+      organization = build(:organization, name: "Organization Name")
+
+      audit =
+        AuditLog.audit(
+          {user, "user_agent"},
+          "billing.update",
+          {
+            organization,
+            %{
+              "email" => "test@example.com",
+              "person" => "Test Person",
+              "company" => "Test Company",
+              "token" => "Test Token",
+              "quantity" => 11
+            }
+          }
+        )
+
+      assert audit.action == "billing.update"
+      assert audit.user_id == user.id
+      assert audit.user_agent == "user_agent"
+      assert audit.params.organization.name == "Organization Name"
+      assert audit.params.email == "test@example.com"
+      assert audit.params.person == "Test Person"
+      assert audit.params.company == "Test Company"
+      assert audit.params.token == "Test Token"
+      assert audit.params.quantity == 11
+    end
   end
 
   describe "audit/4" do

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -43,6 +43,26 @@ defmodule Hexpm.Accounts.AuditLogTest do
       assert audit.params.user.handles.github == user.handles.github
     end
 
+    test "action billing.cancel", %{user: user} do
+      organization = build(:organization, name: "Organization Name")
+
+      audit =
+        AuditLog.build(
+          user,
+          "user_agent",
+          "billing.cancel",
+          {
+            organization,
+            "Organization Name"
+          }
+        )
+
+      assert audit.action == "billing.cancel"
+      assert audit.user_id == user.id
+      assert audit.user_agent == "user_agent"
+      assert audit.params.organization.name == "Organization Name"
+    end
+
     test "action billing.create", %{user: user} do
       organization = build(:organization, name: "Organization Name")
 

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -93,6 +93,27 @@ defmodule Hexpm.Accounts.AuditLogTest do
       assert audit.params.token == "Test Token"
       assert audit.params.quantity == 11
     end
+
+    test "action billing.change_plan", %{user: user} do
+      organization = build(:organization, name: "Organization Name")
+
+      audit =
+        AuditLog.build(
+          user,
+          "user_agent",
+          "billing.change_plan",
+          {
+            organization,
+            %{"plan_id" => "test plan"}
+          }
+        )
+
+      assert audit.action == "billing.change_plan"
+      assert audit.user_id == user.id
+      assert audit.user_agent == "user_agent"
+      assert audit.params.organization.name == "Organization Name"
+      assert audit.params.plan_id == "test plan"
+    end
   end
 
   describe "audit/3" do

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -114,6 +114,27 @@ defmodule Hexpm.Accounts.AuditLogTest do
       assert audit.params.organization.name == "Organization Name"
       assert audit.params.plan_id == "test plan"
     end
+
+    test "action billing.pay_invoice", %{user: user} do
+      organization = build(:organization, name: "Organization Name")
+
+      audit =
+        AuditLog.build(
+          user,
+          "user_agent",
+          "billing.pay_invoice",
+          {
+            organization,
+            897
+          }
+        )
+
+      assert audit.action == "billing.pay_invoice"
+      assert audit.user_id == user.id
+      assert audit.user_agent == "user_agent"
+      assert audit.params.organization.name == "Organization Name"
+      assert audit.params.invoice_id == 897
+    end
   end
 
   describe "audit/3" do

--- a/test/hexpm/billing/billing_test.exs
+++ b/test/hexpm/billing/billing_test.exs
@@ -3,6 +3,28 @@ defmodule Hexpm.BillingTest do
 
   alias Hexpm.Accounts.AuditLogs
 
+  describe "cancel/2" do
+    test "returns whatever impl().cancel/1 returns" do
+      Mox.stub(Hexpm.Billing.Mock, :cancel, fn "organization token" -> :whatever end)
+
+      assert Hexpm.Billing.cancel("organization token",
+               audit: %{audit_data: {insert(:user), "Test User Agent"}, organization: nil}
+             ) == :whatever
+    end
+
+    test "creates an Audit Log for billing.cancel" do
+      Mox.stub(Hexpm.Billing.Mock, :cancel, fn "organization token" -> :whatever end)
+
+      user = insert(:user)
+
+      Hexpm.Billing.cancel("organization token",
+        audit: %{audit_data: {user, "Test User Agent"}, organization: nil}
+      )
+
+      assert [audit_log] = AuditLogs.all_by(user)
+    end
+  end
+
   describe "create/2" do
     test "returns {:ok, whatever} when impl().create/1 succeeds" do
       Mox.stub(Hexpm.Billing.Mock, :create, fn _params -> {:ok, :whatever} end)

--- a/test/hexpm/billing/billing_test.exs
+++ b/test/hexpm/billing/billing_test.exs
@@ -46,4 +46,50 @@ defmodule Hexpm.BillingTest do
       assert [] = AuditLogs.all_by(user)
     end
   end
+
+  describe "update/3" do
+    test "returns {:ok, whatever} when impl().update/1 succeeds" do
+      Mox.stub(Hexpm.Billing.Mock, :update, fn "organization token", _params ->
+        {:ok, :whatever}
+      end)
+
+      assert Hexpm.Billing.update("organization token", %{},
+               audit: %{audit_data: {insert(:user), "Test User Agent"}, organization: nil}
+             ) ==
+               {:ok, :whatever}
+    end
+
+    test "creates an Audit Log for billing.update when impl().update/1 succeeds" do
+      Mox.stub(Hexpm.Billing.Mock, :update, fn _, _params -> {:ok, %{}} end)
+
+      user = insert(:user)
+
+      Hexpm.Billing.update("organization token", %{},
+        audit: %{audit_data: {user, "Test User Agent"}, organization: nil}
+      )
+
+      assert [audit_log] = AuditLogs.all_by(user)
+    end
+
+    test "returns {:error, reason} when impl().update/1 fails" do
+      Mox.stub(Hexpm.Billing.Mock, :update, fn _, _params -> {:error, :reason} end)
+
+      assert Hexpm.Billing.update("organization token", %{},
+               audit: %{audit_data: {insert(:user), "Test User Agent"}, organization: nil}
+             ) ==
+               {:error, :reason}
+    end
+
+    test "does not create an Audit Log when impl().update/1 fails" do
+      Mox.stub(Hexpm.Billing.Mock, :update, fn _, _params -> {:error, :reason} end)
+
+      user = insert(:user)
+
+      Hexpm.Billing.update("organization token", %{},
+        audit: %{audit_data: {user, "Test User Agent"}, organization: nil}
+      )
+
+      assert [] = AuditLogs.all_by(user)
+    end
+  end
 end

--- a/test/hexpm/billing/billing_test.exs
+++ b/test/hexpm/billing/billing_test.exs
@@ -114,4 +114,29 @@ defmodule Hexpm.BillingTest do
       assert [] = AuditLogs.all_by(user)
     end
   end
+
+  describe "change_plan/3" do
+    test "returns :ok when impl().change_plan/2 returns :ok" do
+      Mox.stub(Hexpm.Billing.Mock, :change_plan, fn "organization token",
+                                                    %{"plan_id" => "new_plan"} ->
+        :ok
+      end)
+
+      assert Hexpm.Billing.change_plan("organization token", %{"plan_id" => "new_plan"},
+               audit: %{audit_data: {insert(:user), "Test User Agent"}, organization: nil}
+             ) == :ok
+    end
+
+    test "creates an Audit Log for billing.change_plan" do
+      Mox.stub(Hexpm.Billing.Mock, :change_plan, fn _, _ -> :ok end)
+
+      user = insert(:user)
+
+      Hexpm.Billing.change_plan("organization token", %{"plan_id" => "new_plan"},
+        audit: %{audit_data: {user, "Test User Agent"}, organization: nil}
+      )
+
+      assert [audit_log] = AuditLogs.all_by(user)
+    end
+  end
 end

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -288,26 +288,28 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     assert get_flash(conn, :error) == "Failed to pay invoice: Card failure."
   end
 
-  test "update billing email", %{user: user, organization: organization} do
-    mock_customer(organization)
+  describe "POST /dashboard/orgs/:dashboard_org/update-billing" do
+    test "update billing email", %{user: user, organization: organization} do
+      mock_customer(organization)
 
-    Mox.stub(Hexpm.Billing.Mock, :update, fn token, params ->
-      assert organization.name == token
-      assert %{"email" => "billing@example.com"} = params
-      {:ok, %{}}
-    end)
+      Mox.stub(Hexpm.Billing.Mock, :update, fn token, params ->
+        assert organization.name == token
+        assert %{"email" => "billing@example.com"} = params
+        {:ok, %{}}
+      end)
 
-    insert(:organization_user, organization: organization, user: user, role: "admin")
+      insert(:organization_user, organization: organization, user: user, role: "admin")
 
-    conn =
-      build_conn()
-      |> test_login(user)
-      |> post("dashboard/orgs/#{organization.name}/update-billing", %{
-        "email" => "billing@example.com"
-      })
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("dashboard/orgs/#{organization.name}/update-billing", %{
+          "email" => "billing@example.com"
+        })
 
-    assert redirected_to(conn) == "/dashboard/orgs/#{organization.name}"
-    assert get_flash(conn, :info) == "Updated your billing information."
+      assert redirected_to(conn) == "/dashboard/orgs/#{organization.name}"
+      assert get_flash(conn, :info) == "Updated your billing information."
+    end
   end
 
   test "create organization", %{user: user} do

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -253,64 +253,66 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     assert response(conn, 200) == "Invoice"
   end
 
-  test "pay invoice", %{user: user, organization: organization} do
-    Mox.stub(Hexpm.Billing.Mock, :get, fn token ->
-      assert organization.name == token
+  describe "pay invoice" do
+    test "pay invoice succeed", %{user: user, organization: organization} do
+      Mox.stub(Hexpm.Billing.Mock, :get, fn token ->
+        assert organization.name == token
 
-      invoice = %{
-        "id" => 123,
-        "date" => "2020-01-01T00:00:00Z",
-        "amount_due" => 700,
-        "paid" => true
-      }
+        invoice = %{
+          "id" => 123,
+          "date" => "2020-01-01T00:00:00Z",
+          "amount_due" => 700,
+          "paid" => true
+        }
 
-      %{"invoices" => [invoice]}
-    end)
+        %{"invoices" => [invoice]}
+      end)
 
-    Mox.stub(Hexpm.Billing.Mock, :pay_invoice, fn id ->
-      assert id == 123
-      :ok
-    end)
+      Mox.stub(Hexpm.Billing.Mock, :pay_invoice, fn id ->
+        assert id == 123
+        :ok
+      end)
 
-    insert(:organization_user, organization: organization, user: user, role: "admin")
+      insert(:organization_user, organization: organization, user: user, role: "admin")
 
-    conn =
-      build_conn()
-      |> test_login(user)
-      |> post("dashboard/orgs/#{organization.name}/invoices/123/pay")
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("dashboard/orgs/#{organization.name}/invoices/123/pay")
 
-    assert redirected_to(conn) == "/dashboard/orgs/#{organization.name}"
-    assert get_flash(conn, :info) == "Invoice paid."
-  end
+      assert redirected_to(conn) == "/dashboard/orgs/#{organization.name}"
+      assert get_flash(conn, :info) == "Invoice paid."
+    end
 
-  test "pay invoice failed", %{user: user, organization: organization} do
-    Mox.stub(Hexpm.Billing.Mock, :get, fn token ->
-      assert organization.name == token
+    test "pay invoice failed", %{user: user, organization: organization} do
+      Mox.stub(Hexpm.Billing.Mock, :get, fn token ->
+        assert organization.name == token
 
-      invoice = %{
-        "id" => 123,
-        "date" => "2020-01-01T00:00:00Z",
-        "amount_due" => 700,
-        "paid" => true
-      }
+        invoice = %{
+          "id" => 123,
+          "date" => "2020-01-01T00:00:00Z",
+          "amount_due" => 700,
+          "paid" => true
+        }
 
-      %{"invoices" => [invoice], "checkout_html" => ""}
-    end)
+        %{"invoices" => [invoice], "checkout_html" => ""}
+      end)
 
-    Mox.stub(Hexpm.Billing.Mock, :pay_invoice, fn id ->
-      assert id == 123
-      {:error, %{"errors" => "Card failure"}}
-    end)
+      Mox.stub(Hexpm.Billing.Mock, :pay_invoice, fn id ->
+        assert id == 123
+        {:error, %{"errors" => "Card failure"}}
+      end)
 
-    insert(:organization_user, organization: organization, user: user, role: "admin")
+      insert(:organization_user, organization: organization, user: user, role: "admin")
 
-    conn =
-      build_conn()
-      |> test_login(user)
-      |> post("dashboard/orgs/#{organization.name}/invoices/123/pay")
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("dashboard/orgs/#{organization.name}/invoices/123/pay")
 
-    response(conn, 400)
-    assert get_flash(conn, :error) == "Failed to pay invoice: Card failure."
+      response(conn, 400)
+      assert get_flash(conn, :error) == "Failed to pay invoice: Card failure."
+    end
   end
 
   describe "POST /dashboard/orgs/:dashboard_org/update-billing" do


### PR DESCRIPTION
Hi @ericmj!

As we discussed in #673, I added audit_logs to all "write" functions under `Hexpm.Billing` module
- update
- cancel
- change_plan
- pay_invoice

Note: this PR also includes #849, so feel free to close #849.

Question: Is `Billing.checkout` a write function as well? Do we need to add audit_log for it?