### PR TITLE
feat: add button to copy exact version of mix deps

### DIFF
--- a/assets/css/template/_package-view.scss
+++ b/assets/css/template/_package-view.scss
@@ -115,6 +115,12 @@
     border: 1px #c1bfbf solid;
     border-radius: 2px;
   }
+
+  .dropdown-menu input {
+    background: transparent;
+    border: none;
+    padding-left: 1rem;
+  }
 }
 
 .version-dependency-list {

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -133,6 +133,14 @@ export default class App {
     var button = $(event.currentTarget)
     var succeeded = false
 
+    /**
+     * Allows to control the propagation of the event. When the copying button
+     * is inside a dropdown you may want to stop the dropdown from closing.
+     * */
+    if (event.currentTarget.hasAttribute("data-stop-propagation")) {
+      event.stopPropagation();
+    }
+
     try {
       var snippet = document.getElementById(button.attr("data-input-id"))
       snippet.select()

--- a/lib/hexpm_web/templates/package/show.html.eex
+++ b/lib/hexpm_web/templates/package/show.html.eex
@@ -213,6 +213,28 @@ tools = [
                 <%= icon(:glyphicon, :remove, style: "display: none") %>
                 <%= icon(:glyphicon, :ok, style: "display: none; color: green") %>
               </button>
+
+              <%= if tool == :mix do %>
+                <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  <span class="caret"></span>
+                  <span class="sr-only">Toggle <%= tool %> Dependency Actions</span>
+                </button>
+                <ul class="dropdown-menu dropdown-menu-right">
+                  <li>
+                    <button class="btn btn-link btn-no-hover copy-button" data-stop-propagation type="button" data-input-id="<%= tool %>-exact-snippet">
+                      <%= icon(:glyphicon, :copy) %>
+                      <%= icon(:glyphicon, :remove, style: "display: none") %>
+                      <%= icon(:glyphicon, :ok, style: "display: none; color: green") %>
+                      <input
+                        type="text"
+                        class="snippet"
+                        value="<%= dep_snippet(tool, @package, @current_release, :exact) %>"
+                        readonly="readonly" id="<%= tool %>-exact-snippet"
+                      />
+                    </button>
+                  </li>
+                </ul>
+              <% end %>
             </span>
           </div>
         </div>

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -42,8 +42,8 @@ defmodule HexpmWeb.PackageView do
     end
   end
 
-  def dep_snippet(:mix, package, release) do
-    version = snippet_version(:mix, release.version)
+  def dep_snippet(:mix, package, release, version_range) do
+    version = snippet_version(:mix, release.version, version_range)
     app_name = (release.meta && release.meta.app) || package.name
     organization = snippet_organization(package.repository.name)
 
@@ -53,6 +53,8 @@ defmodule HexpmWeb.PackageView do
       "{#{app_name(:mix, app_name)}, \"#{version}\", hex: :#{package.name}#{organization}}"
     end
   end
+
+  def dep_snippet(:mix, package, release), do: dep_snippet(:mix, package, release, :relax)
 
   def dep_snippet(:rebar, package, release) do
     version = snippet_version(:rebar, release.version)
@@ -69,6 +71,12 @@ defmodule HexpmWeb.PackageView do
     version = snippet_version(:erlang_mk, release.version)
     "dep_#{package.name} = hex #{version}"
   end
+
+  def snippet_version(:mix, %Version{major: major, minor: minor, patch: patch, pre: []}, :exact) do
+    "#{major}.#{minor}.#{patch}"
+  end
+
+  def snippet_version(:mix, version, _version_range), do: snippet_version(:mix, version)
 
   def snippet_version(:mix, %Version{major: 0, minor: minor, patch: patch, pre: []}) do
     "~> 0.#{minor}.#{patch}"

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -100,6 +100,7 @@ defmodule HexpmWeb.PackageViewTest do
     assert PackageView.snippet_version(:mix, version1) == "~> 0.0.2"
     assert PackageView.snippet_version(:mix, version2) == "~> 0.2.99"
     assert PackageView.snippet_version(:mix, version3) == "~> 2.0"
+    assert PackageView.snippet_version(:mix, version1, :exact) == "0.0.2"
   end
 
   test "rebar and erlang.mk config version" do


### PR DESCRIPTION
Hey peeps,

When working in libraries, copying a more "relaxed" version is prudent. Regarding applications, I feel that locking to a particular version (despite the .lock) is sensitive, and all apps I maintain do such a thing.

I added an extra menu that allows you to copy such an exact version much more straightforwardly.

![Screen Shot 2022-07-17 at 12 46 00 AM](https://user-images.githubusercontent.com/4237280/179384306-11270e8c-14c0-4037-a669-d87df447597e.png)
