### PR TITLE
Updates CI workflow to automagically format code and recommit it (if …

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     name: Run mix format
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/mix-format@v1
+      - uses: supersimple/mix-format@v1
         with:
           elixir_version: 1.16.2
           otp_version: 26.2.3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,8 +3,18 @@ name: CI
 on: [push, pull_request]
 
 jobs:
-  format:
-    name: Format
+  formatter:
+    name: Run mix format
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/mix-format@v1
+        with:
+          elixir_version: 1.16.2
+          otp_version: 26.2.3
+          mix_env: dev
+
+  lint:
+    name: Run linters
     runs-on: ubuntu-20.04
     env:
       otp: 26.2.3


### PR DESCRIPTION
…it changed)

@wojtekmach @ericmj WDYT about adding this?
It might save some frustration in the future to just have CI run the formatter. I also think the step called "format" now is probably better referred to as "lint" based on what it does.
If you hate it, feel free to close this PR. I wont be offended.