### PR TITLE
Consolidate Key.revoke_at fields

### DIFF
--- a/lib/hexpm_web/views/api/key_view.ex
+++ b/lib/hexpm_web/views/api/key_view.ex
@@ -20,7 +20,7 @@ defmodule HexpmWeb.API.KeyView do
       authing_key: !!(authing_key && key.id == authing_key.id),
       secret: key.user_secret,
       permissions: render_many(key.permissions, KeyPermissionView, "show.json"),
-      revoked_at: key.revoked_at,
+      revoke_at: key.revoke_at,
       inserted_at: key.inserted_at,
       updated_at: key.updated_at,
       url: url(~p"/api/keys/#{key}")

--- a/priv/repo/migrations/20180704214746_add_internal_to_keys.exs
+++ b/priv/repo/migrations/20180704214746_add_internal_to_keys.exs
@@ -9,10 +9,10 @@ defmodule Hexpm.Repo.Migrations.AddInternalToKeys do
       add(:revoke_at, :timestamp)
     end
 
-    create(index("keys", [:name]))
-    create(index("keys", [:revoked_at]))
-    create(index("keys", [:revoke_at]))
-    create(index("keys", [:public]))
+    create(index(:keys, [:name]))
+    create(index(:keys, [:revoked_at]))
+    create(index(:keys, [:revoke_at]))
+    create(index(:keys, [:public]))
   end
 
   def down do
@@ -23,7 +23,7 @@ defmodule Hexpm.Repo.Migrations.AddInternalToKeys do
       remove(:revoke_at)
     end
 
-    drop(index("keys", [:name]))
-    drop(index("keys", [:revoked_at]))
+    drop(index(:keys, [:name]))
+    drop(index(:keys, [:revoked_at]))
   end
 end

--- a/priv/repo/migrations/20200605151334_add_package_reports_table.exs
+++ b/priv/repo/migrations/20200605151334_add_package_reports_table.exs
@@ -11,7 +11,7 @@ defmodule Hexpm.RepoBase.Migrations.AddPackageReportsTable do
       timestamps()
     end
 
-    create(index("package_reports", [:package_id]))
+    create(index(:package_reports, [:package_id]))
   end
 
   def down() do

--- a/priv/repo/migrations/20200609095835_add_package_report_release_table.exs
+++ b/priv/repo/migrations/20200609095835_add_package_report_release_table.exs
@@ -9,8 +9,8 @@ defmodule Hexpm.RepoBase.Migrations.AddPackageReportReleaseTable do
       timestamps()
     end
 
-    create(index("package_report_releases", [:package_report_id]))
-    create(index("package_report_releases", [:release_id]))
+    create(index(:package_report_releases, [:package_report_id]))
+    create(index(:package_report_releases, [:release_id]))
   end
 
   def drop() do

--- a/priv/repo/migrations/20200711092923_add_package_report_comments_table.exs
+++ b/priv/repo/migrations/20200711092923_add_package_report_comments_table.exs
@@ -10,7 +10,7 @@ defmodule Hexpm.RepoBase.Migrations.AddCommentsTable do
       timestamps()
     end
 
-    create(index("package_report_comments", [:package_report_id]))
+    create(index(:package_report_comments, [:package_report_id]))
   end
 
   def down() do

--- a/priv/repo/migrations/20230510205035_remove_keys_revoked_at.exs
+++ b/priv/repo/migrations/20230510205035_remove_keys_revoked_at.exs
@@ -1,0 +1,19 @@
+defmodule Hexpm.RepoBase.Migrations.RemoveKeysRevokedAt do
+  use Ecto.Migration
+
+  def change do
+    execute "UPDATE keys SET revoke_at = least(revoke_at, revoked_at)"
+
+    drop unique_index(:keys, [:user_id, :name], where: "revoked_at IS NULL", name: "keys_user_id_name_revoked_at_key")
+    drop unique_index(:keys, [:organization_id, :name], where: "revoked_at IS NULL", name: "keys_organization_id_name_revoked_at_key")
+    drop index(:keys, :name)
+
+    create index(:keys, [:user_id, :name])
+    create index(:keys, [:organization_id, :name])
+    create index(:keys, [:public])
+
+    alter table(:keys) do
+      remove(:revoked_at, :timestamp)
+    end
+  end
+end

--- a/test/hexpm/accounts/auth_test.exs
+++ b/test/hexpm/accounts/auth_test.exs
@@ -58,7 +58,7 @@ defmodule Hexpm.Accounts.AuthTest do
     end
 
     test "does not authorize revoked key", %{user: user} do
-      key = insert(:key, user: user, revoked_at: ~N"2017-01-01 00:00:00")
+      key = insert(:key, user: user, revoke_at: ~N"2017-01-01 00:00:00")
       assert Auth.key_auth(key.user_secret, %{}) == :revoked
     end
   end

--- a/test/hexpm_web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/auth_controller_test.exs
@@ -99,7 +99,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
           :key,
           user: user,
           permissions: [build(:key_permission, domain: "api")],
-          revoked_at: ~N[2018-01-01 00:00:00]
+          revoke_at: ~N[2018-01-01 00:00:00]
         )
 
       build_conn()

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -219,7 +219,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert conn.status == 200
       body = Jason.decode!(conn.resp_body)
       assert body["name"] == key_a.name
-      assert body["revoked_at"]
+      assert body["revoke_at"]
       assert body["updated_at"]
       assert body["inserted_at"]
       refute body["secret"]
@@ -295,7 +295,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert conn.status == 200
       body = Jason.decode!(conn.resp_body)
       assert body["name"] == "computer"
-      assert body["revoked_at"]
+      assert body["revoke_at"]
       assert body["updated_at"]
       assert body["inserted_at"]
       refute body["secret"]
@@ -322,7 +322,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert conn.status == 200
       body = Jason.decode!(conn.resp_body)
       assert body["name"] == "current"
-      assert body["revoked_at"]
+      assert body["revoke_at"]
       assert body["updated_at"]
       assert body["inserted_at"]
       refute body["secret"]

--- a/test/hexpm_web/controllers/dashboard/key_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/key_controller_test.exs
@@ -53,7 +53,7 @@ defmodule HexpmWeb.Dashboard.KeyControllerTest do
     end
 
     test "revoking an already revoked key throws an error", c do
-      insert(:key, user: c.user, name: "computer", revoked_at: ~N"2017-01-01 00:00:00")
+      insert(:key, user: c.user, name: "computer", revoke_at: ~N"2017-01-01 00:00:00")
 
       conn =
         build_conn()

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -787,7 +787,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
         :key,
         organization: c.organization,
         name: "computer",
-        revoked_at: ~N"2017-01-01 00:00:00"
+        revoke_at: ~N"2017-01-01 00:00:00"
       )
 
       mock_customer(c.organization)


### PR DESCRIPTION
Simplifies the keys schema by removing the `revoked_at` field and moving that functionality into `revoke_at`.