### PR TITLE
Fix line-height issue on title for Versions page

### DIFF
--- a/assets/css/template/_version-list.scss
+++ b/assets/css/template/_version-list.scss
@@ -1,5 +1,5 @@
 .versions-title {
-  @include font-size(38, $base-line-height);
+  @include font-size(38, 66.88);
   margin: 40px 0;
   color: $color-text-grey;
 


### PR DESCRIPTION
Fixes https://github.com/hexpm/hexpm/issues/1229

This affects packages with long names like https://hex.pm/packages/nerves_toolchain_armv7_nerves_linux_gnueabihf/versions

This is using the `font-size` mixin
https://github.com/hexpm/hexpm/blob/8640de18d58de42b97116c99aae30d6164f43969/assets/css/base/_mixins.scss#L1-L9

Previously it was passing in a `$line-height` of [`$base-line-height`, which is 16](https://github.com/hexpm/hexpm/blob/8640de18d58de42b97116c99aae30d6164f43969/assets/css/base/_variables.scss#L17). The `font-size` mixin would compute this to `1 rem`, which be 10px because `$base-font-size` is 10

The package show page, which does handle long names properly (e.g. https://hex.pm/packages/nerves_toolchain_armv7_nerves_linux_gnueabihf) is using a `line-height` of unitless 1.1.

`font-size` is being set to 38 (technically 3.8 rem, which also ends up being 38), so to achieve the same ratio of 1.1, we need `line-height` to be set to (1.1 * 3.8) = 4.18 rem. To get the `font-size` mixin to resolve `line-height` to 4.18 rem, we need to pass in 4.18 * 16 = 66.88.

This convoluted math is a good example of why [mdn recommends using unitless `line-height`s](https://developer.mozilla.org/en-US/docs/Web/CSS/line-height#prefer_unitless_numbers_for_line-height_values). The `font-size` mixin seems to be used in quite a few places so I didn't think it'd be a good idea to try and refactor that just for this issue. An alternative would be to avoid using the mixin for `.versions-title` and just set `font-size` and `line-height` directly.

![image](https://github.com/hexpm/hexpm/assets/217050/cd9cfb0b-0fd5-4dca-a571-844fed7c40ed)
