### PR TITLE
Update CI runner to 24.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,7 +96,7 @@ jobs:
 
   test-hex:
     name: Test Hex
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     services:
       postgres:


### PR DESCRIPTION
20.04 was retired. Let's hope this works :fingers-crossed:

build failing due to this f.ex. on #1304 