### PR TITLE
Call audit for "email.remove" in Users.remove_email/3

### DIFF
--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -235,7 +235,7 @@ defmodule Hexpm.Accounts.Users do
         {:ok, _} =
           Multi.new()
           |> Ecto.Multi.delete(:email, email)
-          |> audit(audit_data, "email.add", email)
+          |> audit(audit_data, "email.remove", email)
           |> Repo.transaction()
 
         :ok


### PR DESCRIPTION
Found this issue when working on #876 
- it doesn't make sense to log "email.add" here
- and there are no other calls to log "email.remove" anywhere else