### PR TITLE
Add dates to minimal releases view

### DIFF
--- a/lib/hexpm_web/views/api/release_view.ex
+++ b/lib/hexpm_web/views/api/release_view.ex
@@ -37,7 +37,9 @@ defmodule HexpmWeb.API.ReleaseView do
     %{
       version: release.version,
       url: url_for_release(package, release),
-      has_docs: release.has_docs
+      has_docs: release.has_docs,
+      inserted_at: release.inserted_at,
+      updated_at: release.updated_at
     }
   end
 

--- a/lib/hexpm_web/views/api/release_view.ex
+++ b/lib/hexpm_web/views/api/release_view.ex
@@ -38,8 +38,7 @@ defmodule HexpmWeb.API.ReleaseView do
       version: release.version,
       url: url_for_release(package, release),
       has_docs: release.has_docs,
-      inserted_at: release.inserted_at,
-      updated_at: release.updated_at
+      inserted_at: release.inserted_at
     }
   end
 

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -50,7 +50,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
       releases = List.first(result)["releases"]
 
       for release <- releases do
-        assert length(Map.keys(release)) == 3
+        assert length(Map.keys(release)) == 4
         assert Map.has_key?(release, "url")
         assert Map.has_key?(release, "version")
         assert Map.has_key?(release, "has_docs")


### PR DESCRIPTION
Hello,

First off: In this current form this is not meant as a full PR but more a question for the Hex team or rather a feature request. Of course I am willing to turn this into a proper PR if needed.

The Rationale for this is as follows: I am a cofounder for Depfu, a tool that, like GitHub's Dependabot, allows teams to automate dependency updates. When we built and tested Elixir support for Depfu (Elixir support is now in Beta), we quickly ran into rate limiting (even with a user account and API token) when we tried to backfill our list of package releases. The only reason this happened is because we have to query each release in separate requests because the minimal view that is used in the api/packages view does not contain the release date. The release date, on the other hand, is crucial data we can use to run statistics which drive our strategies to create update PRs. This in turn severely downgrades Elixir support right now in contrast to the other supported languages.

This PR adds `inserted_at` and `updated_at` into the minimal view, mainly for symmetry reason (technically, `inserted_at` would be sufficient for us).

I do realize that this is probably going to meet resistance in the form of the "don't just add more and more properties to be returned to the responses", understandably so. I would be happy to make this optional (but with that opening another can of worms altogether) or listen to other solutions for our problem.

Thanks in advance!