### PR TITLE
Add authorization check to package report comments

### DIFF
--- a/lib/hexpm_web/controllers/package_report_controller.ex
+++ b/lib/hexpm_web/controllers/package_report_controller.ex
@@ -10,11 +10,17 @@ defmodule HexpmWeb.PackageReportController do
 
   def comment(conn, params) do
     report = PackageReports.get(safe_string(params["id"]))
+    user = conn.assigns.current_user
 
     if report do
-      author = conn.assigns.current_user
-      PackageReports.new_comment(report, author, params)
-      redirect(conn, to: ~p"/reports/#{report}")
+      for_owner = Owners.get(report.package, user) != nil
+
+      if visible_report?(report, user, for_owner) do
+        PackageReports.new_comment(report, user, params)
+        redirect(conn, to: ~p"/reports/#{report}")
+      else
+        not_found(conn)
+      end
     else
       not_found(conn)
     end

--- a/test/hexpm_web/controllers/package_report_controller_test.exs
+++ b/test/hexpm_web/controllers/package_report_controller_test.exs
@@ -374,6 +374,80 @@ defmodule HexpmWeb.PackageReportControllerTest do
     end
   end
 
+  describe "POST /reports/:id/comment" do
+    test "author can comment on their report", %{user3: user3, report2: report2} do
+      conn =
+        build_conn()
+        |> test_login(user3)
+        |> post("/reports/#{report2.id}/comment", %{"text" => "test comment"})
+
+      assert redirected_to(conn) == "/reports/#{report2.id}"
+    end
+
+    test "moderator can comment on any report", %{user2: user2, report2: report2} do
+      conn =
+        build_conn()
+        |> test_login(user2)
+        |> post("/reports/#{report2.id}/comment", %{"text" => "test comment"})
+
+      assert redirected_to(conn) == "/reports/#{report2.id}"
+    end
+
+    test "owner can comment on accepted report", %{user1: user1, report2: report2} do
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> post("/reports/#{report2.id}/comment", %{"text" => "test comment"})
+
+      assert redirected_to(conn) == "/reports/#{report2.id}"
+    end
+
+    test "unauthorized user cannot comment on to_accept report", %{user4: user4, report1: report1} do
+      conn =
+        build_conn()
+        |> test_login(user4)
+        |> post("/reports/#{report1.id}/comment", %{"text" => "test comment"})
+
+      response(conn, 404)
+    end
+
+    test "owner cannot comment on to_accept report", %{user1: user1, report1: report1} do
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> post("/reports/#{report1.id}/comment", %{"text" => "test comment"})
+
+      response(conn, 404)
+    end
+
+    test "unauthorized user cannot comment on accepted report", %{user4: user4, report2: report2} do
+      conn =
+        build_conn()
+        |> test_login(user4)
+        |> post("/reports/#{report2.id}/comment", %{"text" => "test comment"})
+
+      response(conn, 404)
+    end
+
+    test "unauthorized user cannot comment on rejected report", %{user4: user4, report4: report4} do
+      conn =
+        build_conn()
+        |> test_login(user4)
+        |> post("/reports/#{report4.id}/comment", %{"text" => "test comment"})
+
+      response(conn, 404)
+    end
+
+    test "returns 404 for non-existent report", %{user1: user1} do
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> post("/reports/999999/comment", %{"text" => "test comment"})
+
+      response(conn, 404)
+    end
+  end
+
   describe "solve/2" do
     test "get marked package after solve report", %{
       report2: report2,


### PR DESCRIPTION
The comment/2 function only checked if a report exists, not if the user has access to it.

Add visible_report?/3 check (same as show/2 uses) to ensure only authorized users can comment on reports.