### PR TITLE
Optimize POST /api/oauth/token endpoint

### DIFF
--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -5,22 +5,17 @@ defmodule Hexpm.Accounts.Auth do
   alias Hexpm.Accounts.{Key, Keys, Organization, Organizations, User, Users, UserProviders}
   alias Hexpm.OAuth.{Tokens, JWT}
 
-  def key_auth(user_secret, usage_info) do
+  def key_auth(user_secret, usage_info, opts \\ []) do
     app_secret = Application.get_env(:hexpm, :secret)
 
     <<first::binary-size(32), second::binary-size(32)>> =
       :crypto.mac(:hmac, :sha256, app_secret, user_secret)
       |> Base.encode16(case: :lower)
 
+    preload = Keyword.get(opts, :preload, :full)
+
     result =
-      from(
-        k in Key,
-        where: k.secret_first == ^first,
-        left_join: u in assoc(k, :user),
-        left_join: o in assoc(k, :organization),
-        preload: [user: {u, [:emails, owned_packages: :repository, organizations: :repository]}],
-        preload: [organization: {o, [:repository, user: [:emails, owned_packages: :repository]]}]
-      )
+      key_auth_query(first, preload)
       |> Hexpm.Repo.one()
 
     case result do
@@ -41,13 +36,38 @@ defmodule Hexpm.Accounts.Auth do
                auth_credential: key,
                user: key.user,
                organization: key.organization,
-               email: find_email(key.user, nil)
+               email: if(preload == :full, do: find_email(key.user, nil))
              }}
           end
         else
           :error
         end
     end
+  end
+
+  defp key_auth_query(first, :full) do
+    from(
+      k in Key,
+      where: k.secret_first == ^first,
+      left_join: u in assoc(k, :user),
+      left_join: o in assoc(k, :organization),
+      preload: [user: {u, [:emails, owned_packages: :repository, organizations: :repository]}],
+      preload: [organization: {o, [:repository, user: [:emails, owned_packages: :repository]]}]
+    )
+  end
+
+  # Lightweight preload for OAuth token endpoint: only loads user with organizations
+  # (for scope expansion) and organization. Skips emails and owned_packages
+  # which are not needed for token issuance.
+  defp key_auth_query(first, :oauth) do
+    from(
+      k in Key,
+      where: k.secret_first == ^first,
+      left_join: u in assoc(k, :user),
+      left_join: o in assoc(k, :organization),
+      preload: [user: {u, [:organizations]}],
+      preload: [organization: o]
+    )
   end
 
   def password_auth(username_or_email, password) do

--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -49,8 +49,12 @@ defmodule Hexpm.Accounts.Keys do
     |> Repo.transaction()
   end
 
+  # Throttle last_use updates to at most once per 5 minutes per key,
+  # matching the browser session throttle behavior.
+  @last_use_throttle_seconds 300
+
   def update_last_use(%Key{public: true} = key, usage_info) do
-    if Repo.write_mode?() do
+    if Repo.write_mode?() && should_update_last_use?(key) do
       key
       |> Key.update_last_use(usage_info)
       |> Repo.update!()
@@ -60,6 +64,13 @@ defmodule Hexpm.Accounts.Keys do
   def update_last_use(%Key{public: false} = key, _usage_info) do
     key
   end
+
+  defp should_update_last_use?(%Key{last_use: %{used_at: used_at}})
+       when not is_nil(used_at) do
+    DateTime.diff(DateTime.utc_now(), used_at, :second) >= @last_use_throttle_seconds
+  end
+
+  defp should_update_last_use?(_key), do: true
 
   defp maybe_retry_for_unique_name(
          {:error, :key, %Ecto.Changeset{errors: [{:name, {"has already been taken", _}}]}, _},

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -19,6 +19,7 @@ defmodule Hexpm.Application do
       {Hexpm.Billing.Report, name: Hexpm.Billing.Report, interval: 60_000},
       goth_spec(),
       setup(),
+      load_caches(),
       HexpmWeb.Telemetry,
       HexpmWeb.Endpoint
     ]
@@ -68,6 +69,18 @@ defmodule Hexpm.Application do
 
     %{
       id: :task_setup,
+      start: {Task, :start_link, [fun]},
+      restart: :temporary
+    }
+  end
+
+  defp load_caches() do
+    fun = fn ->
+      Hexpm.OAuth.Clients.load_cache()
+    end
+
+    %{
+      id: :load_caches,
       start: {Task, :start_link, [fun]},
       restart: :temporary
     }

--- a/lib/hexpm/oauth/clients.ex
+++ b/lib/hexpm/oauth/clients.ex
@@ -6,34 +6,62 @@ defmodule Hexpm.OAuth.Clients do
 
   @doc """
   Gets a client by client_id.
+
+  Looks up from the in-memory cache first (populated at application startup
+  via `load_cache/0`), falls back to a database query on cache miss.
   """
   def get(client_id) do
-    Repo.get(Client, client_id)
+    cache = :persistent_term.get({__MODULE__, :cache}, %{})
+
+    case Map.fetch(cache, client_id) do
+      {:ok, client} -> client
+      :error -> Repo.get(Client, client_id)
+    end
+  end
+
+  @doc """
+  Loads all OAuth clients into the in-memory cache.
+  Called at application startup and after mutations.
+  """
+  def load_cache do
+    clients = Repo.all(Client)
+    cache = Map.new(clients, fn client -> {client.client_id, client} end)
+    :persistent_term.put({__MODULE__, :cache}, cache)
   end
 
   @doc """
   Creates a new OAuth client.
   """
   def create(attrs) do
-    %Client{}
-    |> Client.changeset(attrs)
-    |> Repo.insert()
+    result =
+      %Client{}
+      |> Client.changeset(attrs)
+      |> Repo.insert()
+
+    if match?({:ok, _}, result), do: load_cache()
+    result
   end
 
   @doc """
   Updates an OAuth client.
   """
   def update(%Client{} = client, attrs) do
-    client
-    |> Client.changeset(attrs)
-    |> Repo.update()
+    result =
+      client
+      |> Client.changeset(attrs)
+      |> Repo.update()
+
+    if match?({:ok, _}, result), do: load_cache()
+    result
   end
 
   @doc """
   Deletes an OAuth client.
   """
   def delete(%Client{} = client) do
-    Repo.delete(client)
+    result = Repo.delete(client)
+    if match?({:ok, _}, result), do: load_cache()
+    result
   end
 
   @doc """

--- a/lib/hexpm/oauth/tokens.ex
+++ b/lib/hexpm/oauth/tokens.ex
@@ -209,49 +209,46 @@ defmodule Hexpm.OAuth.Tokens do
     expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
     session_expires_at = DateTime.add(DateTime.utc_now(), expires_in, :second)
 
-    Ecto.Multi.new()
-    |> Ecto.Multi.run(:session, fn _repo, _changes ->
-      # Determine if this is a user or organization
-      {user, organization} =
-        case user_or_org do
-          %Hexpm.Accounts.User{} = u -> {u, nil}
-          %Hexpm.Accounts.Organization{} = o -> {nil, o}
-        end
-
-      UserSessions.create_api_key_session(
-        user,
-        organization,
-        client_id,
-        session_expires_at,
-        name: Keyword.get(opts, :name),
-        audit: Keyword.fetch!(opts, :audit)
-      )
-    end)
-    |> Ecto.Multi.run(:update_session_last_use, fn _repo, %{session: session} ->
-      if Keyword.has_key?(opts, :usage_info) do
-        UserSessions.update_last_use(session, Keyword.get(opts, :usage_info))
-      else
-        {:ok, session}
+    {user, organization} =
+      case user_or_org do
+        %Hexpm.Accounts.User{} = u -> {u, nil}
+        %Hexpm.Accounts.Organization{} = o -> {nil, o}
       end
-    end)
-    |> Ecto.Multi.run(:token, fn _repo, %{update_session_last_use: session} ->
-      token_opts =
-        opts
-        |> Keyword.put(:user_session_id, session.id)
-        |> Keyword.put(:expires_in, expires_in)
-        |> Keyword.put(:with_refresh_token, false)
 
-      changeset =
-        create_for_user_or_org(
-          user_or_org,
-          client_id,
-          scopes,
-          grant_type,
-          grant_reference,
-          token_opts
-        )
+    max_sessions =
+      if organization do
+        UserSessions.get_organization_session_limit(organization)
+      else
+        UserSessions.max_user_sessions()
+      end
 
-      Repo.insert(changeset)
+    # Enforce session limit outside transaction
+    UserSessions.enforce_session_limit(user_or_org, max_sessions)
+
+    # Pre-compute JWT outside the transaction (CPU-intensive ES256 signing)
+    token_opts =
+      Keyword.merge(opts, expires_in: expires_in, with_refresh_token: false)
+
+    token_changeset =
+      create_for_user_or_org(
+        user_or_org,
+        client_id,
+        scopes,
+        grant_type,
+        grant_reference,
+        token_opts
+      )
+
+    # Build flat Multi (no nested transactions, last_use folded into INSERT)
+    UserSessions.build_api_key_session_multi(user, organization, client_id, session_expires_at,
+      name: Keyword.get(opts, :name),
+      usage_info: Keyword.get(opts, :usage_info),
+      audit: Keyword.fetch!(opts, :audit)
+    )
+    |> Ecto.Multi.run(:token, fn _repo, %{session: session} ->
+      token_changeset
+      |> Ecto.Changeset.put_change(:user_session_id, session.id)
+      |> Repo.insert()
     end)
     |> Repo.transaction()
     |> case do
@@ -271,32 +268,30 @@ defmodule Hexpm.OAuth.Tokens do
         grant_reference \\ nil,
         opts \\ []
       ) do
-    Ecto.Multi.new()
-    |> Ecto.Multi.run(:session, fn _repo, _changes ->
-      UserSessions.create_oauth_session(
-        user,
-        client_id,
-        name: Keyword.get(opts, :name),
-        audit: Keyword.fetch!(opts, :audit)
-      )
-    end)
-    |> Ecto.Multi.run(:update_session_last_use, fn _repo, %{session: session} ->
-      if Keyword.has_key?(opts, :usage_info) do
-        UserSessions.update_last_use(session, Keyword.get(opts, :usage_info))
-      else
-        {:ok, session}
-      end
-    end)
-    |> Ecto.Multi.run(:token, fn _repo, %{update_session_last_use: session} ->
-      token_opts =
-        opts
-        |> Keyword.put(:user_session_id, session.id)
-        |> Keyword.put(:refresh_token_expires_at, session.expires_at)
+    # Enforce session limit outside transaction
+    UserSessions.enforce_session_limit(user)
 
-      changeset =
-        create_for_user(user, client_id, scopes, grant_type, grant_reference, token_opts)
+    # Compute session expiration upfront (used for both session and refresh token)
+    session_expires_at =
+      DateTime.add(DateTime.utc_now(), UserSessions.default_session_expires_in(), :second)
 
-      Repo.insert(changeset)
+    # Pre-compute JWT outside the transaction (CPU-intensive ES256 signing)
+    token_opts = Keyword.put(opts, :refresh_token_expires_at, session_expires_at)
+
+    token_changeset =
+      create_for_user(user, client_id, scopes, grant_type, grant_reference, token_opts)
+
+    # Build flat Multi (no nested transactions, last_use folded into INSERT)
+    UserSessions.build_oauth_session_multi(user, client_id,
+      expires_at: session_expires_at,
+      name: Keyword.get(opts, :name),
+      usage_info: Keyword.get(opts, :usage_info),
+      audit: Keyword.fetch!(opts, :audit)
+    )
+    |> Ecto.Multi.run(:token, fn _repo, %{session: session} ->
+      token_changeset
+      |> Ecto.Changeset.put_change(:user_session_id, session.id)
+      |> Repo.insert()
     end)
     |> Repo.transaction()
     |> case do
@@ -317,31 +312,25 @@ defmodule Hexpm.OAuth.Tokens do
         grant_reference \\ nil,
         opts \\ []
       ) do
-    alias Hexpm.UserSessions
+    # Pre-compute JWT outside the transaction (CPU-intensive ES256 signing)
+    token_opts =
+      Keyword.put(opts, :refresh_token_expires_at, old_token.refresh_token_expires_at)
+
+    token_changeset =
+      create_for_user(old_token.user, client_id, scopes, grant_type, grant_reference, token_opts)
+
+    session_id = Keyword.get(opts, :user_session_id) || old_token.user_session_id
 
     Ecto.Multi.new()
     |> Ecto.Multi.update(:revoked_token, revoke_changeset(old_token))
     |> Ecto.Multi.run(:new_token, fn _repo, _changes ->
-      # Preserve the absolute expiration from the old token
-      token_opts =
-        Keyword.put(opts, :refresh_token_expires_at, old_token.refresh_token_expires_at)
-
-      changeset =
-        create_for_user(
-          old_token.user,
-          client_id,
-          scopes,
-          grant_type,
-          grant_reference,
-          token_opts
-        )
-
-      Repo.insert(changeset)
+      token_changeset
+      |> Ecto.Changeset.put_change(:user_session_id, session_id)
+      |> Repo.insert()
     end)
-    |> Ecto.Multi.run(:update_session_last_use, fn _repo, %{new_token: new_token} ->
-      # Update session's last_use when token is refreshed
-      if new_token.user_session_id && Keyword.has_key?(opts, :usage_info) do
-        case Repo.get(Hexpm.UserSession, new_token.user_session_id) do
+    |> Ecto.Multi.run(:update_session_last_use, fn _repo, _changes ->
+      if session_id && Keyword.has_key?(opts, :usage_info) do
+        case Repo.get(Hexpm.UserSession, session_id) do
           nil ->
             {:ok, nil}
 

--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -37,6 +37,9 @@ defmodule Hexpm.UserSessions do
   @min_org_sessions 5
   @default_session_expires_in 30 * 24 * 60 * 60
 
+  def default_session_expires_in, do: @default_session_expires_in
+  def max_user_sessions, do: @max_user_sessions
+
   @doc """
   Calculates the session limit for an organization based on seat count.
   Returns max(5, seat_count), using cached billing_seats field.
@@ -173,6 +176,79 @@ defmodule Hexpm.UserSessions do
     case Repo.transaction(multi) do
       {:ok, %{session: session}} -> {:ok, session}
       {:error, :session, changeset, _} -> {:error, changeset}
+    end
+  end
+
+  @doc """
+  Builds an Ecto.Multi for creating an OAuth session without executing a transaction.
+
+  Returns the Multi (caller is responsible for executing the transaction).
+
+  ## Options
+    * `:expires_at` - Session expiration (defaults to now + 30 days)
+    * `:name` - Session name
+    * `:usage_info` - Map with :used_at, :user_agent, :ip to set as initial last_use
+    * `:audit` - Audit data for logging
+  """
+  def build_oauth_session_multi(user, client_id, opts) do
+    expires_at =
+      Keyword.get(
+        opts,
+        :expires_at,
+        DateTime.add(DateTime.utc_now(), @default_session_expires_in, :second)
+      )
+
+    %{
+      user_id: user.id,
+      type: "oauth",
+      client_id: client_id,
+      name: Keyword.get(opts, :name),
+      expires_at: expires_at
+    }
+    |> build_session_multi(opts)
+  end
+
+  @doc """
+  Builds an Ecto.Multi for creating an API key session without executing a transaction.
+
+  Similar to `build_oauth_session_multi/3` but supports both users and organizations,
+  and uses the provided `expires_at` directly (API key sessions have shorter lifetimes).
+
+  Returns the Multi (caller is responsible for executing the transaction).
+  """
+  def build_api_key_session_multi(user, organization, client_id, expires_at, opts) do
+    owner_attrs =
+      if user do
+        %{user_id: user.id}
+      else
+        %{organization_id: organization.id}
+      end
+
+    Map.merge(owner_attrs, %{
+      type: "oauth",
+      client_id: client_id,
+      name: Keyword.get(opts, :name),
+      expires_at: expires_at
+    })
+    |> build_session_multi(opts)
+  end
+
+  defp build_session_multi(attrs, opts) do
+    changeset = UserSession.changeset(%UserSession{}, attrs)
+
+    changeset =
+      if usage_info = Keyword.get(opts, :usage_info) do
+        Ecto.Changeset.put_embed(changeset, :last_use, struct(UserSession.Use, usage_info))
+      else
+        changeset
+      end
+
+    multi = Ecto.Multi.new() |> Ecto.Multi.insert(:session, changeset)
+
+    if audit_data = Keyword.get(opts, :audit) do
+      audit(multi, audit_data, "session.create", fn %{session: session} -> session end)
+    else
+      multi
     end
   end
 

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -260,7 +260,7 @@ defmodule HexpmWeb.API.OAuthController do
   defp authenticate_api_key(api_key_secret, conn) do
     usage_info = build_usage_info(conn)
 
-    case Hexpm.Accounts.Auth.key_auth(api_key_secret, usage_info) do
+    case Hexpm.Accounts.Auth.key_auth(api_key_secret, usage_info, preload: :oauth) do
       {:ok, auth_info} -> {:ok, auth_info}
       :error -> {:error, :invalid_client}
       :revoked -> {:error, :invalid_client}


### PR DESCRIPTION
Reduce DB operations per client_credentials request from 8 to 4:

- Cache OAuth clients in persistent_term at startup with DB fallback
- Add lightweight key_auth preload for OAuth (skip emails, owned_packages)
- Throttle key last_use writes to once per 5 minutes
- Fold session last_use into initial INSERT instead of separate UPDATE
- Eliminate nested transactions via build_session_multi helpers
- Pre-compute JWT signing outside DB transactions
- Remove unnecessary client preload in session creation
- Expose max_user_sessions from UserSessions instead of inline literal