### PR TITLE
Fix add seats modal submit button not working

### DIFF
--- a/lib/hexpm_web/templates/dashboard/organization/components/billing_subscription.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/billing_subscription.ex
@@ -201,7 +201,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
                   addSeatsForm.addEventListener('submit', async function(event) {
                     event.preventDefault();
 
-                    var submitButton = addSeatsForm.querySelector('button[type="submit"]');
+                    var submitButton = document.querySelector('button[type="submit"][form="add-seats-form"]');
                     submitButton.disabled = true;
                     submitButton.textContent = 'Processing...';
 


### PR DESCRIPTION
The submit button is in the modal footer slot, outside the form element, so querying within the form returned null. Query the document instead using the button's form attribute.