### PR TITLE
Validate URL scheme in short URLs

### DIFF
--- a/lib/hexpm/short_urls/short_url.ex
+++ b/lib/hexpm/short_urls/short_url.ex
@@ -54,6 +54,9 @@ defmodule Hexpm.ShortURLs.ShortURL do
     url = URI.parse(url)
 
     cond do
+      url.scheme not in ["http", "https"] ->
+        [url: "must use http or https scheme"]
+
       url.host == "hex.pm" or String.ends_with?(url.host, [".hex.pm"]) ->
         []
 

--- a/test/hexpm/short_urls/short_url_test.exs
+++ b/test/hexpm/short_urls/short_url_test.exs
@@ -33,6 +33,18 @@ defmodule Hexpm.ShortURLs.ShortURLTest do
       assert errors == [{:url, {"can't be blank", [validation: :required]}}]
     end
 
+    test "rejects javascript: scheme" do
+      assert %{valid?: false, errors: errors} =
+               ShortURL.changeset(%{url: "javascript://hex.pm/%0Aalert(1)"})
+
+      assert errors == [url: {"must use http or https scheme", []}]
+    end
+
+    test "rejects non-http schemes" do
+      assert %{valid?: false} = ShortURL.changeset(%{url: "ftp://hex.pm/foo"})
+      assert %{valid?: false} = ShortURL.changeset(%{url: "data://hex.pm/foo"})
+    end
+
     test "where host is not on hex.pm" do
       assert %{valid?: false, errors: errors} =
                ShortURL.changeset(%{url: "https://supersimple.org?spoof=hex.pm"})


### PR DESCRIPTION
Restrict short URLs to only allow http and https schemes, rejecting javascript:, data:, ftp:, and other schemes that could be abused for phishing or client-side exploitation.