### PR TITLE
Remove verified parameter from device authorization flow

### DIFF
--- a/lib/hexpm_web/controllers/device_controller.ex
+++ b/lib/hexpm_web/controllers/device_controller.ex
@@ -17,62 +17,35 @@ defmodule HexpmWeb.DeviceController do
   """
   def show(conn, params) do
     user_code = params["user_code"]
-    show_authorization = params["verified"] == "true"
 
     if logged_in?(conn) do
       # Don't check rate limits for just viewing the form (GET request)
-      cond do
+      if is_nil(user_code) do
         # No code provided, show empty form
-        is_nil(user_code) ->
-          render_verification_form(conn, nil, nil, nil)
+        render_verification_form(conn, nil, nil, nil)
+      else
+        normalized_code = DeviceView.normalize_user_code(user_code)
 
-        # Code provided and verified, show authorization
-        show_authorization ->
-          normalized_code = DeviceView.normalize_user_code(user_code)
+        # Validate the code exists but show verification form
+        case DeviceCodes.get_for_verification(normalized_code) do
+          {:ok, _device_code} ->
+            # Code is valid, show pre-filled verification form
+            render_verification_form(conn, nil, nil, user_code)
 
-          case DeviceCodes.get_for_verification(normalized_code) do
-            {:ok, device_code} ->
-              render_verification_form(conn, device_code, nil, nil)
+          {:error, :invalid_code} ->
+            render_verification_form(conn, nil, "Invalid verification code", user_code)
 
-            {:error, :invalid_code} ->
-              render_verification_form(conn, nil, "Invalid verification code", user_code)
+          {:error, :expired} ->
+            render_verification_form(conn, nil, "Verification code has expired", user_code)
 
-            {:error, :expired} ->
-              render_verification_form(conn, nil, "Verification code has expired", user_code)
-
-            {:error, :already_processed} ->
-              render_verification_form(
-                conn,
-                nil,
-                "This application has already been processed",
-                user_code
-              )
-          end
-
-        # Code provided but not verified yet, show pre-filled form for verification
-        true ->
-          normalized_code = DeviceView.normalize_user_code(user_code)
-
-          # Validate the code exists but show verification form
-          case DeviceCodes.get_for_verification(normalized_code) do
-            {:ok, _device_code} ->
-              # Code is valid, show pre-filled verification form
-              render_verification_form(conn, nil, nil, user_code)
-
-            {:error, :invalid_code} ->
-              render_verification_form(conn, nil, "Invalid verification code", user_code)
-
-            {:error, :expired} ->
-              render_verification_form(conn, nil, "Verification code has expired", user_code)
-
-            {:error, :already_processed} ->
-              render_verification_form(
-                conn,
-                nil,
-                "This application has already been processed",
-                user_code
-              )
-          end
+          {:error, :already_processed} ->
+            render_verification_form(
+              conn,
+              nil,
+              "This application has already been processed",
+              user_code
+            )
+        end
       end
     else
       redirect(conn, to: build_login_redirect_path(user_code))
@@ -95,6 +68,10 @@ defmodule HexpmWeb.DeviceController do
 
         :ok ->
           case params["action"] do
+            "verify" ->
+              normalized_code = DeviceView.normalize_user_code(user_code)
+              handle_verification(conn, normalized_code)
+
             "authorize" ->
               normalized_code = DeviceView.normalize_user_code(user_code)
               handle_authorization(conn, normalized_code, current_user, params)
@@ -145,6 +122,27 @@ defmodule HexpmWeb.DeviceController do
 
       _ ->
         :ok
+    end
+  end
+
+  defp handle_verification(conn, user_code) do
+    case DeviceCodes.get_for_verification(user_code) do
+      {:ok, device_code} ->
+        render_verification_form(conn, device_code, nil, nil)
+
+      {:error, :invalid_code} ->
+        render_verification_form(conn, nil, "Invalid verification code", user_code)
+
+      {:error, :expired} ->
+        render_verification_form(conn, nil, "Verification code has expired", user_code)
+
+      {:error, :already_processed} ->
+        render_verification_form(
+          conn,
+          nil,
+          "This application has already been processed",
+          user_code
+        )
     end
   end
 

--- a/lib/hexpm_web/templates/device/show.html.eex
+++ b/lib/hexpm_web/templates/device/show.html.eex
@@ -24,37 +24,51 @@
         <p class="device-instruction-text">Enter the verification code displayed on your device:</p>
       <% end %>
 
-      <%= form_tag(~p"/oauth/device", method: "get") do %>
-        <div class="form-group device-form-group">
-          <label for="user_code" class="device-code-label">Verification Code</label>
-          <input id="user_code"
-                 type="text"
-                 class="form-control device-code-input<%= if @pre_filled, do: " device-code-input--prefilled" %>"
-                 name="user_code"
-                 value="<%= format_user_code(@user_code) %>"
-                 placeholder="XXXX-XXXX"
-                 pattern="[A-Z0-9]{4}-?[A-Z0-9]{4}"
-                 maxlength="9"
-                 <%= if @pre_filled, do: "readonly" %>
-                 required>
-          <small class="form-text text-muted device-help-text">
-            <%= if @pre_filled do %>
+      <%= if @pre_filled do %>
+        <%= form_tag(~p"/oauth/device", method: "post") do %>
+          <div class="form-group device-form-group">
+            <label for="user_code" class="device-code-label">Verification Code</label>
+            <input id="user_code"
+                   type="text"
+                   class="form-control device-code-input device-code-input--prefilled"
+                   name="user_code"
+                   value="<%= format_user_code(@user_code) %>"
+                   placeholder="XXXX-XXXX"
+                   pattern="[A-Z0-9]{4}-?[A-Z0-9]{4}"
+                   maxlength="9"
+                   readonly
+                   required>
+            <small class="form-text text-muted device-help-text">
               This code was provided in your authorization link. Confirm it matches your device.
-            <% else %>
-              Enter the 8-character code shown on your device (format: XXXX-XXXX)
-            <% end %>
-          </small>
-        </div>
+            </small>
+          </div>
 
-        <%= if @pre_filled do %>
-          <input type="hidden" name="verified" value="true">
+          <input type="hidden" name="action" value="verify">
           <div class="device-button-group">
             <button type="submit" class="btn btn-primary btn-lg device-btn-primary-lg">Verify and Continue</button>
             <a href="<%= ~p"/" %>" class="btn btn-danger btn-lg device-btn-danger-lg">
               <i class="fa fa-times-circle"></i> Code does not match
             </a>
           </div>
-        <% else %>
+        <% end %>
+      <% else %>
+        <%= form_tag(~p"/oauth/device", method: "get") do %>
+          <div class="form-group device-form-group">
+            <label for="user_code" class="device-code-label">Verification Code</label>
+            <input id="user_code"
+                   type="text"
+                   class="form-control device-code-input"
+                   name="user_code"
+                   value="<%= format_user_code(@user_code) %>"
+                   placeholder="XXXX-XXXX"
+                   pattern="[A-Z0-9]{4}-?[A-Z0-9]{4}"
+                   maxlength="9"
+                   required>
+            <small class="form-text text-muted device-help-text">
+              Enter the 8-character code shown on your device (format: XXXX-XXXX)
+            </small>
+          </div>
+
           <button type="submit" class="btn btn-primary device-btn-verify">Verify Code</button>
         <% end %>
       <% end %>

--- a/test/hexpm_web/controllers/device_controller_test.exs
+++ b/test/hexpm_web/controllers/device_controller_test.exs
@@ -60,11 +60,12 @@ defmodule HexpmWeb.DeviceControllerTest do
 
       assert html =~ formatted_code
 
-      # Visit with verified=true should show authorization form
+      # POST with action=verify should show authorization form
       conn =
-        get(
+        post(
           login_user(build_conn(), user),
-          ~p"/oauth/device?user_code=#{response.user_code}&verified=true"
+          ~p"/oauth/device",
+          %{"user_code" => response.user_code, "action" => "verify"}
         )
 
       assert html_response(conn, 200) =~ client.name
@@ -128,9 +129,11 @@ defmodule HexpmWeb.DeviceControllerTest do
       assert html =~ ~r/value="#{formatted_code}"/
       assert html =~ "readonly"
 
-      # Step 2: Submit verification form (user confirms code matches)
+      # Step 2: Submit verification form via POST (user confirms code matches)
       conn = login_user(build_conn(), user)
-      conn = get(conn, ~p"/oauth/device?user_code=#{response.user_code}&verified=true")
+
+      conn =
+        post(conn, ~p"/oauth/device", %{"user_code" => response.user_code, "action" => "verify"})
 
       html = html_response(conn, 200)
       assert html =~ "Authorize Device"
@@ -573,7 +576,9 @@ defmodule HexpmWeb.DeviceControllerTest do
         DeviceCodes.initiate_device_authorization(mock_conn, client.client_id, [malicious_scope])
 
       conn = login_user(build_conn(), user)
-      conn = get(conn, ~p"/oauth/device?user_code=#{response.user_code}&verified=true")
+
+      conn =
+        post(conn, ~p"/oauth/device", %{"user_code" => response.user_code, "action" => "verify"})
 
       html = html_response(conn, 200)
 


### PR DESCRIPTION
The verification step now requires a POST request with `action=verify` instead of accepting a `verified=true` query parameter. This ensures users must submit the verification form rather than navigating directly to the authorization page via URL.