### PR TITLE
Pass CSP nonces to billing service for inline script and style tags

### DIFF
--- a/lib/hexpm/billing/behaviour.ex
+++ b/lib/hexpm/billing/behaviour.ex
@@ -3,14 +3,14 @@ defmodule Hexpm.Billing.Behaviour do
 
   # TODO: Remove when all customers migrated to SCA/PaymentIntents
   @callback checkout(organization(), data :: map()) :: {:ok, map()} | {:error, map()}
-  @callback get(organization()) :: map() | nil
+  @callback get(organization(), opts :: keyword()) :: map() | nil
   @callback cancel(organization()) :: map()
   @callback resume(organization()) :: {:ok, map()} | {:error, map()}
   @callback create(map()) :: {:ok, map()} | {:error, map()}
   @callback update(organization(), map()) ::
               {:ok, map()} | {:requires_action, map()} | {:error, map()}
   @callback change_plan(organization(), map()) :: :ok
-  @callback invoice(id :: pos_integer()) :: binary()
+  @callback invoice(id :: pos_integer(), opts :: keyword()) :: binary()
   @callback void_invoice(organization(), payments_token :: String.t()) :: :ok | {:error, map()}
   @callback pay_invoice(id :: pos_integer()) :: :ok | {:error, map()}
   @callback report() :: [map()]

--- a/lib/hexpm/billing/billing.ex
+++ b/lib/hexpm/billing/billing.ex
@@ -5,12 +5,12 @@ defmodule Hexpm.Billing do
 
   # TODO: Remove when all customers migrated to SCA/PaymentIntents
   def checkout(organization, data), do: impl().checkout(organization, data)
-  def get(organization), do: impl().get(organization)
+  def get(organization, opts \\ []), do: impl().get(organization, opts)
   def cancel(organization), do: impl().cancel(organization)
   def create(params), do: impl().create(params)
   def update(organization, params), do: impl().update(organization, params)
   def change_plan(organization, params), do: impl().change_plan(organization, params)
-  def invoice(id), do: impl().invoice(id)
+  def invoice(id, opts \\ []), do: impl().invoice(id, opts)
   def pay_invoice(id), do: impl().pay_invoice(id)
   def report(), do: impl().report()
 

--- a/lib/hexpm/billing/hexpm.ex
+++ b/lib/hexpm/billing/hexpm.ex
@@ -12,9 +12,12 @@ defmodule Hexpm.Billing.Hexpm do
     end
   end
 
-  def get(organization) do
+  def get(organization, opts \\ []) do
+    query = URI.encode_query(Enum.reject(opts, fn {_k, v} -> is_nil(v) end))
+    url = "/api/customers/#{organization}?#{query}"
+
     result =
-      fn -> get_json("/api/customers/#{organization}") end
+      fn -> get_json(url) end
       |> Hexpm.HTTP.retry("billing")
 
     case result do
@@ -65,9 +68,12 @@ defmodule Hexpm.Billing.Hexpm do
     :ok
   end
 
-  def invoice(id) do
+  def invoice(id, opts \\ []) do
+    query = URI.encode_query(Enum.reject(opts, fn {_k, v} -> is_nil(v) end))
+    url = "/api/invoices/#{id}/html?#{query}"
+
     {:ok, 200, _headers, body} =
-      fn -> get_html("/api/invoices/#{id}/html") end
+      fn -> get_html(url) end
       |> Hexpm.HTTP.retry("billing")
 
     body

--- a/lib/hexpm/billing/local.ex
+++ b/lib/hexpm/billing/local.ex
@@ -6,7 +6,7 @@ defmodule Hexpm.Billing.Local do
     {:ok, %{}}
   end
 
-  def get(_organization) do
+  def get(_organization, _opts \\ []) do
     %{
       "checkout_html" => "",
       "monthly_cost" => 800,
@@ -38,7 +38,7 @@ defmodule Hexpm.Billing.Local do
     :ok
   end
 
-  def invoice(_id) do
+  def invoice(_id, _opts \\ []) do
     %{}
   end
 

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -250,7 +250,8 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
           invoice_ids = Enum.map(customer["invoices"], & &1["id"])
 
           if id in invoice_ids do
-            invoice = Hexpm.Billing.invoice(id)
+            invoice =
+              Hexpm.Billing.invoice(id, style_nonce: conn.assigns[:style_src_nonce])
 
             conn
             |> put_resp_header("content-type", "text/html")
@@ -550,7 +551,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     user = organization.user
     public_email = user && Enum.find(user.emails, & &1.public)
     gravatar_email = user && Enum.find(user.emails, & &1.gravatar)
-    customer = Hexpm.Billing.get(organization.name)
+
+    customer =
+      Hexpm.Billing.get(organization.name, script_nonce: conn.assigns[:script_src_nonce])
+
     keys = Keys.all(organization)
     audit_logs = AuditLogs.all_by(organization, 1, 30)
     audit_logs_total_count = AuditLogs.count_by(organization)

--- a/lib/hexpm_web/templates/dashboard/organization/_billing.html.eex
+++ b/lib/hexpm_web/templates/dashboard/organization/_billing.html.eex
@@ -83,7 +83,7 @@
                       <h4 class="modal-title">Payment method</h4>
                     </div>
                     <div class="modal-body">
-                      <%= raw(add_script_nonces(@checkout_html, @script_src_nonce)) %>
+                      <%= raw(@checkout_html) %>
                     </div>
                   </div>
                 </div>
@@ -94,7 +94,7 @@
                 window.hexpm_billing_post_action = "<%= @post_action %>";
                 window.hexpm_billing_csrf_token = "<%= @csrf_token %>";
               </script>
-              <%= raw(add_script_nonces(@checkout_html, @script_src_nonce)) %>
+              <%= raw(@checkout_html) %>
 
               <div style="display: flex; gap: 10px; align-items: center;">
                 <%= if @subscription && @subscription["cancel_at_period_end"] && @card do %>
@@ -217,7 +217,7 @@
                       <h4 class="modal-title">Payment method</h4>
                     </div>
                     <div class="modal-body">
-                      <%= raw(add_script_nonces(@checkout_html, @script_src_nonce)) %>
+                      <%= raw(@checkout_html) %>
                     </div>
                   </div>
                 </div>
@@ -228,7 +228,7 @@
                 window.hexpm_billing_post_action = "<%= @post_action %>";
                 window.hexpm_billing_csrf_token = "<%= @csrf_token %>";
               </script>
-              <%= raw(add_script_nonces(@checkout_html, @script_src_nonce)) %>
+              <%= raw(@checkout_html) %>
             <% end %>
           <% end %>
         </div>

--- a/lib/hexpm_web/views/dashboard/organization_view.ex
+++ b/lib/hexpm_web/views/dashboard/organization_view.ex
@@ -603,12 +603,6 @@ defmodule HexpmWeb.Dashboard.OrganizationView do
     unquote([{"", ""}] ++ Enum.sort_by(@country_codes, &elem(&1, 1)))
   end
 
-  defp add_script_nonces(nil, _nonce), do: nil
-
-  defp add_script_nonces(html, nonce) do
-    String.replace(html, "<script", ~s(<script nonce="#{nonce}"))
-  end
-
   defp show_person?(person, company, errors) do
     (person || errors["person"]) && !company && !errors["company"]
   end

--- a/test/hexpm/user_sessions_test.exs
+++ b/test/hexpm/user_sessions_test.exs
@@ -338,7 +338,7 @@ defmodule Hexpm.UserSessionsTest do
       organization = insert(:organization)
 
       # Mock billing to return nil/unavailable
-      Mox.stub(Hexpm.Billing.Mock, :get, fn _name -> nil end)
+      Mox.stub(Hexpm.Billing.Mock, :get, fn _name, _opts -> nil end)
 
       # Calculate session limit
       limit = UserSessions.get_organization_session_limit(organization)
@@ -349,7 +349,7 @@ defmodule Hexpm.UserSessionsTest do
       organization = insert(:organization)
 
       # Mock billing to return invalid data
-      Mox.stub(Hexpm.Billing.Mock, :get, fn _name ->
+      Mox.stub(Hexpm.Billing.Mock, :get, fn _name, _opts ->
         %{"quantity" => "invalid"}
       end)
 

--- a/test/hexpm_web/controllers/api/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_controller_test.exs
@@ -2,7 +2,7 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
   use HexpmWeb.ConnCase, async: true
 
   defp mock_customer(context) do
-    stub(Hexpm.Billing.Mock, :get, fn token ->
+    stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
       assert context.organization.name == token
       %{"quantity" => 1}
     end)

--- a/test/hexpm_web/controllers/api/organization_user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_user_controller_test.exs
@@ -3,7 +3,7 @@ defmodule HexpmWeb.API.OrganizationUserControllerTest do
   alias Hexpm.Accounts.Organizations
 
   defp mock_customer(context) do
-    stub(Hexpm.Billing.Mock, :get, fn token ->
+    stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
       assert context.organization.name == token
       %{"quantity" => 2}
     end)

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -10,7 +10,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
   end
 
   defp mock_customer(organization) do
-    stub(Hexpm.Billing.Mock, :get, fn token ->
+    stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
       assert organization.name == token
 
       %{
@@ -124,7 +124,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     test "shows incomplete subscription status", %{user: user, organization: organization} do
       insert(:organization_user, organization: organization, user: user, role: "admin")
 
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
 
         %{
@@ -153,7 +153,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     test "shows incomplete_expired subscription status", %{user: user, organization: organization} do
       insert(:organization_user, organization: organization, user: user, role: "admin")
 
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
 
         %{
@@ -197,7 +197,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
 
   describe "POST /dashboard/orgs/:dashboard_org" do
     test "add member to organization", %{user: user, organization: organization} do
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
 
         %{
@@ -234,7 +234,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       user: user,
       organization: organization
     } do
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
 
         %{
@@ -472,7 +472,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
         {:error, %{"errors" => "No active subscription to resume"}}
       end)
 
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
         %{"checkout_html" => "", "invoices" => []}
       end)
@@ -516,12 +516,12 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
 
   describe "GET /dashboard/orgs/:dashboard_org/invoices/:id" do
     test "show invoice", %{user: user, organization: organization} do
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
         %{"invoices" => [%{"id" => 123}]}
       end)
 
-      stub(Hexpm.Billing.Mock, :invoice, fn id ->
+      stub(Hexpm.Billing.Mock, :invoice, fn id, _opts ->
         assert id == 123
         "Invoice"
       end)
@@ -537,7 +537,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     end
 
     test "returns 404 for non-integer invoice ID", %{user: user, organization: organization} do
-      stub(Hexpm.Billing.Mock, :get, fn _token ->
+      stub(Hexpm.Billing.Mock, :get, fn _token, _opts ->
         %{"invoices" => [%{"id" => 123}]}
       end)
 
@@ -554,7 +554,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
 
   describe "POST /dashboard/orgs/:dashboard_org/invoices/:id/pay" do
     test "pay invoice succeed", %{user: user, organization: organization} do
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
 
         invoice = %{
@@ -584,7 +584,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     end
 
     test "pay invoice failed", %{user: user, organization: organization} do
-      stub(Hexpm.Billing.Mock, :get, fn token ->
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
         assert organization.name == token
 
         invoice = %{
@@ -619,7 +619,7 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       user: user,
       organization: organization
     } do
-      stub(Hexpm.Billing.Mock, :get, fn _token -> %{"invoices" => [%{"id" => 123}]} end)
+      stub(Hexpm.Billing.Mock, :get, fn _token, _opts -> %{"invoices" => [%{"id" => 123}]} end)
       stub(Hexpm.Billing.Mock, :pay_invoice, fn _id -> :ok end)
 
       insert(:organization_user, organization: organization, user: user, role: "admin")


### PR DESCRIPTION
Pass style_src_nonce and script_src_nonce to the billing service so it can render nonces directly on inline <style> and <script> tags. This replaces the previous approach of doing string replacement on the HTML after receiving it from the billing service.