### PR TITLE
Fix github action name

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: 23.1.1
           elixir-version: 1.11.0
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: 23.1.1
           elixir-version: 1.11.0
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
-        uses: actions/setup-elixir@v1
+        uses: erlef/setup-elixir@v1
         with:
           otp-version: 23.1.1
           elixir-version: 1.11.0


### PR DESCRIPTION
The CI seems to be breaking https://github.com/hexpm/hexpm/runs/1853646204.

Updating to use the new action seems to solve the issue.