### PR TITLE
Fix broken links to join Elixir slack

### DIFF
--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -23,7 +23,7 @@ defmodule Hexpm.Accounts.UserHandles do
       {:github, "GitHub", "https://github.com/{handle}"},
       {:elixirforum, "Elixir Forum", "https://elixirforum.com/u/{handle}"},
       {:freenode, "Libera", "irc://irc.libera.chat/elixir"},
-      {:slack, "Slack", "https://elixir-slackin.herokuapp.com/"}
+      {:slack, "Slack", "https://elixir-slack.community"}
     ]
   end
 

--- a/lib/hexpm_web/templates/blog/016-hex-v20-released-with-new-version-solver.html.md
+++ b/lib/hexpm_web/templates/blog/016-hex-v20-released-with-new-version-solver.html.md
@@ -24,4 +24,4 @@ We are planning to replace the current HTTP client in Hex that uses [httpc](http
 
 SSO login with initial support for Okta and Google is also on the roadmap. Along with that we will be adding web authentication for the CLI to support SSO and 2FA.
 
-If you would like to contribute to any of these features or have other improvements you want to work on then you can find the Hex team in the #hex channel on the [Elixir slack](https://elixir-slackin.herokuapp.com/) or find us on GitHub at [github.com/hexpm/hexpm](https://github.com/hexpm/hexpm) or [github.com/hexpm/hex](https://github.com/hexpm/hex).
+If you would like to contribute to any of these features or have other improvements you want to work on then you can find the Hex team in the #hex channel on the [Elixir slack](https://elixir-slack.community) or find us on GitHub at [github.com/hexpm/hexpm](https://github.com/hexpm/hexpm) or [github.com/hexpm/hex](https://github.com/hexpm/hex).

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.eex
@@ -92,7 +92,7 @@
                 <%= label f, :slack %>
                 <%= ViewHelpers.text_input f, :slack, placeholder: "Your organization's nickname on Elixir Slack channel" %>
                 <span class="help-block">Elixir Slack channel:
-                  <a href="https://elixir-slackin.herokuapp.com">elixir-slackin.herokuapp.com</a>
+                  <a href="https://elixir-slack.community">elixir-slack.community</a>
                 </span>
                 <%= ViewHelpers.error_tag f, :slack %>
               </div>

--- a/lib/hexpm_web/templates/dashboard/profile/index.html.eex
+++ b/lib/hexpm_web/templates/dashboard/profile/index.html.eex
@@ -99,7 +99,7 @@
               <%= label f, :slack %>
               <%= ViewHelpers.text_input f, :slack, placeholder: "Your nickname on Elixir Slack channel" %>
               <span class="help-block">Elixir Slack channel:
-                <a href="https://elixir-slackin.herokuapp.com">elixir-slackin.herokuapp.com</a>
+                <a href="https://elixir-slack.community">elixir-slack.community</a>
               </span>
               <%= ViewHelpers.error_tag f, :slack %>
             </div>

--- a/test/hexpm/accounts/user_handles_test.exs
+++ b/test/hexpm/accounts/user_handles_test.exs
@@ -25,7 +25,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
                  {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
-                 {"Slack", "slack", "https://elixir-slackin.herokuapp.com/"}
+                 {"Slack", "slack", "https://elixir-slack.community"}
                ]
     end
 
@@ -50,7 +50,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
                  {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
-                 {"Slack", "slack", "https://elixir-slackin.herokuapp.com/"}
+                 {"Slack", "slack", "https://elixir-slack.community"}
                ]
     end
 
@@ -75,7 +75,7 @@ defmodule Hexpm.Accounts.UserHandlesTest do
                  {"GitHub", "eric", "https://github.com/eric"},
                  {"Elixir Forum", "eric", "https://elixirforum.com/u/eric"},
                  {"Libera", "freenode", "irc://irc.libera.chat/elixir"},
-                 {"Slack", "slack", "https://elixir-slackin.herokuapp.com/"}
+                 {"Slack", "slack", "https://elixir-slack.community"}
                ]
     end
 


### PR DESCRIPTION
Hey!

I finally created a hex.pm profile and noticed that the link in the bottom of https://hex.pm/dashboard/profile does not work.

<img width="768" height="630" alt="Screenshot 2025-11-21 at 07 45 27" src="https://github.com/user-attachments/assets/672558a5-a0c1-4275-b9ae-8cc8fd4cf5be" />

The https://elixir-slack.community seems to be working so I used that instead.