### PR TITLE
Fix exposing retirements in packages list API

### DIFF
--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -77,7 +77,7 @@ defmodule Hexpm.Repository.Packages do
     |> Ecto.Query.preload(
       releases:
         ^from(r in Release,
-          select: struct(r, [:id, :version, :inserted_at, :updated_at, :has_docs])
+          select: struct(r, [:id, :version, :inserted_at, :updated_at, :has_docs, :retirement])
         )
     )
     |> Repo.all()

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -49,7 +49,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
   end
 
   describe "GET /api/packages" do
-    test "multiple packages", %{package1: package1} do
+    test "multiple packages", %{package1: package1, package4: package4} do
       conn = get(build_conn(), "/api/packages")
       result = json_response(conn, 200)
       assert length(result) == 3
@@ -75,6 +75,14 @@ defmodule HexpmWeb.API.PackageControllerTest do
 
       conn = get(build_conn(), "/api/packages?page=2")
       assert [] = json_response(conn, 200)
+
+      conn = get(build_conn(), "/api/packages?search=#{package4.name}")
+      [package] = json_response(conn, 200)
+
+      assert %{
+               "message" => "not backward compatible",
+               "reason" => "other"
+             } = package["retirements"]["0.0.1"]
     end
 
     test "sort order", %{package1: package1, package2: package2} do


### PR DESCRIPTION
## Context

Working on RayCast integration with Hex.pm I found that `retirements` were working properly