### PR TITLE
Add link anchors to FAQ

### DIFF
--- a/lib/hexpm_web/markdown_engine.ex
+++ b/lib/hexpm_web/markdown_engine.ex
@@ -17,7 +17,7 @@ defmodule HexpmWeb.MarkdownEngine do
       HexpmWeb.ViewIcons.icon(:glyphicon, :link, class: "icon-link")
       |> Phoenix.HTML.safe_to_string()
 
-    Regex.replace(~r"<#{tag}>(.*)</#{tag}>", html, fn _, header ->
+    Regex.replace(~r"<#{tag}>\n?(.*)<\/#{tag}>", html, fn _, header ->
       anchor =
         header
         |> String.downcase()

--- a/test/hexpm_web/markdown_engine_test.exs
+++ b/test/hexpm_web/markdown_engine_test.exs
@@ -1,0 +1,64 @@
+defmodule HexpmWeb.MarkdownEngineTest do
+  use ExUnit.Case
+
+  @markdown """
+  ## FAQ
+
+  ### Contact
+
+  #### How do I contact Hex?
+
+  To report an issue in Hex or its services open an issue on the appropriate repository in the [GitHub organization](https://github.com/hexpm) or on the [hexpm repository](https://github.com/hexpm/hexpm/issues).
+  To get in direct contact with Hex core team email [support@hex.pm](mailto:support@hex.pm).
+
+  ### How do I report a security issue?
+
+  Security vulnerabilities should be disclosed to [security@hex.pm](mailto:security@hex.pm).
+  """
+
+  @path Application.get_env(:hexpm, :tmp_dir) <> "faq.md"
+
+  @icon HexpmWeb.ViewIcons.icon(:glyphicon, :link, class: "icon-link")
+        |> Phoenix.HTML.safe_to_string()
+
+  setup do
+    File.write!(@path, @markdown)
+    on_exit(fn -> File.rm!(@path) end)
+  end
+
+  test "does not change h2 tags" do
+    {:safe, html} = HexpmWeb.MarkdownEngine.compile(@path, nil)
+
+    assert html =~ "<h2>"
+  end
+
+  test "adds anchors to h3 tags" do
+    {:safe, html} = HexpmWeb.MarkdownEngine.compile(@path, nil)
+
+    h3 = """
+    <h3 id="contact" class="section-heading">
+      <a href="#contact" class="hover-link">
+        #{@icon}
+      </a>
+      Contact
+    </h3>
+    """
+
+    assert html =~ h3
+  end
+
+  test "adds anchors to h4 tags" do
+    {:safe, html} = HexpmWeb.MarkdownEngine.compile(@path, nil)
+
+    h4 = """
+    <h4 id="how-do-i-contact-hex" class="section-heading">
+      <a href="#how-do-i-contact-hex" class="hover-link">
+        #{@icon}
+      </a>
+      How do I contact Hex?
+    </h4>
+    """
+
+    assert html =~ h4
+  end
+end


### PR DESCRIPTION
Link anchors were aleady implemented in `HexpmWeb.MarkdownEngine` but an incorrect regex prevented them from being created.

This PR corrects the original implementation which results in changes beyond the scope of the [issue](https://github.com/hexpm/hexpm/issues/1039). 

All `h3` and `h4` tags in markdown templates will have link anchors added and a link icon on hover (as per the existing implementation).

The PR also adds a regression test for this bug on the markdown engine.

Resolves #1039