### PR TITLE
Remove package ownerships when removing organization member

### DIFF
--- a/lib/hexpm/release_tasks.ex
+++ b/lib/hexpm/release_tasks.ex
@@ -9,7 +9,7 @@ defmodule Hexpm.ReleaseTasks do
     :ecto_sql
   ]
 
-  @repos Application.get_env(:hexpm, :ecto_repos, [])
+  @repos Application.compile_env(:hexpm, :ecto_repos, [])
 
   def script(args) do
     {:ok, _} = Application.ensure_all_started(:logger)

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -122,7 +122,7 @@ defmodule HexpmWeb.Router do
 
     get "/l/:short_code", ShortURLController, :show
 
-    if Application.fetch_env!(:hexpm, :features)[:package_reports] do
+    if Application.compile_env!(:hexpm, [:features, :package_reports]) do
       get "/reports", PackageReportController, :index
       get "/reports/new", PackageReportController, :new
       post "/reports/create", PackageReportController, :create

--- a/test/hexpm/accounts/organizations_test.exs
+++ b/test/hexpm/accounts/organizations_test.exs
@@ -1,0 +1,42 @@
+defmodule Hexpm.Accounts.OrganizationsTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.Accounts.Organizations
+  alias Hexpm.Repository.PackageOwner
+
+  describe "remove_member/3" do
+    test "cannot remove last member" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_user, organization: organization, user: user)
+
+      assert Organizations.remove_member(organization, user, audit: {build(:user), "UA"}) ==
+               {:error, :last_member}
+
+      assert length(Repo.all(assoc(organization, :users))) == 1
+    end
+
+    test "removes member" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_user, organization: organization, user: insert(:user))
+      insert(:organization_user, organization: organization, user: user)
+
+      assert Organizations.remove_member(organization, user, audit: {build(:user), "UA"})
+      assert length(Repo.all(assoc(organization, :users))) == 1
+    end
+
+    test "removes package ownerships" do
+      user = insert(:user)
+      repository = insert(:repository)
+      organization = insert(:organization, repository: repository)
+      package = insert(:package, repository_id: repository.id, repository: repository)
+      package_owner = insert(:package_owner, package: package, user: user)
+      insert(:organization_user, organization: organization, user: insert(:user))
+      insert(:organization_user, organization: organization, user: user)
+
+      assert Organizations.remove_member(organization, user, audit: {build(:user), "UA"})
+      refute Repo.get(PackageOwner, package_owner.id)
+    end
+  end
+end

--- a/test/hexpm_web/markdown_engine_test.exs
+++ b/test/hexpm_web/markdown_engine_test.exs
@@ -16,7 +16,7 @@ defmodule HexpmWeb.MarkdownEngineTest do
   Security vulnerabilities should be disclosed to [security@hex.pm](mailto:security@hex.pm).
   """
 
-  @path Application.get_env(:hexpm, :tmp_dir) <> "faq.md"
+  @path Application.compile_env(:hexpm, :tmp_dir) <> "faq.md"
 
   @icon HexpmWeb.ViewIcons.icon(:glyphicon, :link, class: "icon-link")
         |> Phoenix.HTML.safe_to_string()

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -1,5 +1,5 @@
 defmodule Hexpm.TestHelpers do
-  @tmp Application.get_env(:hexpm, :tmp_dir)
+  @tmp Application.compile_env(:hexpm, :tmp_dir)
 
   def create_tar(meta, files \\ [{"mix.exs", "mix.exs"}]) do
     meta =


### PR DESCRIPTION
This is only a clean up since we always check organization membership when checking package permissions.

To clean up existing membership:

```sql
# DELETE
SELECT o.name, p.name, u.username
FROM package_owners AS po
JOIN packages AS p ON po.package_id = p.id
JOIN users AS u ON po.user_id = u.id
JOIN repositories AS r ON p.repository_id = r.id
JOIN organizations AS o ON r.organization_id = o.id
WHERE o.id != 1
  AND o.id NOT IN (SELECT id FROM organization_users WHERE organization_id = o.id);
```