### PR TITLE
Add organization emails form

### DIFF
--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -191,10 +191,6 @@ defmodule Hexpm.Accounts.Users do
       else: multi
   end
 
-  def add_email(%User{organization_id: id} = user, _params, _opts) when not is_nil(id) do
-    organization_error(user, "cannot add email to organizations")
-  end
-
   def add_email(user, params, audit: audit_data) do
     email = build_assoc(user, :emails)
 

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -238,10 +238,6 @@ defmodule Hexpm.Accounts.Users do
     end
   end
 
-  def primary_email(%User{organization_id: id} = user, _params, _opts) when not is_nil(id) do
-    organization_error(user, "cannot set email of organizations")
-  end
-
   def primary_email(user, params, opts) do
     multi =
       Multi.new()
@@ -252,10 +248,6 @@ defmodule Hexpm.Accounts.Users do
       {:ok, _} -> :ok
       {:error, :primary_email, reason, _} -> {:error, reason}
     end
-  end
-
-  def gravatar_email(%User{organization_id: id} = user, _params, _opts) when not is_nil(id) do
-    organization_error(user, "cannot set email of organizations")
   end
 
   def gravatar_email(user, params, opts) do
@@ -273,10 +265,6 @@ defmodule Hexpm.Accounts.Users do
 
   defp gravatar_email_multi(multi, user, params, opts) do
     email_flag_multi(multi, user, params, :gravatar, opts)
-  end
-
-  def public_email(%User{organization_id: id} = user, _params, _opts) when not is_nil(id) do
-    organization_error(user, "cannot set email of organizations")
   end
 
   def public_email(user, params, opts) do

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -213,10 +213,6 @@ defmodule Hexpm.Accounts.Users do
     end
   end
 
-  def remove_email(%User{organization_id: id} = user, _params, _opts) when not is_nil(id) do
-    organization_error(user, "cannot remove email of organizations")
-  end
-
   def remove_email(user, params, audit: audit_data) do
     email = find_email(user, params)
 

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -128,7 +128,7 @@ defmodule Hexpm.Accounts.Users do
   end
 
   def verify_email(username, email, key) do
-    with %User{organization_id: nil, emails: emails} <- get(username, :emails),
+    with %User{emails: emails} <- get(username, :emails),
          %Email{} = email <- Enum.find(emails, &(&1.email == email)),
          true <- Email.verify?(email, key),
          {:ok, _} <- Email.verify(email) |> Repo.update() do

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -368,9 +368,14 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     end)
   end
 
-  def add_email(conn, %{"dashboard_org" => organization, "email" => _email}) do
-    access_organization(conn, organization, "admin", fn _organization ->
-      nil
+  def add_email(conn, %{"dashboard_org" => organization, "email" => email_params}) do
+    access_organization(conn, organization, "admin", fn organization ->
+      case Users.add_email(organization.user, email_params, audit: audit_data(conn)) do
+        {:ok, _user} ->
+          conn
+          |> put_flash(:info, "A verification email has been sent to #{email_params["email"]}.")
+          |> redirect(to: Routes.organization_path(conn, :show, organization))
+      end
     end)
   end
 

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -410,12 +410,14 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       container: "container page dashboard",
       organization: organization,
       repository: organization.repository,
+      emails: organization.user.emails,
       keys: keys,
       params: opts[:params],
       errors: opts[:errors],
       delete_key_path: delete_key_path,
       create_key_path: create_key_path,
       key_changeset: opts[:key_changeset] || key_changeset(),
+      email_changeset: opts[:email_changeset] || email_changeset(),
       add_member_changeset: opts[:add_member_changeset] || add_member_changeset()
     ]
 
@@ -478,6 +480,7 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       Organizations.get(organization, [
         :user,
         :organization_users,
+        user: :emails,
         users: :emails,
         repository: :packages
       ])
@@ -510,6 +513,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
   defp key_changeset() do
     Key.changeset(%Key{}, %{}, %{})
+  end
+
+  defp email_changeset() do
+    Email.changeset(%Email{}, :create, %{}, false)
   end
 
   defp cancel_message(nil = _cancel_date) do

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -465,7 +465,12 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     user = conn.assigns.current_user
 
     organization =
-      Organizations.get(organization, [:organization_users, users: :emails, repository: :packages])
+      Organizations.get(organization, [
+        :user,
+        :organization_users,
+        users: :emails,
+        repository: :packages
+      ])
 
     if organization do
       if repo_user = Enum.find(organization.organization_users, &(&1.user_id == user.id)) do

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -368,6 +368,12 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     end)
   end
 
+  def add_email(conn, %{"dashboard_org" => organization, "email" => _email}) do
+    access_organization(conn, organization, "admin", fn _organization ->
+      nil
+    end)
+  end
+
   defp render_new(conn, opts \\ []) do
     render(
       conn,

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -375,6 +375,11 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
           conn
           |> put_flash(:info, "A verification email has been sent to #{email_params["email"]}.")
           |> redirect(to: Routes.organization_path(conn, :show, organization))
+
+        {:error, _changset} ->
+          conn
+          |> put_flash(:error, "Oops, something went wrong!")
+          |> redirect(to: Routes.organization_path(conn, :show, organization))
       end
     end)
   end

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -423,6 +423,22 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     end)
   end
 
+  def resend_verification(conn, %{"dashboard_org" => organization, "email" => email}) do
+    access_organization(conn, organization, "admin", fn organization ->
+      case Users.resend_verify_email(organization.user, %{"email" => email}) do
+        :ok ->
+          conn
+          |> put_flash(:info, "A verification email has been sent to #{email}.")
+          |> redirect(to: Routes.organization_path(conn, :show, organization))
+
+        {:error, _reason} ->
+          conn
+          |> put_flash(:error, "Oops, something went wrong!")
+          |> redirect(to: Routes.organization_path(conn, :show, organization))
+      end
+    end)
+  end
+
   defp render_new(conn, opts \\ []) do
     render(
       conn,

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -407,6 +407,22 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     end)
   end
 
+  def delete_email(conn, %{"dashboard_org" => organization, "email" => email}) do
+    access_organization(conn, organization, "admin", fn organization ->
+      case Users.remove_email(organization.user, %{"email" => email}, audit: audit_data(conn)) do
+        :ok ->
+          conn
+          |> put_flash(:info, "Removed email #{email} from this organization.")
+          |> redirect(to: Routes.organization_path(conn, :show, organization))
+
+        {:error, _reason} ->
+          conn
+          |> put_flash(:error, "Oops, something went wrong!")
+          |> redirect(to: Routes.organization_path(conn, :show, organization))
+      end
+    end)
+  end
+
   defp render_new(conn, opts \\ []) do
     render(
       conn,

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -139,6 +139,7 @@ defmodule HexpmWeb.Router do
     delete "/orgs/:dashboard_org/keys", OrganizationController, :delete_key
     post "/orgs/:dashboard_org/emails", OrganizationController, :add_email
     post "/orgs/:dashboard_org/emails/flag", OrganizationController, :update_email_flag
+    delete "/orgs/:dashboard_org/emails", OrganizationController, :delete_email
     get "/orgs/:dashboard_org/invoices/:id", OrganizationController, :show_invoice
     post "/orgs/:dashboard_org/invoices/:id/pay", OrganizationController, :pay_invoice
     get "/orgs", OrganizationController, :new

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -140,6 +140,7 @@ defmodule HexpmWeb.Router do
     post "/orgs/:dashboard_org/emails", OrganizationController, :add_email
     post "/orgs/:dashboard_org/emails/flag", OrganizationController, :update_email_flag
     delete "/orgs/:dashboard_org/emails", OrganizationController, :delete_email
+    post "/orgs/:dashboard_org/emails/verification", OrganizationController, :resend_verification
     get "/orgs/:dashboard_org/invoices/:id", OrganizationController, :show_invoice
     post "/orgs/:dashboard_org/invoices/:id/pay", OrganizationController, :pay_invoice
     get "/orgs", OrganizationController, :new

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -138,6 +138,7 @@ defmodule HexpmWeb.Router do
     post "/orgs/:dashboard_org/keys", OrganizationController, :create_key
     delete "/orgs/:dashboard_org/keys", OrganizationController, :delete_key
     post "/orgs/:dashboard_org/emails", OrganizationController, :add_email
+    post "/orgs/:dashboard_org/emails/flag", OrganizationController, :update_email_flag
     get "/orgs/:dashboard_org/invoices/:id", OrganizationController, :show_invoice
     post "/orgs/:dashboard_org/invoices/:id/pay", OrganizationController, :pay_invoice
     get "/orgs", OrganizationController, :new

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -137,6 +137,7 @@ defmodule HexpmWeb.Router do
     post "/orgs/:dashboard_org/change-plan", OrganizationController, :change_plan
     post "/orgs/:dashboard_org/keys", OrganizationController, :create_key
     delete "/orgs/:dashboard_org/keys", OrganizationController, :delete_key
+    post "/orgs/:dashboard_org/emails", OrganizationController, :add_email
     get "/orgs/:dashboard_org/invoices/:id", OrganizationController, :show_invoice
     post "/orgs/:dashboard_org/invoices/:id/pay", OrganizationController, :pay_invoice
     get "/orgs", OrganizationController, :new

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -28,6 +28,30 @@
             <%= if email.gravatar do %>
               <span class="label label-success">Gravatar</span>
             <% end %>
+
+            <%= if email.verified and not email.primary do %>
+              <%= form_tag(Routes.organization_path(Endpoint, :update_email_flag, @organization.name), class: "action") do %>
+                <input type="hidden" name="email" value="<%= email.email %>">
+                <input type="hidden" name="flag" value="primary">
+                <button type="submit" class="btn btn-primary btn-xs">Set as primary</button>
+              <% end %>
+            <% end %>
+
+            <%= if email.verified and not email.public do %>
+              <%= form_tag(Routes.organization_path(Endpoint, :update_email_flag, @organization.name), class: "action") do %>
+                <input type="hidden" name="email" value="<%= email.email %>">
+                <input type="hidden" name="flag" value="public">
+                <button type="submit" class="btn btn-primary btn-xs">Set as public</button>
+              <% end %>
+            <% end %>
+
+            <%= if email.verified and not email.gravatar do %>
+              <%= form_tag(Routes.organization_path(Endpoint, :update_email_flag, @organization.name), class: "action") do %>
+                <input type="hidden" name="email" value="<%= email.email %>">
+                <input type="hidden" name="flag" value="gravatar">
+                <button type="submit" class="btn btn-primary btn-xs">Set as gravatar</button>
+              <% end %>
+            <% end %>
           </li>
         <% end %>
 

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -59,6 +59,13 @@
                 <button type="submit" class="btn btn-primary btn-xs">Set as gravatar</button>
               <% end %>
             <% end %>
+
+            <%= unless email.verified do %>
+              <%= form_tag(Routes.organization_path(Endpoint, :resend_verification, @organization.name), class: "action") do %>
+                <input type="hidden" name="email" value="<%= email.email %>">
+                <button type="submit" class="btn btn-link">Resend verification email</button>
+              <% end %>
+            <% end %>
           </li>
         <% end %>
 

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -5,6 +5,46 @@
     <%= render DashboardView, "_sidebar.html", assigns %>
   </div>
 
+  <div class="col-sm-9 email">
+    <div class="panel panel-default">
+      <div class="panel-heading">Emails</div>
+      <div class="panel-body">
+        <p>
+          The <strong>primary</strong> email address will be used when Hex.pm communicates with you.
+          The <strong>public</strong> email address will be displayed on your profile page.
+        </p>
+      </div>
+      <ul class="list-group">
+        <%= for email <- @emails do %>
+          <li class="list-group-item clearfix">
+            <span class="address"><%= email.email %></span>
+
+            <%= if email.primary do %>
+              <span class="label label-success">Primary</span>
+            <% end %>
+            <%= if email.public do %>
+              <span class="label label-success">Public</span>
+            <% end %>
+            <%= if email.gravatar do %>
+              <span class="label label-success">Gravatar</span>
+            <% end %>
+          </li>
+        <% end %>
+
+        <li class="list-group-item">
+          <%= form_for @email_changeset, Routes.organization_path(Endpoint, :add_email, @organization.name), [method: :post], fn f -> %>
+            <%= label f, :email, "Add email address" %>
+            <div class="form-group">
+              <%= email_input f, :email, class: "form-control" %>
+              <%= error_tag f, :email %>
+            </div>
+            <button type="submit" class="btn btn-primary">Add</button>
+          <% end %>
+        </li>
+      </ul>
+    </div>
+  </div>
+
   <div class="col-sm-9 organization members">
     <div class="panel panel-default">
       <div class="panel-heading">Members</div>

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -29,6 +29,13 @@
               <span class="label label-success">Gravatar</span>
             <% end %>
 
+            <%= form_tag(Routes.organization_path(Endpoint, :delete_email, @organization.name), method: :delete, class: "action") do %>
+              <input type="hidden" name="email" value="<%= email.email %>">
+              <button type="submit" class="btn btn-link btn-svg" <%= if email.primary do %>disabled<% end %>>
+                <%= HexpmWeb.ViewIcons.icon(:octicon, :trashcan) %>
+              </button>
+            <% end %>
+
             <%= if email.verified and not email.primary do %>
               <%= form_tag(Routes.organization_path(Endpoint, :update_email_flag, @organization.name), class: "action") do %>
                 <input type="hidden" name="email" value="<%= email.email %>">

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -770,5 +770,20 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       assert redirected_to(conn) == "/dashboard/orgs/#{c.organization.name}"
       assert get_flash(conn, :info) == "A verification email has been sent to test@example.com."
     end
+
+    test "sets error flash and redirects to show page when add_email fails", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "admin")
+      mock_customer(c.organization)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/orgs/#{c.organization.name}/emails", %{
+          "email" => %{"email" => "invalid_email"}
+        })
+
+      assert redirected_to(conn) == "/dashboard/orgs/#{c.organization.name}"
+      assert get_flash(conn, :error) == "Oops, something went wrong!"
+    end
   end
 end

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -909,4 +909,79 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       assert get_flash(conn, :error) == "Oops, something went wrong!"
     end
   end
+
+  describe "DELETE /dashboard/orgs/:dashboard_org/emails" do
+    test "returns 400 if current user is not admin in this org", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "write")
+      mock_customer(c.organization)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> delete("/dashboard/orgs/#{c.organization.name}/emails", %{
+          "email" => "test@example.com"
+        })
+
+      assert response(conn, 400) =~ "You do not have permission for this action."
+    end
+
+    test "remove email from organization user if current user is admin", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "admin")
+
+      insert(:email,
+        email: "test@example.com",
+        user: c.organization.user,
+        primary: false,
+        public: false
+      )
+
+      mock_customer(c.organization)
+
+      build_conn()
+      |> test_login(c.user)
+      |> delete("/dashboard/orgs/#{c.organization.name}/emails", %{
+        "email" => "test@example.com"
+      })
+
+      assert Users.get_email("test@example.com", [:user]) == nil
+    end
+
+    test "sets info flash and redirects to dashboard organization show page", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "admin")
+
+      insert(:email,
+        email: "test@example.com",
+        user: c.organization.user,
+        primary: false,
+        public: false
+      )
+
+      mock_customer(c.organization)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> delete("/dashboard/orgs/#{c.organization.name}/emails", %{
+          "email" => "test@example.com"
+        })
+
+      assert redirected_to(conn) == "/dashboard/orgs/#{c.organization.name}"
+      assert get_flash(conn, :info) == "Removed email test@example.com from this organization."
+    end
+
+    test "sets error flash and redirects to show page when add_email fails", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "admin")
+      mock_customer(c.organization)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> delete("/dashboard/orgs/#{c.organization.name}/emails", %{
+          "email" => "invalid_email"
+        })
+
+      assert redirected_to(conn) == "/dashboard/orgs/#{c.organization.name}"
+      assert get_flash(conn, :error) == "Oops, something went wrong!"
+    end
+  end
 end

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -728,4 +728,18 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       assert response(conn, 400) =~ "The key computer was not found"
     end
   end
+
+  describe "POST /dashboard/orgs/:dashboard_org/emails" do
+    test "returns 400 if current user is not admin in this org", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "write")
+      mock_customer(c.organization)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/orgs/#{c.organization.name}/emails", %{"email" => "test@example.com"})
+
+      assert response(conn, 400) =~ "You do not have permission for this action."
+    end
+  end
 end


### PR DESCRIPTION
related issue: #870 

Hi @ericmj!

After a deep dive, I find it's trickier to support updating gravatar email for organization users.
Since `User.build_organization` doesn't set any email for the user, we need to support adding email to `organization.user` first.

So this is my attempt to add an email form in dashboard organization show page:
- [x] add OrganizationController#add_email endpoint
- [x] add an email list to show all emails associated to this organization
- [x] add an email form for adding email to this organization

<img width="1028" alt="image" src="https://user-images.githubusercontent.com/4723751/70232420-5f06c080-1797-11ea-9a38-1223b6a30589.png">


- [x] update organization email flag (primary/public/gravatar)
- [x] delete organization email
- [x] resend verification email

<img width="999" alt="image" src="https://user-images.githubusercontent.com/4723751/70370969-eecb7c80-1907-11ea-85e5-74eff30fa68e.png">

TODO:
- [ ] extract partial template for `email_form`
- [ ] refine error messages
