### PR TITLE
Add order param in packages API

### DIFF
--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -55,8 +55,8 @@ defmodule Hexpm.Repository.Packages do
     |> attach_repositories(repositories)
   end
 
-  def search_with_versions(repositories, page, packages_per_page, query, sort) do
-    Package.all(repositories, page, packages_per_page, query, sort, nil)
+  def search_with_versions(repositories, page, packages_per_page, query, sort, order) do
+    Package.all(repositories, page, packages_per_page, query, sort, nil, order)
     |> Ecto.Query.preload(
       releases: ^from(r in Release, select: struct(r, [:id, :version, :updated_at, :has_docs]))
     )

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -102,6 +102,10 @@ defmodule Hexpm.Utils do
   def parse_search(""), do: nil
   def parse_search(search), do: String.trim(search)
 
+  def parse_order("asc"), do: :asc
+  def parse_order("desc"), do: :desc
+  def parse_order(order), do: :desc # default
+
   defp diff(a, b) do
     {days, time} = :calendar.time_difference(a, b)
     :calendar.time_to_seconds(time) - days * 24 * 60 * 60

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -13,7 +13,8 @@ defmodule HexpmWeb.API.PackageController do
     page = Hexpm.Utils.safe_int(params["page"])
     search = Hexpm.Utils.parse_search(params["search"])
     sort = sort(params["sort"])
-    packages = Packages.search_with_versions(repositories, page, 100, search, sort)
+    order = Hexpm.Utils.parse_order(params["order"]) # Defaults to :desc
+    packages = Packages.search_with_versions(repositories, page, 100, search, sort, order)
 
     when_stale(conn, packages, [modified: false], fn conn ->
       conn

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -77,7 +77,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
       assert [] = json_response(conn, 200)
     end
 
-    test "sort order", %{package1: package1, package2: package2} do
+    test "sort by field", %{package1: package1, package2: package2} do
       conn = get(build_conn(), "/api/packages?sort=updated_at")
       result = json_response(conn, 200)
       assert hd(result)["name"] == package2.name
@@ -85,6 +85,29 @@ defmodule HexpmWeb.API.PackageControllerTest do
       conn = get(build_conn(), "/api/packages?sort=inserted_at")
       result = json_response(conn, 200)
       assert hd(result)["name"] == package1.name
+    end
+    
+    test "sort by field with order", %{package1: package1, package2: package2} do
+      conn = get(build_conn(), "/api/packages?sort=updated_at&order=desc")
+      result = json_response(conn, 200)
+      assert hd(result)["name"] == package2.name
+
+      conn = get(build_conn(), "/api/packages?sort=inserted_at&order=desc")
+      result = json_response(conn, 200)
+      assert hd(result)["name"] == package1.name
+
+      conn = get(build_conn(), "/api/packages?sort=updated_at&order=asc")
+      result = json_response(conn, 200)
+      assert hd(result)["name"] == package1.name
+
+      conn = get(build_conn(), "/api/packages?sort=inserted_at&order=asc")
+      result = json_response(conn, 200)
+      assert hd(result)["name"] == package2.name
+
+      # Should fall back to desc
+      conn = get(build_conn(), "/api/packages?sort=updated_at&order=INVALID_ORDER")
+      result = json_response(conn, 200)
+      assert hd(result)["name"] == package2.name
     end
 
     test "show private packages", %{user: user, package3: package3} do


### PR DESCRIPTION
This allows clients to list packages based on a specified order of the provided field 

At the moment, the /packages API only supports DESC order and this makes the `updated_after` pagination unusable (Introduced in #1168)

We would like to use this at https://www.softwareheritage.org/ to archive packages hosted on hex.pm.