### PR TITLE
Clear Complete Session on Logout

### DIFF
--- a/lib/hexpm_web/controllers/login_controller.ex
+++ b/lib/hexpm_web/controllers/login_controller.ex
@@ -59,7 +59,7 @@ defmodule HexpmWeb.LoginController do
     end
 
     conn
-    |> delete_session("session_token")
+    |> clear_session()
     |> redirect(to: ~p"/")
   end
 

--- a/test/hexpm_web/controllers/login_controller_test.exs
+++ b/test/hexpm_web/controllers/login_controller_test.exs
@@ -67,16 +67,15 @@ defmodule HexpmWeb.LoginControllerTest do
   end
 
   test "log out", c do
-    conn = post(build_conn(), "/login", %{username: c.user.username, password: "password"})
-    assert redirected_to(conn) == "/users/#{c.user.username}"
-
     conn =
-      conn
-      |> recycle()
+      build_conn()
+      |> test_login(c.user)
+      |> put_session("tfa_setup_secret", "secret")
       |> post("/logout")
 
     assert redirected_to(conn) == "/"
     refute get_session(conn, "session_token")
+    refute get_session(conn, "tfa_setup_secret")
   end
 
   test "login, create hexdocs key and redirect", c do


### PR DESCRIPTION
Prevents sessions beside the session_token from leaking to later logins. For example resetting the tfa_setup_secret between login sessions.