### PR TITLE
update rebar3 links for new docs layout

### DIFF
--- a/lib/hexpm_web/controllers/docs_controller.ex
+++ b/lib/hexpm_web/controllers/docs_controller.ex
@@ -65,7 +65,7 @@ defmodule HexpmWeb.DocsController do
   end
 
   def rebar3_tasks(conn, _params) do
-    redirect(conn, external: "https://rebar3.org/docs/hex_package_management/")
+    redirect(conn, external: "https://www.rebar3.org/docs/package_management/hex_package_management/)
   end
 
   def private(conn, _params) do

--- a/lib/hexpm_web/controllers/docs_controller.ex
+++ b/lib/hexpm_web/controllers/docs_controller.ex
@@ -65,7 +65,7 @@ defmodule HexpmWeb.DocsController do
   end
 
   def rebar3_tasks(conn, _params) do
-    redirect(conn, external: "https://www.rebar3.org/docs/package_management/hex_package_management/)
+    redirect(conn, external: "https://www.rebar3.org/docs/package_management/hex_package_management/")
   end
 
   def private(conn, _params) do

--- a/lib/hexpm_web/controllers/docs_controller.ex
+++ b/lib/hexpm_web/controllers/docs_controller.ex
@@ -65,7 +65,8 @@ defmodule HexpmWeb.DocsController do
   end
 
   def rebar3_tasks(conn, _params) do
-    redirect(conn, external: "https://www.rebar3.org/docs/package_management/hex_package_management/")
+    url = "https://www.rebar3.org/docs/package_management/hex_package_management/"
+    redirect(conn, external: url)
   end
 
   def private(conn, _params) do

--- a/lib/hexpm_web/templates/docs/layout.html.eex
+++ b/lib/hexpm_web/templates/docs/layout.html.eex
@@ -10,7 +10,7 @@
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_usage) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_usage) %>">Usage</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_publish) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_publish) %>">Publishing packages</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_private) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_private) %>">Private packages</a></li>
-      <li class="sidebar-item"><a target="_blank" rel="noopener" href="https://rebar3.org/docs/hex_package_management/">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
+      <li class="sidebar-item"><a target="_blank" rel="noopener" href="https://www.rebar3.org/docs/package_management/hex_package_management/">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
       <li class="sidebar-header">Hex</li>
       <li class="sidebar-item <%= selected_docs(@conn, :faq) %>"><a href="<%= Routes.docs_path(Endpoint, :faq) %>">FAQ</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :mirrors) %>"><a href="<%= Routes.docs_path(Endpoint, :mirrors) %>">Mirrors</a></li>

--- a/lib/hexpm_web/templates/docs/mirrors.html.md
+++ b/lib/hexpm_web/templates/docs/mirrors.html.md
@@ -10,7 +10,7 @@ To permanently select a mirror, simply run the following command in a shell sess
 
 **Mix Example**: `$ mix hex.config mirror_url https://repo.hex.pm`
 
-**Rebar3 Example**: Add to the global or a project's top level `rebar.config`, `{rebar_packages_cdn, "https://repo.hex.pm"}.`. For more information see rebar3's package support and configuration [documentation](https://rebar3.org/docs/dependencies/).
+**Rebar3 Example**: Add to the global or a project's top level `rebar.config`, `{rebar_packages_cdn, "https://repo.hex.pm"}.`. For more information see rebar3's package support and configuration [documentation](https://www.rebar3.org/docs/configuration/dependencies/).
 
 To temporarily select a mirror, Hex commands can be prefixed with an environment variable in the shell.
 

--- a/lib/hexpm_web/templates/docs/rebar3_publish.html.md
+++ b/lib/hexpm_web/templates/docs/rebar3_publish.html.md
@@ -139,4 +139,4 @@ Please test your package after publishing by adding it as dependency to a rebar3
 
 When running the command to publish a package, Hex will create a tar file of all the files and directories listed in the `files` property. When the tarball has been pushed to the Hex servers, it will be uploaded to a CDN for fast and reliable access for users. Hex will also recompile the registry file that all clients will update automatically when fetching dependencies.
 
-The [rebar3 hex plugin's documentation](https://rebar3.org/docs/hex_package_management/) contains more information about the hex plugin itself and publishing packages.
+The [rebar3 hex plugin's documentation](https://www.rebar3.org/docs/package_management/hex_package_management/) contains more information about the hex plugin itself and publishing packages.

--- a/lib/hexpm_web/templates/docs/rebar3_usage.html.md
+++ b/lib/hexpm_web/templates/docs/rebar3_usage.html.md
@@ -16,7 +16,7 @@ Hex packages as dependencies are supported by rebar3 even without the plugin. Th
 ]}.
 ```
 
-For more information on dependencies and using rebar3 see the [rebar3 documentation](https://www.rebar3.org/docs/dependencies).
+For more information on dependencies and using rebar3 see the [rebar3 documentation](https://www.rebar3.org/docs/configuration/dependencies/).
 
 ### Fetching dependencies
 


### PR DESCRIPTION
We've updated the layout of rebar3.org documentation, so this PR updates links to go to the proper docs.