### PR TITLE
Support GitHub Secret Scanning

### DIFF
--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -81,7 +81,7 @@ defmodule Hexpm.Accounts.Auth do
   def gen_key() do
     :crypto.strong_rand_bytes(16)
     |> Base.encode16(case: :lower)
-    |> (fn s -> "hexpm_#{s}" end).()
+    |> String.replace_prefix("", "hexpm_")
   end
 
   defp find_email(nil, _email) do

--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -81,6 +81,7 @@ defmodule Hexpm.Accounts.Auth do
   def gen_key() do
     :crypto.strong_rand_bytes(16)
     |> Base.encode16(case: :lower)
+    |> (fn s -> "hexpm_#{s}" end).()
   end
 
   defp find_email(nil, _email) do

--- a/test/hexpm/accounts/keys_test.exs
+++ b/test/hexpm/accounts/keys_test.exs
@@ -32,7 +32,10 @@ defmodule Hexpm.Accounts.KeysTest do
       assert {:ok, %{key: key}} = Keys.create(user, params, audit: audit_data(user))
       assert key.name == "keyname"
       assert key.user_id == user.id
-      assert {:ok, _} = Base.decode16(key.user_secret, case: :lower)
+
+      [prefix, user_secret] = String.split(key.user_secret, "_")
+
+      assert {"hexpm", {:ok, _}} = {prefix, Base.decode16(user_secret, case: :lower)}
     end
 
     test "organization api permissions", %{organization: organization} do
@@ -46,7 +49,10 @@ defmodule Hexpm.Accounts.KeysTest do
 
       assert key.name == "keyname"
       assert key.organization_id == organization.id
-      assert {:ok, _} = Base.decode16(key.user_secret, case: :lower)
+
+      [prefix, user_secret] = String.split(key.user_secret, "_")
+
+      assert {"hexpm", {:ok, _}} = {prefix, Base.decode16(user_secret, case: :lower)}
     end
 
     test "user package permissions", %{user: user, package: package} do


### PR DESCRIPTION
Changes in this PR are in order to support the [Secrets Scanning Partner Program](https://docs.github.com/en/code-security/secret-scanning/secret-scanning-partner-program) from GitHub.

**The most notable change found within is that newly generated user_secrets will now prepend `hexpm_` to the base16 encoded strings.** e.g. `hexpm_316e6532776f3368726565`

Other changes are just to support the GitHub webhooks for the Secret Scanning flow.