### PR TITLE
Update list of reserved names

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -32,7 +32,7 @@ defmodule Hexpm.Repository.Package do
     webtool wx xmerl
   )
   @inets_names ~w(ftp tftp httpc httpd http_uri)
-  @app_names ~w(firenest toucan net http net_http mint_pool)
+  @app_names ~w(toucan exla nx nex next net http net_http mint_pool)
   @windows_names ~w(
     nul con prn aux com1 com2 com3 com4 com5 com6 com7 com8 com9 lpt1 lpt2
     lpt3 lpt4 lpt5 lpt6 lpt7 lpt8 lpt9


### PR DESCRIPTION
Firenest is not happening for now.
Instead reserve numerical namespace.