### PR TITLE
Sort by dependants count

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -1,6 +1,5 @@
 defmodule Hexpm.Repository.Package do
   use Hexpm.Schema
-  alias Hexpm.Repository.PackageDependant
   import Ecto.Query, only: [from: 2]
 
   @derive {HexpmWeb.Stale, assocs: [:releases, :owners, :downloads]}

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -388,8 +388,8 @@ defmodule Hexpm.Repository.Package do
       p in query,
       join: d in PackageDependant,
       on: p.name == d.name,
-      group_by: [p.name, p.id],
-      order_by: [desc: count(p.name)]
+      group_by: [p.id],
+      order_by: [desc: count(d.dependant_id)]
     )
   end
 

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -1,5 +1,6 @@
 defmodule Hexpm.Repository.Package do
   use Hexpm.Schema
+  alias Hexpm.Repository.PackageDependant
   import Ecto.Query, only: [from: 2]
 
   @derive {HexpmWeb.Stale, assocs: [:releases, :owners, :downloads]}
@@ -380,6 +381,16 @@ defmodule Hexpm.Repository.Package do
       left_join: d in PackageDownload,
       on: p.id == d.package_id and (d.view == "all" or is_nil(d.view)),
       order_by: [fragment("? DESC NULLS LAST", d.downloads)]
+    )
+  end
+
+  defp sort(query, :total_dependants) do
+    from(
+      p in query,
+      join: d in PackageDependant,
+      on: p.name == d.name,
+      group_by: [p.name, p.id],
+      order_by: [desc: count(p.name)]
     )
   end
 

--- a/lib/hexpm/shared.ex
+++ b/lib/hexpm/shared.ex
@@ -26,6 +26,7 @@ defmodule Hexpm.Shared do
         Repository.Owners,
         Repository.Package,
         Repository.PackageDownload,
+        Repository.PackageDependant,
         Repository.PackageMetadata,
         Repository.PackageOwner,
         Repository.Packages,

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -12,7 +12,7 @@ defmodule HexpmWeb.API.PackageController do
        [domain: "api", resource: "read", fun: &repository_access/2]
        when action in [:show]
 
-  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
+  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at total_dependants)
 
   def index(conn, params) do
     repositories = repositories(conn)

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -3,7 +3,7 @@ defmodule HexpmWeb.PackageController do
 
   @packages_per_page 30
   @audit_logs_per_page 10
-  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at recently_published)
+  @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at recently_published total_dependants)
   @letters for letter <- ?A..?Z, do: <<letter>>
 
   def index(conn, params) do

--- a/lib/hexpm_web/templates/package/index.html.eex
+++ b/lib/hexpm_web/templates/package/index.html.eex
@@ -31,6 +31,7 @@
 
   sort_name_params = params(search: @search, page: page, sort: "name")
   sort_total_downloads_params = params(search: @search, page: page, sort: "total_downloads")
+  sort_total_dependants_params = params(search: @search, page: page, sort: "total_dependants")
   sort_recent_downloads_params = params(search: @search, page: page, sort: "recent_downloads")
   sort_created_params = params(search: @search, page: page, sort: "inserted_at")
   sort_updated_params = params(search: @search, page: page, sort: "updated_at")
@@ -56,6 +57,9 @@
           </li>
           <li role="presentation">
             <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_total_downloads_params) %>">Total downloads</a>
+          </li>
+          <li role="presentation">
+            <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_total_dependants_params) %>">Total dependants</a>
           </li>
           <li role="presentation">
             <a role="menuitem" tabindex="-1" href="<%= Routes.package_path(Endpoint, :index, sort_recent_downloads_params) %>">Recent downloads</a>

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -6,6 +6,7 @@ defmodule HexpmWeb.PackageView do
   def show_sort_info(:inserted_at), do: "Sort: Recently created"
   def show_sort_info(:updated_at), do: "Sort: Recently updated"
   def show_sort_info(:total_downloads), do: "Sort: Total downloads"
+  def show_sort_info(:total_dependants), do: "Sort: Total dependants"
   def show_sort_info(:recent_downloads), do: "Sort: Recent downloads"
   def show_sort_info(:recently_published), do: "Sort: Recently published"
   def show_sort_info(_param), do: nil

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -14,6 +14,7 @@ defmodule HexpmWeb.PackageViewTest do
     assert PackageView.show_sort_info(:inserted_at) == "Sort: Recently created"
     assert PackageView.show_sort_info(:updated_at) == "Sort: Recently updated"
     assert PackageView.show_sort_info(:total_downloads) == "Sort: Total downloads"
+    assert PackageView.show_sort_info(:total_dependants) == "Sort: Total dependants"
     assert PackageView.show_sort_info(:recent_downloads) == "Sort: Recent downloads"
     assert PackageView.show_sort_info(:recently_published) == "Sort: Recently published"
     assert PackageView.show_sort_info(nil) == "Sort: Name"


### PR DESCRIPTION
Heads up: I am not new to Phoenix but sort of new to Ecto past very simple CRUD operations. Let me know if there's a more efficient way to do this.

This PR closes #747 by adding a sorting option `Total dependants` that sorts by the dependant amount (per package) in the web UI and the API.

Below is a screenshot - in the seed database only these two packages have dependants.

<img width="1139" alt="Screen Shot 2019-11-04 at 2 29 30 PM" src="https://user-images.githubusercontent.com/8217766/68151949-b3a4ea80-ff10-11e9-87a7-a46a001082f2.png">

