### PR TITLE
Add custom URL to UserHandles

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -368,7 +368,10 @@ defmodule Hexpm.Accounts.AuditLog do
   defp fields(%ReleaseRetirement{}), do: [:status, :message]
   defp fields(%Organization{}), do: [:id, :name, :public, :active, :billing_active]
   defp fields(%User{}), do: [:id, :username]
-  defp fields(%UserHandles{}), do: [:twitter, :bluesky, :github, :elixirforum, :freenode, :slack]
+
+  defp fields(%UserHandles{}),
+    do: [:twitter, :bluesky, :github, :elixirforum, :freenode, :slack, :url]
+
   defp fields(%Hexpm.UserSession{}), do: [:id, :type, :name, :client_id]
   defp fields(%Hexpm.OAuth.Client{}), do: [:id, :name]
 

--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -10,10 +10,25 @@ defmodule Hexpm.Accounts.UserHandles do
     field :elixirforum, :string
     field :freenode, :string
     field :slack, :string
+    field :url, :string
   end
 
   def changeset(handles, params) do
-    cast(handles, params, ~w(twitter bluesky github elixirforum freenode slack)a)
+    handles
+    |> cast(params, ~w(twitter bluesky github elixirforum freenode slack url)a)
+    |> validate_change(:url, fn :url, url ->
+      case URI.new(url) do
+        {:ok, uri} ->
+          if uri.scheme not in ["http", "https"] do
+            [url: "should be a valid http or https URL"]
+          else
+            []
+          end
+
+        {:error, err} ->
+          [url: err]
+      end
+    end)
   end
 
   def services() do

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -154,6 +154,9 @@ defmodule Hexpm.Accounts.Users do
           end)
 
         {:error, %Ecto.Changeset{data: user, errors: errors, valid?: false}}
+
+      {:error, :user, changeset, _} ->
+        {:error, changeset}
     end
   end
 

--- a/lib/hexpm_web/components/user_profile.ex
+++ b/lib/hexpm_web/components/user_profile.ex
@@ -77,13 +77,31 @@ defmodule HexpmWeb.Components.UserProfile do
               </a>
             <% end %>
 
+            <%!-- Custom URL --%>
+            <%= if @user.handles && @user.handles.url do %>
+              <a
+                href={@user.handles.url}
+                class="group relative p-2 rounded-lg bg-grey-100 dark:bg-grey-900 hover:bg-grey-200 dark:hover:bg-grey-800 transition-colors"
+                target="_blank"
+                rel="noopener noreferrer nofollow me"
+                title={@user.handles.url}
+              >
+                {HexpmWeb.ViewIcons.icon(:heroicon, "link",
+                  class: "w-5 h-5 text-grey-700 dark:text-grey-200"
+                )}
+                <span class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1 bg-grey-900 dark:bg-grey-700 text-white text-xs rounded whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none z-10">
+                  {@user.handles.url}
+                </span>
+              </a>
+            <% end %>
+
             <%!-- Social Media Icons --%>
             <%= for {service, handle, url} <- Hexpm.Accounts.UserHandles.render(@user) do %>
               <a
                 href={url}
                 class="group relative p-2 rounded-lg bg-grey-100 dark:bg-grey-900 hover:bg-grey-200 dark:hover:bg-grey-800 transition-colors"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener noreferrer nofollow me"
                 title={"#{service}: #{handle}"}
               >
                 <.social_icon

--- a/lib/hexpm_web/templates/dashboard/organization/components/profile_tab.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/profile_tab.ex
@@ -104,6 +104,13 @@ defmodule HexpmWeb.Dashboard.Organization.Components.ProfileTab do
                   Socials
                 </h3>
                 <div class="space-y-5">
+                  <.text_input
+                    field={fh[:url]}
+                    type="url"
+                    label="URL"
+                    placeholder="Your organization's custom URL"
+                  />
+
                   <.social_input
                     form={fh}
                     field={:twitter}

--- a/lib/hexpm_web/templates/dashboard/profile/index.html.heex
+++ b/lib/hexpm_web/templates/dashboard/profile/index.html.heex
@@ -99,6 +99,14 @@
                   </h3>
 
                   <div class="space-y-5">
+                    <%!-- Custom URL --%>
+                    <.text_input
+                      field={f[:url]}
+                      type="url"
+                      label="URL"
+                      placeholder="Your custom URL"
+                    />
+
                     <%!-- Twitter/X --%>
                     <.social_input
                       form={f}

--- a/test/hexpm/accounts/user_handles_test.exs
+++ b/test/hexpm/accounts/user_handles_test.exs
@@ -14,7 +14,8 @@ defmodule Hexpm.Accounts.UserHandlesTest do
               github: "https://github.com/eric",
               elixirforum: "https://elixirforum.com/u/eric",
               freenode: "freenode",
-              slack: "slack"
+              slack: "slack",
+              url: "https://example.com"
             )
         )
 
@@ -39,7 +40,8 @@ defmodule Hexpm.Accounts.UserHandlesTest do
               github: "http://github.com/eric",
               elixirforum: "http://elixirforum.com/u/eric",
               freenode: "freenode",
-              slack: "slack"
+              slack: "slack",
+              url: "https://example.com"
             )
         )
 
@@ -64,7 +66,8 @@ defmodule Hexpm.Accounts.UserHandlesTest do
               github: "github.com/eric",
               elixirforum: "elixirforum.com/u/eric",
               freenode: "freenode",
-              slack: "slack"
+              slack: "slack",
+              url: "https://example.com"
             )
         )
 

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -200,7 +200,8 @@ defmodule Hexpm.Accounts.UsersTest do
               "github" => "github",
               "elixirforum" => "elixirforum",
               "freenode" => "freenode",
-              "slack" => "slack"
+              "slack" => "slack",
+              "url" => "https://example.com"
             }
           },
           audit: audit_data(build(:user))
@@ -212,7 +213,8 @@ defmodule Hexpm.Accounts.UsersTest do
                github: "github",
                elixirforum: "elixirforum",
                freenode: "freenode",
-               slack: "slack"
+               slack: "slack",
+               url: "https://example.com"
              } = updated_user.handles
     end
 


### PR DESCRIPTION
Fixes #1321

This URL is displayed as-is, above the other handles. I considered adding a separate `url_title` to allow the user to specify the text to display instead of the URL itself, but the simplest option is to just show the URL itself.

Because this "handle" is not displayed in the same way the other handles are there's also something to be said for moving it out of `UserHandles` but I'm not sure there's a more fitting place.

Also add `rel="nofollow me"` to both this new link and existing profile links, to indicate both that hex does not endorse the content of the linked page, and that it represents the same person.

On the dashboard profile page the input is displayed above the other handles:

<img width="737" height="243" alt="image" src="https://github.com/user-attachments/assets/7f10d97a-26c3-4c18-9907-991168a1b804" />

And on the profile it is also displayed above the other handles:

<img width="238" height="219" alt="image" src="https://github.com/user-attachments/assets/d1e3505f-f9a6-4809-b23a-eb22155a3594" />

