### PR TITLE
Add API endpoint to revoke OAuth tokens by hash

### DIFF
--- a/lib/hexpm/oauth/token.ex
+++ b/lib/hexpm/oauth/token.ex
@@ -8,6 +8,7 @@ defmodule Hexpm.OAuth.Token do
   schema "oauth_tokens" do
     field :jti, :string
     field :refresh_jti, :string
+    field :refresh_token_hash, :string
     field :token_type, :string, default: "bearer"
     field :scopes, {:array, :string}, default: []
     field :expires_at, :utc_datetime
@@ -34,6 +35,7 @@ defmodule Hexpm.OAuth.Token do
     |> cast(attrs, [
       :jti,
       :refresh_jti,
+      :refresh_token_hash,
       :token_type,
       :scopes,
       :expires_at,
@@ -60,6 +62,7 @@ defmodule Hexpm.OAuth.Token do
     |> validate_scopes()
     |> unique_constraint(:jti)
     |> unique_constraint(:refresh_jti)
+    |> unique_constraint(:refresh_token_hash)
   end
 
   def build(attrs) do

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -301,6 +301,7 @@ defmodule HexpmWeb.Router do
     post "/oauth/token", OAuthController, :token
     post "/oauth/device_authorization", OAuthController, :device_authorization
     post "/oauth/revoke", OAuthController, :revoke
+    post "/oauth/revoke_by_hash", OAuthController, :revoke_by_hash
   end
 
   if Mix.env() in [:dev, :test, :hex] do

--- a/priv/repo/migrations/20260202233553_add_refresh_token_hash_to_oauth_tokens.exs
+++ b/priv/repo/migrations/20260202233553_add_refresh_token_hash_to_oauth_tokens.exs
@@ -1,0 +1,13 @@
+defmodule Hexpm.RepoBase.Migrations.AddRefreshTokenHashToOauthTokens do
+  use Ecto.Migration
+
+  def change do
+    alter table(:oauth_tokens) do
+      add :refresh_token_hash, :text
+    end
+
+    create unique_index(:oauth_tokens, [:refresh_token_hash],
+             where: "refresh_token_hash IS NOT NULL"
+           )
+  end
+end


### PR DESCRIPTION
Adds POST /api/oauth/revoke_by_hash endpoint that allows revoking OAuth refresh tokens using a SHA256 hash of the token. This enables clients that encrypt tokens (like Gleam) to revoke them even when the user has lost access to the decryption key.

Closes #1370