### PR TITLE
Fix typo in flash message for leaving organization

### DIFF
--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -151,7 +151,7 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
         case Organizations.remove_member(organization, current_user, audit: audit_data(conn)) do
           :ok ->
             conn
-            |> put_flash(:info, "You just left the the organization #{organization.name}.")
+            |> put_flash(:info, "You just left the organization #{organization.name}.")
             |> redirect(to: ~p"/dashboard/profile")
 
           {:error, :last_member} ->


### PR DESCRIPTION
Remove duplicate "the" word from flash message