### PR TITLE
Add api paramter to limit reported downloads to a date range

### DIFF
--- a/lib/hexpm/repository/download.ex
+++ b/lib/hexpm/repository/download.ex
@@ -53,6 +53,10 @@ defmodule Hexpm.Repository.Download do
     end
   end
 
+  def before_date(query, date) do
+    from(d in query, where: d.day <= ^date)
+  end
+
   def since_date(query, date) do
     from(d in query, where: d.day >= ^date)
   end

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -77,6 +77,15 @@ defmodule Hexpm.Utils do
     if binary in allowed, do: String.to_atom(binary)
   end
 
+  def safe_date(nil), do: nil
+
+  def safe_date(string) do
+    case Date.from_iso8601(string) do
+      {:ok, date} -> date
+      _ -> nil
+    end
+  end
+
   def safe_page(page, _count, _per_page) when page < 1 do
     1
   end

--- a/lib/hexpm_web/controllers/api/release_controller.ex
+++ b/lib/hexpm_web/controllers/api/release_controller.ex
@@ -58,7 +58,14 @@ defmodule HexpmWeb.API.ReleaseController do
   def show(conn, params) do
     if release = conn.assigns.release do
       downloads_period = Hexpm.Utils.safe_to_atom(params["downloads"], @download_period_params)
-      downloads = Downloads.by_period(release, downloads_period)
+      downloads_after = Hexpm.Utils.safe_date(params["downloads_after"])
+      downloads_before = Hexpm.Utils.safe_date(params["downloads_before"])
+
+      downloads =
+        Downloads.for_period(release, downloads_period,
+          downloads_after: downloads_after,
+          downloads_before: downloads_before
+        )
 
       release =
         release

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -152,11 +152,14 @@ defmodule HexpmWeb.PackageController do
     start_download_day = Date.add(last_download_day, -30)
     downloads = Downloads.package(package)
 
-    graph_downloads =
+    graph_downloads_for =
       case type do
-        :package -> Downloads.since_date(package, start_download_day)
-        :release -> Downloads.since_date(release, start_download_day)
+        :package -> package
+        :release -> release
       end
+
+    graph_downloads =
+      Downloads.for_period(graph_downloads_for, :day, downloads_after: start_download_day)
 
     graph_downloads = Map.new(graph_downloads, &{Date.from_iso8601!(&1.day), &1})
 

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -1416,5 +1416,22 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
                ["2000-02", 9]
              ]
     end
+
+    test "get release downloads limited to range", %{package: package, release: release} do
+      result =
+        build_conn()
+        |> get(
+          "/api/packages/#{package.name}/releases/#{release.version}?" <>
+            "downloads=day&downloads_after=2000-01-02&downloads_before=2000-02-07"
+        )
+        |> json_response(200)
+
+      assert result["version"] == "#{release.version}"
+
+      assert result["downloads"] == [
+               ["2000-02-01", 3],
+               ["2000-02-07", 2]
+             ]
+    end
   end
 end


### PR DESCRIPTION
For old releases the downloads map/kw list can become quite long and take a while on the api request. This allows continuous consumers* to limit to a more relevant range instead of always requesting everything.

\* I was looking at a monthly email of downloads of my personal packages.