### PR TITLE
Fix OAuth login not creating browser session

### DIFF
--- a/lib/hexpm_web/controllers/auth_controller.ex
+++ b/lib/hexpm_web/controllers/auth_controller.ex
@@ -45,13 +45,11 @@ defmodule HexpmWeb.AuthController do
   defp handle_existing_user_login(conn, user) do
     if User.tfa_enabled?(user) do
       conn
-      |> configure_session(renew: true)
-      |> put_session("tfa_user_id", %{uid: user.id, return: conn.params["return"]})
+      |> start_tfa_session(user, conn.params["return"])
       |> redirect(to: ~p"/tfa")
     else
       conn
-      |> configure_session(renew: true)
-      |> put_session("user_id", user.id)
+      |> start_session_internal(user)
       |> redirect(to: conn.params["return"] || ~p"/users/#{user}")
     end
   end
@@ -174,8 +172,7 @@ defmodule HexpmWeb.AuthController do
       {:ok, user} ->
         conn
         |> delete_session("pending_oauth")
-        |> configure_session(renew: true)
-        |> put_session("user_id", user.id)
+        |> start_session_internal(user)
         |> put_flash(:info, "Account created successfully!")
         |> redirect(to: ~p"/users/#{user}")
 

--- a/lib/hexpm_web/controllers/tfa_auth_controller.ex
+++ b/lib/hexpm_web/controllers/tfa_auth_controller.ex
@@ -20,7 +20,7 @@ defmodule HexpmWeb.TFAAuthController do
           |> configure_session(renew: true)
           |> put_session("session_token", session_token)
         else
-          HexpmWeb.LoginController.start_session_internal(conn, user)
+          start_session_internal(conn, user)
         end
 
       conn

--- a/lib/hexpm_web/controllers/tfa_recovery_controller.ex
+++ b/lib/hexpm_web/controllers/tfa_recovery_controller.ex
@@ -13,7 +13,8 @@ defmodule HexpmWeb.TFARecoveryController do
          {:ok, updated_user} <- Hexpm.Accounts.Users.tfa_recover(user, code) do
       conn
       |> delete_session("tfa_user_id")
-      |> HexpmWeb.LoginController.start_session(updated_user, session["return"])
+      |> start_session_internal(updated_user)
+      |> redirect(to: session["return"] || ~p"/users/#{updated_user}")
     else
       _ ->
         render_show_error(conn)

--- a/test/hexpm_web/controllers/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/auth_controller_test.exs
@@ -73,7 +73,7 @@ defmodule HexpmWeb.AuthControllerTest do
         |> HexpmWeb.AuthController.callback(%{})
 
       assert redirected_to(conn) == "/users/#{user.username}"
-      assert get_session(conn, "user_id") == user.id
+      assert get_session(conn, "session_token")
     end
 
     test "redirects to TFA when user has TFA enabled" do
@@ -87,7 +87,10 @@ defmodule HexpmWeb.AuthControllerTest do
         |> HexpmWeb.AuthController.callback(%{})
 
       assert redirected_to(conn) == "/tfa"
-      assert get_session(conn, "tfa_user_id") == %{uid: user.id, return: nil}
+      tfa_data = get_session(conn, "tfa_user_id")
+      assert tfa_data["uid"] == user.id
+      assert tfa_data["return"] == nil
+      assert tfa_data["session_token"]
     end
   end
 
@@ -230,7 +233,7 @@ defmodule HexpmWeb.AuthControllerTest do
       # GitHub email is pre-verified, user logged in immediately
       assert redirected_to(conn) == "/users/#{chosen_username}"
       assert Phoenix.Flash.get(conn.assigns.flash, "info") == "Account created successfully!"
-      assert get_session(conn, "user_id") == user.id
+      assert get_session(conn, "session_token")
 
       # Session should be cleared
       refute get_session(conn, "pending_oauth")


### PR DESCRIPTION
The OAuth login flow was storing "user_id" directly in the session, but the authentication plug looks for "session_token". This meant users were redirected to their profile page after GitHub OAuth but never actually logged in.

Now the OAuth controller properly creates browser sessions using LoginController.start_session/3 for non-TFA users and pre-creates session tokens for TFA users.