### PR TITLE
Verify SSL peer when connecting to database

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -13,8 +13,6 @@ config :hexpm, HexpmWeb.Endpoint,
   url: [scheme: "https", port: 443],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
-config :hexpm, Hexpm.RepoBase, ssl: true
-
 config :bcrypt_elixir, log_rounds: 12
 
 config :sentry,

--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -83,6 +83,7 @@ defmodule Hexpm.RepoBase do
       ssl_opts =
         if ca_cert do
           [
+            verify: :verify_peer,
             cacerts: [decode_cert(ca_cert)],
             key: decode_key(client_key),
             cert: decode_cert(client_cert),
@@ -92,9 +93,11 @@ defmodule Hexpm.RepoBase do
 
       opts =
         opts
-        |> Keyword.put(:ssl_opts, ssl_opts)
         |> Keyword.put(:url, url)
         |> Keyword.put(:pool_size, pool_size)
+        |> then(fn opts ->
+          if ssl_opts, do: Keyword.put(opts, :ssl, ssl_opts), else: opts
+        end)
 
       {:ok, opts}
     else


### PR DESCRIPTION
Replace ssl: true with ssl: [verify: :verify_peer, ...] to suppress the Postgrex warning.