### PR TITLE
Align the copy version buttons

### DIFF
--- a/assets/css/template/_package-view.scss
+++ b/assets/css/template/_package-view.scss
@@ -179,5 +179,6 @@
 }
 
 .btn.copy-button {
-  padding: 6px 12px 4px;
+  padding: 6px 12px;
+  height: $form-input-height;
 }


### PR DESCRIPTION
The changes are similar to #1283, but I missed that the copy version buttons were also misaligned. Here's before and after the change:

<img src="https://github.com/user-attachments/assets/83825d3e-de4f-427a-977c-db1ca87b1477" width="400"/> <img src="https://github.com/user-attachments/assets/ff05a309-f087-4f41-bc0f-85556b4f20a9" width="400"/>
