### PR TITLE
Expose files list on the release API

### DIFF
--- a/lib/hexpm_web/views/api/release_view.ex
+++ b/lib/hexpm_web/views/api/release_view.ex
@@ -32,7 +32,8 @@ defmodule HexpmWeb.API.ReleaseView do
       meta: %{
         app: release.meta.app,
         build_tools: Enum.uniq(release.meta.build_tools),
-        elixir: release.meta.elixir
+        elixir: release.meta.elixir,
+        files: release.meta.files
       },
       downloads: downloads(release.downloads),
       publisher: render_one(release.publisher, UserView, "minimal.json")


### PR DESCRIPTION
Hello folks 👋🏽 

While working on [warp.build](https://warp.build) I was playing around with the hex.pm API and found out that the file list, while it seems to be present in most packages metadata.config files, isn't part of the release responses.

I recognize that this might be expensive, since some packages may have large lists of files, but it can also be useful for tooling to recognize what package a particular file comes from. Especially in Erlang, it'd be useful to map a module to a file, or to use this list to map header files to packages.

I'll understand if this isn't something we want in the API, but after going back through the history of that file down to ~2006, I couldn't find any rationale for not including it, so I figured I'd open up the PR to have a discussion around it.

wdyt?