### PR TITLE
add --replace option on private packages

### DIFF
--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -74,7 +74,7 @@ defmodule Hexpm.Repository.Release do
     |> changeset(:create, params, package, publisher, inner_checksum, outer_checksum, replace?)
   end
 
-  def update(release, publisher, params, inner_checksum, outer_checksum, replace?) do
+  def update(release, publisher, params, inner_checksum, outer_checksum, replace? \\ false) do
     changeset(
       release,
       :update,

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -69,7 +69,7 @@ defmodule Hexpm.Repository.Release do
     |> Requirement.build_all(package)
   end
 
-  def build(package, publisher, params, inner_checksum, outer_checksum, replace?) do
+  def build(package, publisher, params, inner_checksum, outer_checksum, replace? \\ false) do
     build_assoc(package, :releases)
     |> changeset(:create, params, package, publisher, inner_checksum, outer_checksum, replace?)
   end

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -91,7 +91,7 @@ defmodule Hexpm.Repository.Release do
     force? = Keyword.get(opts, :force, false)
 
     change(release)
-    |> validate_editable(:delete, force?)
+    |> validate_editable(:delete, force?, true)
   end
 
   def retire(release, params) do

--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -69,12 +69,12 @@ defmodule Hexpm.Repository.Release do
     |> Requirement.build_all(package)
   end
 
-  def build(package, publisher, params, inner_checksum, outer_checksum, replace? \\ false) do
+  def build(package, publisher, params, inner_checksum, outer_checksum, replace? \\ true) do
     build_assoc(package, :releases)
     |> changeset(:create, params, package, publisher, inner_checksum, outer_checksum, replace?)
   end
 
-  def update(release, publisher, params, inner_checksum, outer_checksum, replace? \\ false) do
+  def update(release, publisher, params, inner_checksum, outer_checksum, replace? \\ true) do
     changeset(
       release,
       :update,

--- a/lib/hexpm_web/controllers/api/release_controller.ex
+++ b/lib/hexpm_web/controllers/api/release_controller.ex
@@ -22,7 +22,11 @@ defmodule HexpmWeb.API.ReleaseController do
        [domain: "api", resource: "write", fun: [&package_owner/2, &organization_billing_active/2]]
        when action in [:delete]
 
-  def publish(conn, %{"body" => body}) do
+  def replace(conn, %{"body" => body}) do
+    publish(conn, %{"body" => body}, true)
+  end
+
+  def publish(conn, %{"body" => body}, replace \\ false) do
     request_id = List.first(get_resp_header(conn, "x-request-id"))
 
     log_tarball(
@@ -41,7 +45,8 @@ defmodule HexpmWeb.API.ReleaseController do
       conn.assigns.meta,
       conn.assigns.inner_checksum,
       conn.assigns.outer_checksum,
-      audit: audit_data(conn)
+      audit: audit_data(conn),
+      replace: replace
     )
     |> publish_result(conn)
   end
@@ -105,7 +110,7 @@ defmodule HexpmWeb.API.ReleaseController do
     end
   end
 
-  defp handle_tarball(conn, repository, package, user, body) do
+  defp handle_tarball(conn, repository, package, user, body, replace \\ false) do
     case release_metadata(body) do
       {:ok, meta, inner_checksum, outer_checksum} ->
         request_id = List.first(get_resp_header(conn, "x-request-id"))
@@ -119,7 +124,8 @@ defmodule HexpmWeb.API.ReleaseController do
           meta,
           inner_checksum,
           outer_checksum,
-          audit: audit_data(conn)
+          audit: audit_data(conn),
+          replace: replace
         )
 
       {:error, errors} ->

--- a/lib/hexpm_web/controllers/api/release_controller.ex
+++ b/lib/hexpm_web/controllers/api/release_controller.ex
@@ -1,10 +1,10 @@
 defmodule HexpmWeb.API.ReleaseController do
   use HexpmWeb, :controller
 
-  plug :parse_tarball when action in [:publish]
+  plug :parse_tarball when action in [:publish, :replace]
   plug :maybe_fetch_release when action in [:show]
   plug :fetch_release when action in [:delete]
-  plug :maybe_fetch_package when action in [:create, :publish]
+  plug :maybe_fetch_package when action in [:create, :publish, :replace]
 
   plug :maybe_authorize,
        [domain: "api", resource: "read", fun: &repository_access/2]
@@ -16,7 +16,7 @@ defmodule HexpmWeb.API.ReleaseController do
          resource: "write",
          fun: [&maybe_package_owner/2, &organization_billing_active/2]
        ]
-       when action in [:create, :publish]
+       when action in [:create, :publish, :replace]
 
   plug :authorize,
        [domain: "api", resource: "write", fun: [&package_owner/2, &organization_billing_active/2]]

--- a/lib/hexpm_web/controllers/api/release_controller.ex
+++ b/lib/hexpm_web/controllers/api/release_controller.ex
@@ -26,7 +26,7 @@ defmodule HexpmWeb.API.ReleaseController do
     publish(conn, %{"body" => body}, true)
   end
 
-  def publish(conn, %{"body" => body}, replace \\ false) do
+  def publish(conn, %{"body" => body}, replace? \\ false) do
     request_id = List.first(get_resp_header(conn, "x-request-id"))
 
     log_tarball(
@@ -46,7 +46,7 @@ defmodule HexpmWeb.API.ReleaseController do
       conn.assigns.inner_checksum,
       conn.assigns.outer_checksum,
       audit: audit_data(conn),
-      replace: replace
+      replace: replace?
     )
     |> publish_result(conn)
   end
@@ -110,7 +110,7 @@ defmodule HexpmWeb.API.ReleaseController do
     end
   end
 
-  defp handle_tarball(conn, repository, package, user, body, replace \\ false) do
+  defp handle_tarball(conn, repository, package, user, body, replace? \\ false) do
     case release_metadata(body) do
       {:ok, meta, inner_checksum, outer_checksum} ->
         request_id = List.first(get_resp_header(conn, "x-request-id"))
@@ -125,7 +125,7 @@ defmodule HexpmWeb.API.ReleaseController do
           inner_checksum,
           outer_checksum,
           audit: audit_data(conn),
-          replace: replace
+          replace: replace?
         )
 
       {:error, errors} ->

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -163,6 +163,7 @@ defmodule HexpmWeb.Router do
     for prefix <- ["/", "/repos/:repository"] do
       scope prefix do
         post "/publish", ReleaseController, :publish
+        post "/replace", ReleaseController, :replace
         post "/packages/:name/releases", ReleaseController, :create
         post "/packages/:name/releases/:version/docs", DocsController, :create
       end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -163,7 +163,6 @@ defmodule HexpmWeb.Router do
     for prefix <- ["/", "/repos/:repository"] do
       scope prefix do
         post "/publish", ReleaseController, :publish
-        post "/replace", ReleaseController, :replace
         post "/packages/:name/releases", ReleaseController, :create
         post "/packages/:name/releases/:version/docs", DocsController, :create
       end

--- a/test/hexpm/repository/release_test.exs
+++ b/test/hexpm/repository/release_test.exs
@@ -69,7 +69,7 @@ defmodule Hexpm.Repository.ReleaseTest do
     updated_release =
       release
       |> Map.put(:package, package)
-      |> Release.update(new_publisher, %{}, "", "")
+      |> Release.update(new_publisher, %{}, "", "", true)
       |> Hexpm.Repo.update!()
 
     assert updated_release.publisher_id == new_publisher.id
@@ -496,7 +496,7 @@ defmodule Hexpm.Repository.ReleaseTest do
         ]
       })
 
-    Release.update(%{release | package: package2}, publisher, params, "", "")
+    Release.update(%{release | package: package2}, publisher, params, "", "", true)
     |> Hexpm.Repo.update!()
 
     package3_id = package3.id
@@ -542,7 +542,7 @@ defmodule Hexpm.Repository.ReleaseTest do
         version: "1.0"
       })
 
-    changeset = Release.update(%{release | package: package2}, publisher, params, "", "")
+    changeset = Release.update(%{release | package: package2}, publisher, params, "", "", true)
     assert [version: {"is invalid SemVer", _}] = changeset.errors
   end
 

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -40,7 +40,8 @@ defmodule Hexpm.Repository.ReleasesTest do
                  meta,
                  "00",
                  "00",
-                 audit: audit
+                 audit: audit,
+                 replace: false
                )
     end
 
@@ -51,7 +52,10 @@ defmodule Hexpm.Repository.ReleasesTest do
       audit = audit_data(user)
 
       {:ok, %{release: release}} =
-        Releases.publish(repository, nil, user, "BODY", meta, "00", "00", audit: audit)
+        Releases.publish(repository, nil, user, "BODY", meta, "00", "00",
+          audit: audit,
+          replace: false
+        )
 
       assert release.publisher_id == user.id
     end
@@ -73,7 +77,8 @@ defmodule Hexpm.Repository.ReleasesTest do
                  meta,
                  "123abc",
                  "123abc",
-                 audit: audit
+                 audit: audit,
+                 replace: false
                )
 
       assert %{name: "is reserved"} = errors_on(changeset)
@@ -96,7 +101,8 @@ defmodule Hexpm.Repository.ReleasesTest do
                  meta,
                  "123abc",
                  "123abc",
-                 audit: audit
+                 audit: audit,
+                 replace: false
                )
 
       assert %{version: "is reserved"} = errors_on(changeset)
@@ -119,7 +125,8 @@ defmodule Hexpm.Repository.ReleasesTest do
                  meta,
                  "123abc",
                  "123abc",
-                 audit: audit
+                 audit: audit,
+                 replace: false
                )
 
       assert %{version: "is invalid SemVer"} = errors_on(changeset)

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -367,7 +367,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
       build_conn()
       |> put_req_header("content-type", "application/octet-stream")
       |> put_req_header("authorization", key_for(user))
-      |> post("api/publish", create_tar(meta))
+      |> post("api/publish?replace=true", create_tar(meta))
       |> json_response(200)
 
       package = Hexpm.Repo.get_by!(Package, name: meta.name)
@@ -433,7 +433,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
       build_conn()
       |> put_req_header("content-type", "application/octet-stream")
       |> put_req_header("authorization", key_for(user))
-      |> post("api/publish", create_tar(meta))
+      |> post("api/publish?replace=true", create_tar(meta))
       |> json_response(200)
     end
 
@@ -459,7 +459,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
       result = json_response(conn, 422)
 
       assert result["errors"]["inserted_at"] ==
-               "can only modify a release up to one hour after creation"
+               "can only modify a release up to one hour after creation and must include the --replace option"
     end
 
     test "create releases with requirements", %{user: user, package: package} do

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -792,8 +792,68 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
       build_conn()
       |> put_req_header("content-type", "application/octet-stream")
       |> put_req_header("authorization", key_for(user))
-      |> post("api/repos/#{repository.name}/publish", create_tar(meta))
+      |> post("api/repos/#{repository.name}/publish?replace=true", create_tar(meta))
       |> json_response(200)
+    end
+
+    test "cannot update release after grace period even when given replace flag", %{
+      user: user,
+      package: package,
+      release: release
+    } do
+      Ecto.Changeset.change(package, inserted_at: %{DateTime.utc_now() | year: 2000})
+      |> Hexpm.Repo.update!()
+
+      Ecto.Changeset.change(release, inserted_at: %{DateTime.utc_now() | year: 2000})
+      |> Hexpm.Repo.update!()
+
+      meta = %{name: package.name, version: "0.0.1", description: "description"}
+
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put_req_header("authorization", key_for(user))
+        |> post("api/publish?replace=true", create_tar(meta))
+
+      result = json_response(conn, 422)
+
+      assert result["errors"]["inserted_at"] ==
+               "can only modify a release up to one hour after creation and must include the --replace option"
+    end
+
+    test "cannot update private package after grace period if replace flag is missing or false",
+         %{
+           user: user,
+           repository: repository
+         } do
+      package =
+        insert(
+          :package,
+          package_owners: [build(:package_owner, user: user)],
+          repository_id: repository.id
+        )
+
+      insert(
+        :release,
+        package: package,
+        version: "0.0.1",
+        inserted_at: %{DateTime.utc_now() | year: 2000}
+      )
+
+      insert(:organization_user, organization: repository.organization, user: user)
+
+      meta = %{name: package.name, version: "0.0.1", description: "description"}
+
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/octet-stream")
+        |> put_req_header("authorization", key_for(user))
+        |> post("api/repos/#{repository.name}/publish", create_tar(meta))
+
+      result = json_response(conn, 422)
+
+      assert result["errors"]["inserted_at"] ==
+               "must include the --replace flag to update an existing release"
     end
   end
 


### PR DESCRIPTION
It is supposed to be the API side of the new replace option on publishing described in #855 
The replace option is being passed along. The logic is designed only for private packages, but it would just be a 1 line change to enable it for all packages.

Fixes #855 