### PR TITLE
Use process-isolated in-memory store for tests

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,8 @@
 import Config
 
 config :hexpm,
+  repo_bucket: {Hexpm.Store.Memory, "repo_bucket"},
+  logs_bucket: {Hexpm.Store.Memory, "logs_bucket"},
   secret: "796f75666f756e64746865686578",
   jwt_signing_key: """
   -----BEGIN EC PRIVATE KEY-----

--- a/lib/hexpm/store/memory.ex
+++ b/lib/hexpm/store/memory.ex
@@ -1,0 +1,65 @@
+defmodule Hexpm.Store.Memory do
+  # Only used during testing. ETS-backed store with per-process isolation
+  # to allow async tests without shared filesystem conflicts.
+
+  @behaviour Hexpm.Store.Behaviour
+
+  @table __MODULE__
+  @ownership __MODULE__.Ownership
+  @key :store
+
+  def start() do
+    :ets.new(@table, [:named_table, :public, :set])
+    {:ok, _} = NimbleOwnership.start_link(name: @ownership)
+    :ok
+  end
+
+  def checkout() do
+    NimbleOwnership.get_and_update(@ownership, self(), @key, fn _ -> {:ok, true} end)
+  end
+
+  def list(bucket, prefix) do
+    owner = owner_pid()
+
+    :ets.match_object(@table, {{owner, bucket, :_}, :_})
+    |> Enum.flat_map(fn {{_, _, key}, _value} ->
+      if String.starts_with?(key, prefix) do
+        [key]
+      else
+        []
+      end
+    end)
+  end
+
+  def get(bucket, key, _opts) do
+    owner = owner_pid()
+
+    case :ets.lookup(@table, {owner, bucket, key}) do
+      [{_, value}] -> value
+      [] -> nil
+    end
+  end
+
+  def put(bucket, key, body, _opts) do
+    owner = owner_pid()
+    :ets.insert(@table, {{owner, bucket, key}, body})
+  end
+
+  def delete(bucket, key) do
+    owner = owner_pid()
+    :ets.delete(@table, {owner, bucket, key})
+  end
+
+  def delete_many(bucket, keys) do
+    Enum.each(keys, &delete(bucket, &1))
+  end
+
+  defp owner_pid() do
+    callers = [self() | Process.get(:"$callers") || []]
+
+    case NimbleOwnership.fetch_owner(@ownership, callers, @key) do
+      {tag, owner} when tag in [:ok, :shared_owner] -> owner
+      :error -> self()
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule Hexpm.MixProject do
       {:libcluster, "~> 3.0"},
       {:logster, "~> 1.0"},
       {:mox, "~> 1.0", only: :test},
+      {:nimble_ownership, "~> 1.0"},
       {:stream_data, "~> 1.0", only: :test},
       {:phoenix_ecto, "~> 4.0"},
       {:phoenix_html, "~> 4.0"},

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -38,6 +38,7 @@ defmodule HexpmWeb.ConnCase do
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Hexpm.RepoBase)
+    Hexpm.Store.Memory.checkout()
     Bamboo.SentEmail.reset()
     :ok
   end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -30,6 +30,7 @@ defmodule Hexpm.DataCase do
 
   setup do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Hexpm.RepoBase)
+    Hexpm.Store.Memory.checkout()
 
     :ok
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -4,6 +4,7 @@ tmp_dir = Application.get_env(:hexpm, :tmp_dir)
 File.rm_rf(tmp_dir)
 File.mkdir_p(tmp_dir)
 
+Hexpm.Store.Memory.start()
 Hexpm.setup()
 Hexpm.BlockAddress.reload()
 Hexpm.Repository.RegistryBuilder.full(Hexpm.Repository.Repository.hexpm())


### PR DESCRIPTION
Replace Hexpm.Store.Local with a new ETS-backed Hexpm.Store.Memory in tests to fix flaky async tests. The local filesystem store was shared across all test processes, causing RegistryBuilder.full to delete package files created by concurrent tests. The memory store keys data by owner PID (resolved via $callers for spawned workers) so each test process has isolated storage.