### PR TITLE
Fix home page accessibility

### DIFF
--- a/lib/hexpm_web/templates/page/index.html.eex
+++ b/lib/hexpm_web/templates/page/index.html.eex
@@ -15,6 +15,7 @@
               <span class="input-group-btn">
                 <button type="submit" class="btn btn-search" tabindex="1">
                   <%= icon(:glyphicon, :search) %>
+                  <span class="sr-only">Search</span>
                 </button>
               </span>
             </div>

--- a/lib/hexpm_web/views/icons.ex
+++ b/lib/hexpm_web/views/icons.ex
@@ -99,7 +99,7 @@ defmodule HexpmWeb.ViewIcons do
 
     opts =
       opts
-      |> Keyword.put_new(:"aria-hidden", true)
+      |> Keyword.put_new(:"aria-hidden", "true")
       |> Keyword.put_new(:version, "1.1")
       |> Keyword.put_new(:viewBox, "0 0 #{x} 1024")
       |> Keyword.update(:class, class, &"#{class} #{&1}")
@@ -120,7 +120,7 @@ defmodule HexpmWeb.ViewIcons do
 
     opts =
       opts
-      |> Keyword.put_new(:"aria-hidden", true)
+      |> Keyword.put_new(:"aria-hidden", "true")
       |> Keyword.put_new(:version, "1.1")
       |> Keyword.put_new(:viewBox, "0 0 #{x} 1200")
       |> Keyword.update(:class, class, &"#{class} #{&1}")


### PR DESCRIPTION
Hello all 👋

I didn't see a mention in the contributing guide to open an issue before a PR, so forgive me if this was an expected step that I missed. 

This PR introduces a two small accessibility tweaks that targeted the home page, but will also improve the experience for the overall website as well. 

### In lib/hexpm_web/views/icons.ex:

The aria-hidden property being added via the Icon helpers was using `true` as a boolean value. This was not being cast correctly and resulted in either `<element aria-hidden>` or `<element aria-hidden-"">` depending on the browser. This did not work as intended. Per the [spec](https://www.w3.org/TR/wai-aria-1.1/#aria-hidden) , `aria-hidden` is not actually a boolean property such as `required` or `selected`. It actually has three potential states:

> false: The element is exposed to the accessibility API as if it was rendered.
>
> true: The element is hidden from the accessibility API.
> 
> undefined (default): The element's hidden state is determined by the user agent based on whether it is rendered.

Changing the property from a boolean to a string ("true") resolves this particular challenge and will improve accessibility anywhere site-wide that those icon helpers are used.

### lib/hexpm_web/templates/page/index.html.eex

In the search bar HTML, the icon already had aria-hidden applied but it did not have failover text for non-visual users; so Orca on Linux and VoiceOver on MacOS both announced the button as simply "button". I have added a span with the existing `.sr-only` class so that the button now announces as `button, search`.

