### PR TITLE
Set audit_log.organization_id to organization.id or package.organization_id

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -30,7 +30,7 @@ defmodule Hexpm.Accounts.AuditLog do
 
     %AuditLog{
       user_id: user_id,
-      organization_id: params[:repository][:organization_id],
+      organization_id: params[:organization][:id] || params[:package][:organization_id],
       user_agent: user_agent,
       action: action,
       params: params


### PR DESCRIPTION
- see also https://github.com/hexpm/hexpm/issues/864#issuecomment-546999379 for the discussion
- It actually reverts the change made in 609218b174b3d8333aab6b91b12878a6298d42ee