### PR TITLE
Fix link to coc.html.md

### DIFF
--- a/lib/hexpm_web/templates/policy/coc.html.md
+++ b/lib/hexpm_web/templates/policy/coc.html.md
@@ -82,7 +82,7 @@ You are also encouraged to contact us if you are curious about something that mi
 
 ### Changes
 
-This is a living document and may be updated from time to time. Please refer to the [git history](https://github.com/hexpm/hexpm/blob/main/lib/hexpm/web/templates/policy/coc.html.md) for this document to view the changes.
+This is a living document and may be updated from time to time. Please refer to the [git history](https://github.com/hexpm/hexpm/blob/main/lib/hexpm_web/templates/policy/coc.html.md) for this document to view the changes.
 
 ### Credit and License
 


### PR DESCRIPTION
Provided correct link to 'templates/policy/coc.html.md'