### PR TITLE
Require explicit allowed_grant_types on OAuth clients

### DIFF
--- a/lib/hexpm/oauth/client.ex
+++ b/lib/hexpm/oauth/client.ex
@@ -21,6 +21,8 @@ defmodule Hexpm.OAuth.Client do
   @valid_client_types ~w(public confidential)
   @valid_grant_types ~w(authorization_code urn:ietf:params:oauth:grant-type:device_code refresh_token client_credentials)
 
+  def valid_grant_types, do: @valid_grant_types
+
   def changeset(client, attrs) do
     client
     |> cast(attrs, [
@@ -32,7 +34,7 @@ defmodule Hexpm.OAuth.Client do
       :redirect_uris,
       :allowed_scopes
     ])
-    |> validate_required([:client_id, :name, :client_type])
+    |> validate_required([:client_id, :name, :client_type, :allowed_grant_types])
     |> validate_inclusion(:client_type, @valid_client_types)
     |> validate_grant_types()
     |> validate_scopes()

--- a/lib/hexpm/oauth/clients.ex
+++ b/lib/hexpm/oauth/clients.ex
@@ -39,8 +39,6 @@ defmodule Hexpm.OAuth.Clients do
   @doc """
   Validates that the client is allowed to use the specified grant type.
   """
-  def supports_grant_type?(%Client{allowed_grant_types: nil}, _grant_type), do: true
-
   def supports_grant_type?(%Client{allowed_grant_types: grant_types}, grant_type) do
     grant_type in grant_types
   end

--- a/lib/hexpm_web/controllers/test_controller.ex
+++ b/lib/hexpm_web/controllers/test_controller.ex
@@ -67,7 +67,7 @@ defmodule HexpmWeb.TestController do
       client_type: params["client_type"] || "public",
       client_secret: params["client_secret"],
       redirect_uris: params["redirect_uris"] || [],
-      allowed_grant_types: params["allowed_grant_types"]
+      allowed_grant_types: params["allowed_grant_types"] || Client.valid_grant_types()
     }
 
     changeset = Client.changeset(%Client{}, attrs)

--- a/priv/repo/migrations/20260227120000_require_allowed_grant_types_on_oauth_clients.exs
+++ b/priv/repo/migrations/20260227120000_require_allowed_grant_types_on_oauth_clients.exs
@@ -1,0 +1,26 @@
+defmodule Hexpm.RepoBase.Migrations.RequireAllowedGrantTypesOnOauthClients do
+  use Ecto.Migration
+
+  def up do
+    execute """
+    UPDATE oauth_clients
+    SET allowed_grant_types = ARRAY[
+      'authorization_code',
+      'urn:ietf:params:oauth:grant-type:device_code',
+      'refresh_token',
+      'client_credentials'
+    ]
+    WHERE allowed_grant_types IS NULL
+    """
+
+    alter table(:oauth_clients) do
+      modify :allowed_grant_types, {:array, :string}, null: false
+    end
+  end
+
+  def down do
+    alter table(:oauth_clients) do
+      modify :allowed_grant_types, {:array, :string}, null: true
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -1,5 +1,6 @@
 import Hexpm.Factory
 alias Hexpm.Accounts.Users
+alias Hexpm.OAuth.Client
 alias Hexpm.Repository.{PackageDependant, PackageDownload, ReleaseDownload}
 
 Hexpm.Fake.start()
@@ -14,7 +15,8 @@ Hexpm.Repo.transaction(fn ->
   insert(:oauth_client,
     name: "Hex CLI",
     client_id: "78ea6566-89fd-481e-a1d6-7d9d78eacca8",
-    client_type: "public"
+    client_type: "public",
+    allowed_grant_types: Client.valid_grant_types()
   )
 
   insert(

--- a/test/hexpm/oauth/client_test.exs
+++ b/test/hexpm/oauth/client_test.exs
@@ -10,7 +10,8 @@ defmodule Hexpm.OAuth.ClientTest do
       assert %{
                client_id: "can't be blank",
                name: "can't be blank",
-               client_type: "can't be blank"
+               client_type: "can't be blank",
+               allowed_grant_types: "can't be blank"
              } = errors_on(changeset)
     end
 
@@ -92,6 +93,7 @@ defmodule Hexpm.OAuth.ClientTest do
         client_id: "test_client",
         name: "Test Client",
         client_type: "public",
+        allowed_grant_types: ["authorization_code"],
         redirect_uris: [
           "https://example.com/callback",
           "http://localhost:3000/callback",
@@ -173,6 +175,7 @@ defmodule Hexpm.OAuth.ClientTest do
         client_id: "test_client",
         name: "Test Client",
         client_type: "public",
+        allowed_grant_types: ["authorization_code"],
         redirect_uris: ["https://*.example.com/callback"]
       }
 
@@ -185,6 +188,7 @@ defmodule Hexpm.OAuth.ClientTest do
         client_id: "test_client",
         name: "Test Client",
         client_type: "public",
+        allowed_grant_types: ["authorization_code"],
         redirect_uris: ["https://staging-*.example.com/callback"]
       }
 
@@ -198,7 +202,8 @@ defmodule Hexpm.OAuth.ClientTest do
       attrs = %{
         client_id: "test_client",
         name: "Test Client",
-        client_type: "public"
+        client_type: "public",
+        allowed_grant_types: ["authorization_code"]
       }
 
       changeset = Client.build(attrs)


### PR DESCRIPTION
Instead of treating nil allowed_grant_types as "all grants allowed", require each client to explicitly list its grant types.