### PR TITLE
Change key permissions to checkboxes from select

### DIFF
--- a/assets/css/base/_general.scss
+++ b/assets/css/base/_general.scss
@@ -181,3 +181,10 @@ input[type="checkbox"] {
     float: left !important;
   }
 }
+
+.form-label {
+  display: inline-block;
+  max-width: 100%;
+  margin-bottom: 5px;
+  font-weight: 700;
+}

--- a/assets/css/template/_dashboard.scss
+++ b/assets/css/template/_dashboard.scss
@@ -176,3 +176,7 @@
 .dashboard ol {
   font-weight: normal;
 }
+
+.permission-group{
+  .group-child{margin-left: 2rem;}
+}

--- a/assets/css/template/_dashboard.scss
+++ b/assets/css/template/_dashboard.scss
@@ -177,6 +177,8 @@
   font-weight: normal;
 }
 
-.permission-group{
-  .group-child{margin-left: 2rem;}
+.permission-group {
+  .group-child {
+    margin-left: 2rem;
+  }
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -51,6 +51,15 @@ export default class App {
     // Highlight syntax
     hljs.registerLanguage('elixir', elixir);
     hljs.initHighlightingOnLoad()
+
+    //API permissions checkboxes
+    $(".permission-group .group-owner input").change(function(){
+      if (this.checked) {
+        $(this).parents(".permission-group").find(".group-child label input").each(function(idx, value){ $(this).prop("disabled", true); $(this).prop("checked", true)})
+      }else{
+        $(this).parents(".permission-group").find(".group-child label input").each(function(idx, value){ $(this).prop("disabled", false); $(this).prop("checked", false)})
+      }
+    });
   }
 
   onCopy(event) {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -52,14 +52,20 @@ export default class App {
     hljs.registerLanguage('elixir', elixir);
     hljs.initHighlightingOnLoad()
 
-    //API permissions checkboxes
-    $(".permission-group .group-owner input").change(function(){
+    // API permissions checkboxes
+    $(".permission-group .group-owner input").change(function() {
       if (this.checked) {
-        $(this).parents(".permission-group").find(".group-child label input").each(function(idx, value){ $(this).prop("disabled", true); $(this).prop("checked", true)})
-      }else{
-        $(this).parents(".permission-group").find(".group-child label input").each(function(idx, value){ $(this).prop("disabled", false); $(this).prop("checked", false)})
+        $(this).parents(".permission-group").find(".group-child label input").each(function() {
+          $(this).prop("disabled", true)
+          $(this).prop("checked", true)
+        })
+      } else {
+        $(this).parents(".permission-group").find(".group-child label input").each(function() {
+          $(this).prop("disabled", false)
+          $(this).prop("checked", false)
+        })
       }
-    });
+    })
   }
 
   onCopy(event) {

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -331,7 +331,7 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
   def create_key(conn, %{"dashboard_org" => organization} = params) do
     access_organization(conn, organization, "write", fn organization ->
-      key_params = KeyController.fixup_permissions(params["key"])
+      key_params = KeyController.munge_permissions(params["key"])
 
       case Keys.create(organization, key_params, audit: audit_data(conn)) do
         {:ok, %{key: key}} ->

--- a/lib/hexpm_web/templates/dashboard/_keys.html.eex
+++ b/lib/hexpm_web/templates/dashboard/_keys.html.eex
@@ -57,17 +57,19 @@
       </div>
       <span class="form-label">Key permissions</span>
       <div class="permission-group">
-        <div class="checkbox group-owner"><label><input type="checkbox" name="key[permissions][api][all]">API</label></div>
+        <div class="checkbox group-owner"><label><input type="checkbox" name="key[permissions][apis]">API</label></div>
         <div class="checkbox group-child"><label><input type="checkbox" name="key[permissions][api][read]">Read</label></div>
         <div class="checkbox group-child"><label><input type="checkbox" name="key[permissions][api][write]">Write</label></div>
       </div>
       <%= if assigns[:organization] do %>
         <div class="checkbox"><label><input type="checkbox" name="key[permissions][repository][<%= @organization.name %>]">Organization repository</label></div>
       <% else %>
-        <div class="checkbox"><label><input type="checkbox" name="key[permissions][repositories]">All Repositories</label></div>
-        <%= for organization <- @organizations do %>
-          <div class="checkbox"><label><input type="checkbox" name="key[permissions][repository][<%= organization.name %>]">Repository: <%= organization.name %></label></div>
-        <% end %>
+        <div class="permission-group">
+          <div class="checkbox group-owner"><label><input type="checkbox" name="key[permissions][repositories]">All Repositories</label></div>
+          <%= for organization <- @organizations do %>
+            <div class="checkbox group-child"><label><input type="checkbox" name="key[permissions][repository][<%= organization.name %>]">Repository: <%= organization.name %></label></div>
+          <% end %>
+        </div>
       <% end %>
       <button type="submit" class="btn btn-primary">Generate</button>
     <% end %>

--- a/lib/hexpm_web/templates/dashboard/_keys.html.eex
+++ b/lib/hexpm_web/templates/dashboard/_keys.html.eex
@@ -56,8 +56,11 @@
         <%= ViewHelpers.error_tag f, :name %>
       </div>
       <span class="form-label">Key permissions</span>
-      <div class="checkbox"><label><input type="checkbox" name="key[permissions][api][read]">API: read</label></div>
-      <div class="checkbox"><label><input type="checkbox" name="key[permissions][api][write]">API: write</label></div>
+      <div class="permission-group">
+        <div class="checkbox group-owner"><label><input type="checkbox" name="key[permissions][api][all]">API</label></div>
+        <div class="checkbox group-child"><label><input type="checkbox" name="key[permissions][api][read]">Read</label></div>
+        <div class="checkbox group-child"><label><input type="checkbox" name="key[permissions][api][write]">Write</label></div>
+      </div>
       <%= if assigns[:organization] do %>
         <div class="checkbox"><label><input type="checkbox" name="key[permissions][repository][<%= @organization.name %>]">Organization repository</label></div>
       <% else %>

--- a/lib/hexpm_web/templates/dashboard/_keys.html.eex
+++ b/lib/hexpm_web/templates/dashboard/_keys.html.eex
@@ -55,37 +55,16 @@
         <%= ViewHelpers.text_input f, :name, class: "form-control", placeholder: "Name" %>
         <%= ViewHelpers.error_tag f, :name %>
       </div>
-      <%= inputs_for f, :permissions, fn f -> %>
-        <%= label f, :domain, "Permission domain" %>
-        <div class="form-group">
-          <%=
-            ViewHelpers.select(
-              f,
-              :domain,
-              [
-                API: "api",
-                "Organization": "repository"
-              ],
-              class: "form-control"
-            )
-          %>
-          <%= ViewHelpers.error_tag f, :domain %>
-        </div>
-        <%= label f, :domain, "Domain resource" %>
-        <div class="form-group">
-          <%=
-            ViewHelpers.select(
-              f,
-              :resource,
-              [
-                API: ["Read": "read", "Write": "write"],
-                "Organization": organization_resources(assigns),
-              ],
-              class: "form-control"
-            )
-          %>
-          <%= ViewHelpers.error_tag f, :resource %>
-        </div>
+      <span class="form-label">Key permissions</span>
+      <div class="checkbox"><label><input type="checkbox" name="key[permissions][api][read]">API: read</label></div>
+      <div class="checkbox"><label><input type="checkbox" name="key[permissions][api][write]">API: write</label></div>
+      <%= if assigns[:organization] do %>
+        <div class="checkbox"><label><input type="checkbox" name="key[permissions][repository][<%= @organization.name %>]">Organization repository</label></div>
+      <% else %>
+        <div class="checkbox"><label><input type="checkbox" name="key[permissions][repositories]">All Repositories</label></div>
+        <%= for organization <- @organizations do %>
+          <div class="checkbox"><label><input type="checkbox" name="key[permissions][repository][<%= organization.name %>]">Repository: <%= organization.name %></label></div>
+        <% end %>
       <% end %>
       <button type="submit" class="btn btn-primary">Generate</button>
     <% end %>

--- a/lib/hexpm_web/views/dashboard_view.ex
+++ b/lib/hexpm_web/views/dashboard_view.ex
@@ -30,14 +30,8 @@ defmodule HexpmWeb.DashboardView do
     do: "API:#{resource}"
 
   defp permission_name(%KeyPermission{domain: "repository", resource: resource}),
-    do: "ORG:#{resource}"
+    do: "REPO:#{resource}"
 
   defp permission_name(%KeyPermission{domain: "repositories"}),
-    do: "ORGS"
-
-  defp organization_resources(%{organizations: organizations}),
-    do: ["All"] ++ Enum.map(organizations, & &1.name)
-
-  defp organization_resources(%{organization: organization}),
-    do: [organization.name]
+    do: "REPOS"
 end


### PR DESCRIPTION
Changes the key permissions UX when creating a key on the dashboard from select dropdowns to checkboxes. This has the benefit that you can create a key with multiple permissions and you cannot select invalid combinations such as `API: myrepo` or `REPO: read`. The downside is that it doesn't look as good, any advice on how to spice up the UI would be appreciated.

### Previous

<img width="713" alt="Screen Shot 2020-02-12 at 01 34 10" src="https://user-images.githubusercontent.com/316890/74292253-d88ed200-4d37-11ea-80f2-b360a2f0a45d.png">

### New

<img width="713" alt="Screen Shot 2020-02-12 at 01 31 34" src="https://user-images.githubusercontent.com/316890/74292263-dcbaef80-4d37-11ea-815a-2ce7e3935b02.png">
