### PR TITLE
change API to return entire short url instead of short code

### DIFF
--- a/lib/hexpm_web/controllers/api/short_url_controller.ex
+++ b/lib/hexpm_web/controllers/api/short_url_controller.ex
@@ -7,7 +7,7 @@ defmodule HexpmWeb.API.ShortURLController do
       {:ok, short_url} ->
         conn
         |> put_status(201)
-        |> render(:show, short_url: short_url)
+        |> render(:show, short_url: Routes.short_url_url(conn, :show, short_url.short_code))
 
       {:error, changeset} ->
         validation_failed(conn, changeset)

--- a/lib/hexpm_web/controllers/api/short_url_controller.ex
+++ b/lib/hexpm_web/controllers/api/short_url_controller.ex
@@ -7,7 +7,7 @@ defmodule HexpmWeb.API.ShortURLController do
       {:ok, short_url} ->
         conn
         |> put_status(201)
-        |> render(:show, short_url: Routes.short_url_url(conn, :show, short_url.short_code))
+        |> render(:show, url: Routes.short_url_url(conn, :show, short_url.short_code))
 
       {:error, changeset} ->
         validation_failed(conn, changeset)

--- a/lib/hexpm_web/views/api/short_url_view.ex
+++ b/lib/hexpm_web/views/api/short_url_view.ex
@@ -6,6 +6,6 @@ defmodule HexpmWeb.API.ShortURLView do
   end
 
   def render("show", %{short_url: short_url}) do
-    %{short_code: short_url.short_code}
+    %{short_url: short_url}
   end
 end

--- a/lib/hexpm_web/views/api/short_url_view.ex
+++ b/lib/hexpm_web/views/api/short_url_view.ex
@@ -1,11 +1,11 @@
 defmodule HexpmWeb.API.ShortURLView do
   use HexpmWeb, :view
 
-  def render("show." <> _, %{short_url: short_url}) do
-    render(__MODULE__, "show", short_url: short_url)
+  def render("show." <> _, %{url: url}) do
+    render(__MODULE__, "show", url: url)
   end
 
-  def render("show", %{short_url: short_url}) do
-    %{short_url: short_url}
+  def render("show", %{url: url}) do
+    %{url: url}
   end
 end

--- a/test/hexpm_web/controllers/api/short_url_controller_test.exs
+++ b/test/hexpm_web/controllers/api/short_url_controller_test.exs
@@ -6,8 +6,7 @@ defmodule HexpmWeb.API.ShortURLControllerTest do
       assert %{"url" => url} =
                build_conn()
                |> post("api/short_url", %{"url" => "https://diff.hex.pm?diff[]=ecto:3.0.0:3.0.1"})
-               |> response(201)
-               |> Jason.decode!()
+               |> json_response(201)
 
       assert url =~ ~r/\/l\/[\w\d]{5}/
     end

--- a/test/hexpm_web/controllers/api/short_url_controller_test.exs
+++ b/test/hexpm_web/controllers/api/short_url_controller_test.exs
@@ -8,6 +8,7 @@ defmodule HexpmWeb.API.ShortURLControllerTest do
                |> post("api/short_url", %{"url" => "https://diff.hex.pm?diff[]=ecto:3.0.0:3.0.1"})
                |> response(201)
                |> Jason.decode!()
+
       assert url =~ ~r/\/l\/[\w\d]{5}/
     end
 

--- a/test/hexpm_web/controllers/api/short_url_controller_test.exs
+++ b/test/hexpm_web/controllers/api/short_url_controller_test.exs
@@ -3,9 +3,12 @@ defmodule HexpmWeb.API.ShortURLControllerTest do
 
   describe "post /api/short_url" do
     test "creates a short_code" do
-      assert build_conn()
-             |> post("api/short_url", %{"url" => "https://diff.hex.pm?diff[]=ecto:3.0.0:3.0.1"})
-             |> response(201)
+      assert %{"url" => url} =
+               build_conn()
+               |> post("api/short_url", %{"url" => "https://diff.hex.pm?diff[]=ecto:3.0.0:3.0.1"})
+               |> response(201)
+               |> Jason.decode!()
+      assert url =~ ~r/\/l\/[\w\d]{5}/
     end
 
     test "fails given an invalid url" do


### PR DESCRIPTION
Made a small change to the short url API.I realized I would have had to code the short link URL into the CLI otherwise, so now the API returns the entire URL