### PR TITLE
Set `put_root_layout` to false to ignore all layouts in `render_error`

### DIFF
--- a/lib/hexpm_web/controllers/controller_helpers.ex
+++ b/lib/hexpm_web/controllers/controller_helpers.ex
@@ -49,6 +49,7 @@ defmodule HexpmWeb.ControllerHelpers do
     conn
     |> put_status(status)
     |> put_layout(false)
+    |> put_root_layout(false)
     |> put_view(HexpmWeb.ErrorView)
     |> render(:"#{status}", assigns)
     |> halt()


### PR DESCRIPTION
I noticed that if I get to a 404 page on Hex's site, I reach a page that has the root layout wrapping the error view, which subsequently has parts of the root layout embedded in it.

Current view on Hex:

<img width="1504" height="1374" alt="image" src="https://github.com/user-attachments/assets/d7875058-a98d-4e2c-9e49-629e79876338" />

This PR sets the root layout to `false` so that there won't be a root layout rendered when using the `render_error` helper.

The view now (with the fix applied):

<img width="1503" height="1376" alt="image" src="https://github.com/user-attachments/assets/f2d87fac-3d4a-4eca-82fd-285640540a6b" />
