### PR TITLE
Specify Yarn as package manager in package.json

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -20,5 +20,6 @@
     "style-loader": "^4.0.0",
     "webpack-cli": "^5.1.4",
     "webpack": "5.94.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22"
 }


### PR DESCRIPTION
Defines which package manager is expected to be used when working on the current project. see https://nodejs.org/api/corepack.html