### PR TITLE
setup 2fa login

### DIFF
--- a/assets/css/base/_general.scss
+++ b/assets/css/base/_general.scss
@@ -121,6 +121,14 @@ input[type="checkbox"] {
   }
 }
 
+.otp-code {
+  width: 5.5em;
+  height: 1.5em;
+  font-size: 40px;
+  text-align: center;
+  -webkit-text-security: disc;
+}
+
 .panel-body-part {
   padding: 15px;
   border-top: 1px solid #ddd;

--- a/lib/hexpm/accounts/two_factor_auth.ex
+++ b/lib/hexpm/accounts/two_factor_auth.ex
@@ -12,11 +12,13 @@ defmodule Hexpm.Accounts.TwoFactorAuth do
     32 |> :crypto.strong_rand_bytes() |> Base.encode32() |> String.slice(0..15)
   end
 
+  # addwindow 1 creates a token 30 seconds ahead
   def time_based_token(secret) do
-    :pot.totp(secret)
+    :pot.totp(secret, addwindow: 1)
   end
 
+  # Check a token 30 seconds ahead and within a margin of error of 1 second
   def token_valid?(secret, token) do
-    :pot.valid_totp(token, secret)
+    :pot.valid_totp(token, secret, window: 1, addwindow: 1)
   end
 end

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -388,9 +388,12 @@ defmodule Hexpm.Accounts.Users do
   def tfa_recover(%User{} = user, code_str) do
     case Recovery.verify(user.tfa.recovery_codes, code_str) do
       {:ok, %RecoveryCode{} = code} ->
-        user
-        |> User.recovery_code_used(code)
-        |> Repo.update!()
+        user =
+          user
+          |> User.recovery_code_used(code)
+          |> Repo.update!()
+
+        {:ok, user}
 
       err ->
         err

--- a/lib/hexpm_web/controllers/two_factor_auth_controller.ex
+++ b/lib/hexpm_web/controllers/two_factor_auth_controller.ex
@@ -1,0 +1,50 @@
+defmodule HexpmWeb.TwoFactorAuthController do
+  use HexpmWeb, :controller
+
+  plug :authenticate
+
+  def show(conn, _params), do: render_show(conn)
+
+  def create(conn, %{"code" => code}) do
+    %{"uid" => uid} = session = get_session(conn, "two_factor_user_id")
+    user = Hexpm.Accounts.Users.get_by_id(uid)
+    secret = user.tfa.secret
+
+    with {_Int, ""} <- Integer.parse(code),
+         true <- Hexpm.Accounts.TwoFactorAuth.token_valid?(secret, code) do
+      conn
+      |> delete_session("two_factor_user_id")
+      |> HexpmWeb.LoginController.start_session(user, session["return"])
+    else
+      _ ->
+        render_show_error(conn)
+    end
+  end
+
+  defp render_show(conn) do
+    render(
+      conn,
+      "show.html",
+      title: "Two Factor Authentication",
+      container: "container page page-xs login"
+    )
+  end
+
+  defp render_show_error(conn) do
+    msg = "The verification code you provided is incorrect. Please try again."
+
+    conn
+    |> put_flash(:error, msg)
+    |> render_show()
+  end
+
+  defp authenticate(conn, _opts) do
+    case get_session(conn, "two_factor_user_id") do
+      nil ->
+        conn |> redirect(to: "/") |> halt()
+
+      _ ->
+        conn
+    end
+  end
+end

--- a/lib/hexpm_web/controllers/two_factor_recovery_controller.ex
+++ b/lib/hexpm_web/controllers/two_factor_recovery_controller.ex
@@ -1,0 +1,52 @@
+defmodule HexpmWeb.TwoFactorRecoveryController do
+  use HexpmWeb, :controller
+
+  plug :authenticate
+
+  def show(conn, _params), do: render_show(conn)
+
+  def create(conn, %{"code" => code}) do
+    %{"uid" => uid} = session = get_session(conn, "two_factor_user_id")
+    user = Hexpm.Accounts.Users.get_by_id(uid)
+
+    with :ok <- validate_code(code),
+         {:ok, updated_user} <- Hexpm.Accounts.Users.tfa_recover(user, code) do
+      conn
+      |> delete_session("two_factor_user_id")
+      |> HexpmWeb.LoginController.start_session(updated_user, session["return"])
+    else
+      _ ->
+        render_show_error(conn)
+    end
+  end
+
+  defp render_show(conn) do
+    render(
+      conn,
+      "show.html",
+      title: "Two Factor Recovery",
+      container: "container page page-xs login"
+    )
+  end
+
+  defp render_show_error(conn) do
+    msg = "The recovery code you provided is incorrect. Please try again."
+
+    conn
+    |> put_flash(:error, msg)
+    |> render_show()
+  end
+
+  defp authenticate(conn, _opts) do
+    case get_session(conn, "two_factor_user_id") do
+      nil ->
+        conn |> redirect(to: "/") |> halt()
+
+      _ ->
+        conn
+    end
+  end
+
+  defp validate_code(<<_code::binary-size(19)>>), do: :ok
+  defp validate_code(_code), do: :error
+end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -57,6 +57,12 @@ defmodule HexpmWeb.Router do
     post "/login", LoginController, :create
     post "/logout", LoginController, :delete
 
+    get "/two_factor_auth", TwoFactorAuthController, :show
+    post "/two_factor_auth", TwoFactorAuthController, :create
+
+    get "/two_factor_auth/recovery", TwoFactorRecoveryController, :show
+    post "/two_factor_auth/recovery", TwoFactorRecoveryController, :create
+
     get "/signup", SignupController, :show
     post "/signup", SignupController, :create
 

--- a/lib/hexpm_web/templates/two_factor_auth/show.html.eex
+++ b/lib/hexpm_web/templates/two_factor_auth/show.html.eex
@@ -1,0 +1,26 @@
+  <h2>Enter your One Time Password</h2>
+  <%= form_tag(Routes.two_factor_auth_path(Endpoint, :create)) do %>
+    <div class="row">
+      <div class="col-md-4 col-md-offset-4">
+      <input id="code" name="code" type="text" pattern="\d{6}"
+                                                 title="Must be 6 digits and digits only"
+                                                 class="form-control otp-code"  value="" maxlength="6"
+                                                                                         inputmode="numeric" autocomplete="off"/>
+      </div>
+     </div>
+
+
+    <br/>
+
+    <div class="form-row">
+      <div class="col-md-4 col-md-offset-4">
+        <button type="submit"  class="btn btn-primary">Submit</button>
+      </div>
+    </div>
+
+      <div class="form-row">
+      <div class="col-md-6 col-md-offset-4">
+        <a href="<%= Routes.two_factor_recovery_path(Endpoint, :show) %>" class="">Use a recovery code instead</a>
+      </div>
+    </div>
+  <% end %>

--- a/lib/hexpm_web/templates/two_factor_recovery/show.html.eex
+++ b/lib/hexpm_web/templates/two_factor_recovery/show.html.eex
@@ -1,0 +1,17 @@
+  <h2>Enter a recovery code</h2>
+  <%= form_tag(Routes.two_factor_recovery_path(Endpoint, :create)) do %>
+    <div class="row">
+      <div class="col-md-4 col-md-offset-4">
+        <input id="code" name="code" type="text" value="" class="form-control" maxlength="19" pattern="\d{4}-\d{4}-\d{4}-\d{4}" title="Recovery code in xxxx-xxxx-xxxx-xxxx format." value="" autocomplete="off"/>
+      </div>
+     </div>
+
+    <br/>
+
+    <div class="form-row">
+      <div class="col-md-4 col-md-offset-4">
+        <button type="submit"  class="btn btn-primary">Submit</button>
+      </div>
+    </div>
+
+  <% end %>

--- a/lib/hexpm_web/views/two_factor_auth_view.ex
+++ b/lib/hexpm_web/views/two_factor_auth_view.ex
@@ -1,0 +1,3 @@
+defmodule HexpmWeb.TwoFactorAuthView do
+  use HexpmWeb, :view
+end

--- a/lib/hexpm_web/views/two_factor_recovery_view.ex
+++ b/lib/hexpm_web/views/two_factor_recovery_view.ex
@@ -1,0 +1,3 @@
+defmodule HexpmWeb.TwoFactorRecoveryView do
+  use HexpmWeb, :view
+end


### PR DESCRIPTION
Related to #852

 - Added two_factor_auth controller
 - Added two_factor_recovery controllery
 - Changed login_controller to send user down tfa path depending on tfa setting
 - Changed redirect_return in login_controller to accept a return param vs digging into the conn to support a return param coming from the session
 - Fixed up totp token creation for mobile devices which requires tokens that are 30 seconds ahead