### PR TITLE
Add package audit logs index page

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -27,3 +27,4 @@
 @import "template/stats";
 @import "template/user";
 @import "template/version-list";
+@import "template/audit-log-list";

--- a/assets/css/template/_audit-log-list.scss
+++ b/assets/css/template/_audit-log-list.scss
@@ -1,0 +1,10 @@
+.audit-log-title {
+  @include font-size(38, $base-line-height);
+  margin: 40px 0;
+  color: $color-text-grey;
+
+  .audit-log-package-title {
+    color: $color-purple;
+  }
+}
+

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -100,7 +100,9 @@ defmodule HexpmWeb.Router do
 
     get "/packages", PackageController, :index
     get "/packages/:name", PackageController, :show
+    get "/packages/:name/audit_logs", PackageController, :audit_logs
     get "/packages/:name/:version", PackageController, :show
+    get "/packages/:repository/:name/audit_logs", PackageController, :audit_logs
     get "/packages/:repository/:name/:version", PackageController, :show
 
     get "/blog", BlogController, :index

--- a/lib/hexpm_web/templates/package/audit_logs.html.eex
+++ b/lib/hexpm_web/templates/package/audit_logs.html.eex
@@ -1,6 +1,5 @@
-<h2 class="package-title">
-  <%= ViewHelpers.package_name(@package) %>
-  <span class="version">Recent Activities</span>
+<h2 class="audit-log-title">
+  Recent Activities of <%= link ViewHelpers.package_name(@package), to: ViewHelpers.path_for_package(@package), class: "audit-log-package-title" %>
 </h2>
 
 <div class="col-md-12 no-padding">

--- a/lib/hexpm_web/templates/package/audit_logs.html.eex
+++ b/lib/hexpm_web/templates/package/audit_logs.html.eex
@@ -1,0 +1,32 @@
+<h2 class="package-title">
+  <%= ViewHelpers.package_name(@package) %>
+  <span class="version">Recent Activities</span>
+</h2>
+
+<div class="col-md-12 no-padding">
+  <table class="table table-striped">
+    <tr>
+      <th class="col-sm-3" scope="col">Date</th>
+      <th scope="col">Activity</th>
+    </tr>
+
+    <%= for audit_log <- @audit_logs do %>
+      <tr>
+        <td class="col-sm-3"><%= ViewHelpers.pretty_date(audit_log.inserted_at, :short) %></td>
+        <td><%= humanize_audit_log_info(audit_log) %></td>
+      </tr>
+    <% end %>
+  </table>
+
+  <%=
+  render HexpmWeb.SharedView,
+         "_pagination.html",
+         items: @audit_logs,
+         page: @page,
+         total_count: @total_count,
+         per_page: @per_page,
+         unit: "activity",
+         units: "activities",
+         path_fn: &path_for_audit_logs(@package, page: &1)
+  %>
+</div>

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -168,6 +168,10 @@ tools = Keyword.take(tools, compatible_tools)
         </li>
       <% end %>
     </ul>
+
+    <p>
+      <a href="<%= path_for_audit_logs(@package, page: 1) %>">Show All Activities</a>
+    </p>
   </div>
 </div>
 

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -157,6 +157,14 @@ defmodule HexpmWeb.PackageView do
     end
   end
 
+  def path_for_audit_logs(package, options) do
+    if package.repository.id == 1 do
+      Routes.package_path(Endpoint, :audit_logs, package, options)
+    else
+      Routes.package_path(Endpoint, :audit_logs, package.repository, package, options)
+    end
+  end
+
   @doc """
   This function turns an audit_log struct into a short description.
 

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -234,6 +234,36 @@ defmodule HexpmWeb.PackageControllerTest do
     end
   end
 
+  describe "GET /packages/:name/audit_logs" do
+    test "sets title correctly" do
+      _package = insert(:package, name: "Test")
+
+      conn = get(build_conn(), "/packages/Test/audit_logs")
+
+      assert response(conn, :ok) =~ "Recent Activities for Test"
+    end
+
+    test "renders audit_logs correctly" do
+      package = insert(:package, name: "Test")
+      insert(:audit_log, action: "docs.publish", params: %{package: %{id: package.id}})
+
+      conn = get(build_conn(), "/packages/Test/audit_logs")
+
+      assert response(conn, :ok) =~ "Publish documentation"
+    end
+  end
+
+  describe "GET /packages/:repository/:name/audit_logs" do
+    test "requires access to this repository" do
+      repository = insert(:repository, name: "Repo")
+      _package = insert(:package, repository_id: repository.id, name: "Test")
+
+      conn = get(build_conn(), "/packages/Repo/Test/audit_logs")
+
+      assert response(conn, :not_found)
+    end
+  end
+
   defp escape(html) do
     {:safe, safe} = Phoenix.HTML.html_escape(html)
     IO.iodata_to_binary(safe)


### PR DESCRIPTION
This PR adds paginated audit logs page for packages:
![image](https://user-images.githubusercontent.com/4723751/72681759-a0fa8480-3b01-11ea-8473-e9187334b128.png)

and a link to this page in package show page:
<img width="1552" alt="image" src="https://user-images.githubusercontent.com/4723751/72681769-ba9bcc00-3b01-11ea-9329-ac8d7d790920.png">

