### PR TITLE
Optimize slow session revocation queries

### DIFF
--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -443,10 +443,10 @@ defmodule Hexpm.UserSessions do
 
   # Revokes the given number of least recently used sessions and their tokens.
   #
-  # Uses SELECT FOR UPDATE to acquire row locks in deterministic order, preventing
-  # deadlocks when multiple concurrent requests revoke sessions simultaneously.
-  # Session IDs are materialized once to ensure both the session and token
-  # revocations target the same set of sessions.
+  # Uses SKIP LOCKED so concurrent enforcers don't queue on the same rows; at
+  # worst this over-revokes by one or two sessions, which is acceptable for a
+  # soft limit. Session IDs are materialized once so both the session and token
+  # update_all target the same set.
   defp revoke_lru_sessions(owner_filter, revoke_count) do
     now = DateTime.utc_now()
 
@@ -461,7 +461,7 @@ defmodule Hexpm.UserSessions do
           ],
           limit: ^revoke_count,
           select: s.id,
-          lock: "FOR UPDATE"
+          lock: "FOR UPDATE SKIP LOCKED"
         )
         |> Repo.all()
 

--- a/priv/repo/migrations/20260416120000_add_oauth_tokens_user_session_id_index.exs
+++ b/priv/repo/migrations/20260416120000_add_oauth_tokens_user_session_id_index.exs
@@ -1,0 +1,7 @@
+defmodule Hexpm.RepoBase.Migrations.AddOauthTokensUserSessionIdIndex do
+  use Ecto.Migration
+
+  def change do
+    create index(:oauth_tokens, [:user_session_id], where: "revoked_at IS NULL")
+  end
+end


### PR DESCRIPTION
- Add partial index on oauth_tokens(user_session_id) WHERE revoked_at IS NULL. The user_session_id column (added when sessions were unified in 20251010135827) had no index, causing UPDATE ... WHERE user_session_id = ANY($1) AND revoked_at IS NULL to seq-scan oauth_tokens.

- Use FOR UPDATE SKIP LOCKED in revoke_lru_sessions. Concurrent session revocations were queueing on the same rows, showing up as ~1.5s LockRows latency. Skip-locked is acceptable here since the session cap is a soft limit; worst case is a session or two over-revoked.