### PR TITLE
Use random ID in debug tarball keys instead of user-controlled request_id

### DIFF
--- a/lib/hexpm_web/controllers/api/docs_controller.ex
+++ b/lib/hexpm_web/controllers/api/docs_controller.ex
@@ -64,9 +64,13 @@ defmodule HexpmWeb.API.DocsController do
 
   defp log_tarball(repository, package, version, request_id, body) do
     Task.Supervisor.start_child(Hexpm.Tasks, fn ->
-      filename = "#{repository}-#{package}-#{version}-#{request_id}.tar.gz"
+      # Use random ID instead of user-controlled request_id in key to prevent overwrites
+      random_id = Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
+      filename = "#{repository}-#{package}-#{version}-#{random_id}.tar.gz"
       key = Path.join(["debug", "docs", filename])
-      Hexpm.Store.put(:repo_bucket, key, body, [])
+      # Store request_id in metadata for debugging (ignored by Store.Local)
+      opts = [cache_control: "private", meta: %{"request-id" => request_id || "unknown"}]
+      Hexpm.Store.put(:repo_bucket, key, body, opts)
     end)
   end
 end


### PR DESCRIPTION
The x-request-id header is user-controlled and was used directly in the object key for debug tarballs.

Generate a random 16-character hex ID for the key and store the original request_id in object metadata for debugging purposes.