### PR TITLE
Add a blog RSS feed

### DIFF
--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -267,4 +267,46 @@ defmodule Hexpm.Utils do
     diff_url = Application.fetch_env!(:hexpm, :diff_url)
     "#{diff_url}/diff/#{package_name}/#{previous_version}..#{version}"
   end
+
+  @doc """
+  Returns a RFC 2822 format string from a UTC datetime.
+  # TODO: Replace with `Calendar.strftime(datetime, "%a, %b %d %Y %H:%H:%S GMT")` on Elixir v1.11
+  """
+  def datetime_to_rfc2822(%DateTime{calendar: Calendar.ISO, time_zone: "Etc/UTC"} = datetime) do
+    %{year: year, month: month, day: day} = datetime
+
+    day_of_week = Calendar.ISO.day_of_week(year, month, day)
+    time = datetime |> DateTime.to_time() |> Time.to_iso8601()
+
+    [
+      (day_of_week |> day_name_abbr()) <> ",",
+      day |> Integer.to_string() |> String.pad_leading(2, "0"),
+      month |> month_name_abbr(),
+      year |> Integer.to_string(),
+      time,
+      "GMT"
+    ]
+    |> Enum.join(" ")
+  end
+
+  defp day_name_abbr(1), do: "Mon"
+  defp day_name_abbr(2), do: "Tue"
+  defp day_name_abbr(3), do: "Wed"
+  defp day_name_abbr(4), do: "Thu"
+  defp day_name_abbr(5), do: "Fri"
+  defp day_name_abbr(6), do: "Sat"
+  defp day_name_abbr(7), do: "Sun"
+
+  defp month_name_abbr(1), do: "Jan"
+  defp month_name_abbr(2), do: "Feb"
+  defp month_name_abbr(3), do: "Mar"
+  defp month_name_abbr(4), do: "Apr"
+  defp month_name_abbr(5), do: "May"
+  defp month_name_abbr(6), do: "Jun"
+  defp month_name_abbr(7), do: "Jul"
+  defp month_name_abbr(8), do: "Aug"
+  defp month_name_abbr(9), do: "Sep"
+  defp month_name_abbr(10), do: "Oct"
+  defp month_name_abbr(11), do: "Nov"
+  defp month_name_abbr(12), do: "Dec"
 end

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -270,8 +270,8 @@ defmodule Hexpm.Utils do
 
   @doc """
   Returns a RFC 2822 format string from a UTC datetime.
-  # TODO: Replace with `Calendar.strftime(datetime, "%a, %b %d %Y %H:%H:%S GMT")` on Elixir v1.11
   """
+  # TODO: Replace with `Calendar.strftime(datetime, "%a, %b %d %Y %H:%H:%S GMT")` on Elixir v1.11
   def datetime_to_rfc2822(%DateTime{calendar: Calendar.ISO, time_zone: "Etc/UTC"} = datetime) do
     %{year: year, month: month, day: day} = datetime
 

--- a/lib/hexpm_web/controllers/feeds_controller.ex
+++ b/lib/hexpm_web/controllers/feeds_controller.ex
@@ -1,0 +1,10 @@
+defmodule HexpmWeb.FeedsController do
+  use HexpmWeb, :controller
+
+  def blog(conn, _params) do
+    conn
+    |> put_view(HexpmWeb.BlogView)
+    |> put_resp_content_type("application/rss+xml")
+    |> render("index.xml")
+  end
+end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -157,6 +157,7 @@ defmodule HexpmWeb.Router do
     get "/docs_sitemap.xml", SitemapController, :docs
     get "/hexsearch.xml", OpenSearchController, :opensearch
     get "/installs/hex.ez", InstallController, :archive
+    get "/feeds/blog.xml", FeedsController, :blog
   end
 
   scope "/api", HexpmWeb.API, as: :api do

--- a/lib/hexpm_web/templates/blog/001-private-packages-and-organizations.html.md
+++ b/lib/hexpm_web/templates/blog/001-private-packages-and-organizations.html.md
@@ -1,6 +1,6 @@
 ## Private packages and organizations
 
-<div class="subtitle">August 28, 2017 · by Eric Meadows-Jönsson</div>
+<div class="subtitle"><time datetime="2017-08-28T00:00:00Z">August 28, 2017</time> · by Eric Meadows-Jönsson</div>
 
 We are announcing the addition of private packages on Hex.pm. With private packages you can publish
 packages to Hex.pm that only your organization members can access and download. With your organization

--- a/lib/hexpm_web/templates/blog/002-organizations-going-live.html.md
+++ b/lib/hexpm_web/templates/blog/002-organizations-going-live.html.md
@@ -1,6 +1,6 @@
 ## Organizations going live
 
-<div class="subtitle">March 5, 2018 · by Eric Meadows-Jönsson</div>
+<div class="subtitle"><time datetime="2018-03-05T00:00:00Z">March 5, 2018</time> · by Eric Meadows-Jönsson</div>
 
 A few months ago we introduced the beta of private packages and organizations. In the meantime we
 have been building the billing system and iterating on organizations. We'd like to thank beta

--- a/lib/hexpm_web/templates/blog/003-hex-v0.18-released.html.md
+++ b/lib/hexpm_web/templates/blog/003-hex-v0.18-released.html.md
@@ -1,6 +1,6 @@
 ## Hex v0.18 released
 
-<div class="subtitle">July 5, 2018 · by Eric Meadows-Jönsson</div>
+<div class="subtitle"><time datetime="2018-07-05T00:00:00Z">July 5, 2018</time> · by Eric Meadows-Jönsson</div>
 
 The v0.18 release includes improvements to API key handling and workflows when using continuous integration.
 

--- a/lib/hexpm_web/templates/blog/004-announcing-hex-core.html.md
+++ b/lib/hexpm_web/templates/blog/004-announcing-hex-core.html.md
@@ -1,6 +1,6 @@
 ## Announcing hex_core
 
-<div class="subtitle">August 8, 2018 · by Wojtek Mach</div>
+<div class="subtitle"><time datetime="2018-08-08T00:00:00Z">August 8, 2018</time> · by Wojtek Mach</div>
 
 Today we are releasing the first version of hex_core, an Erlang library to interact with Hex.pm and other servers implementing Hex specifications.
 

--- a/lib/hexpm_web/templates/blog/005-private-hexdocs.html.md
+++ b/lib/hexpm_web/templates/blog/005-private-hexdocs.html.md
@@ -1,6 +1,6 @@
 ## Private Hexdocs
 
-<div class="subtitle">August 9, 2018 · by Eric Meadows-Jönsson</div>
+<div class="subtitle"><time datetime="2018-08-09T00:00:00Z">August 9, 2018</time> · by Eric Meadows-Jönsson</div>
 
 Today we are happy to announce the release of [Hexdocs](https://hexdocs.pm/) for private packages. All the private packages you have uploaded documentation for (the default when running `mix hex.publish`) are now available and browsable on Hexdocs.
 

--- a/lib/hexpm_web/templates/blog/006-database-migration.html.md
+++ b/lib/hexpm_web/templates/blog/006-database-migration.html.md
@@ -1,6 +1,6 @@
 ## Database migration
 
-<div class="subtitle">September 28, 2018 · by Eric Meadows-Jönsson</div>
+<div class="subtitle"><time datetime="2018-09-28T00:00:00Z">September 28, 2018</time> · by Eric Meadows-Jönsson</div>
 
 We are changing hosting provider from Heroku to Google Cloud. All applications have already been moved to Google Kubernetes Engine, but we sill have to move the database for hex.pm itself.
 

--- a/lib/hexpm_web/templates/blog/007-hex-v0.19-released.html.md
+++ b/lib/hexpm_web/templates/blog/007-hex-v0.19-released.html.md
@@ -1,6 +1,6 @@
 ## Hex v0.19 released
 
-<div class="subtitle">15 January, 2019 · by Eric Meadows-Jönsson</div>
+<div class="subtitle"><time datetime="2019-01-15T00:00:00Z">15 January, 2019</time> · by Eric Meadows-Jönsson</div>
 
 The v0.19 release includes an important security fix to anyone accessing Hex repositories through a mirror. A bug has been found that would allow a malicious mirror to serve modified versions of Hex packages. [hex](https://github.com/hexpm/hex) versions `0.14.0` to `0.18.2` and [rebar3](https://github.com/erlang/rebar3) versions `3.7.0` to `3.7.5` are vulnerable. Make sure to update to hex `0.19.0` and rebar3 `3.8.0`.
 

--- a/lib/hexpm_web/templates/blog/008-hex-v0.20-released.html.md
+++ b/lib/hexpm_web/templates/blog/008-hex-v0.20-released.html.md
@@ -1,6 +1,6 @@
 ## Hex v0.20 released
 
-<div class="subtitle">10 June, 2019 · by Eric Meadows-Jönsson</div>
+<div class="subtitle"><time datetime="2019-06-10T00:00:00Z">10 June, 2019</time> · by Eric Meadows-Jönsson</div>
 
 ### Organization managed public packages
 

--- a/lib/hexpm_web/templates/blog/009-announcing-hex-diff.html.md
+++ b/lib/hexpm_web/templates/blog/009-announcing-hex-diff.html.md
@@ -1,6 +1,6 @@
 ## Announcing Hex Diff
 
-<div class="subtitle">20 January, 2020 · by Johanna Larsson</div>
+<div class="subtitle"><time datetime="2020-01-20T00:00:00Z">20 January, 2020</time> · by Johanna Larsson</div>
 
 I'm incredibly excited to announce the new web-based Hex package differ: [diff.hex.pm](https://diff.hex.pm), maintained by the Hex team! This is the result of the issue on the [hex.pm Github repo](https://github.com/hexpm/hexpm/issues/848) and the discussion it started.
 

--- a/lib/hexpm_web/templates/blog/index.html.eex
+++ b/lib/hexpm_web/templates/blog/index.html.eex
@@ -1,7 +1,7 @@
 <%= for post <- @posts do %>
   <div class="index-post">
     <h3><a href="<%= Routes.blog_path(Endpoint, :show, post.slug) %>"><%= post.title %></a></h3>
-    <div class="subtitle"><%= post.subtitle %></div>
+    <div class="subtitle"><%= raw post.subtitle %></div>
     <p class="content"><%= raw post.paragraph %></p>
     <a href="<%= Routes.blog_path(Endpoint, :show, post.slug) %>">Read more...</a>
   </div>

--- a/lib/hexpm_web/templates/blog/index.xml.eex
+++ b/lib/hexpm_web/templates/blog/index.xml.eex
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<rss version="2.0">
+
+  <channel>
+
+    <title>Blog posts on hex.pm</title>
+    <link><%= Routes.blog_url(Endpoint, :index) %></link>
+    <description>Blog posts on hex.pm</description>
+    <language>en</language>
+
+    <%= for post <- @posts do %>
+    <item>
+      <title><%= post.title %></title>
+      <description><![CDATA[<%= post.paragraph %>]]></description>
+      <link><%= Routes.blog_url(Endpoint, :show, post.slug) %></link>
+      <pubDate><%= post.published %></pubDate>
+    </item>
+    <% end %>
+
+  </channel>
+
+</rss>

--- a/lib/hexpm_web/templates/layout/header.html.eex
+++ b/lib/hexpm_web/templates/layout/header.html.eex
@@ -12,6 +12,7 @@
 
     <link rel="search" type="application/opensearchdescription+xml" title="Hex" href="/hexsearch.xml">
     <link rel="stylesheet" href="<%= Routes.static_path(Endpoint, "/css/app.css") %>">
+    <link rel="alternate" type="application/rss+xml" title="RSS - Blog" href="/feeds/blog.xml">
   </head>
   <body>
     <!--[if lt IE 10]>

--- a/test/hexpm/utils_test.exs
+++ b/test/hexpm/utils_test.exs
@@ -1,0 +1,15 @@
+defmodule Hexpm.UtilsTest do
+  use ExUnit.Case, async: true
+
+  alias Hexpm.Utils
+
+  describe "datetime_to_rfc2822" do
+    test "formats sample timestamps correctly" do
+      assert Utils.datetime_to_rfc2822(~U[2002-09-07 09:42:31Z]) ==
+               "Sat, 07 Sep 2002 09:42:31 GMT"
+
+      assert Utils.datetime_to_rfc2822(~U[2020-02-23 19:47:26Z]) ==
+               "Sun, 23 Feb 2020 19:47:26 GMT"
+    end
+  end
+end

--- a/test/hexpm_web/controllers/feeds_controller_test.exs
+++ b/test/hexpm_web/controllers/feeds_controller_test.exs
@@ -1,0 +1,12 @@
+defmodule HexpmWeb.FeedsControllerTest do
+  use HexpmWeb.ConnCase, async: true
+
+  test "GET /feeds/blog.xml" do
+    conn = get(build_conn(), "/feeds/blog.xml")
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-type") == ["application/rss+xml; charset=utf-8"]
+    assert String.starts_with?(conn.resp_body, "<?xml version=\"1.0\" encoding=\"utf-8\"?>")
+    assert conn.resp_body =~ "Private packages and organizations"
+  end
+end


### PR DESCRIPTION
My preferred way of keeping up with new posts on blogs is to subscribe
to their RSS feeds. I'd like to follow the Hex blog, but there was no
feed, so this commit/PR adds one.

There existed a feed for new packages around 2014/2015, from which I
took inspiration.

We reuse the `HexpmWeb.BlogView` view, since it already contains most of
what we need.

The feed is quite minimalistic with regards to the kinds of elements it
contains. Still, it is valid (with some recommendations) and serves its
purpose.

In order to support feed readers sorting posts by date, we include a
`pubDate` element on each post. This value is sourced from a new `time`
element added to each current post. It is parsed as a ISO 8601 timestamp
and then formatted as a ISO 2822 timestamp in order to follow the RSS
2.0 specification.

We implement our own `datetime_to_rfc2822` utility function. Pulling in
another dependency just for this didn't seem worth while.

Ref: <https://github.com/hexpm/hexpm/issues/854>
Ref: <https://github.com/hexpm/hexpm/pull/29>
Ref: <https://github.com/hexpm/hexpm/issues/19>
Ref: fba4d99765e441d99771f84f54385a99249d79fd
Ref: c96d46f400fbcfd702ed54a73e85cbb919e80834
Ref: <https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time>
Ref: <https://validator.w3.org/feed/>