### PR TITLE
Removes reference to elixir IRC channel

### DIFF
--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -20,7 +20,7 @@ defmodule Hexpm.Accounts.UserHandles do
       {:twitter, "Twitter", "https://twitter.com/{handle}"},
       {:github, "GitHub", "https://github.com/{handle}"},
       {:elixirforum, "Elixir Forum", "https://elixirforum.com/u/{handle}"},
-      {:freenode, "Freenode", "irc://chat.freenode.net/elixir-lang"},
+      {:freenode, "Libera", "irc://irc.libera.chat/elixir"},
       {:slack, "Slack", "https://elixir-slackin.herokuapp.com/"}
     ]
   end

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -73,7 +73,7 @@
                 <%= label f, :freenode %>
                 <%= ViewHelpers.text_input f, :freenode, placeholder: "Your organization's nickname on Elixir IRC channel" %>
                 <span class="help-block">Elixir IRC channel:
-                  <a href="irc://chat.freenode.net/elixir-lang">irc://chat.freenode.net/elixir-lang</a>
+                  <a href="irc://irc.libera.chat/elixir">irc://irc.libera.chat/elixir</a>
                 </span>
                 <%= ViewHelpers.error_tag f, :freenode %>
               </div>

--- a/lib/hexpm_web/templates/dashboard/profile/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/profile/index.html.eex
@@ -77,10 +77,10 @@
             </div>
 
             <div class="form-group">
-              <%= label f, :freenode %>
+              <%= label f, :freenode, "Libera" %>
               <%= ViewHelpers.text_input f, :freenode, placeholder: "Your nickname on Elixir IRC channel" %>
               <span class="help-block">Elixir IRC channel:
-                <a href="irc://chat.freenode.net/elixir-lang">irc://chat.freenode.net/elixir-lang</a>
+                <a href="irc://irc.libera.chat/elixir">irc://irc.libera.chat/elixir</a>
               </span>
               <%= ViewHelpers.error_tag f, :freenode %>
             </div>

--- a/test/hexpm/accounts/user_handles_test.exs
+++ b/test/hexpm/accounts/user_handles_test.exs
@@ -22,7 +22,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
                  {"Twitter", "eric", "https://twitter.com/eric"},
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
-                 {"Freenode", "freenode", "irc://chat.freenode.net/elixir-lang"},
+                 {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
                  {"Slack", "slack", "https://elixir-slackin.herokuapp.com/"}
                ]
     end
@@ -45,7 +45,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
                  {"Twitter", "eric", "https://twitter.com/eric"},
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
-                 {"Freenode", "freenode", "irc://chat.freenode.net/elixir-lang"},
+                 {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
                  {"Slack", "slack", "https://elixir-slackin.herokuapp.com/"}
                ]
     end
@@ -68,7 +68,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
                  {"Twitter", "eric", "https://twitter.com/eric"},
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
-                 {"Freenode", "freenode", "irc://chat.freenode.net/elixir-lang"},
+                 {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
                  {"Slack", "slack", "https://elixir-slackin.herokuapp.com/"}
                ]
     end


### PR DESCRIPTION
reported by @v0idpwn
The Elixir freenode channel is obsolete/no longer running, so this removes references to it from the user profile