### PR TITLE
Simplify and improve pagination navigation

### DIFF
--- a/lib/hexpm_web/templates/shared/_pagination.html.eex
+++ b/lib/hexpm_web/templates/shared/_pagination.html.eex
@@ -7,37 +7,39 @@ range_end = range_start + shown_items - 1
 
 <div class="pagination-wrapper">
   <div class="pagination-info">
-    <%= if shown_items == 1 do %>
-      Showing last <%= @unit %> of <%= @total_count %> total
+    <%= if paginate[:page_links] == [1] do %>
+      Showing <%= @total_count %> <%= if shown_items == 1 do @unit else @units end%> of <%= @total_count %> total
     <% else %>
       Showing <%= range_start %>&ndash;<%= range_end %> <%= @units %> of <%= @total_count %> total
     <% end %>
   </div>
-  <nav class="pagination-widget">
-    <ul class="pagination pagination-sm">
-      <%= if paginate[:prev] do %>
-        <li><a href="<%= @path_fn.(@page - 1) %>" aria-label="Previous">&laquo;</a></li>
-      <% else %>
-        <li class="disabled"><span>&laquo;</span></li>
-      <% end %>
-      <%= for page <- paginate[:page_links] do %>
-        <%= if page == @page do %>
-          <li class="active">
-            <span><%= page %></span>
-          </li>
+  <%= unless paginate[:page_links] == [1] do %>
+    <nav class="pagination-widget">
+      <ul class="pagination pagination-sm">
+        <%= if paginate[:prev] do %>
+          <li><a href="<%= @path_fn.(@page - 1) %>" aria-label="Previous">&laquo;</a></li>
         <% else %>
-          <li>
-            <a href="<%= @path_fn.(page) %>">
-              <%= page %>
-            </a>
-          </li>
+          <li class="disabled"><span>&laquo;</span></li>
         <% end %>
-      <% end %>
-      <%= if paginate[:next] do %>
-        <li><a href="<%= @path_fn.(@page + 1) %>" aria-label="Next" >&raquo;</a></li>
-      <% else %>
-        <li class="disabled"><span>&raquo;</span></li>
-      <% end %>
-    </ul>
-  </nav>
+        <%= for page <- paginate[:page_links] do %>
+          <%= if page == @page do %>
+            <li class="active">
+              <span><%= page %></span>
+            </li>
+          <% else %>
+            <li>
+              <a href="<%= @path_fn.(page) %>">
+                <%= page %>
+              </a>
+            </li>
+          <% end %>
+        <% end %>
+        <%= if paginate[:next] do %>
+          <li><a href="<%= @path_fn.(@page + 1) %>" aria-label="Next" >&raquo;</a></li>
+        <% else %>
+          <li class="disabled"><span>&raquo;</span></li>
+        <% end %>
+      </ul>
+    </nav>
+  <% end %>
 </div>


### PR DESCRIPTION
- It only shows the navigation if there is at least 2 result pages
- Simplifies the messages to:
  * Showing 1 package of 1 total
  * Showing 11 packages of 11 total
  * Showing 1–30 packages of 114 total