### PR TITLE
Exact match with spaces

### DIFF
--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -210,15 +210,18 @@ defmodule HexpmWeb.PackageController do
   end
 
   defp exact_match(repositories, search) do
-    case String.split(search, "/", parts: 2) do
+    search
+    |> String.replace(" ", "_")
+    |> String.split("/", parts: 2)
+    |> case do
       [repository, package] ->
         if repository in Enum.map(repositories, & &1.name) do
           Packages.get(repository, package)
         end
 
-      _ ->
+      [term] ->
         try do
-          Packages.get(repositories, search)
+          Packages.get(repositories, term)
         rescue
           Ecto.MultipleResultsError ->
             nil

--- a/lib/hexpm_web/templates/package/index.html.eex
+++ b/lib/hexpm_web/templates/package/index.html.eex
@@ -16,11 +16,22 @@
   </div>
 <% end %>
 
-<%= if @package_count == 0 do %>
+<%= if @exact_match do %>
+  <div class="exact-match">
+    <h5>Exact Match:</h5>
+    <ul>
+      <%= render "_package.html", package: @exact_match, package_downloads: downloads_for_package(@exact_match, @downloads), view: @sort %>
+    </ul>
+  </div>
+<% end %>
+
+<%= if !@exact_match and @package_count == 0 do %>
   <div class="package-list no-results">
     <h4>No Results Found</h4>
   </div>
-<% else %>
+<% end %>
+
+<%= if @package_count > 0 do %>
   <%
   page = if @page == 1, do: nil, else: @page
 
@@ -69,15 +80,6 @@
 </nav>
 
 <div class="clearfix"></div>
-
-<%= if @exact_match do %>
-  <div class="exact-match">
-    <h5>Exact Match:</h5>
-    <ul>
-      <%= render "_package.html", package: @exact_match, package_downloads: downloads_for_package(@exact_match, @downloads), view: @sort %>
-    </ul>
-  </div>
-<% end %>
 
 <div class="package-list">
   <%= if @exact_match do %>


### PR DESCRIPTION
Normalize the search term so that spaces are translated to underscores,
before checking for an exact match.

FIXME: Fails to render the match because the main package_count filter
returns 0 and exact matches are nested within that clause.  I would
suggest making the exact match and other package results independent, so
the algorithms can diverge.