### PR TITLE
Use indirect references to modules to avoid compile-time dependencies

### DIFF
--- a/lib/hexpm/emails/bamboo.ex
+++ b/lib/hexpm/emails/bamboo.ex
@@ -1,10 +1,10 @@
-defimpl Bamboo.Formatter, for: Hexpm.Accounts.User do
+defimpl Bamboo.Formatter, for: Module.concat(Hexpm.Accounts, User) do
   def format_email_address(user, _opts) do
     {user.username, Hexpm.Accounts.User.email(user, :primary)}
   end
 end
 
-defimpl Bamboo.Formatter, for: Hexpm.Accounts.Email do
+defimpl Bamboo.Formatter, for: Module.concat(Hexpm.Accounts, Email) do
   def format_email_address(email, _opts) do
     {email.user.username, email.email}
   end

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -5,7 +5,7 @@ defmodule HexpmWeb.Endpoint do
 
   @session_options [
     signing_salt: "NOcCmerj",
-    store: HexpmWeb.Session,
+    store: Module.concat(HexpmWeb, Session),
     key: "_hexpm_key",
     max_age: 60 * 60 * 24 * 30
   ]
@@ -42,7 +42,7 @@ defmodule HexpmWeb.Endpoint do
   plug Logster.Plugs.Logger, excludes: [:params]
 
   plug Plug.Parsers,
-    parsers: [:urlencoded, :json, HexpmWeb.PlugParser],
+    parsers: [:urlencoded, :json, Module.concat(HexpmWeb, PlugParser)],
     pass: ["*/*"],
     json_decoder: Jason
 


### PR DESCRIPTION
This is the fifth and last of a series of PRs.

This is ugly and I am not necessarily expecting it to be merged, but I'm creating it just in case, and to illustrate my forthcoming post on compile-time dependencies.

Details are [here](https://gist.github.com/marcandre/fd999ff3d9e5b9137380f15bab49f417)