### PR TITLE
Re-work database sessions

### DIFF
--- a/lib/hexpm/accounts/session.ex
+++ b/lib/hexpm/accounts/session.ex
@@ -1,18 +1,46 @@
 defmodule Hexpm.Accounts.Session do
   use Hexpm.Schema
+  alias Hexpm.Accounts.User
 
   schema "sessions" do
-    field :token, :binary
+    belongs_to :user, User
+    field :uuid, Ecto.UUID, autogenerate: true
+    field :token_hash, :binary
     field :data, :map
+    field :expires_at, :utc_datetime_usec
+    field :active, :boolean
+
     timestamps()
   end
 
-  def build(data) do
-    change(%Session{}, data: data, token: :crypto.strong_rand_bytes(96))
+  def build(user, data, token) do
+    expires_at = DateTime.add(DateTime.utc_now(), data.expires_in, :second)
+    token_hash = :crypto.hash(:sha256, token)
+
+    change(%Session{},
+      user_id: user.id,
+      active: true,
+      expires_at: expires_at,
+      data: data,
+      token_hash: token_hash
+    )
+  end
+
+  def get_active(uuid) do
+    from(s in __MODULE__,
+      join: u in User,
+      on: u.id == s.user_id,
+      where: [uuid: ^uuid, active: true],
+      preload: [user: {u, [:emails, organizations: :repository]}]
+    )
   end
 
   def update(session, data) do
     change(session, data: data)
+  end
+
+  def expire(%Session{} = session) do
+    change(session, %{active: false, expires_at: DateTime.utc_now()})
   end
 
   def by_id(query \\ __MODULE__, id) do
@@ -21,5 +49,14 @@ defmodule Hexpm.Accounts.Session do
 
   def by_user(query \\ __MODULE__, user) do
     from(s in query, where: fragment("(?->>'user_id')::integer", s.data) == ^user.id)
+  end
+
+  def all_inactive_by_user(user) do
+    now = DateTime.utc_now()
+
+    from(
+      s in Session,
+      where: s.user_id == ^user.id and (s.active == false or s.expires_at <= ^now)
+    )
   end
 end

--- a/lib/hexpm_web/controllers/login_controller.ex
+++ b/lib/hexpm_web/controllers/login_controller.ex
@@ -27,14 +27,14 @@ defmodule HexpmWeb.LoginController do
 
   def delete(conn, _params) do
     conn
-    |> delete_session("user_id")
+    |> HexpmWeb.Session.delete()
     |> redirect(to: Routes.page_path(HexpmWeb.Endpoint, :index))
   end
 
   def start_session(conn, user, return) do
     conn
     |> configure_session(renew: true)
-    |> put_session("user_id", user.id)
+    |> HexpmWeb.Session.create(user)
     |> redirect_return(user, return)
   end
 

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -4,10 +4,13 @@ defmodule HexpmWeb.Endpoint do
   plug HexpmWeb.Plugs.Forwarded
 
   @session_options [
+    encryption_salt: "q1QBAsxhxzlBSxa6kMUiY6bNmZu0LzVL",
+    same_site: "Strict",
     signing_salt: "NOcCmerj",
-    store: HexpmWeb.Session,
+    serializer: HexpmWeb.Session,
+    store: :cookie,
     key: "_hexpm_key",
-    max_age: 60 * 60 * 24 * 30
+    max_age: HexpmWeb.Session.max_age()
   ]
 
   # Serve at "/" the static files from "priv/static" directory.

--- a/lib/hexpm_web/plugs.ex
+++ b/lib/hexpm_web/plugs.ex
@@ -1,7 +1,6 @@
 defmodule HexpmWeb.Plugs do
   import Plug.Conn, except: [read_body: 1]
 
-  alias Hexpm.Accounts.Users
   alias HexpmWeb.ControllerHelpers
 
   # Max filesize: ~10mb
@@ -91,14 +90,14 @@ defmodule HexpmWeb.Plugs do
   end
 
   def login(conn, _opts) do
-    user_id = get_session(conn, "user_id")
-    user = user_id && Users.get_by_id(user_id, [:emails, organizations: :repository])
     conn = assign(conn, :current_organization, nil)
 
-    if user do
-      assign(conn, :current_user, user)
-    else
-      assign(conn, :current_user, nil)
+    case HexpmWeb.Session.get(get_session(conn, "session_id")) do
+      {:ok, session} ->
+        assign(conn, :current_user, session.user)
+
+      _ ->
+        assign(conn, :current_user, nil)
     end
   end
 

--- a/lib/hexpm_web/plugs.ex
+++ b/lib/hexpm_web/plugs.ex
@@ -89,18 +89,6 @@ defmodule HexpmWeb.Plugs do
     end
   end
 
-  def login(conn, _opts) do
-    conn = assign(conn, :current_organization, nil)
-
-    case HexpmWeb.Session.get(get_session(conn, "session_id")) do
-      {:ok, session} ->
-        assign(conn, :current_user, session.user)
-
-      _ ->
-        assign(conn, :current_user, nil)
-    end
-  end
-
   def disable_deactivated(conn, _opts) do
     if conn.assigns.current_user && conn.assigns.current_user.deactivated_at do
       conn

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -14,9 +14,15 @@ defmodule HexpmWeb.Router do
     plug :put_secure_browser_headers
     plug :web_user_agent
     plug :validate_url
-    plug :login
+  end
+
+  pipeline :defaults do
     plug :disable_deactivated
     plug :default_repository
+  end
+
+  pipeline :session do
+    plug HexpmWeb.Session
   end
 
   pipeline :upload do
@@ -51,7 +57,7 @@ defmodule HexpmWeb.Router do
   end
 
   scope "/", HexpmWeb do
-    pipe_through :browser
+    pipe_through [:browser, :login, :defaults]
 
     get "/", PageController, :index
     get "/about", PageController, :about
@@ -136,7 +142,7 @@ defmodule HexpmWeb.Router do
   end
 
   scope "/dashboard", HexpmWeb.Dashboard do
-    pipe_through :browser
+    pipe_through [:browser, :session, :defaults]
 
     get "/profile", ProfileController, :index
     post "/profile", ProfileController, :update

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -14,15 +14,9 @@ defmodule HexpmWeb.Router do
     plug :put_secure_browser_headers
     plug :web_user_agent
     plug :validate_url
-  end
-
-  pipeline :defaults do
+    plug HexpmWeb.Session
     plug :disable_deactivated
     plug :default_repository
-  end
-
-  pipeline :session do
-    plug HexpmWeb.Session
   end
 
   pipeline :upload do
@@ -57,7 +51,7 @@ defmodule HexpmWeb.Router do
   end
 
   scope "/", HexpmWeb do
-    pipe_through [:browser, :login, :defaults]
+    pipe_through [:browser]
 
     get "/", PageController, :index
     get "/about", PageController, :about
@@ -142,7 +136,7 @@ defmodule HexpmWeb.Router do
   end
 
   scope "/dashboard", HexpmWeb.Dashboard do
-    pipe_through [:browser, :session, :defaults]
+    pipe_through [:browser]
 
     get "/profile", ProfileController, :index
     post "/profile", ProfileController, :update

--- a/lib/hexpm_web/session.ex
+++ b/lib/hexpm_web/session.ex
@@ -3,11 +3,6 @@ defmodule HexpmWeb.Session do
 
   alias Hexpm.Accounts.{Session, User}
   alias Hexpm.Repo
-  alias HexpmWeb.Router.Helpers, as: Routes
-  require Logger
-
-  defdelegate redirect(conn, params), to: Phoenix.Controller
-  defdelegate put_flash(conn, atom, message), to: Phoenix.Controller
 
   @type token() :: <<_::64>>
   @type session_id() :: binary()
@@ -197,23 +192,15 @@ defmodule HexpmWeb.Session do
 
   defp not_found(conn) do
     conn
-    |> clear_session()
     |> configure_session(renew: true)
-    |> put_flash(:error, "You must be signed in to access that page.")
-    |> put_return()
-    |> halt()
+    |> assign(:current_user, nil)
+    |> assign(:current_organization, nil)
   end
 
   defp expired(conn) do
     conn
-    |> clear_session()
     |> configure_session(renew: true)
-    |> put_flash(:error, "Your session has expired. Please sign back in.")
-    |> put_return()
-    |> halt()
-  end
-
-  defp put_return(conn) do
-    redirect(conn, to: Routes.login_path(conn, :show, return: conn.request_path))
+    |> assign(:current_user, nil)
+    |> assign(:current_organization, nil)
   end
 end

--- a/lib/hexpm_web/session.ex
+++ b/lib/hexpm_web/session.ex
@@ -128,7 +128,13 @@ defmodule HexpmWeb.Session do
   end
 
   defp parse_id(<<uuid::binary-size(36), base64::binary-size(88)>>) do
-    {:ok, {uuid, base64}}
+    case Ecto.UUID.dump(uuid) do
+      {:ok, _raw} ->
+        {:ok, {uuid, base64}}
+
+      _ ->
+        {:error, :invalid_session_id}
+    end
   end
 
   defp parse_id(_), do: {:error, :invalid_session_id}

--- a/lib/hexpm_web/session.ex
+++ b/lib/hexpm_web/session.ex
@@ -1,65 +1,219 @@
 defmodule HexpmWeb.Session do
-  alias Hexpm.Accounts.Session
+  import Plug.Conn
+
+  alias Hexpm.Accounts.{Session, User}
   alias Hexpm.Repo
+  alias HexpmWeb.Router.Helpers, as: Routes
+  require Logger
 
-  @behaviour Plug.Session.Store
+  defdelegate redirect(conn, params), to: Phoenix.Controller
+  defdelegate put_flash(conn, atom, message), to: Phoenix.Controller
 
-  def init(_opts) do
-    :ok
+  @type token() :: <<_::64>>
+  @type session_id() :: binary()
+
+  # Plug interface for authenticated areas
+  @spec init(Keyword.t()) :: Keyword.t()
+  def init(opts), do: opts
+
+  @spec call(Plug.Conn.t(), any()) :: Plug.Conn.t()
+  def call(conn, _opts) do
+    case get_session(conn, "session_id") do
+      nil ->
+        not_found(conn)
+
+      session_id ->
+        setup_session(conn, session_id)
+    end
   end
 
-  def get(_conn, cookie, _opts) do
-    with {id, "++" <> token} <- Integer.parse(cookie),
-         {:ok, token} <- Base.url_decode64(token),
-         session = Repo.get(Session, id),
-         true <- session && Plug.Crypto.secure_compare(token, session.token) do
-      {{id, token}, session.data}
+  # Serializer for Plug.Session
+  @spec encode(term()) :: {:ok, String.t()} | {:error, Jason.EncodeError.t() | Exception.t()}
+  def encode(val), do: Jason.encode(val)
+
+  @spec decode(String.t()) :: {:ok, term()} | {:error, Jason.DecodeError.t()}
+  def decode(val), do: Jason.decode(val)
+
+  # General Public API
+  def gen_token(), do: :crypto.strong_rand_bytes(64)
+
+  @spec get(String.t() | nil) ::
+          {:ok, Session.t()} | {:error, :expired | :no_session | :invalid_token}
+  def get(nil), do: {:error, :no_session}
+
+  def get(session_id) do
+    with {:ok, {id, token}} <- parse_session_str(session_id),
+         {:ok, session} <- get_active_session(id),
+         {:ok, session} <- validate_token(session, token) do
+      maybe_expire(session)
+    end
+  end
+
+  @spec delete(Plug.Conn.t()) :: Plug.Conn.t()
+  def delete(conn) do
+    with <<session_str::binary>> <- get_session(conn, "session_id"),
+         {:ok, {id, _token}} <- parse_session_str(session_str),
+         {:ok, session} <- get_active_session(id),
+         {:ok, :expired} <- expire(session) do
+      clear_and_drop(conn)
     else
       _ ->
-        {nil, %{}}
+        clear_and_drop(conn)
     end
   end
 
-  def put(_conn, nil, data, _opts) do
-    session = Session.build(data)
+  @spec create(Plug.Conn.t(), User.t()) :: Plug.Conn.t()
+  def create(conn, user) do
+    token = gen_token()
+
+    data = %{
+      expires_in: max_age()
+    }
 
     session =
-      if Repo.write_mode?() do
-        Repo.insert!(session)
-      else
-        Ecto.Changeset.apply_changes(session)
-      end
+      user
+      |> Session.build(data, token)
+      |> Repo.insert!()
 
-    build_cookie(session)
+    # Prune the table when we can until a concurrent session strategy (possibly non-concurrent), 
+    # auditing capablities, and a sweeper job has been devised.
+    user
+    |> Session.all_inactive_by_user()
+    |> Repo.delete_all()
+
+    conn
+    |> configure_session(renew: true)
+    |> put_session(:session_id, to_id(session, token))
+    |> assign(:current_user, user)
+    |> assign(:current_organization, nil)
   end
 
-  def put(_conn, {id, token}, data, _opts) do
-    if Repo.write_mode?() do
-      Repo.update_all(
-        Session.by_id(id),
-        set: [
-          data: data,
-          updated_at: DateTime.utc_now()
-        ]
-      )
+  @spec max_age() :: pos_integer()
+  def max_age(), do: 60 * 60 * 24 * 30
+
+  def to_id(session, token) when byte_size(token) == 64 do
+    "#{session.uuid}#{Base.url_encode64(token)}"
+  end
+
+  def to_id(_, _), do: {:error, :invalid_session_token}
+
+  # Private API
+
+  defp get_active_session(id) do
+    case Repo.one(Session.get_active(id)) do
+      nil ->
+        {:error, :no_session}
+
+      session ->
+        {:ok, session}
     end
-
-    build_cookie(id, token)
   end
 
-  def delete(_conn, {id, _token}, _opts) do
-    if Repo.write_mode?() do
-      Repo.delete_all(Session.by_id(id))
+  defp clear_and_drop(conn) do
+    conn
+    |> clear_session()
+    |> configure_session(drop: true)
+  end
+
+  defp expire(nil), do: {:error, :no_session}
+
+  defp expire(%Session{} = session) do
+    session
+    |> Session.expire()
+    |> Repo.delete!()
+  end
+
+  defp hash_token(token), do: :crypto.hash(:sha256, token)
+
+  defp parse_session_str(session_str) do
+    with {:ok, {id, base64}} <- parse_id(session_str),
+         {:ok, token} <- decode_token(base64) do
+      {:ok, {id, token}}
     end
-
-    :ok
   end
 
-  defp build_cookie(session) do
-    build_cookie(session.id, session.token)
+  defp parse_id(<<uuid::binary-size(36), base64::binary-size(88)>>) do
+    {:ok, {uuid, base64}}
   end
 
-  defp build_cookie(id, token) do
-    "#{id}++#{Base.url_encode64(token)}"
+  defp parse_id(_), do: {:error, :invalid_session_id}
+
+  defp decode_token(base64) do
+    case Base.url_decode64(base64) do
+      {:ok, _token} = return ->
+        return
+
+      _ ->
+        {:error, :invalid_session_token}
+    end
+  end
+
+  defp maybe_expire(session) do
+    now = DateTime.utc_now()
+
+    case DateTime.compare(now, session.expires_at) do
+      :lt ->
+        {:ok, session}
+
+      :gt ->
+        expire(session)
+        {:error, :expired}
+    end
+  end
+
+  defp validate_token(%Session{} = session, token) when byte_size(token) == 64 do
+    case Plug.Crypto.secure_compare(hash_token(token), session.token_hash) do
+      true ->
+        {:ok, session}
+
+      false ->
+        {:error, :invalid_token}
+    end
+  end
+
+  defp validate_token(_, _), do: {:error, :invalid_token}
+
+  defp setup_session(conn, id) do
+    case get(id) do
+      {:error, :no_session} ->
+        not_found(conn)
+
+      {:error, :invalid_session_id} ->
+        not_found(conn)
+
+      {:error, :invalid_token} ->
+        not_found(conn)
+
+      {:error, :expired} ->
+        expired(conn)
+
+      {:ok, session} ->
+        conn
+        |> assign(:current_user, session.user)
+        |> assign(:current_organization, session.user.organization)
+        |> configure_session(renew: true)
+    end
+  end
+
+  defp not_found(conn) do
+    conn
+    |> clear_session()
+    |> configure_session(renew: true)
+    |> put_flash(:error, "You must be signed in to access that page.")
+    |> put_return()
+    |> halt()
+  end
+
+  defp expired(conn) do
+    conn
+    |> clear_session()
+    |> configure_session(renew: true)
+    |> put_flash(:error, "Your session has expired. Please sign back in.")
+    |> put_return()
+    |> halt()
+  end
+
+  defp put_return(conn) do
+    redirect(conn, to: Routes.login_path(conn, :show, return: conn.request_path))
   end
 end

--- a/lib/hexpm_web/session.ex
+++ b/lib/hexpm_web/session.ex
@@ -199,6 +199,7 @@ defmodule HexpmWeb.Session do
   defp not_found(conn) do
     conn
     |> configure_session(renew: true)
+    |> delete_session("session_id")
     |> assign(:current_user, nil)
     |> assign(:current_organization, nil)
   end
@@ -206,6 +207,7 @@ defmodule HexpmWeb.Session do
   defp expired(conn) do
     conn
     |> configure_session(renew: true)
+    |> delete_session("session_id")
     |> assign(:current_user, nil)
     |> assign(:current_organization, nil)
   end

--- a/priv/repo/migrations/20200904184516_alter_sessions.exs
+++ b/priv/repo/migrations/20200904184516_alter_sessions.exs
@@ -1,0 +1,17 @@
+defmodule Hexpm.RepoBase.Migrations.AlterSessions do
+  use Ecto.Migration
+
+  def change do
+    alter table(:sessions) do
+      add(:user_id, references(:users))
+      add(:uuid, :uuid, unique: true)
+      add(:expires_at, :utc_datetime_usec)
+      add(:active, :boolean, default: false)
+    end
+
+    rename(table(:sessions), :token, to: :token_hash)
+    create(unique_index(:sessions, [:token_hash]))
+    create(unique_index(:sessions, [:uuid]))
+    drop(index(:sessions, ["((data->>'user_id')::integer)"]))
+  end
+end

--- a/priv/repo/migrations/20200906160506_alter_session_columns_to_non_nullable.exs
+++ b/priv/repo/migrations/20200906160506_alter_session_columns_to_non_nullable.exs
@@ -1,0 +1,23 @@
+defmodule Hexpm.RepoBase.Migrations.AlterSessionColumnsToNonNullable do
+  use Ecto.Migration
+
+  def up do
+    alter table(:sessions) do
+      modify(:uuid, :uuid, unique: true, null: false)
+      modify(:expires_at, :utc_datetime_usec, null: false)
+      modify(:active, :boolean, default: false, null: false)
+    end
+
+    execute("ALTER TABLE SESSIONS ALTER COLUMN user_id set NOT NULL")
+  end
+
+  def down do
+    alter table(:sessions) do
+      modify(:uuid, :uuid, unique: true, null: true)
+      modify(:expires_at, :utc_datetime_usec, null: true)
+      modify(:active, :boolean, default: false, null: true)
+    end
+
+    execute("ALTER TABLE SESSIONS ALTER COLUMN user_id DROP NOT NULL")
+  end
+end

--- a/test/hexpm_web/controllers/dashboard/email_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/email_controller_test.exs
@@ -102,7 +102,8 @@ defmodule HexpmWeb.Dashboard.EmailControllerTest do
 
     conn = post(build_conn(), "login", %{username: dup_email.email, password: "password"})
     assert redirected_to(conn) == "/users/#{c.user.username}"
-    assert get_session(conn, "user_id") == c.user.id
+    assert get_session(conn, "session_id")
+    assert last_session().user_id == c.user.id
 
     conn =
       build_conn()

--- a/test/hexpm_web/controllers/login_controller_test.exs
+++ b/test/hexpm_web/controllers/login_controller_test.exs
@@ -19,8 +19,8 @@ defmodule HexpmWeb.LoginControllerTest do
     conn = post(build_conn(), "login", %{username: c.user.username, password: "password"})
     assert redirected_to(conn) == "/users/#{c.user.username}"
 
-    assert get_session(conn, "user_id") == c.user.id
-    assert last_session().data["user_id"] == c.user.id
+    assert get_session(conn, "session_id")
+    assert last_session().user_id == c.user.id
   end
 
   @tag :focus
@@ -37,15 +37,16 @@ defmodule HexpmWeb.LoginControllerTest do
     assert redirected_to(conn) == "/users/#{c.user.username}"
 
     conn = conn |> recycle() |> get("/")
-    assert get_session(conn, "user_id") == c.user.id
+    assert get_session(conn, "session_id")
+    assert last_session().user_id == c.user.id
   end
 
   test "log in with wrong password", c do
     conn = post(build_conn(), "login", %{username: c.user.username, password: "WRONG"})
     assert response(conn, 400) =~ "Log in"
     assert get_flash(conn, "error") == "Invalid username, email or password."
-    refute get_session(conn, "user_id")
-    refute last_session().data["user_id"]
+    refute get_session(conn, "session_id")
+    refute last_session()
   end
 
   test "log in with unconfirmed email", c do
@@ -54,8 +55,8 @@ defmodule HexpmWeb.LoginControllerTest do
     conn = post(build_conn(), "login", %{username: c.user.username, password: "password"})
     assert response(conn, 400) =~ "Log in"
     assert get_flash(conn, "error") =~ "Email has not been verified yet."
-    refute get_session(conn, "user_id")
-    refute last_session().data["user_id"]
+    refute get_session(conn, "session_id")
+    refute last_session()
   end
 
   test "log out", c do
@@ -68,8 +69,8 @@ defmodule HexpmWeb.LoginControllerTest do
       |> post("logout")
 
     assert redirected_to(conn) == "/"
-    refute get_session(conn, "user_id")
-    refute last_session().data["user_id"]
+    refute get_session(conn, "session_id")
+    refute last_session()
   end
 
   test "login, create hexdocs key and redirect", c do
@@ -91,8 +92,8 @@ defmodule HexpmWeb.LoginControllerTest do
     assert hd(key.permissions).domain == "docs"
     assert hd(key.permissions).resource == c.organization.name
 
-    assert get_session(conn, "user_id") == c.user.id
-    assert last_session().data["user_id"] == c.user.id
+    assert get_session(conn, "session_id")
+    assert last_session().user_id == c.user.id
   end
 
   test "already logged in, create hexdocs key and redirect", c do

--- a/test/hexpm_web/session_test.exs
+++ b/test/hexpm_web/session_test.exs
@@ -1,0 +1,216 @@
+defmodule HexpmWeb.SessionTest do
+  use HexpmWeb.ConnCase, async: true
+  alias HexpmWeb.Session
+  alias Hexpm.Accounts
+
+  setup do
+    %{
+      user: insert(:user),
+      conn: setup_conn()
+    }
+  end
+
+  test "init/1" do
+    assert HexpmWeb.Session.init([]) == []
+  end
+
+  describe "call/2" do
+    test "when session is found", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+      assert <<session_id::binary>> = conn.private.plug_session["session_id"]
+
+      conn =
+        conn
+        |> fetch_flash()
+        |> Session.call([])
+
+      assert conn.assigns.current_user.id == user.id
+    end
+
+    test "when session is not found", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+      assert <<session_id::binary>> = conn.private.plug_session["session_id"]
+      assert %Plug.Conn{} = conn = Session.delete(conn)
+      refute conn.private.plug_session["id"]
+
+      conn
+      |> fetch_flash()
+      |> Session.call([])
+      |> html_response(302)
+    end
+
+    test "when session is expired", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+      assert <<session_id::binary>> = conn.private.plug_session["session_id"]
+
+      {:ok, session} = HexpmWeb.Session.get(session_id)
+
+      conn
+      |> get("/dashboard/security")
+      |> html_response(200)
+
+      update_expires_at(session, HexpmWeb.Session.max_age() * -1)
+
+      conn
+      |> get("/dashboard/security")
+      |> html_response(302)
+    end
+
+    test "when db session does not exist", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+      assert <<session_id::binary>> = conn.private.plug_session["session_id"]
+      {:ok, session} = HexpmWeb.Session.get(session_id)
+
+      expire_session(session)
+
+      conn
+      |> fetch_flash()
+      |> Session.call([])
+      |> html_response(302)
+    end
+
+    test "when session id is invalid", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+
+      conn
+      |> put_session("session_id", "42")
+      |> fetch_flash()
+      |> Session.call([])
+      |> html_response(302)
+    end
+
+    test "when session token is invalid", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+
+      [session] = Repo.all(Accounts.Session)
+
+      bad_session_str = session.uuid <> Base.url_encode64(:crypto.strong_rand_bytes(64))
+
+      conn
+      |> put_session("session_id", bad_session_str)
+      |> fetch_flash()
+      |> Session.call([])
+      |> html_response(302)
+    end
+  end
+
+  describe "create/1" do
+    test "only expunges expired sessions for the user who is logging in", %{
+      conn: conn,
+      user: user
+    } do
+      data = %{
+        expires_in: 0
+      }
+
+      # 3 expired sessions for user 1
+      for _n <- 1..3, do: insert_session(user, data, Session.gen_token())
+
+      user2 = insert(:user)
+
+      # 3 expired sessions for user 2
+      for _n <- 1..3, do: insert_session(user2, data, Session.gen_token())
+
+      assert session_count() == 6
+
+      assert %Plug.Conn{} = Session.create(conn, user)
+
+      assert session_count() == 4
+    end
+
+    test "when session id not set", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+      assert <<session_id::binary>> = conn.private.plug_session["session_id"]
+      assert %Plug.Conn{} = conn = Session.delete(clear_session(conn))
+      refute conn.private.plug_session["session_id"]
+      assert {:ok, _session} = Session.get(session_id)
+    end
+  end
+
+  describe "delete/1" do
+    test "when session exists", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+      assert <<session_id::binary>> = conn.private.plug_session["session_id"]
+      assert %Plug.Conn{} = conn = Session.delete(conn)
+      refute conn.private.plug_session["session_id"]
+      assert {:error, :no_session} = Session.get(session_id)
+    end
+
+    test "when session id not set", %{conn: conn, user: user} do
+      assert %Plug.Conn{} = conn = Session.create(conn, user)
+      assert <<session_id::binary>> = conn.private.plug_session["session_id"]
+      assert %Plug.Conn{} = conn = Session.delete(clear_session(conn))
+      refute conn.private.plug_session["session_id"]
+      assert {:ok, _session} = Session.get(session_id)
+    end
+  end
+
+  describe "get/1" do
+    test "existing session", %{user: user} do
+      token = HexpmWeb.Session.gen_token()
+
+      data = %{
+        expires_in: 42
+      }
+
+      session = insert_session(user, data, token)
+      session_id = HexpmWeb.Session.to_id(session, token)
+      assert {:ok, %Accounts.Session{} = got_session} = HexpmWeb.Session.get(session_id)
+      assert got_session.expires_at == session.expires_at
+    end
+
+    test "get/1 when session has_expired", %{user: user} do
+      token = HexpmWeb.Session.gen_token()
+
+      data = %{
+        expires_in: 0
+      }
+
+      session = insert_session(user, data, token)
+
+      session_id = HexpmWeb.Session.to_id(session, token)
+
+      assert {:error, :expired} = HexpmWeb.Session.get(session_id)
+    end
+  end
+
+  defp setup_conn() do
+    build_conn()
+    |> Plug.Test.init_test_session(%{})
+    |> fetch_session()
+    |> fetch_query_params()
+    |> put_req_header("content-type", "text/html")
+    |> put_req_header("user-agent", "eh?")
+  end
+
+  defp shift_expires_at(session, seconds) do
+    DateTime.add(session.expires_at, seconds, :second)
+  end
+
+  defp update_expires_at(session, seconds) do
+    expires_at = shift_expires_at(session, seconds)
+
+    Repo.query!("UPDATE SESSIONS set expires_at = $1 where id = $2", [
+      expires_at,
+      session.id
+    ])
+  end
+
+  defp session_count() do
+    Accounts.Session
+    |> Repo.all()
+    |> Enum.count()
+  end
+
+  defp expire_session(session) do
+    session
+    |> Hexpm.Accounts.Session.expire()
+    |> Repo.update!()
+  end
+
+  defp insert_session(user, params, token) do
+    user
+    |> Accounts.Session.build(params, token)
+    |> Repo.insert!()
+  end
+end

--- a/test/hexpm_web/session_test.exs
+++ b/test/hexpm_web/session_test.exs
@@ -19,10 +19,7 @@ defmodule HexpmWeb.SessionTest do
       assert %Plug.Conn{} = conn = Session.create(conn, user)
       assert <<session_id::binary>> = conn.private.plug_session["session_id"]
 
-      conn =
-        conn
-        |> fetch_flash()
-        |> Session.call([])
+      conn = Session.call(conn, [])
 
       assert conn.assigns.current_user.id == user.id
     end
@@ -33,10 +30,7 @@ defmodule HexpmWeb.SessionTest do
       assert %Plug.Conn{} = conn = Session.delete(conn)
       refute conn.private.plug_session["session_id"]
 
-      conn =
-        conn
-        |> fetch_flash()
-        |> Session.call([])
+      conn = Session.call(conn, [])
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
@@ -67,10 +61,7 @@ defmodule HexpmWeb.SessionTest do
 
       expire_session(session)
 
-      conn =
-        conn
-        |> fetch_flash()
-        |> Session.call([])
+      conn = Session.call(conn, [])
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
@@ -83,7 +74,6 @@ defmodule HexpmWeb.SessionTest do
       conn =
         conn
         |> put_session("session_id", "42")
-        |> fetch_flash()
         |> Session.call([])
 
       refute conn.assigns.current_user
@@ -98,7 +88,6 @@ defmodule HexpmWeb.SessionTest do
       conn =
         conn
         |> put_session("session_id", bad_session_id)
-        |> fetch_flash()
         |> Session.call([])
 
       refute conn.assigns.current_user
@@ -116,7 +105,6 @@ defmodule HexpmWeb.SessionTest do
       conn =
         conn
         |> put_session("session_id", bad_session_str)
-        |> fetch_flash()
         |> Session.call([])
 
       refute conn.assigns.current_user

--- a/test/hexpm_web/session_test.exs
+++ b/test/hexpm_web/session_test.exs
@@ -33,10 +33,13 @@ defmodule HexpmWeb.SessionTest do
       assert %Plug.Conn{} = conn = Session.delete(conn)
       refute conn.private.plug_session["id"]
 
-      conn
-      |> fetch_flash()
-      |> Session.call([])
-      |> html_response(302)
+      conn =
+        conn
+        |> fetch_flash()
+        |> Session.call([])
+
+      refute conn.assigns.current_user
+      refute conn.assigns.current_organization
     end
 
     test "when session is expired", %{conn: conn, user: user} do
@@ -63,20 +66,26 @@ defmodule HexpmWeb.SessionTest do
 
       expire_session(session)
 
-      conn
-      |> fetch_flash()
-      |> Session.call([])
-      |> html_response(302)
+      conn =
+        conn
+        |> fetch_flash()
+        |> Session.call([])
+
+      refute conn.assigns.current_user
+      refute conn.assigns.current_organization
     end
 
     test "when session id is invalid", %{conn: conn, user: user} do
       assert %Plug.Conn{} = conn = Session.create(conn, user)
 
-      conn
-      |> put_session("session_id", "42")
-      |> fetch_flash()
-      |> Session.call([])
-      |> html_response(302)
+      conn =
+        conn
+        |> put_session("session_id", "42")
+        |> fetch_flash()
+        |> Session.call([])
+
+      refute conn.assigns.current_user
+      refute conn.assigns.current_organization
     end
 
     test "when session token is invalid", %{conn: conn, user: user} do
@@ -86,11 +95,14 @@ defmodule HexpmWeb.SessionTest do
 
       bad_session_str = session.uuid <> Base.url_encode64(:crypto.strong_rand_bytes(64))
 
-      conn
-      |> put_session("session_id", bad_session_str)
-      |> fetch_flash()
-      |> Session.call([])
-      |> html_response(302)
+      conn =
+        conn
+        |> put_session("session_id", bad_session_str)
+        |> fetch_flash()
+        |> Session.call([])
+
+      refute conn.assigns.current_user
+      refute conn.assigns.current_organization
     end
   end
 

--- a/test/hexpm_web/session_test.exs
+++ b/test/hexpm_web/session_test.exs
@@ -31,7 +31,7 @@ defmodule HexpmWeb.SessionTest do
       assert %Plug.Conn{} = conn = Session.create(conn, user)
       assert <<session_id::binary>> = conn.private.plug_session["session_id"]
       assert %Plug.Conn{} = conn = Session.delete(conn)
-      refute conn.private.plug_session["id"]
+      refute conn.private.plug_session["session_id"]
 
       conn =
         conn
@@ -40,6 +40,7 @@ defmodule HexpmWeb.SessionTest do
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
+      refute conn.private.plug_session["session_id"]
     end
 
     test "when session is expired", %{conn: conn, user: user} do
@@ -73,6 +74,7 @@ defmodule HexpmWeb.SessionTest do
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
+      refute conn.private.plug_session["session_id"]
     end
 
     test "when session id is invalid", %{conn: conn, user: user} do
@@ -86,6 +88,7 @@ defmodule HexpmWeb.SessionTest do
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
+      refute conn.private.plug_session["session_id"]
 
       # Right length, but not a UUID
       bogus_id = Base.url_encode64(:crypto.strong_rand_bytes(26))
@@ -100,6 +103,7 @@ defmodule HexpmWeb.SessionTest do
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
+      refute conn.private.plug_session["session_id"]
     end
 
     test "when session token is invalid", %{conn: conn, user: user} do
@@ -117,6 +121,7 @@ defmodule HexpmWeb.SessionTest do
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
+      refute conn.private.plug_session["session_id"]
     end
   end
 

--- a/test/hexpm_web/session_test.exs
+++ b/test/hexpm_web/session_test.exs
@@ -86,6 +86,20 @@ defmodule HexpmWeb.SessionTest do
 
       refute conn.assigns.current_user
       refute conn.assigns.current_organization
+
+      # Right length, but not a UUID
+      bogus_id = Base.url_encode64(:crypto.strong_rand_bytes(26))
+
+      bad_session_id = bogus_id <> Base.url_encode64(:crypto.strong_rand_bytes(64))
+
+      conn =
+        conn
+        |> put_session("session_id", bad_session_id)
+        |> fetch_flash()
+        |> Session.call([])
+
+      refute conn.assigns.current_user
+      refute conn.assigns.current_organization
     end
 
     test "when session token is invalid", %{conn: conn, user: user} do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -40,13 +40,15 @@ defmodule HexpmWeb.ConnCase do
   end
 
   def test_login(conn, user) do
-    Plug.Test.init_test_session(conn, %{"user_id" => user.id})
+    conn
+    |> Plug.Test.init_test_session(%{})
+    |> HexpmWeb.Session.create(user)
   end
 
   def last_session() do
     import Ecto.Query
 
-    from(s in Hexpm.Accounts.Session, order_by: [desc: s.id], limit: 1)
+    from(s in Hexpm.Accounts.Session, where: [active: true], order_by: [desc: s.id], limit: 1)
     |> Hexpm.Repo.one()
   end
 


### PR DESCRIPTION
- Switch from Plug.Session adapter to a more manual approach for
  handling database sessions

- Make default session store in HexpmWeb.Endpoint cookie

- Add encryption_salt for the cookie session

- Alter sessions table to add user_id, uuid, expires_at, and active
columns

- Update tests as needed