### PR TITLE
Drop www subdomain for rebar3 links

### DIFF
--- a/lib/hexpm_web/controllers/docs_controller.ex
+++ b/lib/hexpm_web/controllers/docs_controller.ex
@@ -65,7 +65,7 @@ defmodule HexpmWeb.DocsController do
   end
 
   def rebar3_tasks(conn, _params) do
-    url = "https://www.rebar3.org/docs/package_management/hex_package_management/"
+    url = "https://rebar3.org/docs/package_management/hex_package_management/"
     redirect(conn, external: url)
   end
 

--- a/lib/hexpm_web/templates/blog/003-hex-v0.18-released.html.md
+++ b/lib/hexpm_web/templates/blog/003-hex-v0.18-released.html.md
@@ -22,6 +22,6 @@ By passing the `--yes` flag to `mix hex.publish` you can publish your package (t
 
 This release focused on workflow improvements when working in CI environments and running commands that requires authentication. Users that have private packages will have better security because they can use specialized keys for their organizations.
 
-The work of moving functionality from the Hex client to [hex_core](https://github.com/hexpm/hex_core) is ongoing. hex_core is an effort started by Hex team member Wojtek Mach, the idea is to move the core functionality needed to create a Hex package manager client to a common Erlang library. This reduces duplicate development effort and will allow tools such as [rebar3](https://www.rebar3.org/) and [erlang.mk](https://erlang.mk/) to stay up to date with the latest changes and improvements to Hex.
+The work of moving functionality from the Hex client to [hex_core](https://github.com/hexpm/hex_core) is ongoing. hex_core is an effort started by Hex team member Wojtek Mach, the idea is to move the core functionality needed to create a Hex package manager client to a common Erlang library. This reduces duplicate development effort and will allow tools such as [rebar3](https://rebar3.org/) and [erlang.mk](https://erlang.mk/) to stay up to date with the latest changes and improvements to Hex.
 
 Next up for the core team is releasing private HexDocs and adding annual billing for organizations. The full list of changes for Hex v0.18.0 is available in our [release notes](https://github.com/hexpm/hex/releases/tag/v0.18.0).

--- a/lib/hexpm_web/templates/docs/layout.html.eex
+++ b/lib/hexpm_web/templates/docs/layout.html.eex
@@ -10,7 +10,7 @@
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_usage) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_usage) %>">Usage</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_publish) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_publish) %>">Publishing packages</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :rebar3_private) %>"><a href="<%= Routes.docs_path(Endpoint, :rebar3_private) %>">Private packages</a></li>
-      <li class="sidebar-item"><a target="_blank" rel="noopener" href="https://www.rebar3.org/docs/package_management/hex_package_management/">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
+      <li class="sidebar-item"><a target="_blank" rel="noopener" href="https://rebar3.org/docs/package_management/hex_package_management/">Tasks <%= icon(:glyphicon, "new-window") %></a></li>
       <li class="sidebar-header">Hex</li>
       <li class="sidebar-item <%= selected_docs(@conn, :faq) %>"><a href="<%= Routes.docs_path(Endpoint, :faq) %>">FAQ</a></li>
       <li class="sidebar-item <%= selected_docs(@conn, :self_hosting) %>"><a href="<%= Routes.docs_path(Endpoint, :self_hosting) %>">Self-hosting</a></li>

--- a/lib/hexpm_web/templates/docs/mirrors.html.md
+++ b/lib/hexpm_web/templates/docs/mirrors.html.md
@@ -10,7 +10,7 @@ To permanently select a mirror, simply run the following command in a shell sess
 
 **Mix Example**: `$ mix hex.config mirror_url https://repo.hex.pm`
 
-**Rebar3 Example**: Add to the global or a project's top level `rebar.config`, `{rebar_packages_cdn, "https://repo.hex.pm"}.`. For more information see rebar3's package support and configuration [documentation](https://www.rebar3.org/docs/configuration/dependencies/).
+**Rebar3 Example**: Add to the global or a project's top level `rebar.config`, `{rebar_packages_cdn, "https://repo.hex.pm"}.`. For more information see rebar3's package support and configuration [documentation](https://rebar3.org/docs/configuration/dependencies/).
 
 To temporarily select a mirror, Hex commands can be prefixed with an environment variable in the shell.
 

--- a/lib/hexpm_web/templates/docs/rebar3_publish.html.md
+++ b/lib/hexpm_web/templates/docs/rebar3_publish.html.md
@@ -139,4 +139,4 @@ Please test your package after publishing by adding it as dependency to a rebar3
 
 When running the command to publish a package, Hex will create a tar file of all the files and directories listed in the `files` property. When the tarball has been pushed to the Hex servers, it will be uploaded to a CDN for fast and reliable access for users. Hex will also recompile the registry file that all clients will update automatically when fetching dependencies.
 
-The [rebar3 hex plugin's documentation](https://www.rebar3.org/docs/package_management/hex_package_management/) contains more information about the hex plugin itself and publishing packages.
+The [rebar3 hex plugin's documentation](https://rebar3.org/docs/package_management/hex_package_management/) contains more information about the hex plugin itself and publishing packages.

--- a/lib/hexpm_web/templates/docs/rebar3_usage.html.md
+++ b/lib/hexpm_web/templates/docs/rebar3_usage.html.md
@@ -16,7 +16,7 @@ Hex packages as dependencies are supported by rebar3 even without the plugin. Th
 ]}.
 ```
 
-For more information on dependencies and using rebar3 see the [rebar3 documentation](https://www.rebar3.org/docs/configuration/dependencies/).
+For more information on dependencies and using rebar3 see the [rebar3 documentation](https://rebar3.org/docs/configuration/dependencies/).
 
 ### Fetching dependencies
 

--- a/lib/hexpm_web/templates/page/about.html.eex
+++ b/lib/hexpm_web/templates/page/about.html.eex
@@ -3,7 +3,7 @@
 <p>
   Hex is a package manager for the BEAM ecosystem, any language that compiles to run on the BEAM VM, such as <a href="https://elixir-lang.org/">Elixir</a> and <a href="http://www.erlang.org/">Erlang</a>, can be used to build Hex packages.
   Hex consists of the <a href="https://github.com/hexpm/specifications/blob/main/http_api.md">HTTP API</a>, <a href="/">this website</a>, the repository serving packages and indexes, <a href="https://hexdocs.pm">HexDocs</a>, the <a href="https://github.com/hexpm/hex">Mix build-tool integration</a>, and <a href="https://github.com/hexpm">other services</a>.
-  Many build tools support Hex packages including <a href="https://hexdocs.pm/mix">Mix</a> for Elixir projects, <a href="https://www.rebar3.org/">Rebar</a> and <a href="https://erlang.mk/">erlang.mk</a> for Erlang projects.
+  Many build tools support Hex packages including <a href="https://hexdocs.pm/mix">Mix</a> for Elixir projects, <a href="https://rebar3.org/">Rebar</a> and <a href="https://erlang.mk/">erlang.mk</a> for Erlang projects.
 </p>
 
 <p>


### PR DESCRIPTION
Something's kind of not working great with the redirect to drop the
subdomain (which I have no control over) so this instead prevents
display issues people get when coming off of the hex website.

Reference: https://github.com/tsloughter/rebar3.org/issues/76#issuecomment-845543555