### PR TITLE
Bump actions/checkout from v2 to v3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
       elixir: 1.14.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
@@ -52,7 +52,7 @@ jobs:
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1
@@ -106,7 +106,7 @@ jobs:
       elixir: 1.14.0
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install OTP and Elixir
         uses: erlef/setup-beam@v1


### PR DESCRIPTION
GitHub Actions displays a warning message that it has deprecated Node.js v12 and encourages to use v16. See for example https://github.com/hexpm/hexpm/actions/runs/3876399765, in which the exact message is as follows:

```
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout@v2
```

The message is coming from actions/checkout@v2 and I believe it can be taken care of by upgrading to actions/checkout@v3.
