### PR TITLE
Add Preview icon on version lines

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,6 +5,7 @@ config :hexpm,
   private_key: File.read!("test/fixtures/private.pem"),
   docs_url: "http://localhost:4002",
   diff_url: "http://localhost:4004",
+  preview_url: "http://localhost:4005",
   cdn_url: "http://localhost:4000",
   billing_url: "http://localhost:4001",
   billing_key: "hex_billing_key"

--- a/config/hex.exs
+++ b/config/hex.exs
@@ -6,6 +6,7 @@ config :hexpm,
   user_confirm: false,
   docs_url: "http://localhost:4043",
   diff_url: "http://localhost:4004",
+  preview_url: "http://localhost:4005",
   cdn_url: "http://localhost:4043"
 
 config :hexpm, HexpmWeb.Endpoint,

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -12,6 +12,7 @@ if config_env() == :prod do
     logs_bucket: System.fetch_env!("HEXPM_LOGS_BUCKET"),
     docs_url: System.fetch_env!("HEXPM_DOCS_URL"),
     diff_url: System.fetch_env!("HEXPM_DIFF_URL"),
+    preview_url: System.fetch_env!("HEXPM_PREVIEW_URL"),
     cdn_url: System.fetch_env!("HEXPM_CDN_URL"),
     email_host: System.fetch_env!("HEXPM_EMAIL_HOST"),
     ses_rate: System.fetch_env!("HEXPM_SES_RATE"),

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,6 +8,7 @@ config :hexpm,
   cdn_url: "http://localhost:5000",
   docs_url: "http://localhost:5002",
   diff_url: "http://localhost:5004",
+  preview_url: "http://localhost:5005",
   billing_impl: Hexpm.Billing.Mock,
   pwned_impl: Hexpm.Pwned.Mock
 

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -275,6 +275,11 @@ defmodule Hexpm.Utils do
     "#{diff_url}/diff/#{package_name}/#{previous_version}..#{version}"
   end
 
+  def preview_html_url(package_name, version) do
+    preview_url = Application.fetch_env!(:hexpm, :preview_url)
+    "#{preview_url}/preview/#{package_name}/#{version}"
+  end
+
   @doc """
   Returns a RFC 2822 format string from a UTC datetime.
   """

--- a/lib/hexpm_web/templates/package/versions.html.eex
+++ b/lib/hexpm_web/templates/package/versions.html.eex
@@ -21,6 +21,7 @@ version_map = Enum.map(@all_releases, & &1.version)
           <a href="<%= raw Hexpm.Utils.diff_html_url(@package.name, release.version, previous_version) %>" title="Diff"><%= icon(:octicon, :diff) %></a>
         <% end %>
       <% end %>
+        <a href="<%= raw Hexpm.Utils.preview_html_url(@package.name, release.version) %>" title="Preview"><%= icon(:octicon, :code) %></a>
     <% end %>
   </li>
 <% end %>


### PR DESCRIPTION
This adds an additional octicon link on the version lines on `packages/<package name>` that links to `http://localhost:4005/preview/<package name>/<version>`
![Screenshot from 2021-01-24 20-09-06](https://user-images.githubusercontent.com/1919781/105658034-e6732f80-5e82-11eb-8eeb-2c069a14f5d7.png)

I tried to use the [code-review octicon](https://primer.style/octicons/code-review-16), but ended up using the [code octicon](https://primer.style/octicons/code-16) after realizing that `code-review` is not in `assets/vendor/icons/octicons.svg`.