### PR TITLE
Add Gleam syntax highlighting (new makeup_gleam package!)

### DIFF
--- a/lib/hexpm_web/markdown_engine.ex
+++ b/lib/hexpm_web/markdown_engine.ex
@@ -6,7 +6,8 @@ defmodule HexpmWeb.MarkdownEngine do
 
   @supported_languages %{
     "elixir" => Makeup.Lexers.ElixirLexer,
-    "erlang" => Makeup.Lexers.ErlangLexer
+    "erlang" => Makeup.Lexers.ErlangLexer,
+    "gleam" => Makeup.Lexers.GleamLexer
   }
 
   def compile(path, _name) do

--- a/mix.exs
+++ b/mix.exs
@@ -59,6 +59,7 @@ defmodule Hexpm.MixProject do
       {:makeup_elixir, "~> 1.0"},
       {:makeup_erlang, "~> 1.0"},
       {:makeup_syntect, "~> 0.1"},
+      {:makeup_gleam, "~> 1.0"},
       {:mox, "~> 1.0", only: :test},
       {:nimble_ownership, "~> 1.0"},
       {:stream_data, "~> 1.0", only: :test},


### PR DESCRIPTION
Hey Hex folks!

Love the new design, it's very snazzy. After noticing Gleam snippets aren't highlighted in READMEs, I had a chat to Louis and they whipped together a Makeup parser for Gleam, so we can get all the major BEAM languages looking their prettiest.

Let me know if there's something big I've missed - I wasn't in the position to spin up a proper local instance with a database and such.