### PR TITLE
Move test script which has been unexecuted due to deformed filename

### DIFF
--- a/test/hexpm_web/erlang_format_test.exs
+++ b/test/hexpm_web/erlang_format_test.exs
@@ -5,8 +5,9 @@ defmodule HexpmWeb.ErlangFormatTest do
   test "decode/1" do
     long_binary = IO.iodata_to_binary(Enum.map(1..1000, fn _ -> "foobar" end))
 
+    assert decode("") == {:ok, nil}
     assert decode(:erlang.term_to_binary("foobar")) == {:ok, "foobar"}
-    assert decode(long_binary) == {:ok, long_binary}
+    assert decode(:erlang.term_to_binary(long_binary)) == {:ok, long_binary}
 
     assert {:error, _} = decode(:erlang.term_to_binary(fn -> :ok end))
     assert {:error, _} = decode(:erlang.term_to_binary(long_binary, compressed: 9))


### PR DESCRIPTION
There's been a test file which contains whitespace in its filename since #916. Placed it in the conforming path since it seems obvious which module is supposed to get tested, and tweaked it a bit to get it pass.