### PR TITLE
Improvements to exact match display

### DIFF
--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -9,6 +9,17 @@ defmodule Hexpm.Repository.Packages do
     Repo.one!(Package.count(repositories, filter))
   end
 
+  def diff(packages, nil), do: packages
+
+  def diff(packages, remove) when is_list(remove) do
+    names = remove |> Enum.map(& &1.name)
+
+    packages
+    |> Enum.reject(&Enum.member?(names, &1.name))
+  end
+
+  def diff(packages, remove), do: diff(packages, [remove])
+
   def get(repository, name) when is_binary(repository) do
     repository = Repositories.get(repository)
     repository && get(repository, name)

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -12,10 +12,10 @@ defmodule Hexpm.Repository.Packages do
   def diff(packages, nil), do: packages
 
   def diff(packages, remove) when is_list(remove) do
-    names = remove |> Enum.map(& &1.name)
+    names = Enum.map(remove, & &1.name)
 
     packages
-    |> Enum.reject(&Enum.member?(names, &1.name))
+    |> Enum.reject(&(&1.name in names))
   end
 
   def diff(packages, remove), do: diff(packages, [remove])

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -11,14 +11,12 @@ defmodule Hexpm.Repository.Packages do
 
   def diff(packages, nil), do: packages
 
-  def diff(packages, remove) when is_list(remove) do
-    names = Enum.map(remove, & &1.name)
+  def diff(packages, remove) do
+    names = Enum.map(List.wrap(remove), & &1.name)
 
     packages
     |> Enum.reject(&(&1.name in names))
   end
-
-  def diff(packages, remove), do: diff(packages, [remove])
 
   def get(repository, name) when is_binary(repository) do
     repository = Repositories.get(repository)

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -28,9 +28,18 @@ defmodule HexpmWeb.PackageController do
     page_param = Hexpm.Utils.safe_int(params["page"]) || 1
     package_count = Packages.count(repositories, filter)
     page = Hexpm.Utils.safe_page(page_param, package_count, @packages_per_page)
+<<<<<<< HEAD
     packages = fetch_packages(repositories, page, @packages_per_page, filter, sort)
     downloads = Downloads.packages_all_views(packages)
+=======
+>>>>>>> 09a97cc (Remove exact match from the main search results)
     exact_match = exact_match(repositories, search)
+
+    packages =
+      fetch_packages(repositories, page, @packages_per_page, filter, sort)
+      |> Packages.diff(exact_match)
+
+    downloads = Packages.packages_downloads_with_all_views(packages)
 
     render(
       conn,

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -28,18 +28,13 @@ defmodule HexpmWeb.PackageController do
     page_param = Hexpm.Utils.safe_int(params["page"]) || 1
     package_count = Packages.count(repositories, filter)
     page = Hexpm.Utils.safe_page(page_param, package_count, @packages_per_page)
-<<<<<<< HEAD
-    packages = fetch_packages(repositories, page, @packages_per_page, filter, sort)
-    downloads = Downloads.packages_all_views(packages)
-=======
->>>>>>> 09a97cc (Remove exact match from the main search results)
     exact_match = exact_match(repositories, search)
 
     packages =
       fetch_packages(repositories, page, @packages_per_page, filter, sort)
       |> Packages.diff(exact_match)
 
-    downloads = Packages.packages_downloads_with_all_views(packages)
+    downloads = Downloads.packages_all_views(packages)
 
     render(
       conn,

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -233,6 +233,13 @@ defmodule HexpmWeb.PackageController do
             nil
         end
     end
+    |> case do
+      nil ->
+        nil
+
+      package ->
+        hd(Packages.attach_versions([package]))
+    end
   end
 
   defp fixup_params(%{"name" => name, "version" => version} = params) do

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -242,7 +242,8 @@ defmodule HexpmWeb.PackageController do
         nil
 
       package ->
-        hd(Packages.attach_versions([package]))
+        [package] = Packages.attach_latest_releases([package])
+        package
     end
   end
 

--- a/lib/hexpm_web/templates/package/index.html.eex
+++ b/lib/hexpm_web/templates/package/index.html.eex
@@ -25,13 +25,13 @@
   </div>
 <% end %>
 
-<%= if !@exact_match and Enum.empty?(@packages) do %>
+<%= if !@exact_match and @packages == [] do %>
   <div class="package-list no-results">
     <h4>No Results Found</h4>
   </div>
 <% end %>
 
-<%= if !Enum.empty?(@packages) do %>
+<%= if @packages != [] do %>
   <%
   page = if @page == 1, do: nil, else: @page
 

--- a/lib/hexpm_web/templates/package/index.html.eex
+++ b/lib/hexpm_web/templates/package/index.html.eex
@@ -25,13 +25,13 @@
   </div>
 <% end %>
 
-<%= if !@exact_match and @package_count == 0 do %>
+<%= if !@exact_match and Enum.empty?(@packages) do %>
   <div class="package-list no-results">
     <h4>No Results Found</h4>
   </div>
 <% end %>
 
-<%= if @package_count > 0 do %>
+<%= if !Enum.empty?(@packages) do %>
   <%
   page = if @page == 1, do: nil, else: @page
 

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -108,7 +108,7 @@ defmodule HexpmWeb.PackageControllerTest do
     test "search with whitespace", %{package5: package5} do
       conn = get(build_conn(), "/packages?search=with underscore")
       assert response(conn, 200) =~ "exact-match"
-      assert response(conn, 200) =~ package5.name
+      assert response(conn, 200) =~ ~r/#{package5.name}.*0.0.1/s
       refute response(conn, 200) =~ "no-results"
     end
 

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -112,6 +112,12 @@ defmodule HexpmWeb.PackageControllerTest do
       refute response(conn, 200) =~ "no-results"
     end
 
+    test "search with exact match" do
+      conn = get(build_conn(), "/packages?search=with_underscore")
+      assert response(conn, 200) =~ "exact-match"
+      refute response(conn, 200) =~ "results-found"
+    end
+
     test "search without match" do
       conn = get(build_conn(), "/packages?search=nonexistent")
       assert response(conn, 200) =~ "no-results"


### PR DESCRIPTION
* Include the latest release number for exact match.
* Suppress redundant exact match from main results.

Follows up on #1089.