### PR TITLE
Allow user to leave organization 

### DIFF
--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -71,9 +71,15 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
 
       case Organizations.remove_member(organization, user, audit: audit_data(conn)) do
         :ok ->
-          conn
-          |> put_flash(:info, "User #{username} has been removed from the organization.")
-          |> redirect(to: Routes.organization_path(conn, :show, organization))
+          if user.id == conn.assigns.current_user.id do
+            conn
+            |> put_flash(:info, "You just left the the organization #{organization.name}.")
+            |> redirect(to: Routes.profile_path(conn, :index))
+          else
+            conn
+            |> put_flash(:info, "User #{username} has been removed from the organization.")
+            |> redirect(to: Routes.organization_path(conn, :show, organization))
+          end
 
         {:error, :last_member} ->
           conn

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -120,9 +120,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
   end
 
   def leave(conn, %{
-    "dashboard_org" => organization,
-    "organization_name" => organization_name
-    }) do
+        "dashboard_org" => organization,
+        "organization_name" => organization_name
+      }) do
     access_organization(conn, organization, "read", fn organization ->
       if organization.name == organization_name do
         current_user = conn.assigns.current_user

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -169,6 +169,7 @@ defmodule HexpmWeb.Router do
     get "/repos/*glob", OrganizationController, :redirect_repo
     get "/orgs/:dashboard_org", OrganizationController, :show
     post "/orgs/:dashboard_org", OrganizationController, :update
+    post "/orgs/:dashboard_org/leave", OrganizationController, :leave
     post "/orgs/:dashboard_org/billing-token", OrganizationController, :billing_token
     post "/orgs/:dashboard_org/cancel-billing", OrganizationController, :cancel_billing
     post "/orgs/:dashboard_org/update-billing", OrganizationController, :update_billing

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -128,7 +128,7 @@
                   <%= form_tag Routes.organization_path(Endpoint, :update, @organization), class: "remove-role" do %>
                     <input type="hidden" name="action" value="remove_member">
                     <input type="hidden" name="organization_user[username]" value="<%= organization_user.user.username %>">
-                    <%= submit "Remove", class: "btn btn-danger" %>
+                    <%= submit "Remove", class: "btn btn-danger", disabled: organization_user.user.id == @current_user.id %>
                   <% end %>
               </div>
             </div>
@@ -414,6 +414,22 @@
       <% end %>
     </div>
   </div>
+
+  <div class="col-sm-9 organization">
+    <div class="panel panel-danger">
+    <div class="panel-heading">Danger zone</div>
+      <ul class="list-group clearfix">
+        <li class="list-group-item clearfix" style="display: flex; flex-direction: row; align-items: center;">
+          <div style="flex: 1">
+            <p><strong>Leave organization</strong></p>
+            <p>Once you leave the organization there is no going back, please be certain.</p>
+          </div>
+          <button type="button" class="btn btn-danger" data-toggle="modal" data-target="#leave-organization">
+            Leave this organization
+          </button>
+        </li>
+      </ul>
+  </div>
 </div>
 
 <div class="modal fade" id="change-plan" tabindex="-1" role="dialog" >
@@ -457,6 +473,28 @@
           <button type="submit" class="btn btn-primary">Change plan</button>
         <% end %>
       </div>
+    </div>
+  </div>
+</div>
+
+<div class="modal fade" id="leave-organization" tabindex="-1" role="dialog">
+  <div class="modal-dialog" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+        <h4 class="modal-title">Leave organization</h4>
+      </div>
+      <%= form_tag Routes.organization_path(Endpoint, :leave, @organization) do %>
+        <div class="modal-body">
+          <p>This action cannot be undone. You will permanently leave the organization <strong><%= @organization.name %>.</p>
+          <p>Please type <strong><%= @organization.name %></strong> to confirm.</p>
+          <input type="text" name="organization_name" style="width: 100%; margin-top: 15px;" autocomplete="off" required>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+          <%= submit "Leave", class: "btn btn-danger" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -128,7 +128,7 @@
                   <%= form_tag Routes.organization_path(Endpoint, :update, @organization), class: "remove-role" do %>
                     <input type="hidden" name="action" value="remove_member">
                     <input type="hidden" name="organization_user[username]" value="<%= organization_user.user.username %>">
-                    <%= submit "Remove", class: "btn btn-danger", disabled: organization_user.user.id == @current_user.id %>
+                    <%= submit "Remove", class: "btn btn-danger" %>
                   <% end %>
               </div>
             </div>

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -156,24 +156,6 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     refute Repo.get_by(assoc(organization, :organization_users), user_id: new_user.id)
   end
 
-  test "leave organization", %{user: user, organization: organization} do
-    insert(:organization_user, organization: organization, user: user, role: "admin")
-    new_user = insert(:user)
-    insert(:organization_user, organization: organization, user: new_user)
-    params = %{"username" => user.username}
-
-    conn =
-      build_conn()
-      |> test_login(user)
-      |> post("dashboard/orgs/#{organization.name}", %{
-        "action" => "remove_member",
-        "organization_user" => params
-      })
-
-    assert redirected_to(conn) == "/dashboard/profile"
-    refute Repo.get_by(assoc(organization, :organization_users), user_id: user.id)
-  end
-
   test "change role of member in organization", %{user: user, organization: organization} do
     insert(:organization_user, organization: organization, user: user, role: "admin")
     new_user = insert(:user)
@@ -191,6 +173,21 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     assert redirected_to(conn) == "/dashboard/orgs/#{organization.name}"
     assert repo_user = Repo.get_by(assoc(organization, :organization_users), user_id: new_user.id)
     assert repo_user.role == "read"
+  end
+
+  test "leave organization", %{user: user, organization: organization} do
+    insert(:organization_user, organization: organization, user: user, role: "admin")
+    new_user = insert(:user)
+    insert(:organization_user, organization: organization, user: new_user, role: "admin")
+    params = %{"organization_name" => organization.name}
+
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> post("dashboard/orgs/#{organization.name}/leave", params)
+
+    assert redirected_to(conn) == "/dashboard/profile"
+    refute Repo.get_by(assoc(organization, :organization_users), user_id: user.id)
   end
 
   describe "update payment method" do

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -156,6 +156,24 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     refute Repo.get_by(assoc(organization, :organization_users), user_id: new_user.id)
   end
 
+  test "leave organization", %{user: user, organization: organization} do
+    insert(:organization_user, organization: organization, user: user, role: "admin")
+    new_user = insert(:user)
+    insert(:organization_user, organization: organization, user: new_user)
+    params = %{"username" => user.username}
+
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> post("dashboard/orgs/#{organization.name}", %{
+        "action" => "remove_member",
+        "organization_user" => params
+      })
+
+    assert redirected_to(conn) == "/dashboard/profile"
+    refute Repo.get_by(assoc(organization, :organization_users), user_id: user.id)
+  end
+
   test "change role of member in organization", %{user: user, organization: organization} do
     insert(:organization_user, organization: organization, user: user, role: "admin")
     new_user = insert(:user)


### PR DESCRIPTION
Closes #991

Enable the `remove from organization` button, even for the current user, allowing a user to remove itself from a organization. The user is then redirected to the profile page.

![image](https://user-images.githubusercontent.com/13632762/109437844-f93ece00-7a05-11eb-85b5-7f82f04109c2.png)
![image](https://user-images.githubusercontent.com/13632762/109437849-ffcd4580-7a05-11eb-9297-78eee091ca70.png)
