### PR TITLE
Replace HexpmWeb.ViewHelpers import with an alias

### DIFF
--- a/lib/hexpm_web/templates/dashboard/_keys.html.eex
+++ b/lib/hexpm_web/templates/dashboard/_keys.html.eex
@@ -31,7 +31,7 @@
                     data-placement="bottom"
                     title="Last use"
                     data-content="<strong>Used at:</strong> <%= last_use.used_at %><br><strong>IP:</strong> <%= last_use.ip %><br><strong>User agent:</strong> <%= last_use.user_agent %>">
-                      <%= pretty_date(last_use.used_at) %> ...
+                      <%= ViewHelpers.pretty_date(last_use.used_at) %> ...
                   </a>
                 <% end %>
               </small>
@@ -52,14 +52,14 @@
     <%= form_for @key_changeset, @create_key_path, [method: :post], fn f -> %>
       <%= label f, :name, "Key name" %>
       <div class="form-group">
-        <%= text_input f, :name, class: "form-control", placeholder: "Name" %>
-        <%= error_tag f, :name %>
+        <%= ViewHelpers.text_input f, :name, class: "form-control", placeholder: "Name" %>
+        <%= ViewHelpers.error_tag f, :name %>
       </div>
       <%= inputs_for f, :permissions, fn f -> %>
         <%= label f, :domain, "Permission domain" %>
         <div class="form-group">
           <%=
-            select(
+            ViewHelpers.select(
               f,
               :domain,
               [
@@ -69,12 +69,12 @@
               class: "form-control"
             )
           %>
-          <%= error_tag f, :domain %>
+          <%= ViewHelpers.error_tag f, :domain %>
         </div>
         <%= label f, :domain, "Domain resource" %>
         <div class="form-group">
           <%=
-            select(
+            ViewHelpers.select(
               f,
               :resource,
               [
@@ -84,7 +84,7 @@
               class: "form-control"
             )
           %>
-          <%= error_tag f, :resource %>
+          <%= ViewHelpers.error_tag f, :resource %>
         </div>
       <% end %>
       <button type="submit" class="btn btn-primary">Generate</button>

--- a/lib/hexpm_web/templates/dashboard/email/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/email/index.html.eex
@@ -1,4 +1,4 @@
-<%= changeset_error(@create_changeset) %>
+<%= ViewHelpers.changeset_error(@create_changeset) %>
 
 <div class="row">
   <div class="col-sm-3">
@@ -70,8 +70,8 @@
           <%= form_for @create_changeset, Routes.email_path(Endpoint, :create), [method: :post], fn f -> %>
             <%= label f, :email, "Add email address" %>
             <div class="form-group">
-              <%= email_input f, :email, class: "form-control" %>
-              <%= error_tag f, :email %>
+              <%= ViewHelpers.email_input f, :email, class: "form-control" %>
+              <%= ViewHelpers.error_tag f, :email %>
             </div>
             <button type="submit" class="btn btn-primary">Add</button>
           <% end %>

--- a/lib/hexpm_web/templates/dashboard/key/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/key/index.html.eex
@@ -1,4 +1,4 @@
-<%= changeset_error(@key_changeset) %>
+<%= ViewHelpers.changeset_error(@key_changeset) %>
 
 <div class="row">
   <div class="col-sm-3">

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -1,4 +1,4 @@
-<%= changeset_error(@key_changeset) %>
+<%= ViewHelpers.changeset_error(@key_changeset) %>
 
 <div class="row">
   <div class="col-sm-3">
@@ -11,7 +11,7 @@
       <div class="panel-body">
         <div class="form-group">
           <label>Profile picture</label>
-          <img src="<%= gravatar_url(User.email(@organization.user, :gravatar), :large) %>">
+          <img src="<%= ViewHelpers.gravatar_url(User.email(@organization.user, :gravatar), :large) %>">
           <p>
             <small>
               Gravatar is used to display organization profile picture. You can update the Gravatar email below or
@@ -23,20 +23,20 @@
         <%= form_for @changeset, Routes.organization_path(Endpoint, :update_profile, @organization), [method: :post, as: :profile], fn f -> %>
           <div class="form-group">
             <%= label f, :full_name %>
-            <%= text_input f, :full_name %>
-            <%= error_tag f, :full_name %>
+            <%= ViewHelpers.text_input f, :full_name %>
+            <%= ViewHelpers.error_tag f, :full_name %>
           </div>
 
           <div class="form-group">
             <%= label f, :public_email %>
-            <%= text_input f, :public_email, placeholder: "Your organization's public email", value: @public_email %>
-            <%= error_tag f, :public_email %>
+            <%= ViewHelpers.text_input f, :public_email, placeholder: "Your organization's public email", value: @public_email %>
+            <%= ViewHelpers.error_tag f, :public_email %>
           </div>
 
           <div class="form-group">
             <%= label f, :gravatar_email %>
-            <%= text_input f, :gravatar_email, placeholder: "Your organization's gravatar email", value: @gravatar_email %>
-            <%= error_tag f, :gravatar_email %>
+            <%= ViewHelpers.text_input f, :gravatar_email, placeholder: "Your organization's gravatar email", value: @gravatar_email %>
+            <%= ViewHelpers.error_tag f, :gravatar_email %>
           </div>
 
           <%= inputs_for f, :handles, fn f -> %>
@@ -44,46 +44,46 @@
               <%= label f, :twitter %>
               <div class="input-group">
                 <div class="input-group-addon">twitter.com/</div>
-                <%= text_input f, :twitter, placeholder: "organization_twitter_id" %>
+                <%= ViewHelpers.text_input f, :twitter, placeholder: "organization_twitter_id" %>
               </div>
 
-              <%= error_tag f, :twitter %>
+              <%= ViewHelpers.error_tag f, :twitter %>
             </div>
 
             <div class="form-group">
               <%= label f, :github, "GitHub" %>
               <div class="input-group">
                 <div class="input-group-addon">github.com/</div>
-                <%= text_input f, :github, placeholder: "organization_github_id" %>
+                <%= ViewHelpers.text_input f, :github, placeholder: "organization_github_id" %>
               </div>
-              <%= error_tag f, :github %>
+              <%= ViewHelpers.error_tag f, :github %>
             </div>
 
             <div class="form-group">
               <%= label f, :elixirforum, "Elixir Forum" %>
               <div class="input-group">
                 <div class="input-group-addon">elixirforum.com/users/</div>
-                <%= text_input f, :elixirforum, placeholder: "organization_elixir_forum_id" %>
+                <%= ViewHelpers.text_input f, :elixirforum, placeholder: "organization_elixir_forum_id" %>
               </div>
-              <%= error_tag f, :elixirforum %>
+              <%= ViewHelpers.error_tag f, :elixirforum %>
             </div>
 
             <div class="form-group">
               <%= label f, :freenode %>
-              <%= text_input f, :freenode, placeholder: "Your organization's nickname on Elixir IRC channel" %>
+              <%= ViewHelpers.text_input f, :freenode, placeholder: "Your organization's nickname on Elixir IRC channel" %>
               <span class="help-block">Elixir IRC channel:
                 <a href="irc://chat.freenode.net/elixir-lang">irc://chat.freenode.net/elixir-lang</a>
               </span>
-              <%= error_tag f, :freenode %>
+              <%= ViewHelpers.error_tag f, :freenode %>
             </div>
 
             <div class="form-group">
               <%= label f, :slack %>
-              <%= text_input f, :slack, placeholder: "Your organization's nickname on Elixir Slack channel" %>
+              <%= ViewHelpers.text_input f, :slack, placeholder: "Your organization's nickname on Elixir Slack channel" %>
               <span class="help-block">Elixir Slack channel:
                 <a href="https://elixir-slackin.herokuapp.com">elixir-slackin.herokuapp.com</a>
               </span>
-              <%= error_tag f, :slack %>
+              <%= ViewHelpers.error_tag f, :slack %>
             </div>
           <% end %>
 
@@ -100,7 +100,7 @@
       <ul class="list-group clearfix">
         <%= for organization_user <- @organization.organization_users do %>
           <li class="list-group-item clearfix">
-            <img src="<%= gravatar_url(User.email(organization_user.user, :gravatar), :small) %>" class="member-avatar">
+            <img src="<%= ViewHelpers.gravatar_url(User.email(organization_user.user, :gravatar), :small) %>" class="member-avatar">
             <a class="member-username" href="<%= Routes.user_path(Endpoint, :show, organization_user.user) %>"><%= organization_user.user.username %></a>
             <div style="float: right">
               <div class="dropdown role-dropdown">
@@ -134,12 +134,12 @@
             <%= content_tag :fieldset, disabled: @billing_active? and @quantity <= length(@organization.organization_users) do %>
               <input type="hidden" name="action" value="add_member">
               <div class="form-group">
-                <%= text_input f, :username, style: "width: 250px", placeholder: "Username or email address", required: true %>
-                <%= error_tag f, :username %>
+                <%= ViewHelpers.text_input f, :username, style: "width: 250px", placeholder: "Username or email address", required: true %>
+                <%= ViewHelpers.error_tag f, :username %>
               </div>
               <div class="form-group">
-                <%= select f, :role, organization_roles_selector(), style: "width: 80px" %>
-                <%= error_tag f, :role %>
+                <%= ViewHelpers.select f, :role, organization_roles_selector(), style: "width: 80px" %>
+                <%= ViewHelpers.error_tag f, :role %>
               </div>
               <button type="submit" class="btn btn-primary">Add member</button>
             <% end %>
@@ -163,7 +163,7 @@
           <ul class="organization-package-list">
             <%= for package <- @repository.packages do %>
               <li>
-                <a href="<%= path_for_package(@repository.name, package.name) %>"><%= package.name %></a>
+                <a href="<%= ViewHelpers.path_for_package(@repository.name, package.name) %>"><%= package.name %></a>
                 <%= package.latest_version %>
               </li>
             <% end %>

--- a/lib/hexpm_web/templates/dashboard/organization/new.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/new.html.eex
@@ -1,4 +1,4 @@
-<%= changeset_error(@changeset) %>
+<%= ViewHelpers.changeset_error(@changeset) %>
 
 <div class="row">
   <div class="col-sm-3">
@@ -27,10 +27,10 @@
         <%= form_for @changeset, Routes.organization_path(Endpoint, :create), fn f -> %>
           <div class="form-group">
             <%= label f, :password_current, "Organization name" %>
-            <%= text_input f, :name, [placeholder: "Only allows lowercase letters and underscore", required: true, pattern: "[a-z]\\w*", "aria-describedby": "name-helpblock"] %>
-            <%= error_tag f, :name %>
+            <%= ViewHelpers.text_input f, :name, [placeholder: "Only allows lowercase letters and underscore", required: true, pattern: "[a-z]\\w*", "aria-describedby": "name-helpblock"] %>
+            <%= ViewHelpers.error_tag f, :name %>
             <%# from User.username unique constraint %>
-            <%= error_tag f, :username %>
+            <%= ViewHelpers.error_tag f, :username %>
             <span id="name-helpbox" class="help-block">This name will be used when you declare your dependencies in <code>mix.exs</code>.</span>
           </div>
           <%= submit "Submit", class: "btn btn-primary" %>

--- a/lib/hexpm_web/templates/dashboard/password/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/password/index.html.eex
@@ -1,4 +1,4 @@
-<%= changeset_error(@changeset) %>
+<%= ViewHelpers.changeset_error(@changeset) %>
 
 <div class="row">
   <div class="col-sm-3">
@@ -12,20 +12,20 @@
         <%= form_for @changeset, Routes.dashboard_password_path(Endpoint, :update), [method: :post], fn f -> %>
           <div class="form-group">
             <%= label f, :password_current, "Current password" %>
-            <%= password_input f, :password_current %>
-            <%= error_tag f, :password_current %>
+            <%= ViewHelpers.password_input f, :password_current %>
+            <%= ViewHelpers.error_tag f, :password_current %>
           </div>
 
           <div class="form-group">
             <%= label f, :password %>
-            <%= password_input f, :password %>
-            <%= error_tag f, :password %>
+            <%= ViewHelpers.password_input f, :password %>
+            <%= ViewHelpers.error_tag f, :password %>
           </div>
 
           <div class="form-group">
             <%= label f, :password_confirmation %>
-            <%= password_input f, :password_confirmation %>
-            <%= error_tag f, :password_confirmation %>
+            <%= ViewHelpers.password_input f, :password_confirmation %>
+            <%= ViewHelpers.error_tag f, :password_confirmation %>
           </div>
 
           <button type="submit" class="btn btn-primary">Save</button>

--- a/lib/hexpm_web/templates/dashboard/profile/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/profile/index.html.eex
@@ -1,4 +1,4 @@
-<%= changeset_error(@changeset) %>
+<%= ViewHelpers.changeset_error(@changeset) %>
 
 <div class="row">
   <div class="col-sm-3">
@@ -11,7 +11,7 @@
       <div class="panel-body">
         <div class="form-group">
           <label>Profile picture</label>
-          <img src="<%= gravatar_url(User.email(@current_user, :gravatar), :large) %>">
+          <img src="<%= ViewHelpers.gravatar_url(User.email(@current_user, :gravatar), :large) %>">
           <p>
             <small>
               <%= if User.email(@current_user, :gravatar) do %>
@@ -28,14 +28,14 @@
         <%= form_for @changeset, Routes.profile_path(Endpoint, :update), [method: :post], fn f -> %>
           <div class="form-group">
             <%= label f, :full_name %>
-            <%= text_input f, :full_name %>
-            <%= error_tag f, :full_name %>
+            <%= ViewHelpers.text_input f, :full_name %>
+            <%= ViewHelpers.error_tag f, :full_name %>
           </div>
 
           <div class="form-group">
             <%= label f, :public_email %>
-            <%= select f, :public_email, public_email_options(@changeset.data), value: public_email_value(@changeset.data) %>
-            <%= error_tag f, :public_email %>
+            <%= ViewHelpers.select f, :public_email, public_email_options(@changeset.data), value: public_email_value(@changeset.data) %>
+            <%= ViewHelpers.error_tag f, :public_email %>
             <small>
               You can add or remove email address on the <a href="<%= Routes.email_path(Endpoint, :index) %>">email settings page</a>.
             </small>
@@ -43,8 +43,8 @@
 
           <div class="form-group">
             <%= label f, :gravatar_email %>
-            <%= select f, :gravatar_email, gravatar_email_options(@changeset.data), value: gravatar_email_value(@changeset.data) %>
-            <%= error_tag f, :gravatar_email %>
+            <%= ViewHelpers.select f, :gravatar_email, gravatar_email_options(@changeset.data), value: gravatar_email_value(@changeset.data) %>
+            <%= ViewHelpers.error_tag f, :gravatar_email %>
           </div>
 
           <%= inputs_for f, :handles, fn f -> %>
@@ -52,46 +52,46 @@
               <%= label f, :twitter %>
               <div class="input-group">
                 <div class="input-group-addon">twitter.com/</div>
-                <%= text_input f, :twitter, placeholder: "your_twitter_id" %>
+                <%= ViewHelpers.text_input f, :twitter, placeholder: "your_twitter_id" %>
               </div>
 
-              <%= error_tag f, :twitter %>
+              <%= ViewHelpers.error_tag f, :twitter %>
             </div>
 
             <div class="form-group">
               <%= label f, :github, "GitHub" %>
               <div class="input-group">
                 <div class="input-group-addon">github.com/</div>
-                <%= text_input f, :github, placeholder: "your_github_id" %>
+                <%= ViewHelpers.text_input f, :github, placeholder: "your_github_id" %>
               </div>
-              <%= error_tag f, :github %>
+              <%= ViewHelpers.error_tag f, :github %>
             </div>
 
             <div class="form-group">
               <%= label f, :elixirforum, "Elixir Forum" %>
               <div class="input-group">
                 <div class="input-group-addon">elixirforum.com/users/</div>
-                <%= text_input f, :elixirforum, placeholder: "your_elixir_forum_id" %>
+                <%= ViewHelpers.text_input f, :elixirforum, placeholder: "your_elixir_forum_id" %>
               </div>
-              <%= error_tag f, :elixirforum %>
+              <%= ViewHelpers.error_tag f, :elixirforum %>
             </div>
 
             <div class="form-group">
               <%= label f, :freenode %>
-              <%= text_input f, :freenode, placeholder: "Your nickname on Elixir IRC channel" %>
+              <%= ViewHelpers.text_input f, :freenode, placeholder: "Your nickname on Elixir IRC channel" %>
               <span class="help-block">Elixir IRC channel:
                 <a href="irc://chat.freenode.net/elixir-lang">irc://chat.freenode.net/elixir-lang</a>
               </span>
-              <%= error_tag f, :freenode %>
+              <%= ViewHelpers.error_tag f, :freenode %>
             </div>
 
             <div class="form-group">
               <%= label f, :slack %>
-              <%= text_input f, :slack, placeholder: "Your nickname on Elixir Slack channel" %>
+              <%= ViewHelpers.text_input f, :slack, placeholder: "Your nickname on Elixir Slack channel" %>
               <span class="help-block">Elixir Slack channel:
                 <a href="https://elixir-slackin.herokuapp.com">elixir-slackin.herokuapp.com</a>
               </span>
-              <%= error_tag f, :slack %>
+              <%= ViewHelpers.error_tag f, :slack %>
             </div>
           <% end %>
 

--- a/lib/hexpm_web/templates/layout/header.html.eex
+++ b/lib/hexpm_web/templates/layout/header.html.eex
@@ -55,11 +55,11 @@
             <li><a href="<%= Routes.page_path(Endpoint, :pricing) %>">Pricing</a></li>
             <li><a href="<%= Routes.docs_path(Endpoint, :index) %>">Docs</a></li>
 
-            <%= if logged_in?(assigns) do %>
+            <%= if ViewHelpers.logged_in?(assigns) do %>
               <li class="dropdown">
                 <a href="#" class="dropdown-toggle" data-toggle="dropdown">
                   <%= @current_user.username %>
-                  <img src="<%= gravatar_url(User.email(@current_user, :gravatar), :small) %>" class="navbar-avatar">
+                  <img src="<%= ViewHelpers.gravatar_url(User.email(@current_user, :gravatar), :small) %>" class="navbar-avatar">
                   <b class="caret"></b>
                 </a>
                 <ul class="dropdown-menu">

--- a/lib/hexpm_web/templates/package/_package.html.eex
+++ b/lib/hexpm_web/templates/package/_package.html.eex
@@ -1,12 +1,12 @@
 <li>
   <div class="downloads-info">
-    <span class="download-count"><%= human_number_space(display_downloads(@package_downloads, @view)|| 0) %></span> <br>
+    <span class="download-count"><%= ViewHelpers.human_number_space(display_downloads(@package_downloads, @view)|| 0) %></span> <br>
     <div class="downloads-count-wrapper">
       <span class="downloads-count-desc"><%= display_downloads_view_title(@view) %></span><br>
       <span class="tooltiptext"><%= display_downloads_for_opposite_views(@package_downloads, @view) %></span>
     </div>
   </div>
-  <a href="<%= path_for_package(@package) %>"><%= package_name(@package) %></a>
+  <a href="<%= ViewHelpers.path_for_package(@package) %>"><%= ViewHelpers.package_name(@package) %></a>
   <span class="version"><%= @package.latest_version %></span>
-  <p><%= text_length(@package.meta.description, 140) %></p>
+  <p><%= ViewHelpers.text_length(@package.meta.description, 140) %></p>
 </li>

--- a/lib/hexpm_web/templates/package/_user.html.eex
+++ b/lib/hexpm_web/templates/package/_user.html.eex
@@ -1,3 +1,3 @@
 <a href="<%= Router.user_path(@user) %>">
-  <img src="<%= gravatar_url(User.email(@user, :gravatar), :small) %>" class="user-avatar"><%= @user.username %>
+  <img src="<%= ViewHelpers.gravatar_url(User.email(@user, :gravatar), :small) %>" class="user-avatar"><%= @user.username %>
 </a>

--- a/lib/hexpm_web/templates/package/index.html.eex
+++ b/lib/hexpm_web/templates/package/index.html.eex
@@ -23,20 +23,20 @@
 <% else %>
   <%
   shown_packages = length(@packages)
-  paginate = paginate(@page, @package_count, items_per_page: @per_page, page_links: 5)
+  paginate = ViewHelpers.paginate(@page, @package_count, items_per_page: @per_page, page_links: 5)
 
   range_start = (@page - 1) * @per_page + 1
   range_end = range_start + shown_packages - 1
   page = if @page == 1, do: nil, else: @page
 
-  sort_name_params = params(search: @search, page: page, sort: "name")
-  sort_total_downloads_params = params(search: @search, page: page, sort: "total_downloads")
-  sort_recent_downloads_params = params(search: @search, page: page, sort: "recent_downloads")
-  sort_created_params = params(search: @search, page: page, sort: "inserted_at")
-  sort_updated_params = params(search: @search, page: page, sort: "updated_at")
-  sort_recently_published_params = params(search: @search, page: page, sort: "recently_published")
-  prev_page_params = params(search: @search, page: @page-1, sort: @sort, letter: @letter)
-  next_page_params = params(search: @search, page: @page+1, sort: @sort, letter: @letter)
+  sort_name_params = ViewHelpers.params(search: @search, page: page, sort: "name")
+  sort_total_downloads_params = ViewHelpers.params(search: @search, page: page, sort: "total_downloads")
+  sort_recent_downloads_params = ViewHelpers.params(search: @search, page: page, sort: "recent_downloads")
+  sort_created_params = ViewHelpers.params(search: @search, page: page, sort: "inserted_at")
+  sort_updated_params = ViewHelpers.params(search: @search, page: page, sort: "updated_at")
+  sort_recently_published_params = ViewHelpers.params(search: @search, page: page, sort: "recently_published")
+  prev_page_params = ViewHelpers.params(search: @search, page: @page-1, sort: @sort, letter: @letter)
+  next_page_params = ViewHelpers.params(search: @search, page: @page+1, sort: @sort, letter: @letter)
   %>
 
 <nav>
@@ -119,7 +119,7 @@
           </li>
         <% else %>
           <li>
-            <a href="<%= Routes.package_path(Endpoint, :index, params(search: @search, page: counter, sort: @sort, letter: @letter)) %>">
+            <a href="<%= Routes.package_path(Endpoint, :index, ViewHelpers.params(search: @search, page: counter, sort: @sort, letter: @letter)) %>">
               <%= counter %>
             </a>
           </li>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -27,7 +27,7 @@ compatible_tools =
 tools = Keyword.take(tools, compatible_tools)
 %>
 
-<h2 class="package-title"><%= package_name(@package) %>
+<h2 class="package-title"><%= ViewHelpers.package_name(@package) %>
   <%= if @current_release do %>
     <%= if @current_release.retirement do %>
       <span class="version retired"><%= @current_release.version %> (retired)</span>
@@ -45,7 +45,7 @@ tools = Keyword.take(tools, compatible_tools)
 
 <%= if description do %>
   <div class="description with-divider">
-    <%= text_length(description, 300) |> text_to_html(insert_brs: false) %>
+    <%= ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false) %>
   </div>
 <% end %>
 
@@ -81,10 +81,10 @@ tools = Keyword.take(tools, compatible_tools)
           <%= icon(:octicon, :calendar, class: "stat-icon stat-icon-calendar") %>
           <span class="stat-info">
             <span class="count-info wrap">
-              <%= human_number_space(downloads, 5) %>
+              <%= ViewHelpers.human_number_space(downloads, 5) %>
             </span>
             <span class="count-info no-wrap">
-              <%= human_number_space(downloads) %>
+              <%= ViewHelpers.human_number_space(downloads) %>
             </span>
             <br> <span class="stat-text">downloads <br> this version</span>
           </span>
@@ -93,10 +93,10 @@ tools = Keyword.take(tools, compatible_tools)
           <%= icon(:octicon, :calendar, class: "stat-icon stat-icon-calendar") %>
           <span class="stat-info">
             <span class="count-info wrap">
-              <%= human_number_space(@downloads["day"] || 0, 5) %>
+              <%= ViewHelpers.human_number_space(@downloads["day"] || 0, 5) %>
             </span>
             <span class="count-info no-wrap">
-              <%= human_number_space(@downloads["day"] || 0) %>
+              <%= ViewHelpers.human_number_space(@downloads["day"] || 0) %>
             </span>
             <br> <span class="stat-text">downloads <br> yesterday</span>
           </span>
@@ -105,10 +105,10 @@ tools = Keyword.take(tools, compatible_tools)
           <%= icon(:octicon, :calendar, class: "stat-icon stat-icon-calendar") %>
           <span class="stat-info">
             <span class="count-info wrap">
-              <%= human_number_space(@downloads["week"] || 0, 5) %>
+              <%= ViewHelpers.human_number_space(@downloads["week"] || 0, 5) %>
             </span>
             <span class="count-info no-wrap">
-              <%= human_number_space(@downloads["week"] || 0) %>
+              <%= ViewHelpers.human_number_space(@downloads["week"] || 0) %>
             </span>
             <br> <span class="stat-text">downloads <br> last 7 days</span>
           </span>
@@ -117,10 +117,10 @@ tools = Keyword.take(tools, compatible_tools)
           <%= icon(:octicon, :calendar, class: "stat-icon stat-icon-calendar") %>
           <span class="stat-info">
             <span class="count-info wrap">
-              <%= human_number_space(@downloads["all"] || 0, 5) %>
+              <%= ViewHelpers.human_number_space(@downloads["all"] || 0, 5) %>
             </span>
             <span class="count-info no-wrap">
-              <%= human_number_space(@downloads["all"] || 0) %>
+              <%= ViewHelpers.human_number_space(@downloads["all"] || 0) %>
             </span>
             <br> <span class="stat-text">downloads <br> all time</span>
           </span>
@@ -139,7 +139,7 @@ tools = Keyword.take(tools, compatible_tools)
 
     <%= if length(@releases) > show_latest_versions do %>
       <p class="show-versions">
-        <a href="<%= path_for_releases(@package) %>">Show All Versions</a>
+        <a href="<%= ViewHelpers.path_for_releases(@package) %>">Show All Versions</a>
       </p>
     <% end %>
   </div>
@@ -149,7 +149,7 @@ tools = Keyword.take(tools, compatible_tools)
       <%= if @current_release do %>
         <%= for %{repository: repository, name: name, requirement: req, app: app, optional: optional} <- @current_release.requirements do %>
         <li>
-          <a href="<%= path_for_package(repository, name) %>"><%= package_name(repository, name) %></a> <%= req %>
+          <a href="<%= ViewHelpers.path_for_package(repository, name) %>"><%= ViewHelpers.package_name(repository, name) %></a> <%= req %>
           <%= if app != name do %>(app: <%= app %>)<% end %>
           <%= if optional do %><span class="attr-optional">(optional)</span><% end %>
         </li>
@@ -164,7 +164,7 @@ tools = Keyword.take(tools, compatible_tools)
     <ul class="audit-logs-list">
       <%= for audit_log <- @audit_logs do %>
         <li>
-          <%= pretty_date(audit_log.inserted_at, :short) %> <%= humanize_audit_log_info(audit_log) %>
+          <%= ViewHelpers.pretty_date(audit_log.inserted_at, :short) %> <%= humanize_audit_log_info(audit_log) %>
         </li>
       <% end %>
     </ul>
@@ -235,8 +235,8 @@ tools = Keyword.take(tools, compatible_tools)
     <% end %>
 
     <h3>Dependents (<%= @dependants_count %>)</h3>
-    <%= safe_join(@dependants, ", ", fn package ->
-      link(package_name(package), to: path_for_package(package))
+    <%= ViewHelpers.safe_join(@dependants, ", ", fn package ->
+      link(ViewHelpers.package_name(package), to: ViewHelpers.path_for_package(package))
     end) %><%= if @dependants_count != 0 do %>,
     <a href="<%= Routes.package_path(Endpoint, :index, search: "depends:#{@repository_name}:#{@package.name}") %>">show all...</a>
     <% end %>

--- a/lib/hexpm_web/templates/package/versions.html.eex
+++ b/lib/hexpm_web/templates/package/versions.html.eex
@@ -1,7 +1,7 @@
 <%= for release <- @releases do %>
   <li>
-    <a href="<%= path_for_release(@package, release) %>"><strong><%= release.version %></strong></a>
-    <%= pretty_date(release.inserted_at, :short) %>
+    <a href="<%= ViewHelpers.path_for_release(@package, release) %>"><strong><%= release.version %></strong></a>
+    <%= ViewHelpers.pretty_date(release.inserted_at, :short) %>
 
     <%= if release.retirement do %>
       (<span class="version-retirement">retired</span>)

--- a/lib/hexpm_web/templates/page/_package.html.eex
+++ b/lib/hexpm_web/templates/page/_package.html.eex
@@ -4,17 +4,17 @@
   </div>
   <p>
     <%= if @downloads do %>
-      <span class="info"><%= human_number_space @downloads %> downloads</span>
+      <span class="info"><%= ViewHelpers.human_number_space @downloads %> downloads</span>
     <% end %>
     <%= if @description do %>
-      <span class="description"><%= text_length(@description, 100) %></span>
+      <span class="description"><%= ViewHelpers.text_length(@description, 100) %></span>
     <% end %>
     <%= if @inserted_at do %>
       <span class="published-at">
         <%= if @version do %>
           <a href="<%= Routes.package_path(Endpoint, :show, @package) %>"><%= @version %></a>
         <% end %>
-        published <%= human_relative_time_from_now(@inserted_at) %>
+        published <%= ViewHelpers.human_relative_time_from_now(@inserted_at) %>
       </span>
     <% end %>
   </p>

--- a/lib/hexpm_web/templates/page/index.html.eex
+++ b/lib/hexpm_web/templates/page/index.html.eex
@@ -111,10 +111,10 @@
       <%= icon(:octicon, :package, class: "stat-icon stat-icon-package") %>
       <span class="stat-info">
         <span class="count-info wrap">
-          <%= human_number_space(@num_packages, 5) %>
+          <%= ViewHelpers.human_number_space(@num_packages, 5) %>
         </span>
         <span class="count-info no-wrap">
-          <%= human_number_space(@num_packages) %>
+          <%= ViewHelpers.human_number_space(@num_packages) %>
         </span>
         <br> packages <br> available
       </span>
@@ -123,10 +123,10 @@
       <%= icon(:octicon, :versions, class: "stat-icon stat-icon-versions") %>
       <span class="stat-info">
         <span class="count-info wrap">
-          <%= human_number_space(@num_releases, 5) %>
+          <%= ViewHelpers.human_number_space(@num_releases, 5) %>
         </span>
         <span class="count-info no-wrap">
-          <%= human_number_space(@num_releases) %>
+          <%= ViewHelpers.human_number_space(@num_releases) %>
         </span>
         <br> package <br> versions
       </span>
@@ -135,10 +135,10 @@
       <%= icon(:octicon, :calendar, class: "stat-icon stat-icon-calendar") %>
       <span class="stat-info">
         <span class="count-info wrap">
-          <%= human_number_space(@total["day"], 5) %>
+          <%= ViewHelpers.human_number_space(@total["day"], 5) %>
         </span>
         <span class="count-info no-wrap">
-          <%= human_number_space(@total["day"]) %>
+          <%= ViewHelpers.human_number_space(@total["day"]) %>
         </span>
         <br> downloads <br> yesterday
       </span>
@@ -147,10 +147,10 @@
       <%= icon(:octicon, :calendar, class: "stat-icon stat-icon-calendar") %>
       <span class="stat-info">
         <span class="count-info wrap">
-          <%= human_number_space(@total["week"], 5) %>
+          <%= ViewHelpers.human_number_space(@total["week"], 5) %>
         </span>
         <span class="count-info no-wrap">
-          <%= human_number_space(@total["week"]) %>
+          <%= ViewHelpers.human_number_space(@total["week"]) %>
         </span>
         <br> downloads <br> last 7 days
       </span>
@@ -159,10 +159,10 @@
       <%= icon(:octicon, :calendar, class: "stat-icon stat-icon-calendar") %>
       <span class="stat-info">
         <span class="count-info wrap">
-          <%= human_number_space(@total["all"], 5) %>
+          <%= ViewHelpers.human_number_space(@total["all"], 5) %>
         </span>
         <span class="count-info no-wrap">
-          <%= human_number_space(@total["all"]) %>
+          <%= ViewHelpers.human_number_space(@total["all"]) %>
         </span>
         <br> downloads <br> all time
       </span>

--- a/lib/hexpm_web/templates/password/show.html.eex
+++ b/lib/hexpm_web/templates/password/show.html.eex
@@ -1,18 +1,18 @@
-<%= changeset_error(@changeset) %>
+<%= ViewHelpers.changeset_error(@changeset) %>
 <h2>Choose a new password</h2>
 
 <%= form_for @changeset, Routes.password_path(Endpoint, :update), [method: :post], fn f -> %>
 
   <div class="form-group">
     <%= label f, :password %>
-    <%= password_input f, :password %>
-    <%= error_tag f, :password %>
+    <%= ViewHelpers.password_input f, :password %>
+    <%= ViewHelpers.error_tag f, :password %>
   </div>
 
   <div class="form-group">
     <%= label f, :password_confirmation %>
-    <%= password_input f, :password_confirmation %>
-    <%= error_tag f, :password_confirmation %>
+    <%= ViewHelpers.password_input f, :password_confirmation %>
+    <%= ViewHelpers.error_tag f, :password_confirmation %>
   </div>
 
   <div class="form-group">

--- a/lib/hexpm_web/templates/signup/show.html.eex
+++ b/lib/hexpm_web/templates/signup/show.html.eex
@@ -1,43 +1,43 @@
-<%= changeset_error(@changeset) %>
+<%= ViewHelpers.changeset_error(@changeset) %>
 <h2>Sign up</h2>
 
 <%= form_for @changeset, Routes.signup_path(Endpoint, :create), fn f -> %>
   <div class="form-group">
     <%= label f, :full_name %>
-    <%= text_input f, :full_name %>
-    <%= error_tag f, :full_name %>
+    <%= ViewHelpers.text_input f, :full_name %>
+    <%= ViewHelpers.error_tag f, :full_name %>
   </div>
 
   <div class="form-group">
     <%= label f, :username %>
-    <%= text_input f, :username %>
-    <%= error_tag f, :username %>
+    <%= ViewHelpers.text_input f, :username %>
+    <%= ViewHelpers.error_tag f, :username %>
   </div>
 
   <%= inputs_for f, :emails, [append: [%Email{}]], fn f -> %>
     <div class="form-group">
       <%= label f, :email %>
-      <%= email_input f, :email %>
-      <%= error_tag f, :email %>
+      <%= ViewHelpers.email_input f, :email %>
+      <%= ViewHelpers.error_tag f, :email %>
     </div>
 
     <div class="form-group">
       <%= label f, :email_confirmation %>
-      <%= email_input f, :email_confirmation %>
-      <%= error_tag f, :email_confirmation %>
+      <%= ViewHelpers.email_input f, :email_confirmation %>
+      <%= ViewHelpers.error_tag f, :email_confirmation %>
     </div>
   <% end %>
 
   <div class="form-group">
     <%= label f, :password %>
-    <%= password_input f, :password %>
-    <%= error_tag f, :password %>
+    <%= ViewHelpers.password_input f, :password %>
+    <%= ViewHelpers.error_tag f, :password %>
   </div>
 
   <div class="form-group">
     <%= label f, :password_confirmation %>
-    <%= password_input f, :password_confirmation %>
-    <%= error_tag f, :password_confirmation %>
+    <%= ViewHelpers.password_input f, :password_confirmation %>
+    <%= ViewHelpers.error_tag f, :password_confirmation %>
   </div>
 
   <p>

--- a/lib/hexpm_web/templates/user/show.html.eex
+++ b/lib/hexpm_web/templates/user/show.html.eex
@@ -9,7 +9,7 @@
       <ul class="user-package-list">
         <%= for package <- @packages do %>
           <li>
-            <a href="<%= path_for_package(package) %>"><%= package_name(package) %></a>
+            <a href="<%= ViewHelpers.path_for_package(package) %>"><%= ViewHelpers.package_name(package) %></a>
             <%= package.latest_version %>
           </li>
         <% end %>
@@ -18,7 +18,7 @@
   </div>
 
   <div class="col-sm-3">
-    <img src="<%= gravatar_url(@gravatar_email, :large) %>" class="avatar">
+    <img src="<%= ViewHelpers.gravatar_url(@gravatar_email, :large) %>" class="avatar">
 
     <h4><%= @user.full_name %></h4>
     <ul class="user-profile-list">

--- a/lib/hexpm_web/templates/version/_version.html.eex
+++ b/lib/hexpm_web/templates/version/_version.html.eex
@@ -1,6 +1,6 @@
 <li>
-  <a href="<%= path_for_release(@package, @release) %>" class="version-number"><strong><%= @release.version %></strong></a>
-  <span class="release-date"><%= pretty_date(@release.inserted_at) %></span>
+  <a href="<%= ViewHelpers.path_for_release(@package, @release) %>" class="version-number"><strong><%= @release.version %></strong></a>
+  <span class="release-date"><%= ViewHelpers.pretty_date(@release.inserted_at) %></span>
 
   <%= if @release.retirement do %>
     (<span class="version-retirement">retired</span>)

--- a/lib/hexpm_web/templates/version/index.html.eex
+++ b/lib/hexpm_web/templates/version/index.html.eex
@@ -1,5 +1,5 @@
 <h2 class="versions-title">
-  All available versions of <%= link package_name(@package), to: path_for_package(@package), class: "version-package-title" %>
+  All available versions of <%= link ViewHelpers.package_name(@package), to: ViewHelpers.path_for_package(@package), class: "version-package-title" %>
 </h2>
 <div class="clearfix"></div>
 <div class="version-list">

--- a/lib/hexpm_web/views/api/key_view.ex
+++ b/lib/hexpm_web/views/api/key_view.ex
@@ -25,7 +25,7 @@ defmodule HexpmWeb.API.KeyView do
       updated_at: key.updated_at,
       url: Routes.api_key_url(Endpoint, :show, key)
     }
-    |> include_if_loaded(:last_use, key.last_use, &render_use/1)
+    |> ViewHelpers.include_if_loaded(:last_use, key.last_use, &render_use/1)
   end
 
   defp render_use(use) do

--- a/lib/hexpm_web/views/api/organization_view.ex
+++ b/lib/hexpm_web/views/api/organization_view.ex
@@ -21,7 +21,12 @@ defmodule HexpmWeb.API.OrganizationView do
       updated_at: organization.updated_at,
       seats: customer["quantity"]
     }
-    |> include_if_loaded(:users, organization.organization_users, OrganizationUserView, "show")
+    |> ViewHelpers.include_if_loaded(
+      :users,
+      organization.organization_users,
+      OrganizationUserView,
+      "show"
+    )
   end
 
   def render("audit_logs." <> _, %{audit_logs: audit_logs}) do

--- a/lib/hexpm_web/views/api/package_view.ex
+++ b/lib/hexpm_web/views/api/package_view.ex
@@ -20,9 +20,9 @@ defmodule HexpmWeb.API.PackageView do
       name: package.name,
       inserted_at: package.inserted_at,
       updated_at: package.updated_at,
-      url: url_for_package(package),
-      html_url: html_url_for_package(package),
-      docs_html_url: docs_html_url_for_package(package),
+      url: ViewHelpers.url_for_package(package),
+      html_url: ViewHelpers.html_url_for_package(package),
+      docs_html_url: ViewHelpers.docs_html_url_for_package(package),
       meta: %{
         description: package.meta.description,
         licenses: package.meta.licenses || [],
@@ -30,16 +30,21 @@ defmodule HexpmWeb.API.PackageView do
         maintainers: package.meta.maintainers || []
       }
     }
-    |> include_if_loaded(
+    |> ViewHelpers.include_if_loaded(
       :releases,
       package.releases,
       ReleaseView,
       "minimal.json",
       package: package
     )
-    |> include_if_loaded(:retirements, package.releases, RetirementView, "package.json")
-    |> include_if_loaded(:downloads, package.downloads, DownloadView, "show.json")
-    |> include_if_loaded(:owners, package.owners, UserView, "minimal.json")
+    |> ViewHelpers.include_if_loaded(
+      :retirements,
+      package.releases,
+      RetirementView,
+      "package.json"
+    )
+    |> ViewHelpers.include_if_loaded(:downloads, package.downloads, DownloadView, "show.json")
+    |> ViewHelpers.include_if_loaded(:owners, package.owners, UserView, "minimal.json")
     |> group_downloads()
     |> group_retirements()
   end

--- a/lib/hexpm_web/views/api/release_view.ex
+++ b/lib/hexpm_web/views/api/release_view.ex
@@ -18,10 +18,10 @@ defmodule HexpmWeb.API.ReleaseView do
       inserted_at: release.inserted_at,
       updated_at: release.updated_at,
       retirement: render_one(release.retirement, RetirementView, "show.json"),
-      package_url: url_for_package(release.package),
-      url: url_for_release(release.package, release),
-      html_url: html_url_for_release(release.package, release),
-      docs_html_url: docs_html_url_for_release(release.package, release),
+      package_url: ViewHelpers.url_for_package(release.package),
+      url: ViewHelpers.url_for_release(release.package, release),
+      html_url: ViewHelpers.html_url_for_release(release.package, release),
+      docs_html_url: ViewHelpers.docs_html_url_for_release(release.package, release),
       requirements: requirements(release.requirements),
       meta: %{
         app: release.meta.app,
@@ -36,7 +36,7 @@ defmodule HexpmWeb.API.ReleaseView do
   def render("minimal", %{release: release, package: package}) do
     %{
       version: release.version,
-      url: url_for_release(package, release),
+      url: ViewHelpers.url_for_release(package, release),
       has_docs: release.has_docs,
       inserted_at: release.inserted_at
     }

--- a/lib/hexpm_web/views/api/user_view.ex
+++ b/lib/hexpm_web/views/api/user_view.ex
@@ -31,8 +31,8 @@ defmodule HexpmWeb.API.UserView do
       inserted_at: user.inserted_at,
       updated_at: user.updated_at
     }
-    |> include_if_loaded(:owned_packages, user.owned_packages, &owned_packages/1)
-    |> include_if_loaded(:packages, user.owned_packages, &packages/1)
+    |> ViewHelpers.include_if_loaded(:owned_packages, user.owned_packages, &owned_packages/1)
+    |> ViewHelpers.include_if_loaded(:packages, user.owned_packages, &packages/1)
   end
 
   def render("me", %{user: user}) do
@@ -57,7 +57,7 @@ defmodule HexpmWeb.API.UserView do
   # TODO: deprecated
   defp owned_packages(packages) do
     Enum.into(packages, %{}, fn package ->
-      {package.name, url_for_package(package)}
+      {package.name, ViewHelpers.url_for_package(package)}
     end)
   end
 
@@ -68,8 +68,8 @@ defmodule HexpmWeb.API.UserView do
       %{
         name: package.name,
         repository: repository_name(package),
-        url: url_for_package(package),
-        html_url: html_url_for_package(package)
+        url: ViewHelpers.url_for_package(package),
+        html_url: ViewHelpers.html_url_for_package(package)
       }
     end)
   end

--- a/lib/hexpm_web/views/dashboard/organization_view.ex
+++ b/lib/hexpm_web/views/dashboard/organization_view.ex
@@ -93,7 +93,7 @@ defmodule HexpmWeb.Dashboard.OrganizationView do
          %{"status" => "trialing", "trial_end" => trial_end},
          card
        ) do
-    trial_end = trial_end |> NaiveDateTime.from_iso8601!() |> pretty_date()
+    trial_end = trial_end |> NaiveDateTime.from_iso8601!() |> ViewHelpers.pretty_date()
     raw("Trial ends on #{trial_end}, #{trial_status_message(card)}")
   end
 
@@ -147,7 +147,7 @@ defmodule HexpmWeb.Dashboard.OrganizationView do
   end
 
   def payment_date(iso_8601_datetime_string) do
-    iso_8601_datetime_string |> NaiveDateTime.from_iso8601!() |> pretty_date()
+    iso_8601_datetime_string |> NaiveDateTime.from_iso8601!() |> ViewHelpers.pretty_date()
   end
 
   defp money(integer) when is_integer(integer) and integer >= 0 do

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -28,11 +28,11 @@ defmodule HexpmWeb.PackageView do
     case view do
       :recent_downloads ->
         downloads = display_downloads(package_downloads, :all) || 0
-        "total downloads: #{human_number_space(downloads)}"
+        "total downloads: #{ViewHelpers.human_number_space(downloads)}"
 
       _ ->
         downloads = display_downloads(package_downloads, :recent_downloads) || 0
-        "recent downloads: #{human_number_space(downloads)}"
+        "recent downloads: #{ViewHelpers.human_number_space(downloads)}"
     end
   end
 

--- a/lib/hexpm_web/web.ex
+++ b/lib/hexpm_web/web.ex
@@ -56,8 +56,9 @@ defmodule HexpmWeb do
           select: 4
         ]
 
-      import HexpmWeb.{ViewHelpers, ViewIcons}
+      import HexpmWeb.ViewIcons
 
+      alias HexpmWeb.ViewHelpers
       alias HexpmWeb.{Endpoint, Router}
       alias HexpmWeb.Router.Helpers, as: Routes
 


### PR DESCRIPTION
To do this I used a small tool I was working on recently, [import2alias.exs](https://gist.github.com/wojtekmach/4e04cbda82ba88af3f84c44ec746b7ca): `mix run import2alias.exs Hexpm.ViewHelpers ViewHelpers`. More info about that soon-ish, I'm planning to write up a blog post about it with some additional background information.