### PR TITLE
Add erlang as reserved package name.

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -20,8 +20,8 @@ defmodule Hexpm.Repository.Package do
     embeds_one :meta, PackageMetadata, on_replace: :delete
   end
 
-  @elixir_names ~w(eex elixir ex_unit iex logger mix)
-  @tool_names ~w(erlang rebar rebar3 hex hexpm mix_hex)
+  @elixir_names ~w(eex elixir elixirc ex_unit iex logger mix)
+  @tool_names ~w(erlang typer to_erl run_erl escript erlc erl epmd dialyzer ct_run rebar rebar3 hex hexpm mix_hex)
   @otp_names ~w(
     appmon asn1 common_test compiler cosEvent cosEventDomain cosFileTransfer
     cosNotification cosProperty cosTime cosTransactions crypto debugger

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -21,7 +21,7 @@ defmodule Hexpm.Repository.Package do
   end
 
   @elixir_names ~w(eex elixir ex_unit iex logger mix)
-  @tool_names ~w(rebar rebar3 hex hexpm mix_hex)
+  @tool_names ~w(erlang rebar rebar3 hex hexpm mix_hex)
   @otp_names ~w(
     appmon asn1 common_test compiler cosEvent cosEventDomain cosFileTransfer
     cosNotification cosProperty cosTime cosTransactions crypto debugger


### PR DESCRIPTION
I accidentally pushed my package to the "erlang" namespace last week when going through an Erlang/Mix tutorial 😬 

The url `https://hex.pm/packages/erlang` seems easily phishable, so I propose adding it to the list of reserved names.

Should other commands be added too? e.g. erl, erlc, escript, etc.