### PR TITLE
Make ReleaseControllerTest run green on leap days

### DIFF
--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -892,7 +892,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
     end
 
     test "delete release", %{user: user, package: package, release: release} do
-      Ecto.Changeset.change(release, inserted_at: %{DateTime.utc_now() | year: 2030})
+      Ecto.Changeset.change(release, inserted_at: DateTime.add(DateTime.utc_now(), 60, :second))
       |> Hexpm.Repo.update!()
 
       RegistryBuilder.full(Repository.hexpm())
@@ -915,7 +915,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
     end
 
     test "delete non-last package release", %{user: user, package: package, release: release} do
-      Ecto.Changeset.change(release, inserted_at: %{DateTime.utc_now() | year: 2030})
+      Ecto.Changeset.change(release, inserted_at: DateTime.add(DateTime.utc_now(), 60, :second))
       |> Hexpm.Repo.update!()
 
       insert(:release, package: package)


### PR DESCRIPTION
The following two test cases failed today (2020-02-29) because the year
2030 is not a leap year.

    1) test DELETE /api/packages/:name/releases/:version delete non-last
         package release (HexpmWeb.API.ReleaseControllerTest)
       test/hexpm_web/controllers/api/release_controller_test.exs:917
       ** (ArgumentError) invalid date: 2030-02-29
       code: Ecto.Changeset.change(release, inserted_at: %{DateTime.utc_now() | year: 2030})

    2) test DELETE /api/packages/:name/releases/:version delete release
         (HexpmWeb.API.ReleaseControllerTest)
       test/hexpm_web/controllers/api/release_controller_test.exs:894
       ** (ArgumentError) invalid date: 2030-02-29
       code: Ecto.Changeset.change(release, inserted_at: %{DateTime.utc_now() | year: 2030})

Assuming that the reason why we modify the year here is to ensure
that the release is fresh enough to be editable (see
`Hexpm.Repository.Release.editable?/2`), moving it a minute into the
future should be sufficient.