### PR TITLE
Fix Elixir Forum url

### DIFF
--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -19,7 +19,7 @@ defmodule Hexpm.Accounts.UserHandles do
     [
       {:twitter, "Twitter", "https://twitter.com/{handle}"},
       {:github, "GitHub", "https://github.com/{handle}"},
-      {:elixirforum, "Elixir Forum", "https://elixirforum.com/users/{handle}"},
+      {:elixirforum, "Elixir Forum", "https://elixirforum.com/u/{handle}"},
       {:freenode, "Freenode", "irc://chat.freenode.net/elixir-lang"},
       {:slack, "Slack", "https://elixir-slackin.herokuapp.com/"}
     ]
@@ -43,7 +43,7 @@ defmodule Hexpm.Accounts.UserHandles do
 
   def handle(:twitter, handle), do: unuri(handle, "twitter.com", "/")
   def handle(:github, handle), do: unuri(handle, "github.com", "/")
-  def handle(:elixirforum, handle), do: unuri(handle, "elixirforum.com", "/users/")
+  def handle(:elixirforum, handle), do: unuri(handle, "elixirforum.com", "/u/")
   def handle(_service, handle), do: handle
 
   defp unuri(handle, host, path) do

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -63,7 +63,7 @@
               <div class="form-group">
                 <%= label f, :elixirforum, "Elixir Forum" %>
                 <div class="input-group">
-                  <div class="input-group-addon">elixirforum.com/users/</div>
+                  <div class="input-group-addon">elixirforum.com/u/</div>
                   <%= ViewHelpers.text_input f, :elixirforum, placeholder: "organization_elixir_forum_id" %>
                 </div>
                 <%= ViewHelpers.error_tag f, :elixirforum %>

--- a/lib/hexpm_web/templates/dashboard/profile/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/profile/index.html.eex
@@ -70,7 +70,7 @@
             <div class="form-group">
               <%= label f, :elixirforum, "Elixir Forum" %>
               <div class="input-group">
-                <div class="input-group-addon">elixirforum.com/users/</div>
+                <div class="input-group-addon">elixirforum.com/u/</div>
                 <%= ViewHelpers.text_input f, :elixirforum, placeholder: "your_elixir_forum_id" %>
               </div>
               <%= ViewHelpers.error_tag f, :elixirforum %>


### PR DESCRIPTION
The url for profile on Elixir Forum is `https://elixirforum.com/u/{username}`, for example, https://elixirforum.com/u/goofansu.