### PR TITLE
Add per_page param to /api/packages

### DIFF
--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -15,6 +15,7 @@ defmodule HexpmWeb.API.PackageController do
     search = Hexpm.Utils.parse_search(params["search"])
     sort = sort(params["sort"])
     per_page = Hexpm.Utils.safe_int(params["per_page"]) || @packages_per_page
+    per_page = Enum.min([per_page, @packages_per_page])
     packages = Packages.search_with_versions(repositories, page, per_page, search, sort)
 
     when_stale(conn, packages, [modified: false], fn conn ->

--- a/lib/hexpm_web/controllers/api/package_controller.ex
+++ b/lib/hexpm_web/controllers/api/package_controller.ex
@@ -7,13 +7,15 @@ defmodule HexpmWeb.API.PackageController do
   plug :authorize, domains: [{"api", "read"}], fun: {AuthHelpers, :organization_access}
 
   @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
+  @packages_per_page 100
 
   def index(conn, params) do
     repositories = repositories(conn)
     page = Hexpm.Utils.safe_int(params["page"])
     search = Hexpm.Utils.parse_search(params["search"])
     sort = sort(params["sort"])
-    packages = Packages.search_with_versions(repositories, page, 100, search, sort)
+    per_page = Hexpm.Utils.safe_int(params["per_page"]) || @packages_per_page
+    packages = Packages.search_with_versions(repositories, page, per_page, search, sort)
 
     when_stale(conn, packages, [modified: false], fn conn ->
       conn

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -95,6 +95,12 @@ defmodule HexpmWeb.API.PackageControllerTest do
       assert hd(result)["name"] == package1.name
     end
 
+    test "per page" do
+      conn = get(build_conn(), "/api/packages?per_page=1")
+      result = json_response(conn, 200)
+      assert length(result) == 1
+    end
+
     test "filter by last_updated", %{package2: package2} do
       conn = get(build_conn(), "/api/packages?page=1&search=updated_after:2029-01-01T00:00:00Z")
       assert [result] = json_response(conn, 200)


### PR DESCRIPTION
I recently added hex search to searxng. But by default it loads too many results. This allows to reduce the results count.