### PR TITLE
Cache dependencies in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,6 +102,8 @@ jobs:
 
     env:
       HEXPM_PATH: ..
+      otp: 23.1.1
+      elixir: 1.14.0
 
     steps:
       - uses: actions/checkout@v2
@@ -109,8 +111,16 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 23.1.1
-          elixir-version: 1.14.0
+          otp-version: ${{ env.otp }}
+          elixir-version: ${{ env.elixir }}
+
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
 
       - name: Install hexpm dependencies
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,8 +54,6 @@ jobs:
             deps
             _build
           key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-
 
       - name: Install dependencies
         run: mix do deps.get, deps.compile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,18 @@ jobs:
           otp-version: 25.1.0
           elixir-version: 1.14.0
 
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-
+
       - name: Install dependencies
-        run: mix deps.get
+        run: mix do deps.get, deps.compile
 
       - name: Compile
         run: MIX_ENV=test mix compile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,9 @@ jobs:
   test-hexpm:
     name: Test Hexpm
     runs-on: ubuntu-latest
+    env:
+      otp: 25.1.0
+      elixir: 1.14.0
 
     services:
       postgres:
@@ -41,8 +44,8 @@ jobs:
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 25.1.0
-          elixir-version: 1.14.0
+          otp-version: ${{ env.otp }}
+          elixir-version: ${{ env.elixir }}
 
       - name: Cache dependencies
         uses: actions/cache@v2
@@ -50,7 +53,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-${{ env.elixir }}-${{ env.otp }}-
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,9 +127,20 @@ jobs:
           mix deps.get
           mix deps.compile
 
-      - name: Clone hex and install dependencies
+      - name: Clone hex
         run: |
           git clone https://github.com/hexpm/hex hex -b ${{ matrix.hex-version }} --depth 1
+
+      - name: Cache hex dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            hex/deps
+            hex/_build
+          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-hex-${{ matrix.hex-version }}-${{ hashFiles('hex/mix.lock') }}
+
+      - name: Install dependencies
+        run: |
           cd hex && mix deps.get && MIX_ENV=test mix deps.compile && cd ..
 
       - name: Run tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,17 +6,30 @@ jobs:
   format:
     name: Format
     runs-on: ubuntu-latest
+    env:
+      otp: 25.1.0
+      elixir: 1.14.0
+
     steps:
       - uses: actions/checkout@v1
 
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
         with:
-          otp-version: 25.1.0
-          elixir-version: 1.14.0
+          otp-version: ${{ env.otp }}
+          elixir-version: ${{ env.elixir }}
 
-      - run: mix deps.get
-      - run: mix deps.compile
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            deps
+            _build
+          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
+
+      - name: Install dependencies
+        run: mix do deps.get, deps.compile
+
       - run: mix compile --warnings-as-errors
       - run: mix format --check-formatted
 
@@ -48,7 +61,7 @@ jobs:
           elixir-version: ${{ env.elixir }}
 
       - name: Cache dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             deps


### PR DESCRIPTION
The following commit adds:

- Support for caching hexpm's dependencies
- Support for caching hex's dependencies (in the integration tests)

With the following differences in workflow job runtime:

- Format has been decreased from 2 min to 37 secs
- Test has been decreased from 2 min to 1 min
- Hex integration tests have been decreased from an average of 4.6 mins to an average of 1.74 mins

Overall, instead of 5 mins for the CI complete, only 2 mins are spent, resulting in a 3 min gain.