### PR TITLE
Fix flaky SCA integration tests

### DIFF
--- a/test/hexpm_web/integration/sca_test.exs
+++ b/test/hexpm_web/integration/sca_test.exs
@@ -43,6 +43,17 @@ if Code.ensure_loaded?(Wallaby) do
     defp setup_card(session, card_number, expiry \\ @card_expiry, cvc \\ @card_cvc) do
       fill_stripe_card(session, card_number, expiry, cvc)
 
+      # Verify card was actually filled (retry if not)
+      card_error =
+        evaluate_js(session, """
+          var errors = document.getElementById('card-errors');
+          return errors ? errors.textContent.trim() : '';
+        """)
+
+      if card_error != "" && String.contains?(card_error, "incomplete") do
+        fill_stripe_card(session, card_number, expiry, cvc)
+      end
+
       # Wait for Stripe Elements to fully process the card input
       wait_until(2000, fn ->
         evaluate_js(session, """

--- a/test/support/integration_helpers.ex
+++ b/test/support/integration_helpers.ex
@@ -7,7 +7,7 @@ defmodule HexpmWeb.IntegrationHelpers do
   import ExUnit.Assertions
 
   @poll_interval 1_000
-  @poll_timeout 60_000
+  @poll_timeout 90_000
 
   # Shared JS function that finds the 3DS challenge iframe.
   # Excludes iframes inside #card-element (Stripe Elements).
@@ -54,7 +54,7 @@ defmodule HexpmWeb.IntegrationHelpers do
       :ok
     else
       if System.monotonic_time(:millisecond) >= deadline do
-        :ok
+        :timeout
       else
         Process.sleep(50)
         do_wait_until(deadline, fun)


### PR DESCRIPTION
Fix wait_until returning :ok on timeout, which made the retry logic in type_in_stripe_field dead code. Return :timeout instead so card field input is retried when keystrokes are missed.

Add card fill verification in setup_card to retry fill_stripe_card when Stripe Elements reports incomplete card errors before form submission.

Increase poll timeout from 60s to 90s for end_trial webhook delivery.