### PR TITLE
Allow getting release manifests without download count

### DIFF
--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -1416,5 +1416,16 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
                ["2000-02", 9]
              ]
     end
+
+    test "get release without downloads", %{package: package, release: release} do
+      result =
+        build_conn()
+        |> get("/api/packages/#{package.name}/releases/#{release.version}?downloads=none")
+        |> json_response(200)
+
+      assert result["version"] == "#{release.version}"
+
+      assert result["downloads"] == nil
+    end
   end
 end


### PR DESCRIPTION
Many build tools rely on checksums to ensure a remote resource didn't change unexpectedly, Hex itself does it for package tarballs. Having the ever-changing `downloads` field in the manifests makes it impossible to checksum them.

This change fixes that and allows the release manifests to be used in a hermetic manner.