### PR TITLE
Order audit logs by newest first

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -211,4 +211,8 @@ defmodule Hexpm.Accounts.AuditLog do
   def all_by(%Hexpm.Accounts.User{} = user) do
     Ecto.assoc(user, :audit_logs)
   end
+
+  def newest_first(query) do
+    Ecto.Query.order_by(query, desc: :inserted_at)
+  end
 end

--- a/lib/hexpm/accounts/audit_logs.ex
+++ b/lib/hexpm/accounts/audit_logs.ex
@@ -5,11 +5,13 @@ defmodule Hexpm.Accounts.AuditLogs do
 
   def all_by(schema) do
     AuditLog.all_by(schema)
+    |> AuditLog.newest_first()
     |> Repo.all()
   end
 
   def all_by(schema, page, per_page) do
     AuditLog.all_by(schema)
+    |> AuditLog.newest_first()
     |> Hexpm.Utils.paginate(page, per_page)
     |> Repo.all()
   end

--- a/test/hexpm/accounts/audit_logs_test.exs
+++ b/test/hexpm/accounts/audit_logs_test.exs
@@ -62,6 +62,23 @@ defmodule Hexpm.Accounts.AuditLogsTest do
 
       assert [] = AuditLogs.all_by(this_package)
     end
+
+    test "orders audit_logs by inserted_at timestamp" do
+      this_package = insert(:package)
+
+      insert(:audit_log,
+        params: %{identifier: "new", package: %{id: this_package.id}},
+        inserted_at: ~N{2019-08-10 10:00:00}
+      )
+
+      insert(:audit_log,
+        params: %{identifier: "old", package: %{id: this_package.id}},
+        inserted_at: ~N{2019-07-10 10:00:00}
+      )
+
+      assert [%{params: %{"identifier" => "new"}}, %{params: %{"identifier" => "old"}}] =
+               AuditLogs.all_by(this_package)
+    end
   end
 
   describe "all_by(user, page, per_page)" do


### PR DESCRIPTION
Solve the ordering issue reported in https://github.com/hexpm/hexpm/issues/754#issuecomment-534174478