### PR TITLE
Upgrade to Elixir 1.14 and Erlang/OTP 25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: 25.1.0
           elixir-version: 1.14.0
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: 25.1.0
           elixir-version: 1.14.0
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Install OTP and Elixir
-        uses: erlef/setup-elixir@v1
+        uses: erlef/setup-beam@v1
         with:
           otp-version: 25.1.0
           elixir-version: 1.14.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,8 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-elixir@v1
         with:
-          otp-version: 24.1.7
-          elixir-version: 1.12.3
+          otp-version: 25.1.0
+          elixir-version: 1.14.0
 
       - run: mix deps.get
       - run: mix deps.compile
@@ -41,8 +41,8 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-elixir@v1
         with:
-          otp-version: 24.1.7
-          elixir-version: 1.12.3
+          otp-version: 25.1.0
+          elixir-version: 1.14.0
 
       - name: Install dependencies
         run: mix deps.get
@@ -85,8 +85,8 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-elixir@v1
         with:
-          otp-version: 23.1.1
-          elixir-version: 1.12.3
+          otp-version: 25.1.0
+          elixir-version: 1.14.0
 
       - name: Install hexpm dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 24.1.7
+          otp-version: 23.1.1
           elixir-version: 1.14.0
 
       - name: Install hexpm dependencies

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 25.1.0
+          otp-version: 24.1.7
           elixir-version: 1.14.0
 
       - name: Install hexpm dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hexpm/elixir:1.12.3-erlang-24.1.7-alpine-3.14.2 as build
+FROM hexpm/elixir:1.14.0-erlang-25.1-alpine-3.15.6 as build
 
 # install build dependencies
 RUN apk add --no-cache --update git build-base nodejs yarn
@@ -35,7 +35,7 @@ COPY rel rel
 RUN mix release
 
 # prepare release image
-FROM alpine:3.14.2 AS app
+FROM alpine:3.15.6 AS app
 RUN apk add --no-cache --update bash openssl libstdc++
 
 RUN mkdir /app


### PR DESCRIPTION
This PR upgrades the Dockerfile and CI's Elixir and OTP versions to 1.14 and 25 respectively.
However, the OTP version for the hex integration tests has been left unchanged as the hex client depends on some functions that have been removed since OTP 24.