### PR TITLE
Email all package owners when package was published

### DIFF
--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -66,10 +66,11 @@ defmodule Hexpm.Emails do
     |> render(:organization_invite)
   end
 
-  def package_published(user, name, version) do
+  def package_published(owners, publisher, name, version) do
     email()
-    |> email_to(user)
+    |> email_to(owners)
     |> subject("Hex.pm - Package #{name} v#{version} published")
+    |> assign(:publisher, publisher)
     |> assign(:version, version)
     |> assign(:package, name)
     |> render(:package_published)

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -136,7 +136,7 @@ defmodule Hexpm.Repository.Releases do
 
     Assets.push_release(release, body)
     update_package_in_registry(package)
-    email_package_publisher(user, package, release)
+    email_package_owners(package, release, user)
 
     {:ok, %{result | release: release, package: package}}
   end
@@ -240,10 +240,10 @@ defmodule Hexpm.Repository.Releases do
     end
   end
 
-  defp email_package_publisher(user, package, release) do
-    user
-    |> Hexpm.Repo.preload(organization: [users: :emails])
-    |> Emails.package_published(package.name, release.version)
+  defp email_package_owners(package, release, publisher) do
+    Hexpm.Repo.all(assoc(package, :owners))
+    |> Hexpm.Repo.preload([:emails, organization: [users: :emails]])
+    |> Emails.package_published(publisher, package.name, release.version)
     |> Mailer.deliver_now_throttled()
   end
 

--- a/lib/hexpm_web/templates/email/package_published.html.eex
+++ b/lib/hexpm_web/templates/email/package_published.html.eex
@@ -1,4 +1,4 @@
-<p><%= PackagePublished.intro(@package, @version) %></p>
+<p><%= PackagePublished.intro(@publisher, @package, @version) %></p>
 
 <p>
     For mix:

--- a/lib/hexpm_web/templates/email/package_published.text.eex
+++ b/lib/hexpm_web/templates/email/package_published.text.eex
@@ -1,4 +1,4 @@
-<%= PackagePublished.intro(@package, @version) %>
+<%= PackagePublished.intro(@publisher, @package, @version) %>
 
 For mix:
 

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -86,10 +86,19 @@ defmodule HexpmWeb.EmailView do
   end
 
   defmodule PackagePublished do
-    def intro(package, version) do
+    def intro(nil, package, version) do
       """
-      You have recently published package #{package} v#{version}.
-      If this wasn't done by you, you should reset your account and revert or retire the version.
+      Package #{package} v#{version} was recently published.
+      If this wasn't done by you or one of the other package owners, you should
+      reset your account and revert or retire the version.
+      """
+    end
+
+    def intro(publisher, package, version) do
+      """
+      Package #{package} v#{version} was recently published by #{publisher.username}.
+      If this wasn't done by you or one of the other package owners, you should
+      reset your account and revert or retire the version.
       """
     end
 


### PR DESCRIPTION
This change should help notify other package owners if the package was published by a malicious user.