### PR TITLE
Align home and navigation form search buttons

### DIFF
--- a/assets/css/base/_variables.scss
+++ b/assets/css/base/_variables.scss
@@ -21,3 +21,11 @@ $base-title-font-family:  'Lato', sans-serif;
 // Elements
 $base-border: 1px solid $color-grey;
 $base-box-shadow: x 1px 4px rgba(0, 0, 0 , .2);
+$base-box-shadow: x 1px 4px rgba(0, 0, 0, 0.2);
+
+// Matches Bootstrap's `$input-height-base`:
+//  @line-height-base:        1.428571429; // 20/14
+//  @line-height-computed:    floor((@font-size-base * @line-height-base)); // ~20px
+//  @padding-base-vertical:    6px;
+//  @input-height-base:       (@line-height-computed + (@padding-base-vertical * 2) + 2);
+$form-input-height: 34px;

--- a/assets/css/template/_home.scss
+++ b/assets/css/template/_home.scss
@@ -189,6 +189,10 @@
   margin-bottom: 40px;
   text-align: center;
 
+  .input {
+      height: $form-input-height;
+  }
+
   .input-group {
     border: 10px solid rgba(0, 0, 0, .1);
     border-radius: 8px;
@@ -199,7 +203,11 @@
     }
 
     .btn {
-      padding: 6px 12px 4px;
+      padding: 6px 12px;
+    }
+
+    .btn-search {
+        height: $form-input-height;
     }
   }
 }

--- a/assets/css/template/_navbar.scss
+++ b/assets/css/template/_navbar.scss
@@ -80,12 +80,15 @@
     border-color: #fff;
     box-shadow: none;
     -webkit-box-shadow: none;
+
+    // Override bootstrap input fields height.
+    height: $form-input-height;
   }
 
   button.btn {
     color: #adb3b6;
     background: $color-white;
-    padding: 5px 12px;
+    padding: 6px 12px;
   }
 }
 


### PR DESCRIPTION
Hi everyone, sorry in advance for such a silly request, but bear with me 🙏 

## The issue

I've noticed that the search button is a bit off. That is true for both home search and navigation bar search:

![Screenshot 2024-11-20 at 21-38-50 Hex](https://github.com/user-attachments/assets/83a07a9e-4dfc-475d-a711-6eb8fae85b84)

![Screenshot 2024-11-20 at 21-35-56 Packages Hex](https://github.com/user-attachments/assets/5fe47dbc-95ec-4d33-90aa-ffb136b96e7e)

This happens because the current Bootstrap version doesn't treat button tags as form controls. Both places use `button` instead of `input`:

https://github.com/hexpm/hexpm/blob/7edc9d4ff2e8cab6fa1e2986ade16d1f64016336/lib/hexpm_web/templates/page/index.html.eex#L16-L19 

https://github.com/hexpm/hexpm/blob/7edc9d4ff2e8cab6fa1e2986ade16d1f64016336/lib/hexpm_web/templates/layout/header.html.eex#L53-L55

The `button` tag makes helps with button icons. Inputs don't support icons out-of-box. If you replace the `button` tag with `input` one, the search button aligns in both places, but the magnifier icon is gone.

## The solution

In fact, there are multiple solutions. Somehow we need to propagate the Bootsrap form inputs' height to hexpm css.

What I've come up with:

- We can grab style height in runtime using JS. Though it's possible, that sounds off.
- Duplicate the Bootstrap input height formula. That's possible, but it would make little sense, as the formula will be used in two places and won't correlate with the rest of styles.

So, I've decided to hardcode the value and specify where it comes from in case one has to tweak it.

## The result

I use https://darkreader.org/ to derive dark styles. They make the change more prominent.

![Screenshot 2024-11-20 at 21-35-15 Packages Hex](https://github.com/user-attachments/assets/6abdd8df-e361-4fdb-8854-188563c73a25)
![Screenshot 2024-11-20 at 21-35-04 Packages Hex](https://github.com/user-attachments/assets/d2fcb720-78b6-4524-851b-5bcb31cc4171)
![Screenshot 2024-11-20 at 21-37-53 Hex](https://github.com/user-attachments/assets/6da70344-2817-4bc0-af3c-17533d436647)
![Screenshot 2024-11-20 at 21-37-43 Hex](https://github.com/user-attachments/assets/7cbaa4a2-0769-4e85-9b2f-2ed689baf243)

<details>
<summary>Screenshots from Safari and Chrome accordingly</summary>

![CleanShot 2024-11-20 at 21 39 43@2x](https://github.com/user-attachments/assets/6cc137b7-12db-45ea-87f7-9843d10fc6d6)
![CleanShot 2024-11-20 at 21 40 17@2x](https://github.com/user-attachments/assets/ec55dde1-a2f3-488d-aec8-a7546cb50705)

![CleanShot 2024-11-20 at 21 41 13@2x](https://github.com/user-attachments/assets/100685d0-a9f1-4047-b554-afbf4bcc76ca)
![CleanShot 2024-11-20 at 21 40 58@2x](https://github.com/user-attachments/assets/1424c4f4-f6b8-4993-b035-8f248368b5a2)

</details>

Please let me know whether the tweak makes sense or if I missed anything 🙇 
