### PR TITLE
Add audit logs' full date on hover

### DIFF
--- a/lib/hexpm_web/templates/package/audit_logs.html.eex
+++ b/lib/hexpm_web/templates/package/audit_logs.html.eex
@@ -11,7 +11,9 @@
 
     <%= for audit_log <- @audit_logs do %>
       <tr>
-        <td class="col-sm-3"><%= ViewHelpers.pretty_date(audit_log.inserted_at, :short) %></td>
+        <td class="col-sm-3" title="<%= audit_log.inserted_at %>">
+          <%= ViewHelpers.pretty_date(audit_log.inserted_at, :short) %>
+        </td>
         <td><%= humanize_audit_log_info(audit_log) %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
Adds a quick and easy way to see the exact date and time of the audit log, especially useful if there are two audit logs in short succession.

<img width="506" alt="image" src="https://user-images.githubusercontent.com/1941348/80480495-1374cf00-8951-11ea-965a-92347ff8d412.png">
