### PR TITLE
Improve package exact match search UI and relative time display

### DIFF
--- a/lib/hexpm_web/templates/package/_package.html.heex
+++ b/lib/hexpm_web/templates/package/_package.html.heex
@@ -1,18 +1,32 @@
-<li class="p-6 hover:bg-grey-50 transition-colors">
+<li class={[
+  "group p-6 transition-colors",
+  @exact_match? && "hover:bg-green-100",
+  not @exact_match? && "hover:bg-grey-50"
+]}>
   <div class="flex items-start justify-between gap-6">
     <%!-- Package Info --%>
     <div class="flex-1 min-w-0">
       <div class="flex items-center gap-3 mb-2">
         <a
           href={ViewHelpers.path_for_package(@package)}
-          class="text-grey-900 font-semibold text-xl hover:text-primary-600 transition-colors"
+          class={[
+            "text-grey-900 font-semibold text-xl transition-colors",
+            @exact_match? && "hover:text-green-600",
+            not @exact_match? && "hover:text-primary-600"
+          ]}
         >
           {ViewHelpers.package_name(@package)}
         </a>
         <%= if @package.latest_release do %>
           <a
             href={ViewHelpers.path_for_package(@package)}
-            class="inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium bg-grey-100 text-grey-700 hover:bg-primary-100 hover:text-primary-700 transition-colors"
+            class={[
+              "inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium transition-colors",
+              @exact_match? &&
+                "bg-green-100 group-hover:bg-green-200 text-green-700 hover:text-green-800",
+              not @exact_match? &&
+                "bg-grey-100 text-grey-700 hover:bg-primary-100 hover:text-primary-700"
+            ]}
           >
             v{@package.latest_release.version}
           </a>

--- a/lib/hexpm_web/templates/package/index.html.heex
+++ b/lib/hexpm_web/templates/package/index.html.heex
@@ -37,6 +37,7 @@
         </div>
         <ul class="bg-white rounded-lg overflow-hidden">
           {render("_package.html",
+            exact_match?: true,
             package: @exact_match,
             package_downloads: downloads_for_package(@exact_match, @downloads),
             view: @sort
@@ -103,6 +104,7 @@
         <ul class="divide-y divide-grey-200">
           <%= for package <- @packages do %>
             {render("_package.html",
+              exact_match?: false,
               package: package,
               package_downloads: downloads_for_package(package, @downloads),
               view: @sort

--- a/lib/hexpm_web/views/page_view.ex
+++ b/lib/hexpm_web/views/page_view.ex
@@ -5,17 +5,4 @@ defmodule HexpmWeb.PageView do
   import HexpmWeb.Components.Home
   import HexpmWeb.Components.Pricing
   import HexpmWeb.Components.Sponsors
-
-  def render_package(data) do
-    data =
-      [
-        downloads: nil,
-        description: nil,
-        inserted_at: nil,
-        version: nil
-      ]
-      |> Keyword.merge(data)
-
-    render("_package.html", data)
-  end
 end

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -299,7 +299,13 @@ defmodule HexpmWeb.ViewHelpers do
   defp rel_from_now({0, {hour, _, _}}) when hour < 24, do: "#{hour} hours ago"
   defp rel_from_now({1, {_, _, _}}), do: "1 day ago"
   defp rel_from_now({day, {_, _, _}}) when day < 0, do: "about now"
-  defp rel_from_now({day, {_, _, _}}), do: "#{day} days ago"
+  defp rel_from_now({day, {_, _, _}}) when day < 7, do: "#{day} days ago"
+  defp rel_from_now({day, {_, _, _}}) when day < 14, do: "1 week ago"
+  defp rel_from_now({day, {_, _, _}}) when day < 30, do: "#{div(day, 7)} weeks ago"
+  defp rel_from_now({day, {_, _, _}}) when day < 60, do: "1 month ago"
+  defp rel_from_now({day, {_, _, _}}) when day < 365, do: "#{div(day, 30)} months ago"
+  defp rel_from_now({day, {_, _, _}}) when day < 730, do: "about 1 year ago"
+  defp rel_from_now({day, {_, _, _}}), do: "about #{div(day, 365)} years ago"
 
   def pretty_datetime(datetime) do
     Calendar.strftime(datetime, "%b %d, %Y, %H:%M")

--- a/test/hexpm_web/views/view_helpers_test.exs
+++ b/test/hexpm_web/views/view_helpers_test.exs
@@ -48,6 +48,83 @@ defmodule HexpmWeb.ViewHelpersTest do
     end
   end
 
+  describe "human_relative_time_from_now/1" do
+    defp rel(days, hours \\ 0, minutes \\ 0, seconds \\ 0) do
+      datetime =
+        NaiveDateTime.utc_now()
+        |> NaiveDateTime.add(-(days * 86_400 + hours * 3_600 + minutes * 60 + seconds))
+
+      human_relative_time_from_now(datetime) |> Phoenix.HTML.safe_to_string()
+    end
+
+    defp extract_text(html) do
+      Regex.run(~r/>([^<]+)</, html) |> List.last()
+    end
+
+    test "about now" do
+      assert extract_text(rel(0, 0, 0, 5)) == "about now"
+    end
+
+    test "1 minute ago" do
+      assert extract_text(rel(0, 0, 1, 15)) == "1 minute ago"
+    end
+
+    test "minutes ago" do
+      assert extract_text(rel(0, 0, 5)) == "5 minutes ago"
+      assert extract_text(rel(0, 0, 45)) == "45 minutes ago"
+    end
+
+    test "1 hour ago" do
+      assert extract_text(rel(0, 1)) == "1 hour ago"
+    end
+
+    test "hours ago" do
+      assert extract_text(rel(0, 3)) == "3 hours ago"
+      assert extract_text(rel(0, 23)) == "23 hours ago"
+    end
+
+    test "1 day ago" do
+      assert extract_text(rel(1)) == "1 day ago"
+    end
+
+    test "days ago" do
+      assert extract_text(rel(3)) == "3 days ago"
+      assert extract_text(rel(6)) == "6 days ago"
+    end
+
+    test "1 week ago" do
+      assert extract_text(rel(7)) == "1 week ago"
+      assert extract_text(rel(13)) == "1 week ago"
+    end
+
+    test "weeks ago" do
+      assert extract_text(rel(14)) == "2 weeks ago"
+      assert extract_text(rel(21)) == "3 weeks ago"
+      assert extract_text(rel(29)) == "4 weeks ago"
+    end
+
+    test "1 month ago" do
+      assert extract_text(rel(30)) == "1 month ago"
+      assert extract_text(rel(59)) == "1 month ago"
+    end
+
+    test "months ago" do
+      assert extract_text(rel(60)) == "2 months ago"
+      assert extract_text(rel(120)) == "4 months ago"
+      assert extract_text(rel(364)) == "12 months ago"
+    end
+
+    test "about 1 year ago" do
+      assert extract_text(rel(365)) == "about 1 year ago"
+      assert extract_text(rel(729)) == "about 1 year ago"
+    end
+
+    test "about years ago" do
+      assert extract_text(rel(730)) == "about 2 years ago"
+      assert extract_text(rel(1095)) == "about 3 years ago"
+    end
+  end
+
   describe "human_number_space" do
     test "without compaction" do
       assert human_number_space(0) == "0"


### PR DESCRIPTION
Highlight exact match results with green styling in package search. Extend relative time helper to show weeks, months, and years instead of only days. Remove unused render_package/1 from PageView.

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td><video src="https://github.com/user-attachments/assets/ec477241-f017-44fe-ad0a-c8df539cc135" />
 <td><video src="https://github.com/user-attachments/assets/6a62eee3-2cbc-4132-9b91-5f8ba5c22f5b" />
</table>
