### PR TITLE
Add organization profile form

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -235,7 +235,7 @@ defmodule Hexpm.Accounts.AuditLog do
   defp fields(%Release{}), do: [:id, :version, :checksum, :has_docs, :package_id]
   defp fields(%ReleaseMetadata{}), do: [:app, :build_tools, :elixir]
   defp fields(%ReleaseRetirement{}), do: [:status, :message]
-  defp fields(%Organization{}), do: [:name, :public, :active, :billing_active]
+  defp fields(%Organization{}), do: [:id, :name, :public, :active, :billing_active]
   defp fields(%User{}), do: [:id, :username]
   defp fields(%UserHandles{}), do: [:github, :twitter, :freenode]
 

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -125,14 +125,35 @@ defmodule Hexpm.Accounts.AuditLog do
   defp extract_params("release.unretire", {package, release}),
     do: %{package: serialize(package), release: serialize(release)}
 
+  defp extract_params("email.add", {organization, email}),
+    do: Map.merge(%{organization: serialize(organization)}, serialize(email))
+
   defp extract_params("email.add", email), do: serialize(email)
+
+  defp extract_params("email.remove", {organization, email}),
+    do: Map.merge(%{organization: serialize(organization)}, serialize(email))
+
   defp extract_params("email.remove", email), do: serialize(email)
 
   defp extract_params("email.primary", {old_email, new_email}),
     do: %{old_email: serialize(old_email), new_email: serialize(new_email)}
 
+  defp extract_params("email.public", {organization, {old_email, new_email}}),
+    do: %{
+      organization: serialize(organization),
+      old_email: serialize(old_email),
+      new_email: serialize(new_email)
+    }
+
   defp extract_params("email.public", {old_email, new_email}),
     do: %{old_email: serialize(old_email), new_email: serialize(new_email)}
+
+  defp extract_params("email.gravatar", {organization, {old_email, new_email}}),
+    do: %{
+      organization: serialize(organization),
+      old_email: serialize(old_email),
+      new_email: serialize(new_email)
+    }
 
   defp extract_params("email.gravatar", {old_email, new_email}),
     do: %{old_email: serialize(old_email), new_email: serialize(new_email)}

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -40,6 +40,22 @@ defmodule Hexpm.Accounts.Email do
     |> put_change(:verification_expiry, DateTime.utc_now())
   end
 
+  def changeset(email, :create_for_org, params, false) do
+    cast(email, params, ~w(email public gravatar)a)
+    |> validate_required(~w(email)a)
+    |> update_change(:email, &String.downcase/1)
+    |> validate_format(:email, @email_regex)
+    # TODO: these comments are for code review, need to be removed before merge
+    # |> validate_confirmation(:email, message: "does not match email")
+    # |> validate_verified_email_exists(:email, message: "already in use")
+    |> unique_constraint(:email, name: "emails_email_key")
+    |> unique_constraint(:email, name: "emails_email_user_key")
+    |> put_change(:verified, false)
+
+    # |> put_change(:verification_key, Auth.gen_key())
+    # |> put_change(:verification_expiry, DateTime.utc_now())
+  end
+
   def verification(email) do
     change(email, %{
       verification_key: Auth.gen_key(),

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -81,6 +81,14 @@ defmodule Hexpm.Accounts.Email do
     |> unique_constraint(:email, name: "emails_email_key", message: "already in use")
   end
 
+  def update_email(email, new_address) do
+    change(email, %{email: new_address})
+    |> validate_required(~w(email)a)
+    |> validate_format(:email, @email_regex)
+    |> unique_constraint(:email, name: "emails_email_key")
+    |> unique_constraint(:email, name: "emails_email_user_key")
+  end
+
   def toggle_flag(email, flag, value) do
     change(email, %{flag => value})
   end

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -78,6 +78,7 @@ defmodule Hexpm.Accounts.Email do
   def update_email(email, new_address) do
     change(email, %{email: new_address})
     |> validate_required(~w(email)a)
+    |> update_change(:email, &String.downcase/1)
     |> validate_format(:email, @email_regex)
     |> unique_constraint(:email, name: "emails_email_key")
     |> unique_constraint(:email, name: "emails_email_user_key")

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -45,15 +45,9 @@ defmodule Hexpm.Accounts.Email do
     |> validate_required(~w(email)a)
     |> update_change(:email, &String.downcase/1)
     |> validate_format(:email, @email_regex)
-    # TODO: these comments are for code review, need to be removed before merge
-    # |> validate_confirmation(:email, message: "does not match email")
-    # |> validate_verified_email_exists(:email, message: "already in use")
     |> unique_constraint(:email, name: "emails_email_key")
     |> unique_constraint(:email, name: "emails_email_user_key")
     |> put_change(:verified, false)
-
-    # |> put_change(:verification_key, Auth.gen_key())
-    # |> put_change(:verification_expiry, DateTime.utc_now())
   end
 
   def verification(email) do

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -74,8 +74,35 @@ defmodule Hexpm.Accounts.Users do
     email
   end
 
-  def update_profile(%User{organization_id: id} = user, _params, _opts) when not is_nil(id) do
-    organization_error(user, "cannot update profile of organizations")
+  def update_profile(%User{organization_id: id} = user, params, audit: audit_data)
+      when not is_nil(id) do
+    multi =
+      Multi.new()
+      |> Multi.update(:user, User.update_profile(user, params))
+      |> audit(audit_data, "user.update", fn %{user: user} -> user end)
+      |> insert_or_update_or_delete_email_multi(user, :public, params["public_email"],
+        audit: audit_data
+      )
+      |> insert_or_update_or_delete_email_multi(user, :gravatar, params["gravatar_email"],
+        audit: audit_data
+      )
+
+    case Repo.transaction(multi) do
+      {:ok, %{user: user}} ->
+        {:ok, user}
+
+      {:error, :public_email, _, _} ->
+        {:error,
+         %Ecto.Changeset{data: user, errors: [public_email: {"unknown error", []}], valid?: false}}
+
+      {:error, :gravatar_email, _, _} ->
+        {:error,
+         %Ecto.Changeset{
+           data: user,
+           errors: [gravatar_email: {"unknown error", []}],
+           valid?: false
+         }}
+    end
   end
 
   def update_profile(user, params, audit: audit_data) do
@@ -346,6 +373,47 @@ defmodule Hexpm.Accounts.Users do
         multi
         |> Multi.update(new_email_op_name, Email.toggle_flag(new_email, flag, true))
         |> audit(audit_data, "email.#{flag}", {old_email, new_email})
+    end
+  end
+
+  def insert_or_update_or_delete_email_multi(multi, _user, _flag, nil, _params) do
+    multi
+  end
+
+  def insert_or_update_or_delete_email_multi(multi, user, flag, "", audit: audit_data) do
+    if old_email = Enum.find(user.emails, &Map.get(&1, flag)) do
+      email_op = String.to_atom("#{flag}_email")
+
+      multi
+      |> Multi.delete(email_op, old_email)
+      |> audit(audit_data, "email.remove", old_email)
+    else
+      multi
+    end
+  end
+
+  def insert_or_update_or_delete_email_multi(multi, user, flag, email_address, audit: audit_data) do
+    email_op = String.to_atom("#{flag}_email")
+
+    if old_email = Enum.find(user.emails, &Map.get(&1, flag)) do
+      multi
+      |> Multi.update(email_op, Email.update_email(old_email, email_address))
+      |> audit(audit_data, "email.#{flag}", fn %{^email_op => new_email} ->
+        {old_email, new_email}
+      end)
+    else
+      multi
+      |> Multi.insert(
+        email_op,
+        Email.changeset(
+          build_assoc(user, :emails),
+          :create_for_org,
+          %{:email => email_address, flag => true},
+          false
+        )
+      )
+      |> audit(audit_data, "email.add", fn %{^email_op => email} -> email end)
+      |> audit(audit_data, "email.#{flag}", fn %{^email_op => email} -> {nil, email} end)
     end
   end
 

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -368,6 +368,23 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     end)
   end
 
+  def update_profile(conn, %{"dashboard_org" => organization, "profile" => profile_params}) do
+    access_organization(conn, organization, "admin", fn organization ->
+      case Users.update_profile(organization.user, profile_params, audit: audit_data(conn)) do
+        {:ok, _updated_user} ->
+          conn
+          |> put_flash(:info, "Profile updated successfully.")
+          |> redirect(to: Routes.organization_path(conn, :show, organization))
+
+        {:error, _} ->
+          conn
+          |> put_status(400)
+          |> put_flash(:error, "Oops, something went wrong!")
+          |> render_index(organization)
+      end
+    end)
+  end
+
   defp render_new(conn, opts \\ []) do
     render(
       conn,

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -139,6 +139,7 @@ defmodule HexpmWeb.Router do
     delete "/orgs/:dashboard_org/keys", OrganizationController, :delete_key
     get "/orgs/:dashboard_org/invoices/:id", OrganizationController, :show_invoice
     post "/orgs/:dashboard_org/invoices/:id/pay", OrganizationController, :pay_invoice
+    post "/orgs/:dashboard_org/profile", OrganizationController, :update_profile
     get "/orgs", OrganizationController, :new
     post "/orgs", OrganizationController, :create
 

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -7,6 +7,92 @@
 
   <div class="col-sm-9 organization members">
     <div class="panel panel-default">
+      <div class="panel-heading">Public profile</div>
+      <div class="panel-body">
+        <div class="form-group">
+          <label>Profile picture</label>
+          <img src="<%= gravatar_url(User.email(@organization.user, :gravatar), :large) %>">
+          <p>
+            <small>
+              Gravatar is used to display organization profile picture. You can update the Gravatar email below or
+              go to <a href="https://en.gravatar.com/emails/">Gravatar</a> to change the image.
+            </small>
+          </p>
+        </div>
+
+        <%= form_for @changeset, Routes.organization_path(Endpoint, :update_profile, @organization), [method: :post, as: :profile], fn f -> %>
+          <div class="form-group">
+            <%= label f, :full_name %>
+            <%= text_input f, :full_name %>
+            <%= error_tag f, :full_name %>
+          </div>
+
+          <div class="form-group">
+            <%= label f, :public_email %>
+            <%= text_input f, :public_email, placeholder: "Your organization's public email", value: @public_email %>
+            <%= error_tag f, :public_email %>
+          </div>
+
+          <div class="form-group">
+            <%= label f, :gravatar_email %>
+            <%= text_input f, :gravatar_email, placeholder: "Your organization's gravatar email", value: @gravatar_email %>
+            <%= error_tag f, :gravatar_email %>
+          </div>
+
+          <%= inputs_for f, :handles, fn f -> %>
+            <div class="form-group">
+              <%= label f, :twitter %>
+              <div class="input-group">
+                <div class="input-group-addon">twitter.com/</div>
+                <%= text_input f, :twitter, placeholder: "organization_twitter_id" %>
+              </div>
+
+              <%= error_tag f, :twitter %>
+            </div>
+
+            <div class="form-group">
+              <%= label f, :github, "GitHub" %>
+              <div class="input-group">
+                <div class="input-group-addon">github.com/</div>
+                <%= text_input f, :github, placeholder: "organization_github_id" %>
+              </div>
+              <%= error_tag f, :github %>
+            </div>
+
+            <div class="form-group">
+              <%= label f, :elixirforum, "Elixir Forum" %>
+              <div class="input-group">
+                <div class="input-group-addon">elixirforum.com/users/</div>
+                <%= text_input f, :elixirforum, placeholder: "organization_elixir_forum_id" %>
+              </div>
+              <%= error_tag f, :elixirforum %>
+            </div>
+
+            <div class="form-group">
+              <%= label f, :freenode %>
+              <%= text_input f, :freenode, placeholder: "Your organization's nickname on Elixir IRC channel" %>
+              <span class="help-block">Elixir IRC channel:
+                <a href="irc://chat.freenode.net/elixir-lang">irc://chat.freenode.net/elixir-lang</a>
+              </span>
+              <%= error_tag f, :freenode %>
+            </div>
+
+            <div class="form-group">
+              <%= label f, :slack %>
+              <%= text_input f, :slack, placeholder: "Your organization's nickname on Elixir Slack channel" %>
+              <span class="help-block">Elixir Slack channel:
+                <a href="https://elixir-slackin.herokuapp.com">elixir-slackin.herokuapp.com</a>
+              </span>
+              <%= error_tag f, :slack %>
+            </div>
+          <% end %>
+
+          <button type="submit" class="btn btn-primary">Save</button>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
       <div class="panel-heading">Members</div>
       <div class="panel-body">
         Here you control your organization members and their roles. Mouse-over the role for more details.

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -59,7 +59,7 @@ defmodule Hexpm.Accounts.AuditLogTest do
       assert audit.user_id == user.id
       assert audit.user_agent == "user_agent"
       assert audit.organization_id == 5
-      assert audit.params == %{billing_active: false, name: "Test"}
+      assert audit.params == %{billing_active: false, name: "Test", id: 5}
     end
 
     test "action billing.checkout", %{user: user} do

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -77,9 +77,22 @@ defmodule Hexpm.Accounts.UsersTest do
       assert email.user_id == organization.user.id
       assert email.public == true
 
+      current_user_id = current_user.id
+      organization_id = organization.id
       # TODO: these audit_logs shall belong to organization or organization user?
-      assert [%{action: "email.public"}, %{action: "email.add"}, _user_update] =
-               Hexpm.Accounts.AuditLogs.all_by(current_user)
+      assert [
+               %{
+                 action: "email.public",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               %{
+                 action: "email.add",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               _user_update
+             ] = Hexpm.Accounts.AuditLogs.all_by(current_user)
     end
 
     test "updates public email if it exists" do
@@ -101,8 +114,17 @@ defmodule Hexpm.Accounts.UsersTest do
       assert email.user_id == organization.user.id
       assert email.public == true
 
-      assert [%{action: "email.public"}, _user_update] =
-               Hexpm.Accounts.AuditLogs.all_by(current_user)
+      current_user_id = current_user.id
+      organization_id = organization.id
+
+      assert [
+               %{
+                 action: "email.public",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               _user_update
+             ] = Hexpm.Accounts.AuditLogs.all_by(current_user)
     end
 
     test "inserts gravatar email if it doesn't exist yet" do
@@ -121,8 +143,22 @@ defmodule Hexpm.Accounts.UsersTest do
       assert email.gravatar == true
 
       # TODO: these audit_logs shall belong to organization or organization user?
-      assert [%{action: "email.gravatar"}, %{action: "email.add"}, _user_update] =
-               Hexpm.Accounts.AuditLogs.all_by(current_user)
+      current_user_id = current_user.id
+      organization_id = organization.id
+
+      assert [
+               %{
+                 action: "email.gravatar",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               %{
+                 action: "email.add",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               _user_update
+             ] = Hexpm.Accounts.AuditLogs.all_by(current_user)
     end
 
     test "updates gravatar email if it exists" do
@@ -144,8 +180,17 @@ defmodule Hexpm.Accounts.UsersTest do
       assert email.user_id == organization.user.id
       assert email.gravatar == true
 
-      assert [%{action: "email.gravatar"}, _user_update] =
-               Hexpm.Accounts.AuditLogs.all_by(current_user)
+      current_user_id = current_user.id
+      organization_id = organization.id
+
+      assert [
+               %{
+                 action: "email.gravatar",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               _user_update
+             ] = Hexpm.Accounts.AuditLogs.all_by(current_user)
     end
 
     test "returns {:error, changeset} when public_email is invalid" do
@@ -187,8 +232,17 @@ defmodule Hexpm.Accounts.UsersTest do
 
       assert Users.get_email("old@example.com") == nil
 
-      assert [%{action: "email.remove"}, _user_update] =
-               Hexpm.Accounts.AuditLogs.all_by(current_user)
+      current_user_id = current_user.id
+      organization_id = organization.id
+
+      assert [
+               %{
+                 action: "email.remove",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               _user_update
+             ] = Hexpm.Accounts.AuditLogs.all_by(current_user)
     end
 
     test "does nothing to emails when public_email is empty" do
@@ -219,8 +273,17 @@ defmodule Hexpm.Accounts.UsersTest do
 
       assert Users.get_email("old@example.com") == nil
 
-      assert [%{action: "email.remove"}, _user_update] =
-               Hexpm.Accounts.AuditLogs.all_by(current_user)
+      current_user_id = current_user.id
+      organization_id = organization.id
+
+      assert [
+               %{
+                 action: "email.remove",
+                 user_id: ^current_user_id,
+                 organization_id: ^organization_id
+               },
+               _user_update
+             ] = Hexpm.Accounts.AuditLogs.all_by(current_user)
     end
 
     test "does nothing to emails when gravatar_email is empty" do

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -1,0 +1,237 @@
+defmodule Hexpm.Accounts.UsersTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.Accounts.Users
+
+  describe "update_profile/3 when user belongs to an organization" do
+    test "updates full_name" do
+      organization = insert(:organization, user: build(:user, full_name: "Old Full Name"))
+
+      {:ok, updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{"full_name" => "New Full Name"},
+          audit: {build(:user), "UA"}
+        )
+
+      assert %{full_name: "New Full Name"} = updated_user
+    end
+
+    test "updates handles" do
+      organization = insert(:organization, user: build(:user))
+
+      {:ok, updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{
+            "handles" => %{
+              "twitter" => "twitter",
+              "github" => "github",
+              "elixirforum" => "elixirforum",
+              "freenode" => "freenode",
+              "slack" => "slack"
+            }
+          },
+          audit: {build(:user), "UA"}
+        )
+
+      assert %{
+               twitter: "twitter",
+               github: "github",
+               elixirforum: "elixirforum",
+               freenode: "freenode",
+               slack: "slack"
+             } = updated_user.handles
+    end
+
+    test "audits user.update action" do
+      organization =
+        insert(:organization, user: build(:user, username: "organization.user", emails: []))
+
+      current_user = insert(:user)
+
+      {:ok, _} =
+        Users.update_profile(
+          organization.user,
+          %{},
+          audit: {current_user, "UA"}
+        )
+
+      # TODO: attach this audit_log to organization as well?
+      assert [%{action: "user.update", params: %{"username" => "organization.user"}}] =
+               Hexpm.Accounts.AuditLogs.all_by(current_user)
+    end
+
+    test "inserts public email if it doesn't exist yet" do
+      organization = insert(:organization, user: build(:user, emails: []))
+      current_user = insert(:user)
+
+      {:ok, _updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{"public_email" => "public@example.com"},
+          audit: {current_user, "UA"}
+        )
+
+      email = Users.get_email("public@example.com")
+      assert email.user_id == organization.user.id
+      assert email.public == true
+
+      # TODO: these audit_logs shall belong to organization or organization user?
+      assert [%{action: "email.public"}, %{action: "email.add"}, _user_update] =
+               Hexpm.Accounts.AuditLogs.all_by(current_user)
+    end
+
+    test "updates public email if it exists" do
+      organization =
+        insert(:organization,
+          user: build(:user, emails: [build(:email, email: "old@example.com", public: true)])
+        )
+
+      current_user = insert(:user)
+
+      {:ok, _updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{"public_email" => "public@example.com"},
+          audit: {current_user, "UA"}
+        )
+
+      email = Users.get_email("public@example.com")
+      assert email.user_id == organization.user.id
+      assert email.public == true
+
+      assert [%{action: "email.public"}, _user_update] =
+               Hexpm.Accounts.AuditLogs.all_by(current_user)
+    end
+
+    test "inserts gravatar email if it doesn't exist yet" do
+      organization = insert(:organization, user: build(:user, emails: []))
+      current_user = insert(:user)
+
+      {:ok, _updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{"gravatar_email" => "gravatar@example.com"},
+          audit: {current_user, "UA"}
+        )
+
+      email = Users.get_email("gravatar@example.com")
+      assert email.user_id == organization.user.id
+      assert email.gravatar == true
+
+      # TODO: these audit_logs shall belong to organization or organization user?
+      assert [%{action: "email.gravatar"}, %{action: "email.add"}, _user_update] =
+               Hexpm.Accounts.AuditLogs.all_by(current_user)
+    end
+
+    test "updates gravatar email if it exists" do
+      organization =
+        insert(:organization,
+          user: build(:user, emails: [build(:email, email: "old@example.com", gravatar: true)])
+        )
+
+      current_user = insert(:user)
+
+      {:ok, _updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{"gravatar_email" => "gravatar@example.com"},
+          audit: {current_user, "UA"}
+        )
+
+      email = Users.get_email("gravatar@example.com")
+      assert email.user_id == organization.user.id
+      assert email.gravatar == true
+
+      assert [%{action: "email.gravatar"}, _user_update] =
+               Hexpm.Accounts.AuditLogs.all_by(current_user)
+    end
+
+    test "returns {:error, changeset} when public_email is invalid" do
+      organization = insert(:organization, user: build(:user, emails: []))
+
+      assert {:error, _changeset} =
+               Users.update_profile(
+                 organization.user,
+                 %{"public_email" => "public"},
+                 audit: {build(:user), "UA"}
+               )
+    end
+
+    test "returns {:error, changeset} when gravatar_email is invalid" do
+      organization = insert(:organization, user: build(:user, emails: []))
+
+      assert {:error, _changeset} =
+               Users.update_profile(
+                 organization.user,
+                 %{"gravatar_email" => "gravatar"},
+                 audit: {build(:user), "UA"}
+               )
+    end
+
+    test "removes public email when public_email is empty" do
+      organization =
+        insert(:organization,
+          user: build(:user, emails: [build(:email, email: "old@example.com", public: true)])
+        )
+
+      current_user = insert(:user)
+
+      {:ok, _updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{"public_email" => ""},
+          audit: {current_user, "UA"}
+        )
+
+      assert Users.get_email("old@example.com") == nil
+
+      assert [%{action: "email.remove"}, _user_update] =
+               Hexpm.Accounts.AuditLogs.all_by(current_user)
+    end
+
+    test "does nothing to emails when public_email is empty" do
+      organization = insert(:organization, user: build(:user, emails: []))
+
+      assert {:ok, _updated_user} =
+               Users.update_profile(
+                 organization.user,
+                 %{"public_email" => ""},
+                 audit: {build(:user), "UA"}
+               )
+    end
+
+    test "removes gravatar email when gravatar_email is empty" do
+      organization =
+        insert(:organization,
+          user: build(:user, emails: [build(:email, email: "old@example.com", gravatar: true)])
+        )
+
+      current_user = insert(:user)
+
+      {:ok, _updated_user} =
+        Users.update_profile(
+          organization.user,
+          %{"gravatar_email" => ""},
+          audit: {current_user, "UA"}
+        )
+
+      assert Users.get_email("old@example.com") == nil
+
+      assert [%{action: "email.remove"}, _user_update] =
+               Hexpm.Accounts.AuditLogs.all_by(current_user)
+    end
+
+    test "does nothing to emails when gravatar_email is empty" do
+      organization = insert(:organization, user: build(:user, emails: []))
+
+      assert {:ok, _updated_user} =
+               Users.update_profile(
+                 organization.user,
+                 %{"gravatar_email" => ""},
+                 audit: {build(:user), "UA"}
+               )
+    end
+  end
+end

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -57,7 +57,6 @@ defmodule Hexpm.Accounts.UsersTest do
           audit: {current_user, "UA"}
         )
 
-      # TODO: attach this audit_log to organization as well?
       assert [%{action: "user.update", params: %{"username" => "organization.user"}}] =
                Hexpm.Accounts.AuditLogs.all_by(current_user)
     end
@@ -79,7 +78,7 @@ defmodule Hexpm.Accounts.UsersTest do
 
       current_user_id = current_user.id
       organization_id = organization.id
-      # TODO: these audit_logs shall belong to organization or organization user?
+
       assert [
                %{
                  action: "email.public",
@@ -142,7 +141,6 @@ defmodule Hexpm.Accounts.UsersTest do
       assert email.user_id == organization.user.id
       assert email.gravatar == true
 
-      # TODO: these audit_logs shall belong to organization or organization user?
       current_user_id = current_user.id
       organization_id = organization.id
 


### PR DESCRIPTION
- [x] add `Users.update_profile/3` handler for organization.user
- [x] add `OrganizationController#update_profile` endpoint
- [x] add a profile form section in `organization#index.html.eex` template

Hi @ericmj!

I've finished the functions listed in https://github.com/hexpm/hexpm/issues/870#issuecomment-563508505. And I also added a blank email handler so that when `public/gravatar_email` is empty, the old organization_email would be deleted.

Feel free to merge this PR, and I'll open new PRs for the rest of todos.
If this PR is not merged, I'll continue push to this branch.

Update:
Now the dashboard organization index page looks like this:
![image](https://user-images.githubusercontent.com/4723751/70998245-cadf1680-2111-11ea-8108-8dd2327e351a.png)
