### PR TITLE
Do not start runtime_tools and os_mon in tests

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -20,9 +20,12 @@ defmodule Hexpm.MixProject do
   def application() do
     [
       mod: {Hexpm.Application, []},
-      extra_applications: [:logger, :runtime_tools, :os_mon]
+      extra_applications: extra_applications(Mix.env())
     ]
   end
+
+  defp extra_applications(:test), do: [:logger]
+  defp extra_applications(_), do: [:logger, :runtime_tools, :os_mon]
 
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]


### PR DESCRIPTION
Before this patch we had:

    ~/src/hexpm[main]% mix test
    Finished in 5.4 seconds (4.8s async, 0.6s sync)
    669 tests, 0 failures, 3 skipped

    Randomized with seed 594000
    [os_mon] memory supervisor port (memsup): Erlang has closed
    [os_mon] cpu supervisor port (cpu_sup): Erlang has closed

Now we have:

    ~/src/hexpm[main]% mix test
    Finished in 5.4 seconds (4.8s async, 0.6s sync)
    669 tests, 0 failures, 3 skipped

    Randomized with seed 594000

So just removing unnecessary logs in the test output.

It doesn't hurt to keep `runtime_tools` but I think it is not useful either.
