### PR TITLE
WIP: Add supporting code for 2FA account recovery

### DIFF
--- a/lib/hexpm/accounts/recovery.ex
+++ b/lib/hexpm/accounts/recovery.ex
@@ -1,0 +1,52 @@
+defmodule Hexpm.Accounts.Recovery do
+  @moduledoc """
+  Functions used for generating and verifying recovery codes.
+
+  ### Examples:
+  iex(1)> codes = [code|_more_codes] = Hexpm.Accounts.Recovery.gen_recovery_codes
+  iex(2)> _hashes = [hash|_more_hashes] = Hexpm.Accounts.Recovery.hash_recovery_codes(codes)
+  iex(3)> true = Hexpm.Accounts.Recovery.verify_code(code, hash)
+  true
+  iex(4)> true = Hexpm.Accounts.Recovery.verify_code(String.split(code, "-"), hash)
+  true
+  iex(5)> false = Hexpm.Accounts.Recovery.verify_code("foo", hash)
+  false
+  iex(6)> false = Hexpm.Accounts.Recovery.verify_code(code, "bad_hash")
+  false
+  """
+
+  @rand_bytes 10
+  @part_size 4
+
+  def gen_recovery_codes, do: Enum.map(1..5, fn _ -> gen_code() end)
+
+  def hash_recovery_codes(codes), do: Enum.map(codes, &hash_code/1)
+
+  # It is not clear whether this should take a binary or a list of binaries at this point.
+  # It depends how the form in UI is implemented as well as plans for the CLI.
+  def verify_code(<<code::binary-size(19)>>, hash) do
+    code
+    |> String.split("-")
+    |> verify_code(hash)
+  end
+
+  def verify_code([_p1, _p2, _p3, _p4] = parts, hash) do
+    parts
+    |> Enum.join("-")
+    |> Bcrypt.verify_pass(hash)
+  end
+
+  def verify_code(_, _), do: false
+
+  def hash_code(code), do: Bcrypt.hash_pwd_salt(code)
+
+  defp gen_code do
+    :crypto.strong_rand_bytes(@rand_bytes)
+    |> Base.hex_encode32()
+    |> String.downcase()
+    |> String.codepoints()
+    |> Enum.chunk_every(@part_size)
+    |> Enum.reduce("", fn s, acc -> Enum.join(s) <> "-" <> acc end)
+    |> String.trim_trailing("-")
+  end
+end

--- a/lib/hexpm/accounts/recovery_code.ex
+++ b/lib/hexpm/accounts/recovery_code.ex
@@ -1,0 +1,18 @@
+defmodule Hexpm.Accounts.RecoveryCode do
+  use Hexpm.Schema
+
+  schema "user_recovery_codes" do
+    field :code_digest, :string
+    field :used_at, :utc_datetime_usec
+    timestamps()
+
+    belongs_to :user, User
+  end
+
+  def changeset(recovery_code, params) do
+    cast(recovery_code, params, [:code_digest, :used_at])
+    |> validate_required([:code_digest, :used_at])
+    |> unique_constraint(:code_digest)
+  end
+
+end

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -24,6 +24,7 @@ defmodule Hexpm.Accounts.User do
     has_many :keys, Key
     has_many :audit_logs, AuditLog
     has_many :password_resets, PasswordReset
+    has_many :recovery_codes, Hexpm.Accounts.RecoveryCode
   end
 
   @username_regex ~r"^[a-z0-9_\-\.]+$"

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -62,7 +62,7 @@ defmodule HexpmWeb.EmailView do
 
     def table(candidates) do
       candidates
-      |> Enum.map(fn([n, c, d]) -> "#{n},#{c},#{d}" end)
+      |> Enum.map(fn [n, c, d] -> "#{n},#{c},#{d}" end)
       |> Enum.join("\n")
     end
   end

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -227,6 +227,7 @@ defmodule HexpmWeb.ViewHelpers do
   end
 
   def human_number_space(0, _max), do: "0"
+
   def human_number_space(int, max) when is_integer(int) do
     unit =
       cond do

--- a/priv/repo/migrations/20191015010144_create_user_recovery_codes.exs
+++ b/priv/repo/migrations/20191015010144_create_user_recovery_codes.exs
@@ -1,0 +1,14 @@
+defmodule Hexpm.RepoBase.Migrations.CreateUserRecoveryCodes do
+  use Ecto.Migration
+
+  def change do
+    create table("user_recovery_codes") do
+      add :user_id, references(:users), null: false
+      add :code_digest, :string, null: false
+      add :used_at, :utc_datetime_usec
+      timestamps()
+    end
+
+    create unique_index(:user_recovery_codes, [:code_digest])
+  end
+end

--- a/test/hexpm/accounts/recovery_code_test.exs
+++ b/test/hexpm/accounts/recovery_code_test.exs
@@ -1,0 +1,21 @@
+defmodule Hexpm.Accounts.RecoveryCodeTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.Accounts.RecoveryCode
+
+  setup do
+    %{user: create_user("starbelly", "starbelly@mail.com", "hunter42")}
+  end
+
+  test "create recovery code and get", %{user: user} do
+    recovery_code = %RecoveryCode{user_id: user.id, code_digest: "1234"} |> Hexpm.Repo.insert!()
+    assert Hexpm.Repo.get(RecoveryCode, recovery_code.id).user_id == user.id
+  end
+
+  test "create unique key name", %{user: user} do
+    assert %RecoveryCode{} = %RecoveryCode{user_id: user.id, code_digest: "1234"} |> Hexpm.Repo.insert!()
+    assert %RecoveryCode{} = %RecoveryCode{user_id: user.id, code_digest: "12345"} |> Hexpm.Repo.insert!()
+    assert_raise Ecto.ConstraintError, fn -> %RecoveryCode{user_id: user.id, code_digest: "1234"} |> Hexpm.Repo.insert!() end
+  end
+
+end

--- a/test/hexpm/accounts/recovery_test.exs
+++ b/test/hexpm/accounts/recovery_test.exs
@@ -1,0 +1,5 @@
+defmodule Hexpm.Accounts.RecoveryTest do
+  use ExUnit.Case, async: true
+  doctest  Hexpm.Accounts.Recovery
+end
+


### PR DESCRIPTION
This is PR is intended to resolve the recovery codes portion of the 2FA initiative for hex documented in https://github.com/hexpm/hexpm/issues/852. There's a bit of discussion to be had I'm sure and as such this is opened as WIP. 

 This PR could possibly resolve the UI flow and code for recovering account, regardless such flow needs to be discussed in order to finish up this part of the initiative. This is ideal but not required. Such matters could be handled into multiple follow up PRs. 

Items up for discussion: 

- How many codes do we want to issue? 
    - 5 seems to be the average. 
- What happens when one code is successful used?
    - Invaliding the rest and generating new codes seems logical to me. 
- What happens when someone has attempted to unlock an account using the recovery method? 
    - How many times do we allow this action before locking the account? 
    - Where should we keep track of such? 
      - A recovery_sessions table makes sense to me. 
- This initial WIP hashes the codes using bcrypt, so there's no way to display recover codes to the user post initial generation.
    - This is ideal to me, but maybe there's good rationale for pub/key crypto ala github. This is of course not the norm AFAIK. Github is one of the only app/services that allows for this. 
- Should recovery codes have an expiration? 

TODO: 

- [ ] Finish up Docs (pending feedback)
- [ ] Finish up implementation (pending feedback)
- [ ] Finish up testing (pending feedback)