### PR TITLE
Fix FunctionClauseError in audit_with_user during signup

### DIFF
--- a/lib/hexpm_web/controllers/signup_controller.ex
+++ b/lib/hexpm_web/controllers/signup_controller.ex
@@ -11,28 +11,34 @@ defmodule HexpmWeb.SignupController do
   end
 
   def create(conn, params) do
-    if HexpmWeb.Captcha.verify(params["h-captcha-response"]) do
-      case Users.add(params["user"], audit: audit_data(conn)) do
-        {:ok, _user} ->
-          flash =
-            "A confirmation email has been sent, " <>
-              "you will have access to your account shortly."
+    cond do
+      logged_in?(conn) ->
+        path = ~p"/users/#{conn.assigns.current_user}"
+        redirect(conn, to: path)
 
-          conn
-          |> put_flash(:info, flash)
-          |> redirect(to: ~p"/")
+      HexpmWeb.Captcha.verify(params["h-captcha-response"]) ->
+        case Users.add(params["user"], audit: audit_data(conn)) do
+          {:ok, _user} ->
+            flash =
+              "A confirmation email has been sent, " <>
+                "you will have access to your account shortly."
 
-        {:error, changeset} ->
-          conn
-          |> put_status(400)
-          |> render_show(changeset)
-      end
-    else
-      changeset = %{User.build(sanitize_params(params["user"])) | action: :insert}
+            conn
+            |> put_flash(:info, flash)
+            |> redirect(to: ~p"/")
 
-      conn
-      |> put_status(400)
-      |> render_show(changeset, "Please complete the captcha to sign up")
+          {:error, changeset} ->
+            conn
+            |> put_status(400)
+            |> render_show(changeset)
+        end
+
+      true ->
+        changeset = %{User.build(sanitize_params(params["user"])) | action: :insert}
+
+        conn
+        |> put_status(400)
+        |> render_show(changeset, "Please complete the captcha to sign up")
     end
   end
 

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -331,7 +331,7 @@ defmodule Hexpm.Accounts.AuditLogTest do
   end
 
   describe "audit_with_user/4" do
-    test "action user.create", %{user: user, key: key} do
+    test "with nil user in audit_data", %{user: user, key: key} do
       audit_data = %{
         user: nil,
         auth_credential: key,
@@ -349,6 +349,18 @@ defmodule Hexpm.Accounts.AuditLogTest do
 
       assert {_, fun} = Ecto.Multi.to_list(multi)[:"log.user.create.0"]
       assert {:ok, %AuditLog{action: "user.create"}} = fun.(Hexpm.Repo, %{user: user})
+    end
+
+    test "with nil audit_data" do
+      multi =
+        AuditLog.audit_with_user(
+          Ecto.Multi.new(),
+          nil,
+          "user.create",
+          fn %{user: user} -> user end
+        )
+
+      assert Ecto.Multi.to_list(multi) == []
     end
   end
 

--- a/test/hexpm_web/controllers/signup_controller_test.exs
+++ b/test/hexpm_web/controllers/signup_controller_test.exs
@@ -8,10 +8,35 @@ defmodule HexpmWeb.SignupControllerTest do
       conn = get(build_conn(), "/signup")
       assert response(conn, 200) =~ "Sign up"
     end
+
+    test "redirect when logged in" do
+      user = insert(:user)
+      conn = test_login(build_conn(), user)
+      conn = get(conn, "/signup")
+      assert redirected_to(conn) == "/users/#{user.username}"
+    end
   end
 
   describe "POST /signup" do
     setup :mock_captcha_success
+
+    test "redirect when logged in" do
+      user = insert(:user)
+      conn = test_login(build_conn(), user)
+
+      conn =
+        post(conn, "/signup", %{
+          "user" => %{
+            "username" => Fake.sequence(:username),
+            "emails" => [%{"email" => Fake.sequence(:email)}],
+            "password" => "hunter42",
+            "full_name" => "José"
+          },
+          "h-captcha-response" => "captcha"
+        })
+
+      assert redirected_to(conn) == "/users/#{user.username}"
+    end
 
     test "create user" do
       username = Fake.sequence(:username)


### PR DESCRIPTION
A logged-in user POSTing to the signup endpoint caused a FunctionClauseError because audit_with_user/4 has no clause for audit_data with a non-nil user, which is correct, it should only be called during user creation when no user is logged in.

Add a logged_in? guard to SignupController.create matching the existing show action to prevent the invalid code path.