### PR TITLE
Use grey background color as default for build tools

### DIFF
--- a/assets/css/template/_package-view.scss
+++ b/assets/css/template/_package-view.scss
@@ -85,6 +85,7 @@
   display: inline-block;
   padding: 4px 6px;
   color: $color-white;
+  background: $color-text-grey;
   border-radius: 4px;
 
   &.mix {
@@ -97,10 +98,6 @@
 
   &.rebar3 {
     background: #c65252;
-  }
-
-  &.make {
-    background: $color-text-grey;
   }
 }
 


### PR DESCRIPTION
I made the grey variant, currently reserved for `make`, the default background color. Any objections to that? Should I maybe use another grey(-ish) color instead?

___
closes #1062