### PR TITLE
Add support for Bluesky user handle on profiles

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -292,7 +292,7 @@ defmodule Hexpm.Accounts.AuditLog do
   defp fields(%ReleaseRetirement{}), do: [:status, :message]
   defp fields(%Organization{}), do: [:id, :name, :public, :active, :billing_active]
   defp fields(%User{}), do: [:id, :username]
-  defp fields(%UserHandles{}), do: [:twitter, :github, :elixirforum, :freenode, :slack]
+  defp fields(%UserHandles{}), do: [:twitter, :bluesky, :github, :elixirforum, :freenode, :slack]
 
   defp multi_key(multi, action) do
     :"log.#{action}.#{length(Multi.to_list(multi))}"

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -292,7 +292,7 @@ defmodule Hexpm.Accounts.AuditLog do
   defp fields(%ReleaseRetirement{}), do: [:status, :message]
   defp fields(%Organization{}), do: [:id, :name, :public, :active, :billing_active]
   defp fields(%User{}), do: [:id, :username]
-  defp fields(%UserHandles{}), do: [:github, :twitter, :freenode]
+  defp fields(%UserHandles{}), do: [:twitter, :github, :elixirforum, :freenode, :slack]
 
   defp multi_key(multi, action) do
     :"log.#{action}.#{length(Multi.to_list(multi))}"

--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -5,6 +5,7 @@ defmodule Hexpm.Accounts.UserHandles do
 
   embedded_schema do
     field :twitter, :string
+    field :bluesky, :string
     field :github, :string
     field :elixirforum, :string
     field :freenode, :string
@@ -12,12 +13,13 @@ defmodule Hexpm.Accounts.UserHandles do
   end
 
   def changeset(handles, params) do
-    cast(handles, params, ~w(twitter github elixirforum freenode slack)a)
+    cast(handles, params, ~w(twitter bluesky github elixirforum freenode slack)a)
   end
 
   def services() do
     [
       {:twitter, "Twitter", "https://twitter.com/{handle}"},
+      {:bluesky, "Bluesky", "https://bsky.app/profile/{handle}"},
       {:github, "GitHub", "https://github.com/{handle}"},
       {:elixirforum, "Elixir Forum", "https://elixirforum.com/u/{handle}"},
       {:freenode, "Libera", "irc://irc.libera.chat/elixir"},
@@ -43,6 +45,7 @@ defmodule Hexpm.Accounts.UserHandles do
   end
 
   def handle(:twitter, handle), do: unuri(handle, "twitter.com", "/")
+  def handle(:bluesky, handle), do: unuri(handle, "bsky.app", "/profile/")
   def handle(:github, handle), do: unuri(handle, "github.com", "/")
   def handle(:elixirforum, handle), do: unuri(handle, "elixirforum.com", "/u/")
   def handle(_service, handle), do: handle

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -52,6 +52,16 @@
               </div>
 
               <div class="form-group">
+                <%= label f, :bluesky %>
+                <div class="input-group">
+                  <div class="input-group-addon">bsky.app/profile/</div>
+                  <%= ViewHelpers.text_input f, :bluesky, placeholder: "organization_bluesky_id" %>
+                </div>
+
+                <%= ViewHelpers.error_tag f, :bluesky %>
+              </div>
+
+              <div class="form-group">
                 <%= label f, :github, "GitHub" %>
                 <div class="input-group">
                   <div class="input-group-addon">github.com/</div>

--- a/lib/hexpm_web/templates/dashboard/profile/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/profile/index.html.eex
@@ -59,6 +59,16 @@
             </div>
 
             <div class="form-group">
+              <%= label f, :bluesky %>
+              <div class="input-group">
+                <div class="input-group-addon">bsky.app/profile/</div>
+                <%= ViewHelpers.text_input f, :bluesky, placeholder: "your_bluesky_id" %>
+              </div>
+
+              <%= ViewHelpers.error_tag f, :bluesky %>
+            </div>
+
+            <div class="form-group">
               <%= label f, :github, "GitHub" %>
               <div class="input-group">
                 <div class="input-group-addon">github.com/</div>

--- a/test/hexpm/accounts/user_handles_test.exs
+++ b/test/hexpm/accounts/user_handles_test.exs
@@ -10,6 +10,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
           handles:
             build(:user_handles,
               twitter: "https://twitter.com/eric",
+              bluesky: "https://bsky.app/profile/eric.bsky.social",
               github: "https://github.com/eric",
               elixirforum: "https://elixirforum.com/u/eric",
               freenode: "freenode",
@@ -20,6 +21,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
       assert UserHandles.render(user) ==
                [
                  {"Twitter", "eric", "https://twitter.com/eric"},
+                 {"Bluesky", "eric.bsky.social", "https://bsky.app/profile/eric.bsky.social"},
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
                  {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
@@ -33,6 +35,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
           handles:
             build(:user_handles,
               twitter: "http://twitter.com/eric",
+              bluesky: "http://bsky.app/profile/eric.bsky.social",
               github: "http://github.com/eric",
               elixirforum: "http://elixirforum.com/u/eric",
               freenode: "freenode",
@@ -43,6 +46,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
       assert UserHandles.render(user) ==
                [
                  {"Twitter", "eric", "https://twitter.com/eric"},
+                 {"Bluesky", "eric.bsky.social", "https://bsky.app/profile/eric.bsky.social"},
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
                  {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
@@ -56,6 +60,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
           handles:
             build(:user_handles,
               twitter: "twitter.com/eric",
+              bluesky: "bsky.app/profile/eric.bsky.social",
               github: "github.com/eric",
               elixirforum: "elixirforum.com/u/eric",
               freenode: "freenode",
@@ -66,6 +71,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
       assert UserHandles.render(user) ==
                [
                  {"Twitter", "eric", "https://twitter.com/eric"},
+                 {"Bluesky", "eric.bsky.social", "https://bsky.app/profile/eric.bsky.social"},
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
                  {"Libera", "freenode", "irc://irc.libera.chat/elixir"},

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -26,6 +26,7 @@ defmodule Hexpm.Accounts.UsersTest do
           %{
             "handles" => %{
               "twitter" => "twitter",
+              "bluesky" => "bluesky",
               "github" => "github",
               "elixirforum" => "elixirforum",
               "freenode" => "freenode",
@@ -37,6 +38,7 @@ defmodule Hexpm.Accounts.UsersTest do
 
       assert %{
                twitter: "twitter",
+               bluesky: "bluesky",
                github: "github",
                elixirforum: "elixirforum",
                freenode: "freenode",


### PR DESCRIPTION
Fixes #1316

This adds the option for users to set their Bluesky profile on their dashboard:

<img width="707" height="290" alt="image" src="https://github.com/user-attachments/assets/7b1fd6a4-8d75-4014-89f7-58e130344cf9" />

It will then be displayed on their profile like so:

<img width="229" height="121" alt="image" src="https://github.com/user-attachments/assets/1815b71d-3a91-41c5-a67a-fc9dca3c861a" />

I also noticed the audit log fields for `UserHandles` was missing `:elixirforum` and `:slack`. I added them in a separate commit first (and reordered the list to match the schema).