### PR TITLE
Automatically start private package trial when creating organization

### DIFF
--- a/lib/hexpm/factory.ex
+++ b/lib/hexpm/factory.ex
@@ -52,7 +52,8 @@ defmodule Hexpm.Factory do
     %Hexpm.Accounts.Organization{
       name: name,
       user: build(:user, username: name),
-      billing_active: true
+      billing_active: true,
+      trial_end: ~U[2020-01-01T00:00:00Z]
     }
   end
 

--- a/lib/hexpm_web/controllers/auth_helpers.ex
+++ b/lib/hexpm_web/controllers/auth_helpers.ex
@@ -297,11 +297,13 @@ defmodule HexpmWeb.AuthHelpers do
     organization_billing_active(conn.assigns.organization, nil)
   end
 
-  def organization_billing_active(%Organization{billing_active: true}, _user_or_organization),
-    do: :ok
-
-  def organization_billing_active(%Organization{billing_active: false}, _user_or_organization),
-    do: {:error, :auth, "organization has no active billing subscription"}
+  def organization_billing_active(%Organization{} = organization, _user_or_organization) do
+    if Organization.billing_active?(organization) do
+      :ok
+    else
+      {:error, :auth, "organization has no active billing subscription"}
+    end
+  end
 
   def repository_access(%Plug.Conn{} = conn, user_or_organization) do
     repository_access(conn.assigns.repository, user_or_organization)

--- a/lib/hexpm_web/templates/dashboard/organization/_billing.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/_billing.html.eex
@@ -200,7 +200,14 @@
         <% end %>
       <% else %>
         <div class="panel-body">
-          Subscription is not active. Private packages will not be available until a payment method has been added.<br><br>
+          <%= if Organization.trialing?(@organization) do %>
+            Subscription is in trial mode until <%= ViewHelpers.pretty_date(@organization.trial_end) %>.
+            After the trial is over private packages will not be available.
+            To ensure you can still use private packages after the trial has ended add a payment method.<br><br>
+          <% else %>
+            Subscription is not active. Private packages will not be available until a payment method has been added.<br><br>
+          <% end %>
+
           Subscription cost is <strong>$7.00 per user / month</strong> + local VAT when applicable.<br><br>
           First enter your billing information below to enable the payment method form:<br><br>
 

--- a/priv/repo/migrations/20211102164710_add_trial_end_to_organizations.exs
+++ b/priv/repo/migrations/20211102164710_add_trial_end_to_organizations.exs
@@ -1,0 +1,13 @@
+defmodule Hexpm.RepoBase.Migrations.AddTrialEndToOrganizations do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      add(:trial_end, :utc_datetime_usec, default: "NOW()")
+    end
+
+    alter table(:organizations) do
+      modify(:trial_end, :utc_datetime_usec, default: nil, null: false)
+    end
+  end
+end


### PR DESCRIPTION
Before this change a billing context was required to start the trial and
the a billing context was created by entering your billing information.
Now this is no longer required.