### PR TITLE
Display latest release timestamp in "Most Downloaded"

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -9,6 +9,7 @@ defmodule Hexpm.Repository.Package do
     field :name, :string
     field :docs_updated_at, :utc_datetime_usec
     field :latest_version, Hexpm.Version, virtual: true
+    field :latest_release, :map, virtual: true
     timestamps()
 
     belongs_to :repository, Repository

--- a/lib/hexpm_web/templates/page/index.html.eex
+++ b/lib/hexpm_web/templates/page/index.html.eex
@@ -181,7 +181,7 @@
         </h3>
         <ul>
           <%= for {package, downloads} <- @package_top do %>
-            <%= render_package package: package.name, downloads: downloads, inserted_at: package.inserted_at, description: package.meta.description, version: package.latest_version %>
+            <%= render_package package: package.name, downloads: downloads, inserted_at: package.latest_release.inserted_at, description: package.meta.description, version: package.latest_release.version %>
           <% end %>
         </ul>
       </div>

--- a/test/hexpm_web/controllers/page_controller_test.exs
+++ b/test/hexpm_web/controllers/page_controller_test.exs
@@ -50,7 +50,7 @@ defmodule HexpmWeb.PageControllerTest do
     %{package1: p1, package2: p2, package3: p3}
   end
 
-  test "index", %{package1: %{id: package1_id}, package2: %{id: package2_id}} do
+  test "index", c do
     conn = get(build_conn(), "/")
 
     assert conn.status == 200
@@ -61,9 +61,10 @@ defmodule HexpmWeb.PageControllerTest do
     assert Enum.count(conn.assigns.releases_new) == 6
     assert Enum.count(conn.assigns.package_new) == 3
 
-    assert [
-             {%Hexpm.Repository.Package{id: ^package1_id}, 7},
-             {%Hexpm.Repository.Package{id: ^package2_id}, 2}
-           ] = conn.assigns.package_top
+    assert [{package1, 7}, {package2, 2}] = conn.assigns.package_top
+    assert package1.id == c.package1.id
+    assert package1.latest_release.version == "0.1.0"
+    assert package2.id == c.package2.id
+    assert package2.latest_release.version == "0.0.2"
   end
 end


### PR DESCRIPTION
Previously we showed _package_ timestamp which was incorrect, e.g.:

```
phoenix
8 833 678 downloads
Peace of mind from prototype to production
1.6.15 published 3156 days ago
                 ^^^^
```
