### PR TITLE
Fixes ability to delete email address

### DIFF
--- a/lib/hexpm_web/templates/dashboard/email/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/email/index.html.eex
@@ -29,7 +29,7 @@
               <span class="label label-success">Gravatar</span>
             <% end %>
 
-            <%= form_tag(~p"/dashboard/email", class: "action") do %>
+            <%= form_tag(~p"/dashboard/email", method: :delete, class: "action") do %>
               <input type="hidden" name="email" value="<%= email.email %>">
               <button type="submit" class="btn btn-link btn-svg" <%= if email.primary do %>disabled<% end %>>
                 <%= HexpmWeb.ViewIcons.icon(:octicon, :trashcan) %>


### PR DESCRIPTION
Currently clicking the trash icon gives me 400 bad request because is POSTing to the create action, not delete?

I think this might be broken since https://github.com/hexpm/hexpm/pull/1185/files#diff-6610674510372ed6a190eec9120caedb76fc7d1b157bb47b37c64e5332ec7cc5L32 possibly?