### PR TITLE
Compile with --warnings-as-errors on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,9 +51,10 @@ jobs:
         run: MIX_ENV=test mix compile
 
       - name: Run tests
-        run: |
-          mix test
-          mix ecto.setup
+        run: mix test
+
+      - name: Verify seeds
+        run: MIX_ENV=test mix run priv/repo/seeds.exs
 
   test-hex:
     name: Test Hex

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,13 +13,12 @@ jobs:
         uses: actions/setup-elixir@v1
         with:
           otp-version: 22.2
-          elixir-version: 1.10.0
+          elixir-version: 1.10.3
 
-      - name: Install dependencies
-        run: mix deps.get
-
-      - name: Check mix format
-        run: mix format --check-formatted
+      - run: mix deps.get
+      - run: mix deps.compile
+      - run: mix compile --warnings-as-errors
+      - run: mix format --check-formatted
 
   test-hexpm:
     name: Test Hexpm
@@ -46,9 +45,10 @@ jobs:
           elixir-version: 1.10.0
 
       - name: Install dependencies
-        run: |
-          mix deps.get
-          mix deps.compile
+        run: mix deps.get
+
+      - name: Compile
+        run: MIX_ENV=test mix compile
 
       - name: Run tests
         run: |
@@ -95,7 +95,7 @@ jobs:
       - name: Clone hex and install dependencies
         run: |
           git clone https://github.com/hexpm/hex hex -b ${{ matrix.hex-version }} --depth 1
-          cd hex && mix deps.get && mix deps.compile && cd ..
+          cd hex && mix deps.get && MIX_ENV=test mix deps.compile && cd ..
 
       - name: Run tests
         run: cd hex && mix test --include integration && cd ..

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -168,7 +168,7 @@ defmodule Hexpm.Accounts.Users do
       )
       |> audit(audit_data, "security.update", fn %{user: user} -> user end)
 
-    {:ok, %{user: user}} = Repo.transaction(multi)
+    {:ok, _} = Repo.transaction(multi)
   end
 
   def tfa_disable(user, audit: audit_data) do


### PR DESCRIPTION
Also fixes a couple of other steps, we need to compile in MIX_ENV=test,
otherwise we'd compile again when running `mix test`.