### PR TITLE
Access copyright year programmatically

### DIFF
--- a/lib/hexpm_web/templates/layout/footer.html.eex
+++ b/lib/hexpm_web/templates/layout/footer.html.eex
@@ -41,7 +41,7 @@
             </div>
 
             <div class="col-md-3 copyright">
-              <p><%= DateTime.utc_now.year %> © Six Colors AB.</p>
+              <p><%= Date.utc_today().year %> © Six Colors AB.</p>
               <p>Powered by the <a href="https://www.erlang.org/">Erlang VM</a> and the <a href="https://elixir-lang.org/">Elixir programming language</a>.</p>
             </div>
           </div>

--- a/lib/hexpm_web/templates/layout/footer.html.eex
+++ b/lib/hexpm_web/templates/layout/footer.html.eex
@@ -41,7 +41,7 @@
             </div>
 
             <div class="col-md-3 copyright">
-              <p>2020 © Six Colors AB.</p>
+              <p><%= DateTime.utc_now.year %> © Six Colors AB.</p>
               <p>Powered by the <a href="https://www.erlang.org/">Erlang VM</a> and the <a href="https://elixir-lang.org/">Elixir programming language</a>.</p>
             </div>
           </div>


### PR DESCRIPTION
Currently the copyright year at the footer is static and is set to 2020.

This PR will make hexpm set the copyright year to the current year dynamically.