### PR TITLE
Increases TOTP shared secret security bits from 80 to 160

### DIFF
--- a/lib/hexpm/accounts/tfa.ex
+++ b/lib/hexpm/accounts/tfa.ex
@@ -9,6 +9,10 @@ defmodule Hexpm.Accounts.TFA do
     embeds_many :recovery_codes, Hexpm.Accounts.RecoveryCode
   end
 
+  # As recommended by requirement R6 in Section 4 of RFC 4226
+  # https://www.rfc-editor.org/rfc/rfc4226.html#section-4
+  @secret_security_bits 160
+
   def changeset(tfa, params) do
     tfa
     |> cast(params, ~w(secret app_enabled tfa_enabled)a)
@@ -16,7 +20,8 @@ defmodule Hexpm.Accounts.TFA do
   end
 
   def generate_secret() do
-    10
+    @secret_security_bits
+    |> div(8)
     |> :crypto.strong_rand_bytes()
     |> Base.encode32()
   end


### PR DESCRIPTION
As per recommended by RFC 4226

From https://datatracker.ietf.org/doc/html/rfc4226#section-4:

>  R6 - The algorithm MUST use a strong shared secret.  The length of
>  the shared secret MUST be at least 128 bits.  This document
>  RECOMMENDs a shared secret length of 160 bits.

---

The current implementation causes for example for app FreeOTP to warn "Token is unsafe" when scanning the QR code.

Curiously GitHub itself also appears to have a less-than-recommended OTP secret security: https://github.com/freeotp/freeotp-android/issues/334.

---

This change only affects generation of future secrets.
Existing secrets on the database remain unchanged of course. Doing so would invalidate all users token setups.