### PR TITLE
Sort by updated_at ASC if updated_after search query is used

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -246,8 +246,9 @@ defmodule Hexpm.Repository.Package do
   end
 
   defp search_param("updated_after", search, query) do
+    query = Ecto.Query.exclude(query, :order_by)
     case DateTime.from_iso8601(search) do
-      {:ok, updated_after, 0} -> from(p in query, where: p.updated_at >= ^updated_after)
+      {:ok, updated_after, 0} -> from(p in query, where: p.updated_at >= ^updated_after, order_by: [asc: p.updated_at])
       # invalid date, ignore the filter
       _ -> query
     end

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -1,6 +1,6 @@
 defmodule Hexpm.Repository.Package do
   use Hexpm.Schema
-  import Ecto.Query, only: [from: 2]
+  import Ecto.Query
 
   @derive {HexpmWeb.Stale, assocs: [:releases, :owners]}
   @derive {Phoenix.Param, key: :name}
@@ -246,11 +246,16 @@ defmodule Hexpm.Repository.Package do
   end
 
   defp search_param("updated_after", search, query) do
-    query = Ecto.Query.exclude(query, :order_by)
     case DateTime.from_iso8601(search) do
-      {:ok, updated_after, 0} -> from(p in query, where: p.updated_at >= ^updated_after, order_by: [asc: p.updated_at])
+      {:ok, updated_after, 0} ->
+        query
+        |> where([p], p.updated_at >= ^updated_after)
+        |> exclude(:order_by)
+        |> order_by([p], asc: p.updated_at)
+
       # invalid date, ignore the filter
-      _ -> query
+      _ ->
+        query
     end
   end
 

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -12,6 +12,7 @@ defmodule HexpmWeb.API.PackageController do
     repositories = repositories(conn)
     page = Hexpm.Utils.safe_int(params["page"])
     search = Hexpm.Utils.parse_search(params["search"])
+
     sort = sort(params["sort"])
     packages = Packages.search_with_versions(repositories, page, 100, search, sort)
 

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -12,7 +12,6 @@ defmodule HexpmWeb.API.PackageController do
     repositories = repositories(conn)
     page = Hexpm.Utils.safe_int(params["page"])
     search = Hexpm.Utils.parse_search(params["search"])
-
     sort = sort(params["sort"])
     packages = Packages.search_with_versions(repositories, page, 100, search, sort)
 


### PR DESCRIPTION
Sort by updated_at ASC if the query string contains `search=updated_after:<iso_date>`

Based on the suggestion by @ericmj in #1171 as an alternative to adding `order` param in the /packages API

We would like to use this at https://www.softwareheritage.org/ to archive packages hosted on hex.pm.