### PR TITLE
Fix deprecation warnings for Sass

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -1,3 +1,5 @@
+@use 'sass:math';
+
 @import "../vendor/css/github";
 
 @import "vendor/media-queries";

--- a/assets/css/base/_mixins.scss
+++ b/assets/css/base/_mixins.scss
@@ -1,15 +1,15 @@
 @mixin font-size($size-value, $line-height: 14) {
   font: {
-    size: ($size-value / $base-font-size) + rem;
+    size: math.div($size-value, $base-font-size) + rem;
   };
 
   @if $line-height != 14 {
-    line-height: ($line-height / $base-line-height) + rem;
+    line-height: math.div($line-height, $base-line-height) + rem;
   }
 }
 
 @mixin line-height($size-value) {
-  line-height: ($size-value / $base-line-height) + rem;
+  line-height: math.div($size-value, $base-line-height) + rem;
 }
 
 @mixin font-face($font-family, $file-path, $weight: normal, $style: normal) {


### PR DESCRIPTION
Here's an example of a deprecation warning which is now fixed:

```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($size-value, $base-font-size)

More info and automated migrator: https://sass-lang.com/d/slash-div

  ╷
3 │     size: ($size-value / $base-font-size) + rem;
  │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
    css/base/_mixins.scss 3:12  font-size()
    css/base/_general.scss 8:3  @import
    stdin 8:9                   root stylesheet
```