### PR TITLE
Optimize dependants page queries

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -138,6 +138,71 @@ defmodule Hexpm.Repository.Package do
     |> fields(fields)
   end
 
+  def downloaded_dependant_ids(repositories, dependency, view, limit, offset) do
+    repository_ids = Enum.map(repositories, & &1.id)
+
+    from(
+      pd in PackageDownload,
+      join: p in Package,
+      as: :package,
+      on: p.id == pd.package_id,
+      where: pd.view == ^view,
+      where: p.repository_id in ^repository_ids,
+      where: exists(dependency_exists_query(dependency.id)),
+      order_by: [fragment("? DESC NULLS LAST", pd.downloads)],
+      limit: ^limit,
+      offset: ^offset,
+      select: p.id
+    )
+  end
+
+  def count_downloaded_dependants(repositories, dependency, view) do
+    repository_ids = Enum.map(repositories, & &1.id)
+
+    from(
+      pd in PackageDownload,
+      join: p in Package,
+      as: :package,
+      on: p.id == pd.package_id,
+      where: pd.view == ^view,
+      where: p.repository_id in ^repository_ids,
+      where: exists(dependency_exists_query(dependency.id)),
+      select: count()
+    )
+  end
+
+  def undownloaded_dependant_ids(repositories, dependency, view, limit, offset) do
+    repository_ids = Enum.map(repositories, & &1.id)
+
+    from(
+      p in Package,
+      as: :package,
+      where: p.repository_id in ^repository_ids,
+      where: exists(dependency_exists_query(dependency.id)),
+      where:
+        not exists(
+          from(pd in PackageDownload,
+            where: pd.package_id == parent_as(:package).id,
+            where: pd.view == ^view
+          )
+        ),
+      order_by: p.id,
+      limit: ^limit,
+      offset: ^offset,
+      select: p.id
+    )
+  end
+
+  def by_ids(ids, nil) do
+    from(p in Package, where: p.id in ^ids, preload: :downloads)
+  end
+
+  def by_ids(ids, fields) do
+    fields = Enum.uniq([:id, :repository_id | fields])
+
+    from(p in Package, where: p.id in ^ids, select: ^fields)
+  end
+
   def recent(repository, count) do
     from(
       p in assoc(repository, :packages),
@@ -361,6 +426,15 @@ defmodule Hexpm.Repository.Package do
       on: rel.id == req.release_id,
       where: req.dependency_id == ^dependency_id,
       select: rel.package_id
+    )
+  end
+
+  defp dependency_exists_query(dependency_id) do
+    from(r in Release,
+      join: req in Requirement,
+      on: req.release_id == r.id,
+      where: r.package_id == parent_as(:package).id,
+      where: req.dependency_id == ^dependency_id
     )
   end
 

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -86,9 +86,13 @@ defmodule Hexpm.Repository.Packages do
   end
 
   def dependants(repositories, dependency, page, packages_per_page, sort, fields \\ nil) do
-    Package.dependants(repositories, dependency, page, packages_per_page, sort, fields)
-    |> Repo.all()
-    |> attach_repositories(repositories)
+    if sort in [:recent_downloads, :total_downloads] do
+      dependants_by_downloads(repositories, dependency, page, packages_per_page, sort, fields)
+    else
+      Package.dependants(repositories, dependency, page, packages_per_page, sort, fields)
+      |> Repo.all()
+      |> attach_repositories(repositories)
+    end
   end
 
   def search_with_versions(repositories, page, packages_per_page, query, sort) do
@@ -112,6 +116,68 @@ defmodule Hexpm.Repository.Packages do
       %{package | repository: repository}
     end)
   end
+
+  defp dependants_by_downloads(repositories, dependency, page, packages_per_page, sort, fields) do
+    view = dependant_download_view(sort)
+    offset = (page - 1) * packages_per_page
+
+    downloaded_ids =
+      Package.downloaded_dependant_ids(
+        repositories,
+        dependency,
+        view,
+        packages_per_page,
+        offset
+      )
+      |> Repo.all()
+
+    remaining = packages_per_page - length(downloaded_ids)
+
+    package_ids =
+      if remaining > 0 do
+        downloaded_count =
+          if downloaded_ids == [] and offset > 0 do
+            Repo.one!(Package.count_downloaded_dependants(repositories, dependency, view))
+          else
+            offset + length(downloaded_ids)
+          end
+
+        zero_download_offset = max(offset - downloaded_count, 0)
+
+        zero_download_ids =
+          Package.undownloaded_dependant_ids(
+            repositories,
+            dependency,
+            view,
+            remaining,
+            zero_download_offset
+          )
+          |> Repo.all()
+
+        downloaded_ids ++ zero_download_ids
+      else
+        downloaded_ids
+      end
+
+    load_dependants(repositories, package_ids, fields)
+  end
+
+  defp load_dependants(_repositories, [], _fields), do: []
+
+  defp load_dependants(repositories, package_ids, fields) do
+    packages =
+      package_ids
+      |> Package.by_ids(fields)
+      |> Repo.all()
+      |> attach_repositories(repositories)
+
+    packages_by_id = Map.new(packages, &{&1.id, &1})
+
+    Enum.map(package_ids, &Map.fetch!(packages_by_id, &1))
+  end
+
+  defp dependant_download_view(:recent_downloads), do: "recent"
+  defp dependant_download_view(:total_downloads), do: "all"
 
   def recent(repository, count) do
     Repo.all(Package.recent(repository, count))

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -284,6 +284,79 @@ defmodule Hexpm.Repository.PackageTest do
              |> Enum.map(& &1.name)
   end
 
+  test "dependants sort by recent downloads uses download order and repo scoping", %{
+    repository: repository
+  } do
+    private_repo = insert(:repository)
+    dependency = insert(:package, name: "dependency", repository_id: repository.id)
+    top = insert(:package, name: "top", repository_id: repository.id)
+    middle = insert(:package, name: "middle", repository_id: repository.id)
+    zero = insert(:package, name: "zero", repository_id: repository.id)
+    hidden = insert(:package, name: "hidden", repository_id: private_repo.id)
+
+    insert(:release,
+      package: top,
+      daily_downloads: [build(:download, package_id: top.id, downloads: 10)]
+    )
+
+    insert(:release,
+      package: middle,
+      daily_downloads: [build(:download, package_id: middle.id, downloads: 5)]
+    )
+
+    insert(:release,
+      package: zero,
+      daily_downloads: [
+        build(:download, package_id: zero.id, downloads: 10, day: Hexpm.Utils.utc_days_ago(91))
+      ]
+    )
+
+    insert(:release,
+      package: hidden,
+      daily_downloads: [build(:download, package_id: hidden.id, downloads: 100)]
+    )
+
+    for package <- [top, middle, zero, hidden] do
+      rel = Repo.one!(assoc(package, :releases))
+      insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+    end
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [top.id, middle.id, zero.id] ==
+             Packages.dependants([repository], dependency, 1, 10, :recent_downloads)
+             |> Enum.map(& &1.id)
+  end
+
+  test "dependants sort by recent downloads paginates into zero-download dependants", %{
+    repository: repository
+  } do
+    dependency = insert(:package, name: "dependency", repository_id: repository.id)
+    top = insert(:package, name: "top", repository_id: repository.id)
+    zero_one = insert(:package, name: "zero_one", repository_id: repository.id)
+    zero_two = insert(:package, name: "zero_two", repository_id: repository.id)
+
+    insert(:release,
+      package: top,
+      daily_downloads: [build(:download, package_id: top.id, downloads: 10)]
+    )
+
+    for package <- [zero_one, zero_two] do
+      insert(:release, package: package)
+    end
+
+    for package <- [top, zero_one, zero_two] do
+      rel = Repo.one!(assoc(package, :releases))
+      insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+    end
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [zero_two.id] ==
+             Packages.dependants([repository], dependency, 2, 2, :recent_downloads)
+             |> Enum.map(& &1.id)
+  end
+
   test "depends search can return private packages if caller passes a broad repository list", %{
     repository: repository
   } do


### PR DESCRIPTION
## Summary
- Replaces `Packages.search(... "depends:repo:pkg" ...)` with dedicated `Packages.dependants/6` and `Packages.count_dependants/2`, driven by `EXISTS` subqueries instead of `IN (subquery)`.
- For `:recent_downloads`/`:total_downloads` sort, uses a download-first two-phase plan (ordered ids from `package_downloads`, then `NOT EXISTS` backfill for zero-download dependants, then hydrate by id) instead of `packages LEFT JOIN package_downloads`.
- Replaces the single-column `requirements(dependency_id)` index with a composite `(dependency_id, release_id)` to better serve the reverse-dependency `EXISTS` shape.
- Adds depends-search authorization coverage so private repositories' dependants don't leak via the public search path.