### PR TITLE
Fix KeyError on dependents page for missing exact_match? assign

### DIFF
--- a/lib/hexpm_web/templates/package/_package.html.heex
+++ b/lib/hexpm_web/templates/package/_package.html.heex
@@ -1,7 +1,8 @@
+<% exact_match? = assigns[:exact_match?] || false %>
 <li class={[
   "group p-6 transition-colors",
-  @exact_match? && "hover:bg-green-100",
-  not @exact_match? && "hover:bg-grey-50"
+  exact_match? && "hover:bg-green-100",
+  not exact_match? && "hover:bg-grey-50"
 ]}>
   <div class="flex items-start justify-between gap-6">
     <%!-- Package Info --%>
@@ -11,8 +12,8 @@
           href={ViewHelpers.path_for_package(@package)}
           class={[
             "text-grey-900 font-semibold text-xl transition-colors",
-            @exact_match? && "hover:text-green-600",
-            not @exact_match? && "hover:text-primary-600"
+            exact_match? && "hover:text-green-600",
+            not exact_match? && "hover:text-primary-600"
           ]}
         >
           {ViewHelpers.package_name(@package)}
@@ -22,9 +23,9 @@
             href={ViewHelpers.path_for_package(@package)}
             class={[
               "inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium transition-colors",
-              @exact_match? &&
+              exact_match? &&
                 "bg-green-100 group-hover:bg-green-200 text-green-700 hover:text-green-800",
-              not @exact_match? &&
+              not exact_match? &&
                 "bg-grey-100 text-grey-700 hover:bg-primary-100 hover:text-primary-700"
             ]}
           >

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -1,6 +1,8 @@
 defmodule HexpmWeb.PackageViewTest do
   use HexpmWeb.ConnCase, async: true
 
+  import Phoenix.View
+
   alias HexpmWeb.PackageView
 
   defp parse_html_list_to_string(html_map) do
@@ -117,6 +119,35 @@ defmodule HexpmWeb.PackageViewTest do
     assert PackageView.snippet_version(:erlang_mk, version1) == "0.0.2"
     assert PackageView.snippet_version(:erlang_mk, version2) == "0.2.99"
     assert PackageView.snippet_version(:erlang_mk, version3) == "2.0.2"
+  end
+
+  describe "_package.html" do
+    test "renders package partial without exact_match?" do
+      package =
+        build(:package,
+          repository_id: 1,
+          repository: build(:repository, id: 1, name: "hexpm"),
+          inserted_at: ~U[2025-01-01 00:00:00Z]
+        )
+
+      package = %{
+        package
+        | latest_release: %Hexpm.Repository.Release{
+            version: Version.parse!("1.0.0"),
+            inserted_at: ~N[2025-01-01 00:00:00]
+          }
+      }
+
+      result =
+        render_to_string(PackageView, "_package.html",
+          package: package,
+          package_downloads: %{"all" => 1000, "recent" => 100},
+          view: :recent_downloads
+        )
+
+      assert result =~ package.name
+      assert result =~ "v1.0.0"
+    end
   end
 
   describe "retirement_message/1" do


### PR DESCRIPTION
The _package.html partial now defaults exact_match? to false instead of requiring it from every caller, fixing a crash on the dependents page introduced in d75801f.