### PR TITLE
Allow OAuth client callback origin in CSP form-action

### DIFF
--- a/lib/hexpm_web/controllers/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/oauth_controller.ex
@@ -28,7 +28,9 @@ defmodule HexpmWeb.OAuthController do
          {:ok, _} <- validate_state(params),
          {:ok, _} <- validate_pkce_params(params) do
       if logged_in?(conn) do
-        render(conn, "authorize.html", %{
+        conn
+        |> HexpmWeb.Plugs.ContentSecurityPolicy.allow_form_action(redirect_uri)
+        |> render("authorize.html", %{
           container: "container page page-xs oauth",
           client: client,
           redirect_uri: redirect_uri,

--- a/lib/hexpm_web/plugs/content_security_policy.ex
+++ b/lib/hexpm_web/plugs/content_security_policy.ex
@@ -13,6 +13,35 @@ defmodule HexpmWeb.Plugs.ContentSecurityPolicy do
 
   @report_group "csp-endpoint"
 
+  @doc """
+  Extends the form-action CSP directive to allow a redirect URI's origin.
+
+  Chrome applies form-action to redirects after form submission, so OAuth
+  consent pages need to allow the client's callback origin.
+  """
+  def allow_form_action(conn, redirect_uri) do
+    origin = uri_origin(redirect_uri)
+
+    case get_resp_header(conn, "content-security-policy") do
+      [csp] ->
+        updated = String.replace(csp, "form-action 'self'", "form-action 'self' #{origin}")
+        put_resp_header(conn, "content-security-policy", updated)
+
+      _ ->
+        conn
+    end
+  end
+
+  defp uri_origin(url) do
+    uri = URI.parse(url)
+
+    if uri.port && uri.port != URI.default_port(uri.scheme) do
+      "#{uri.scheme}://#{uri.host}:#{uri.port}"
+    else
+      "#{uri.scheme}://#{uri.host}"
+    end
+  end
+
   @impl Plug
   def init(opts), do: opts
 

--- a/test/hexpm_web/controllers/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/oauth_controller_test.exs
@@ -88,6 +88,24 @@ defmodule HexpmWeb.OAuthControllerTest do
       assert html =~ "api:read"
       assert html =~ "repositories"
     end
+
+    test "CSP form-action includes redirect URI origin", %{client: client} do
+      user = insert(:user)
+      conn = login_user(build_conn(), user)
+
+      conn =
+        get(conn, ~p"/oauth/authorize", %{
+          "client_id" => client.client_id,
+          "redirect_uri" => "https://example.com/callback",
+          "scope" => "api:read",
+          "state" => "test_state",
+          "code_challenge" => "challenge123",
+          "code_challenge_method" => "S256"
+        })
+
+      [csp] = get_resp_header(conn, "content-security-policy")
+      assert csp =~ "form-action 'self' https://example.com"
+    end
   end
 
   describe "POST /oauth/authorize (consent)" do

--- a/test/hexpm_web/plugs/content_security_policy_test.exs
+++ b/test/hexpm_web/plugs/content_security_policy_test.exs
@@ -76,4 +76,33 @@ defmodule HexpmWeb.Plugs.ContentSecurityPolicyTest do
       assert get_resp_header(conn, "reporting-endpoints") == []
     end
   end
+
+  describe "allow_form_action/2" do
+    test "adds redirect URI origin to form-action" do
+      conn =
+        build_conn()
+        |> ContentSecurityPolicy.call(
+          nonces_for: [:script_src],
+          directives: %{form_action: ~w('self')}
+        )
+        |> ContentSecurityPolicy.allow_form_action("https://acme.hexdocs.pm/oauth/callback")
+
+      [csp] = get_resp_header(conn, "content-security-policy")
+      assert csp =~ "form-action 'self' https://acme.hexdocs.pm"
+      refute csp =~ "/oauth/callback"
+    end
+
+    test "handles redirect URI with non-default port" do
+      conn =
+        build_conn()
+        |> ContentSecurityPolicy.call(
+          nonces_for: [:script_src],
+          directives: %{form_action: ~w('self')}
+        )
+        |> ContentSecurityPolicy.allow_form_action("http://localhost:4002/oauth/callback")
+
+      [csp] = get_resp_header(conn, "content-security-policy")
+      assert csp =~ "form-action 'self' http://localhost:4002"
+    end
+  end
 end


### PR DESCRIPTION
Chrome applies the form-action CSP directive to redirects after form submission. This blocks the OAuth consent flow because after the user submits the authorization form on hex.pm, the server redirects to the OAuth client's callback URL which is on a different origin.

Extend the form-action directive per-request on the OAuth authorization page to include the validated redirect URI's origin.