### PR TITLE
fix/1279: fix missing recent downloads in pseudo-exact matches

### DIFF
--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -30,7 +30,8 @@ defmodule HexpmWeb.PackageController do
     page = Hexpm.Utils.safe_page(page_param, package_count, @packages_per_page)
     exact_match = exact_match(repositories, search)
     all_matches = fetch_packages(repositories, page, @packages_per_page, filter, sort)
-    downloads = Downloads.packages_all_views(all_matches)
+    matches_for_downloads = if exact_match, do: [exact_match | all_matches], else: all_matches
+    downloads = Downloads.packages_all_views(matches_for_downloads)
     packages = Packages.diff(all_matches, exact_match)
 
     maybe_log_search(search, package_count)

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -107,9 +107,19 @@ defmodule HexpmWeb.PackageControllerTest do
       assert response(conn, 200) =~ ~r/#{package2.name}.*1.0.0/s
     end
 
-    test "search with whitespace", %{package5: package5} do
+    test "search with whitespace", %{package5: package5, package5_release: package5_release} do
+      insert(:download,
+        package: package5,
+        release: package5_release,
+        downloads: 1_234,
+        day: Hexpm.Utils.utc_yesterday()
+      )
+
+      :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
       conn = get(build_conn(), "/packages?search=with underscore")
       assert response(conn, 200) =~ "exact-match"
+      assert response(conn, 200) =~ "total downloads: 1 234"
       assert response(conn, 200) =~ ~r/#{package5.name}.*0.0.1/s
       refute response(conn, 200) =~ "no-results"
     end


### PR DESCRIPTION
Fixes issue #1279

There seems to have been a related fix in https://github.com/hexpm/hexpm/pull/1255 for something identical-sounding, but I can attest that this issue is  present in `main`. Looking more closely, it seems that the PR fixes the downloads for *actually* exact matches, but what the code considers an "exact match" in some scenarios is slightly different.

This reported issue seems to happen because the view in `lib/hexpm_web/templates/package/index.html.eex` tries to display the downloads of the package and defaults to 0 if it can't find a value from the `downloads` that matches a given package's `id` (see `HexpmWeb.PackageView.downloads_for_package/2`). So, clearly we're not finding the "exact match" from the downloads!

Why could this be? Well, let's investigate! 👀 

It seems that `HexpmWeb.PackageController` houses an `exact_match/2` function that replaces spaces with underscores in an attempt to find this elusive exact match. So, when a user searches for ` "fun with flags"`, the function actually ends up searching for a package called ` "fun_with_flags"`. So far so good.

However, the issue here is that the controller's `index/2` function doesn't actually use that information about an exact match when it defines `downloads`, and so the `downloads` will never contain the "exact match" if the user didn't *actually* search for a "true exact match" but rather for a space-separated phony. Thus, the `downloads` that ends up in the view will never have a chance of finding the downloads for that package.

A quick and simple solution could be to make sure that if we find an exact match, we ensure `downloads` is also defined with that package in mind. This is what I've done here in this PR.