### PR TITLE
Use dark background for code blocks in package README rendering

### DIFF
--- a/lib/hexpm_web/views/readme_view.ex
+++ b/lib/hexpm_web/views/readme_view.ex
@@ -18,9 +18,9 @@ defmodule HexpmWeb.ReadmeView do
     .readme a { color: #0366d6; text-decoration: none; }
     .readme a:hover { text-decoration: underline; }
     .readme img { max-width: 100%; height: auto; margin: 2px; }
-    .readme pre { padding: 16px; overflow: auto; font-size: 85%; line-height: 1.45; background-color: #f6f8fa; border-radius: 6px; margin-bottom: 16px; }
-    .readme code { padding: 0.2em 0.4em; font-size: 85%; background-color: #f6f8fa; border-radius: 3px; font-family: SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; }
-    .readme pre code { padding: 0; background: transparent; font-size: 100%; }
+    .readme pre { padding: 1rem; overflow-x: auto; background-color: #111827; border-radius: 0.5rem; margin-bottom: 1rem; }
+    .readme code { padding: 0.125rem 0.375rem; font-size: 0.875rem; background-color: #f3f4f6; border-radius: 0.25rem; font-family: ui-monospace, monospace; color: #1f2937; }
+    .readme pre code { padding: 0; background: transparent; font-size: 0.875rem; color: #e5e7eb; }
     .readme blockquote { padding: 0 1em; color: #6a737d; border-left: 0.25em solid #dfe2e5; margin-bottom: 16px; }
     .readme ul, .readme ol { padding-left: 2em; margin-bottom: 16px; }
     .readme li { margin-top: 0.25em; }
@@ -34,7 +34,7 @@ defmodule HexpmWeb.ReadmeView do
     .readme dl { padding: 0; margin-bottom: 16px; }
     .readme dl dt { padding: 0; margin-top: 16px; font-size: 1em; font-style: italic; font-weight: 600; }
     .readme dl dd { padding: 0 16px; margin-bottom: 16px; }
-    .readme kbd { display: inline-block; padding: 3px 5px; font: 11px SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace; line-height: 10px; color: #444d56; vertical-align: middle; background-color: #fafbfc; border: 1px solid #d1d5da; border-radius: 3px; box-shadow: inset 0 -1px 0 #d1d5da; }
+    .readme kbd { display: inline-block; padding: 3px 5px; font: 11px ui-monospace, monospace; line-height: 10px; color: #444d56; vertical-align: middle; background-color: #fafbfc; border: 1px solid #d1d5da; border-radius: 3px; box-shadow: inset 0 -1px 0 #d1d5da; }
     .readme input[type="checkbox"] { margin-right: 0.5em; }
     .color-scheme-dark { display: none !important; }
     """


### PR DESCRIPTION
Match the docs page style with dark background (#111827) and light text (#e5e7eb) for better contrast in README code blocks.

Closes https://github.com/hexpm/hexpm/issues/1452.