### PR TITLE
Update the syntax for retiring a package in email view with rebar3_hex

### DIFF
--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -114,7 +114,7 @@ defmodule HexpmWeb.EmailView do
       """
       cd #{package}; rebar3 hex publish --revert #{version}
       # or
-      rebar3 hex retire --pkg #{package} --vsn #{version} --reason security --message "Not published by owners"
+      rebar3 hex retire #{package} #{version} security --message "Not published by owners"
       """
     end
   end


### PR DESCRIPTION
The syntax changed in rebar3 hex v7, this commit updates the view to reflect that.