### PR TITLE
fix: Properly render nested GFM TODO lists

### DIFF
--- a/lib/hexpm_web/readme/task_list.ex
+++ b/lib/hexpm_web/readme/task_list.ex
@@ -56,7 +56,7 @@ defmodule HexpmWeb.Readme.TaskList do
     end
   end
 
-  defp convert_li_children(children), do: children
+  defp convert_li_children(children), do: Enum.map(children, &convert_node/1)
 
   defp checkbox_input(" ") do
     {"input", [{"type", "checkbox"}, {"disabled", "disabled"}], [], %{}}

--- a/lib/hexpm_web/readme/task_list.ex
+++ b/lib/hexpm_web/readme/task_list.ex
@@ -28,10 +28,10 @@ defmodule HexpmWeb.Readme.TaskList do
     case Regex.run(@checkbox_pattern, text) do
       [match, marker] ->
         remaining = String.slice(text, String.length(match)..-1//1)
-        [checkbox_input(marker) | prepend_if_nonempty(remaining, rest)]
+        [checkbox_input(marker) | prepend_if_nonempty(remaining, Enum.map(rest, &convert_node/1))]
 
       nil ->
-        [text | rest]
+        [text | Enum.map(rest, &convert_node/1)]
     end
   end
 
@@ -40,11 +40,19 @@ defmodule HexpmWeb.Readme.TaskList do
     case Regex.run(@checkbox_pattern, text) do
       [match, marker] ->
         remaining = String.slice(text, String.length(match)..-1//1)
-        p_children = [checkbox_input(marker) | prepend_if_nonempty(remaining, p_rest)]
-        [{"p", p_attrs, p_children, p_meta} | rest]
+
+        p_children = [
+          checkbox_input(marker)
+          | prepend_if_nonempty(remaining, Enum.map(p_rest, &convert_node/1))
+        ]
+
+        [{"p", p_attrs, p_children, p_meta} | Enum.map(rest, &convert_node/1)]
 
       nil ->
-        [{"p", p_attrs, [text | p_rest], p_meta} | rest]
+        [
+          {"p", p_attrs, [text | Enum.map(p_rest, &convert_node/1)], p_meta}
+          | Enum.map(rest, &convert_node/1)
+        ]
     end
   end
 

--- a/priv/preview/files/decimal/0.1.0/README.md
+++ b/priv/preview/files/decimal/0.1.0/README.md
@@ -68,8 +68,8 @@ end)
 - [x] Configurable precision
 - [x] Rounding modes
 - [ ] Functions
-  - Trigonometric
-  - Logarithmic
+  - [ ] Trigonometric
+  - [ ] Logarithmic
 
 ## Type Specifications
 

--- a/priv/preview/files/decimal/0.1.0/README.md
+++ b/priv/preview/files/decimal/0.1.0/README.md
@@ -67,9 +67,8 @@ end)
 - [x] Basic arithmetic operations
 - [x] Configurable precision
 - [x] Rounding modes
-- [ ] Functions
-  - [ ] Trigonometric
-  - [ ] Logarithmic
+- [ ] Trigonometric functions
+- [ ] Logarithmic functions
 
 ## Type Specifications
 

--- a/priv/preview/files/decimal/0.1.0/README.md
+++ b/priv/preview/files/decimal/0.1.0/README.md
@@ -67,8 +67,9 @@ end)
 - [x] Basic arithmetic operations
 - [x] Configurable precision
 - [x] Rounding modes
-- [ ] Trigonometric functions
-- [ ] Logarithmic functions
+- [ ] Functions
+  - Trigonometric
+  - Logarithmic
 
 ## Type Specifications
 

--- a/test/hexpm_web/readme/task_list_test.exs
+++ b/test/hexpm_web/readme/task_list_test.exs
@@ -112,23 +112,24 @@ defmodule HexpmWeb.Readme.TaskListTest do
       assert [{"li", _, [^checked_cb, "list"], _}] = nested2
     end
 
-    test "converts TODO list inside list" do
+    test "converts ordered TODO list inside list" do
       unchecked_cb = checkbox(false)
       checked_cb = checkbox(true)
 
       ast =
         parse_and_convert("""
-        TODO
-          - [x] Task1
-          - [ ] Task2
+        - TODO
+          1. [x] Task1
+          2. [ ] Task2
         """)
 
-      assert [{"p", _attrs, ["TODO"], _meta}, {"ul", _, items, _}] = ast
+      assert [{"ul", _attrs, [{"li", _, ["TODO", items], _}], _}] = ast
 
-      assert [
-               {"li", _, [^checked_cb, "Task1"], _},
-               {"li", _, [^unchecked_cb, "Task2"], _}
-             ] = items
+      assert {"ol", _,
+              [
+                {"li", _, [^checked_cb, "Task1"], _},
+                {"li", _, [^unchecked_cb, "Task2"], _}
+              ], _} = items
     end
 
     test "mixed list with checkboxes and normal items" do

--- a/test/hexpm_web/readme/task_list_test.exs
+++ b/test/hexpm_web/readme/task_list_test.exs
@@ -79,7 +79,7 @@ defmodule HexpmWeb.Readme.TaskListTest do
              ] = items
     end
 
-    test "nested list inside TODO list is render normally" do
+    test "nested list inside TODO list is rendered normally" do
       unchecked_cb = checkbox(false)
 
       ast =

--- a/test/hexpm_web/readme/task_list_test.exs
+++ b/test/hexpm_web/readme/task_list_test.exs
@@ -79,6 +79,21 @@ defmodule HexpmWeb.Readme.TaskListTest do
              ] = items
     end
 
+    test "nested list inside TODO list is render normally" do
+      unchecked_cb = checkbox(false)
+
+      ast =
+        parse_and_convert("""
+        - [ ] TODO
+          - Not a task
+        """)
+
+      assert [{"ul", _attrs, items, _meta}] = ast
+
+      assert [{"li", _, [^unchecked_cb, "TODO", nested], _}] = items
+      assert {"ul", _, [{"li", _, ["Not a task"], _}], _} = nested
+    end
+
     test "converts nested TODO lists" do
       unchecked_cb = checkbox(false)
       checked_cb = checkbox(true)

--- a/test/hexpm_web/readme/task_list_test.exs
+++ b/test/hexpm_web/readme/task_list_test.exs
@@ -79,6 +79,43 @@ defmodule HexpmWeb.Readme.TaskListTest do
              ] = items
     end
 
+    test "converts nested TODO lists" do
+      unchecked_cb = checkbox(false)
+      checked_cb = checkbox(true)
+
+      ast =
+        parse_and_convert("""
+        - [ ] nested
+          - [X] TODO
+            * [x] list
+        """)
+
+      [{"ul", _attrs, items, _meta}] = ast
+
+      assert [{"li", _, [^unchecked_cb, "nested", {"ul", _, nested1, _}], _}] = items
+      assert [{"li", _, [^checked_cb, "TODO", {"ul", _, nested2, _}], _}] = nested1
+      assert [{"li", _, [^checked_cb, "list"], _}] = nested2
+    end
+
+    test "converts TODO list inside list" do
+      unchecked_cb = checkbox(false)
+      checked_cb = checkbox(true)
+
+      ast =
+        parse_and_convert("""
+        TODO
+          - [x] Task1
+          - [ ] Task2
+        """)
+
+      assert [{"p", _attrs, ["TODO"], _meta}, {"ul", _, items, _}] = ast
+
+      assert [
+               {"li", _, [^checked_cb, "Task1"], _},
+               {"li", _, [^unchecked_cb, "Task2"], _}
+             ] = items
+    end
+
     test "mixed list with checkboxes and normal items" do
       unchecked_cb = checkbox(false)
       checked_cb = checkbox(true)


### PR DESCRIPTION
The workaround in `HexpmWeb.Readme.TaskList` only converts top-level GFM TODO lists. Not sure if this is the right way to fix the issue, but I tested adding extra indentation in the local README for decimal and it renders properly (see images for before/after)
 
<img width="360" height="310" alt="before" src="https://github.com/user-attachments/assets/00eec596-8050-4508-ac30-c54d0cb77f07" />
<img width="347" height="296" alt="after" src="https://github.com/user-attachments/assets/3567598b-8661-4271-9445-527aa92a5bf7" />