### PR TITLE
Make all migrations idempotent

### DIFF
--- a/priv/repo/migrations/20140128201839_add_users_table.exs
+++ b/priv/repo/migrations/20140128201839_add_users_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddUsersTable do
 
   def up() do
     execute("""
-      CREATE TABLE users (
+      CREATE TABLE IF NOT EXISTS users (
         id serial PRIMARY KEY,
         username text,
         email text UNIQUE,

--- a/priv/repo/migrations/20140128205233_add_packages_table.exs
+++ b/priv/repo/migrations/20140128205233_add_packages_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddPackagesTables do
 
   def up() do
     execute("""
-      CREATE TABLE packages (
+      CREATE TABLE IF NOT EXISTS packages (
         id serial PRIMARY KEY,
         name text,
         owner_id integer REFERENCES users,

--- a/priv/repo/migrations/20140128213400_add_releases_table.exs
+++ b/priv/repo/migrations/20140128213400_add_releases_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddReleasesTable do
 
   def up() do
     execute("""
-      CREATE TABLE releases (
+      CREATE TABLE IF NOT EXISTS releases (
         id serial PRIMARY KEY,
         package_id integer REFERENCES packages,
         version text,

--- a/priv/repo/migrations/20140128213543_add_requirements_table.exs
+++ b/priv/repo/migrations/20140128213543_add_requirements_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddRequirementsTable do
 
   def up() do
     execute("""
-      CREATE TABLE requirements (
+      CREATE TABLE IF NOT EXISTS requirements (
         id serial PRIMARY KEY,
         release_id integer REFERENCES releases,
         dependency_id integer REFERENCES packages,

--- a/priv/repo/migrations/20140220143758_add_registries_table.exs
+++ b/priv/repo/migrations/20140220143758_add_registries_table.exs
@@ -5,7 +5,7 @@ defmodule Hexpm.Repo.Migrations.AddRegistriesTable do
     execute("CREATE TYPE building_state AS ENUM ('waiting', 'working', 'done')")
 
     execute("""
-      CREATE TABLE registries (
+      CREATE TABLE IF NOT EXISTS registries (
         id serial PRIMARY KEY,
         state building_state,
         created_at timestamp DEFAULT now(),

--- a/priv/repo/migrations/20140316111040_add_keys_table.exs
+++ b/priv/repo/migrations/20140316111040_add_keys_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddKeysTable do
 
   def up() do
     execute("""
-      CREATE TABLE keys (
+      CREATE TABLE IF NOT EXISTS keys (
         id serial PRIMARY KEY,
         user_id integer REFERENCES users,
         name text,
@@ -15,6 +15,6 @@ defmodule Hexpm.Repo.Migrations.AddKeysTable do
   end
 
   def down() do
-    execute("DROP TABLE keys")
+    execute("DROP TABLE IF EXISTS keys")
   end
 end

--- a/priv/repo/migrations/20140320212302_add_downloads_table.exs
+++ b/priv/repo/migrations/20140320212302_add_downloads_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddStatsTable do
 
   def up() do
     execute("""
-      CREATE TABLE downloads (
+      CREATE TABLE IF NOT EXISTS downloads (
         id serial PRIMARY KEY,
         release_id integer REFERENCES releases,
         downloads integer,

--- a/priv/repo/migrations/20140323211856_add_release_downloads_view.exs
+++ b/priv/repo/migrations/20140323211856_add_release_downloads_view.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddReleaseDownloadsView do
 
   def up() do
     execute("""
-      CREATE MATERIALIZED VIEW release_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS release_downloads (
         release_id,
         downloads) AS
           SELECT d.release_id, SUM(d.downloads)

--- a/priv/repo/migrations/20140323232653_add_package_downloads_view.exs
+++ b/priv/repo/migrations/20140323232653_add_package_downloads_view.exs
@@ -5,7 +5,7 @@ defmodule Hexpm.Repo.Migrations.AddPackageDownloadsView do
     execute("CREATE TYPE calendar_view AS ENUM ('day', 'week', 'all')")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         package_id,
         view,
         downloads) AS

--- a/priv/repo/migrations/20140510114425_add_installs_table.exs
+++ b/priv/repo/migrations/20140510114425_add_installs_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddInstallsTable do
 
   def up() do
     execute("""
-      CREATE TABLE installs (
+      CREATE TABLE IF NOT EXISTS installs (
         id serial PRIMARY KEY,
         hex text,
         elixir text)

--- a/priv/repo/migrations/20140527204944_change_packages_index_to_trigram.exs
+++ b/priv/repo/migrations/20140527204944_change_packages_index_to_trigram.exs
@@ -3,8 +3,12 @@ defmodule Hexpm.Repo.Migrations.ChangePackagesIndexToTrigram do
 
   def up() do
     execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
-    execute("CREATE INDEX packages_name_trgm ON packages USING GIN (name gin_trgm_ops)")
-    execute("DROP INDEX packages_lower_idx")
+
+    execute(
+      "CREATE INDEX IF NOT EXISTS packages_name_trgm ON packages USING GIN (name gin_trgm_ops)"
+    )
+
+    execute("DROP INDEX IF EXISTS packages_lower_idx")
   end
 
   def down() do

--- a/priv/repo/migrations/20140606173220_add_packages_description_index.exs
+++ b/priv/repo/migrations/20140606173220_add_packages_description_index.exs
@@ -19,7 +19,7 @@ defmodule Hexpm.Repo.Migrations.AddPackagesDescriptionIndex do
     """)
 
     execute("""
-      CREATE INDEX packages_description_text ON
+      CREATE INDEX IF NOT EXISTS packages_description_text ON
         packages USING GIN (to_tsvector('english', json_access(meta, 'description')))
     """)
   end

--- a/priv/repo/migrations/20140623215331_add_package_owners_table.exs
+++ b/priv/repo/migrations/20140623215331_add_package_owners_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddPackageOwnersTable do
 
   def up() do
     execute("""
-      CREATE TABLE package_owners (
+      CREATE TABLE IF NOT EXISTS package_owners (
         id serial PRIMARY KEY,
         package_id integer REFERENCES packages,
         owner_id integer REFERENCES users)

--- a/priv/repo/migrations/20140819195307_split_and_hmac_keys.exs
+++ b/priv/repo/migrations/20140819195307_split_and_hmac_keys.exs
@@ -8,8 +8,8 @@ defmodule Hexpm.Repo.Migrations.SplitAndHmacKeys do
 
     execute("""
       ALTER TABLE keys
-        ADD COLUMN secret_first text UNIQUE,
-        ADD COLUMN secret_second text
+        ADD COLUMN IF NOT EXISTS secret_first text UNIQUE,
+        ADD COLUMN IF NOT EXISTS secret_second text
     """)
 
     execute("""
@@ -20,7 +20,7 @@ defmodule Hexpm.Repo.Migrations.SplitAndHmacKeys do
 
     execute("""
       ALTER TABLE keys
-        DROP COLUMN secret
+        DROP COLUMN IF EXISTS secret
     """)
   end
 

--- a/priv/repo/migrations/20141011150402_add_confirmation_to_users.exs
+++ b/priv/repo/migrations/20141011150402_add_confirmation_to_users.exs
@@ -4,8 +4,8 @@ defmodule Hexpm.Repo.Migrations.AddConfirmationToUsers do
   def up() do
     execute("""
       ALTER TABLE users
-        ADD COLUMN confirmed boolean DEFAULT false,
-        ADD COLUMN confirmation_key text
+        ADD COLUMN IF NOT EXISTS confirmed boolean DEFAULT false,
+        ADD COLUMN IF NOT EXISTS confirmation_key text
     """)
 
     execute("""

--- a/priv/repo/migrations/20141030030723_add_blocked_addresses.exs
+++ b/priv/repo/migrations/20141030030723_add_blocked_addresses.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.BlockedAddresses do
 
   def up() do
     execute("""
-      CREATE TABLE blocked_addresses (
+      CREATE TABLE IF NOT EXISTS blocked_addresses (
         id serial PRIMARY KEY,
         ip text,
         comment text)

--- a/priv/repo/migrations/20150117064046_add_reset_key_to_users.exs
+++ b/priv/repo/migrations/20150117064046_add_reset_key_to_users.exs
@@ -4,8 +4,8 @@ defmodule Hexpm.Repo.Migrations.AddResetKeyToUsers do
   def up() do
     execute("""
       ALTER TABLE users
-        ADD COLUMN reset_key text,
-        ADD COLUMN reset_expiry timestamp
+        ADD COLUMN IF NOT EXISTS reset_key text,
+        ADD COLUMN IF NOT EXISTS reset_expiry timestamp
     """)
   end
 

--- a/priv/repo/migrations/20150318235407_remove_unnecessary_functions.exs
+++ b/priv/repo/migrations/20150318235407_remove_unnecessary_functions.exs
@@ -7,7 +7,7 @@ defmodule Hexpm.Repo.Migrations.RemoveUnnecessaryFunctions do
     execute("DROP FUNCTION IF EXISTS text_match(tsvector, tsquery)")
 
     execute("""
-      CREATE INDEX packages_description_text ON
+      CREATE INDEX IF NOT EXISTS packages_description_text ON
         packages USING GIN (to_tsvector('english', (meta->'description')::text))
     """)
   end
@@ -32,7 +32,7 @@ defmodule Hexpm.Repo.Migrations.RemoveUnnecessaryFunctions do
     """)
 
     execute("""
-      CREATE INDEX packages_description_text ON
+      CREATE INDEX IF NOT EXISTS packages_description_text ON
         packages USING GIN (to_tsvector('english', json_access(meta, 'description')))
     """)
   end

--- a/priv/repo/migrations/20150412185310_add_packages_name_index.exs
+++ b/priv/repo/migrations/20150412185310_add_packages_name_index.exs
@@ -2,10 +2,10 @@ defmodule Hexpm.Repo.Migrations.AddPackagesNameIndex do
   use Ecto.Migration
 
   def up() do
-    execute("CREATE INDEX packages_name ON packages (name)")
+    execute("CREATE INDEX IF NOT EXISTS packages_name ON packages (name)")
   end
 
   def down() do
-    execute("DROP INDEX packages_name")
+    execute("DROP INDEX IF EXISTS packages_name")
   end
 end

--- a/priv/repo/migrations/20150428053201_change_to_citext.exs
+++ b/priv/repo/migrations/20150428053201_change_to_citext.exs
@@ -4,7 +4,7 @@ defmodule Hexpm.Repo.Migrations.ChangeToCitext do
   def up() do
     execute("CREATE EXTENSION citext")
 
-    drop(index(:users, [:username], name: :users_lower_idx))
+    drop_if_exists(index(:users, [:username], name: :users_lower_idx))
 
     alter table(:users) do
       modify(:username, :citext)
@@ -14,11 +14,11 @@ defmodule Hexpm.Repo.Migrations.ChangeToCitext do
       modify(:name, :citext)
     end
 
-    create(index(:users, [:username]))
+    create_if_not_exists(index(:users, [:username]))
   end
 
   def down() do
-    drop(index(:users, [:username]))
+    drop_if_exists(index(:users, [:username]))
 
     alter table(:users) do
       modify(:username, :text)
@@ -28,7 +28,7 @@ defmodule Hexpm.Repo.Migrations.ChangeToCitext do
       modify(:name, :text)
     end
 
-    create(index(:users, ["lower(username)"], name: :users_lower_idx))
+    create_if_not_exists(index(:users, ["lower(username)"], name: :users_lower_idx))
 
     execute("DROP EXTENSION IF EXISTS citext")
   end

--- a/priv/repo/migrations/20150806212017_change_package_description_index.exs
+++ b/priv/repo/migrations/20150806212017_change_package_description_index.exs
@@ -5,7 +5,7 @@ defmodule Hexpm.Repo.Migrations.ChangePackageDescriptionIndex do
     execute("DROP INDEX IF EXISTS packages_description_text")
 
     execute("""
-      CREATE INDEX packages_description_text ON
+      CREATE INDEX IF NOT EXISTS packages_description_text ON
         packages USING GIN (to_tsvector('english', regexp_replace((meta->'description')::text, '/', ' ')))
     """)
   end
@@ -14,7 +14,7 @@ defmodule Hexpm.Repo.Migrations.ChangePackageDescriptionIndex do
     execute("DROP INDEX IF EXISTS packages_description_text")
 
     execute("""
-      CREATE INDEX packages_description_text ON
+      CREATE INDEX IF NOT EXISTS packages_description_text ON
         packages USING GIN (to_tsvector('english', (meta->'description')::text))
     """)
   end

--- a/priv/repo/migrations/20151123193006_fix_package_downloads_view_week.exs
+++ b/priv/repo/migrations/20151123193006_fix_package_downloads_view_week.exs
@@ -2,10 +2,10 @@ defmodule Hexpm.Repo.Migrations.FixPackageDownloadsViewWeek do
   use Ecto.Migration
 
   def up() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         package_id,
         view,
         downloads) AS
@@ -42,10 +42,10 @@ defmodule Hexpm.Repo.Migrations.FixPackageDownloadsViewWeek do
   end
 
   def down() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         package_id,
         view,
         downloads) AS

--- a/priv/repo/migrations/20160201230456_add_packages_unique_name_index.exs
+++ b/priv/repo/migrations/20160201230456_add_packages_unique_name_index.exs
@@ -2,15 +2,15 @@ defmodule Hexpm.Repo.Migrations.AddPackagesUniqueNameIndex do
   use Ecto.Migration
 
   def up() do
-    execute("DROP INDEX packages_name")
-    execute("DROP INDEX users_username_index")
+    execute("DROP INDEX IF EXISTS packages_name")
+    execute("DROP INDEX IF EXISTS users_username_index")
 
     execute("CREATE UNIQUE INDEX ON packages (name)")
     execute("CREATE UNIQUE INDEX ON users (username)")
   end
 
   def down() do
-    execute("DROP INDEX packages_name_idx")
-    execute("DROP INDEX users_username_idx")
+    execute("DROP INDEX IF EXISTS packages_name_idx")
+    execute("DROP INDEX IF EXISTS users_username_idx")
   end
 end

--- a/priv/repo/migrations/20160215102451_add_audit_logs_table.exs
+++ b/priv/repo/migrations/20160215102451_add_audit_logs_table.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.Repo.Migrations.AddAuditLogsTable do
   use Ecto.Migration
 
   def change() do
-    create table(:audit_logs) do
+    create_if_not_exists table(:audit_logs) do
       add(:actor_id, references(:users))
       add(:action, :string, null: false)
       add(:params, :jsonb, null: false)

--- a/priv/repo/migrations/20160317073758_add_package_downloads_pk.exs
+++ b/priv/repo/migrations/20160317073758_add_package_downloads_pk.exs
@@ -2,10 +2,10 @@ defmodule Hexpm.Repo.Migrations.AddPackageDownloadsPk do
   use Ecto.Migration
 
   def up() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         id,
         package_id,
         view,
@@ -43,10 +43,10 @@ defmodule Hexpm.Repo.Migrations.AddPackageDownloadsPk do
   end
 
   def down() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         package_id,
         view,
         downloads) AS

--- a/priv/repo/migrations/20160530102429_add_missing_timestamp_indicies_to_packages_and_releases.exs
+++ b/priv/repo/migrations/20160530102429_add_missing_timestamp_indicies_to_packages_and_releases.exs
@@ -8,8 +8,8 @@ defmodule Hexpm.Repo.Migrations.AddimestampIndiciesToPackagesAndReleases do
   end
 
   def down() do
-    execute("DROP INDEX packages_inserted_at_idx")
-    execute("DROP INDEX packages_updated_at_idx")
-    execute("DROP INDEX releases_inserted_at_idx")
+    execute("DROP INDEX IF EXISTS packages_inserted_at_idx")
+    execute("DROP INDEX IF EXISTS packages_updated_at_idx")
+    execute("DROP INDEX IF EXISTS releases_inserted_at_idx")
   end
 end

--- a/priv/repo/migrations/20160530111051_optimize_downloads_view_indicies.exs
+++ b/priv/repo/migrations/20160530111051_optimize_downloads_view_indicies.exs
@@ -2,14 +2,14 @@ defmodule Hexpm.Repo.Migrations.OptimizeDownloadsViewIndicies do
   use Ecto.Migration
 
   def up() do
-    execute("DROP INDEX package_downloads_view_downloads_idx")
+    execute("DROP INDEX IF EXISTS package_downloads_view_downloads_idx")
     execute("CREATE INDEX ON package_downloads (view)")
     execute("CREATE INDEX ON package_downloads (downloads DESC NULLS LAST)")
   end
 
   def down() do
-    execute("DROP INDEX package_downloads_view_idx")
-    execute("DROP INDEX package_downloads_downloads_idx")
+    execute("DROP INDEX IF EXISTS package_downloads_view_idx")
+    execute("DROP INDEX IF EXISTS package_downloads_downloads_idx")
     execute("CREATE INDEX ON package_downloads (view, downloads)")
   end
 end

--- a/priv/repo/migrations/20160610143806_add_meta_extra_index.exs
+++ b/priv/repo/migrations/20160610143806_add_meta_extra_index.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddMetaExtraIndex do
 
   def up() do
     execute("""
-      CREATE INDEX packages_meta_extra_idx ON
+      CREATE INDEX IF NOT EXISTS packages_meta_extra_idx ON
         packages USING GIN ((meta->'extra') jsonb_path_ops)
     """)
   end

--- a/priv/repo/migrations/20160720221809_drop_registries.exs
+++ b/priv/repo/migrations/20160720221809_drop_registries.exs
@@ -2,11 +2,11 @@ defmodule Hexpm.Repo.Migrations.DropRegistries do
   use Ecto.Migration
 
   def up() do
-    drop(table(:registries))
+    drop_if_exists(table(:registries))
   end
 
   def down() do
-    create table(:registries) do
+    create_if_not_exists table(:registries) do
       add(:state, :string)
       add(:inserted_at, :datetime)
       add(:started_at, :datetime)

--- a/priv/repo/migrations/20161011231213_add_emails_table.exs
+++ b/priv/repo/migrations/20161011231213_add_emails_table.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddEmailsTable do
 
   def up() do
     execute("""
-    CREATE TABLE emails (
+    CREATE TABLE IF NOT EXISTS emails (
       id serial PRIMARY KEY,
       email varchar(255) UNIQUE,
       verified boolean,
@@ -33,9 +33,9 @@ defmodule Hexpm.Repo.Migrations.AddEmailsTable do
 
     execute("""
     ALTER TABLE users
-      DROP COLUMN email,
-      DROP COLUMN confirmed,
-      DROP COLUMN confirmation_key
+      DROP COLUMN IF EXISTS email,
+      DROP COLUMN IF EXISTS confirmed,
+      DROP COLUMN IF EXISTS confirmation_key
     """)
   end
 

--- a/priv/repo/migrations/20161030220220_modify_emails_unique_constraint.exs
+++ b/priv/repo/migrations/20161030220220_modify_emails_unique_constraint.exs
@@ -3,13 +3,17 @@ defmodule Hexpm.Repo.Migrations.ModifyEmailsUniqueConstraint do
 
   def up() do
     execute("ALTER TABLE emails DROP CONSTRAINT emails_email_key")
-    execute("CREATE UNIQUE INDEX emails_email_key ON emails (email) WHERE verified = 'true'")
-    execute("CREATE UNIQUE INDEX emails_email_user_key ON emails (email, user_id)")
+
+    execute(
+      "CREATE UNIQUE INDEX IF NOT EXISTS emails_email_key ON emails (email) WHERE verified = 'true'"
+    )
+
+    execute("CREATE UNIQUE INDEX IF NOT EXISTS emails_email_user_key ON emails (email, user_id)")
   end
 
   def down() do
-    execute("DROP INDEX emails_email_key")
-    execute("DROP INDEX emails_email_user_key")
+    execute("DROP INDEX IF EXISTS emails_email_key")
+    execute("DROP INDEX IF EXISTS emails_email_user_key")
     execute("ALTER TABLE emails ADD CONSTRAINT emails_email_key UNIQUE (email)")
   end
 end

--- a/priv/repo/migrations/20170308190933_add_repositories_table.exs
+++ b/priv/repo/migrations/20170308190933_add_repositories_table.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.Repo.Migrations.AddRepositoriesTable do
   use Ecto.Migration
 
   def up() do
-    create table(:repositories) do
+    create_if_not_exists table(:repositories) do
       add(:name, :string, null: false)
       add(:public, :boolean, null: false, default: false)
       timestamps()
@@ -20,10 +20,10 @@ defmodule Hexpm.Repo.Migrations.AddRepositoriesTable do
       modify(:repository_id, :integer, null: false, default: nil)
     end
 
-    create(unique_index(:repositories, [:name]))
-    create(index(:repositories, [:public]))
-    create(unique_index(:packages, [:repository_id, :name]))
-    drop(index(:packages, [:name], name: "packages_name_idx"))
+    create_if_not_exists(unique_index(:repositories, [:name]))
+    create_if_not_exists(index(:repositories, [:public]))
+    create_if_not_exists(unique_index(:packages, [:repository_id, :name]))
+    drop_if_exists(index(:packages, [:name], name: "packages_name_idx"))
   end
 
   def down() do
@@ -31,8 +31,8 @@ defmodule Hexpm.Repo.Migrations.AddRepositoriesTable do
       remove(:repository_id)
     end
 
-    drop(table(:repositories))
+    drop_if_exists(table(:repositories))
 
-    create(unique_index(:packages, [:name], name: "packages_name_idx"))
+    create_if_not_exists(unique_index(:packages, [:name], name: "packages_name_idx"))
   end
 end

--- a/priv/repo/migrations/20170308191944_add_repository_users_table.exs
+++ b/priv/repo/migrations/20170308191944_add_repository_users_table.exs
@@ -4,18 +4,18 @@ defmodule Hexpm.Repo.Migrations.AddRepositoryUsersTable do
   def up() do
     execute("CREATE TYPE repository_user_role AS ENUM ('owner', 'admin', 'write', 'read')")
 
-    create table(:repository_users) do
+    create_if_not_exists table(:repository_users) do
       add(:role, :repository_user_role, null: false)
       add(:repository_id, references(:repositories))
       add(:user_id, references(:users))
     end
 
-    create(unique_index(:repository_users, [:repository_id, :user_id]))
-    create(index(:repository_users, [:user_id]))
+    create_if_not_exists(unique_index(:repository_users, [:repository_id, :user_id]))
+    create_if_not_exists(index(:repository_users, [:user_id]))
   end
 
   def down() do
-    drop(table(:repository_users))
+    drop_if_exists(table(:repository_users))
     execute("DROP TYPE repository_user_role")
   end
 end

--- a/priv/repo/migrations/20170429120741_add_sessions_table.exs
+++ b/priv/repo/migrations/20170429120741_add_sessions_table.exs
@@ -2,14 +2,14 @@ defmodule Hexpm.Repo.Migrations.AddSessionsTable do
   use Ecto.Migration
 
   def up() do
-    create table(:sessions) do
+    create_if_not_exists table(:sessions) do
       add(:token, :binary, null: false)
       add(:data, :jsonb, null: false)
 
       timestamps()
     end
 
-    create(index(:sessions, ["((data->>'user_id')::integer)"]))
+    create_if_not_exists(index(:sessions, ["((data->>'user_id')::integer)"]))
 
     alter table(:users) do
       remove(:session_key)
@@ -17,7 +17,7 @@ defmodule Hexpm.Repo.Migrations.AddSessionsTable do
   end
 
   def down() do
-    drop(table(:sessions))
+    drop_if_exists(table(:sessions))
 
     alter table(:users) do
       add(:session_key, :string)

--- a/priv/repo/migrations/20170613205641_add_package_dependants_view.exs
+++ b/priv/repo/migrations/20170613205641_add_package_dependants_view.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddPackageDependantsView do
 
   def up() do
     execute("""
-      CREATE MATERIALIZED VIEW package_dependants (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_dependants (
         name,
         dependant_id) AS
           SELECT DISTINCT p3.name AS name, p0.id AS dependant_id
@@ -17,6 +17,6 @@ defmodule Hexpm.Repo.Migrations.AddPackageDependantsView do
   end
 
   def down() do
-    execute("DROP MATERIALIZED VIEW package_dependants")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_dependants")
   end
 end

--- a/priv/repo/migrations/20170902072705_add_ninety_days_to_package_downloads_view.exs
+++ b/priv/repo/migrations/20170902072705_add_ninety_days_to_package_downloads_view.exs
@@ -2,10 +2,10 @@ defmodule Hexpm.Repo.Migrations.AddNinetyDaysToPackageDownloadsView do
   use Ecto.Migration
 
   def up() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         id,
         package_id,
         view,
@@ -51,10 +51,10 @@ defmodule Hexpm.Repo.Migrations.AddNinetyDaysToPackageDownloadsView do
   end
 
   def down() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         id,
         package_id,
         view,

--- a/priv/repo/migrations/20170909142545_remove_pk_from_package_downloads.exs
+++ b/priv/repo/migrations/20170909142545_remove_pk_from_package_downloads.exs
@@ -2,10 +2,10 @@ defmodule Hexpm.Repo.Migrations.RemovePkFromPackageDownloads do
   use Ecto.Migration
 
   def up() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         package_id,
         view,
         downloads) AS
@@ -50,10 +50,10 @@ defmodule Hexpm.Repo.Migrations.RemovePkFromPackageDownloads do
   end
 
   def down() do
-    execute("DROP MATERIALIZED VIEW package_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_downloads (
         id,
         package_id,
         view,

--- a/priv/repo/migrations/20180513160026_add_repository_id_to_audit_log.exs
+++ b/priv/repo/migrations/20180513160026_add_repository_id_to_audit_log.exs
@@ -6,8 +6,8 @@ defmodule Hexpm.Repo.Migrations.AddRepositoryIdToAuditLog do
       add(:repository_id, references(:repositories))
     end
 
-    create(index(:audit_logs, [:actor_id]))
-    create(index(:audit_logs, [:repository_id]))
+    create_if_not_exists(index(:audit_logs, [:actor_id]))
+    create_if_not_exists(index(:audit_logs, [:repository_id]))
 
     execute("ALTER TABLE audit_logs RENAME actor_id TO user_id")
 

--- a/priv/repo/migrations/20180527001017_add_reserved_packages.exs
+++ b/priv/repo/migrations/20180527001017_add_reserved_packages.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.Repo.Migrations.AddReservedPackages do
   use Ecto.Migration
 
   def change do
-    create table(:reserved_packages) do
+    create_if_not_exists table(:reserved_packages) do
       add(
         :repository_id,
         references(:repositories, on_delete: :delete_all, on_update: :update_all),
@@ -14,6 +14,6 @@ defmodule Hexpm.Repo.Migrations.AddReservedPackages do
       add(:reason, :string)
     end
 
-    create(unique_index(:reserved_packages, [:repository_id, :name, :version]))
+    create_if_not_exists(unique_index(:reserved_packages, [:repository_id, :name, :version]))
   end
 end

--- a/priv/repo/migrations/20180609210018_add_password_resets.exs
+++ b/priv/repo/migrations/20180609210018_add_password_resets.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.Repo.Migrations.AddPasswordResets do
   use Ecto.Migration
 
   def change do
-    create table(:password_resets) do
+    create_if_not_exists table(:password_resets) do
       add(:key, :string, null: false)
       add(:primary_email, :string, null: false)
       add(:user_id, references(:users))
@@ -10,7 +10,7 @@ defmodule Hexpm.Repo.Migrations.AddPasswordResets do
       timestamps(updated_at: false)
     end
 
-    create(index(:password_resets, [:user_id]))
+    create_if_not_exists(index(:password_resets, [:user_id]))
 
     execute("""
     INSERT INTO password_resets (key, primary_email, user_id, inserted_at)

--- a/priv/repo/migrations/20180701174643_add_installs_uniq_constraint.exs
+++ b/priv/repo/migrations/20180701174643_add_installs_uniq_constraint.exs
@@ -2,6 +2,6 @@ defmodule Hexpm.Repo.Migrations.AddInstallsUniqConstraint do
   use Ecto.Migration
 
   def change do
-    create(unique_index(:installs, [:hex]))
+    create_if_not_exists(unique_index(:installs, [:hex]))
   end
 end

--- a/priv/repo/migrations/20180704214746_add_internal_to_keys.exs
+++ b/priv/repo/migrations/20180704214746_add_internal_to_keys.exs
@@ -9,10 +9,10 @@ defmodule Hexpm.Repo.Migrations.AddInternalToKeys do
       add(:revoke_at, :timestamp)
     end
 
-    create(index(:keys, [:name]))
-    create(index(:keys, [:revoked_at]))
-    create(index(:keys, [:revoke_at]))
-    create(index(:keys, [:public]))
+    create_if_not_exists(index(:keys, [:name]))
+    create_if_not_exists(index(:keys, [:revoked_at]))
+    create_if_not_exists(index(:keys, [:revoke_at]))
+    create_if_not_exists(index(:keys, [:public]))
   end
 
   def down do
@@ -23,7 +23,7 @@ defmodule Hexpm.Repo.Migrations.AddInternalToKeys do
       remove(:revoke_at)
     end
 
-    drop(index(:keys, [:name]))
-    drop(index(:keys, [:revoked_at]))
+    drop_if_exists(index(:keys, [:name]))
+    drop_if_exists(index(:keys, [:revoked_at]))
   end
 end

--- a/priv/repo/migrations/20181019154146_add_unique_index_to_materialized_views.exs
+++ b/priv/repo/migrations/20181019154146_add_unique_index_to_materialized_views.exs
@@ -2,13 +2,13 @@ defmodule Hexpm.RepoBase.Migrations.AddUniqueIndexToMaterializedViews do
   use Ecto.Migration
 
   def change do
-    execute("DROP INDEX package_dependants_name_idx")
+    execute("DROP INDEX IF EXISTS package_dependants_name_idx")
     execute("CREATE UNIQUE INDEX ON package_dependants (name, dependant_id)")
 
-    execute("DROP INDEX package_downloads_package_id_idx")
+    execute("DROP INDEX IF EXISTS package_downloads_package_id_idx")
     execute("CREATE UNIQUE INDEX ON package_downloads (package_id, view)")
 
-    execute("DROP INDEX release_downloads_release_id_idx")
+    execute("DROP INDEX IF EXISTS release_downloads_release_id_idx")
     execute("CREATE UNIQUE INDEX ON release_downloads (release_id)")
   end
 end

--- a/priv/repo/migrations/20190129165916_add_repositories_table_2.exs
+++ b/priv/repo/migrations/20190129165916_add_repositories_table_2.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.AddRepositoriesTable2 do
   use Ecto.Migration
 
   def up do
-    create table(:repositories) do
+    create_if_not_exists table(:repositories) do
       add(:name, :string, null: false)
       add(:public, :boolean, null: false, default: false)
       add(:organization_id, references(:organizations))
@@ -49,10 +49,10 @@ defmodule Hexpm.RepoBase.Migrations.AddRepositoriesTable2 do
 
     execute("UPDATE organizations SET billing_active = true WHERE id = 1")
 
-    create(unique_index(:repositories, [:name]))
-    create(index(:repositories, [:public]))
-    create(unique_index(:packages, [:repository_id, :name]))
-    create(unique_index(:reserved_packages, [:repository_id, :name, :version]))
+    create_if_not_exists(unique_index(:repositories, [:name]))
+    create_if_not_exists(index(:repositories, [:public]))
+    create_if_not_exists(unique_index(:packages, [:repository_id, :name]))
+    create_if_not_exists(unique_index(:reserved_packages, [:repository_id, :name, :version]))
   end
 
   def down() do
@@ -85,8 +85,8 @@ defmodule Hexpm.RepoBase.Migrations.AddRepositoriesTable2 do
 
     execute("UPDATE organizations SET billing_active = false WHERE id = 1")
 
-    drop(table(:repositories))
-    create(unique_index(:packages, [:organization_id, :name]))
-    create(unique_index(:reserved_packages, [:organization_id, :name, :version]))
+    drop_if_exists(table(:repositories))
+    create_if_not_exists(unique_index(:packages, [:organization_id, :name]))
+    create_if_not_exists(unique_index(:reserved_packages, [:organization_id, :name, :version]))
   end
 end

--- a/priv/repo/migrations/20190208150347_add_repositories_organization_id_index.exs
+++ b/priv/repo/migrations/20190208150347_add_repositories_organization_id_index.exs
@@ -2,6 +2,6 @@ defmodule Hexpm.RepoBase.Migrations.AddRepositoriesOrganizationIdIndex do
   use Ecto.Migration
 
   def change do
-    create(unique_index(:repositories, [:organization_id]))
+    create_if_not_exists(unique_index(:repositories, [:organization_id]))
   end
 end

--- a/priv/repo/migrations/20190523204039_add_organization_id_to_users.exs
+++ b/priv/repo/migrations/20190523204039_add_organization_id_to_users.exs
@@ -6,6 +6,6 @@ defmodule Hexpm.RepoBase.Migrations.AddOrganizationIdToUsers do
       add(:organization_id, references(:organizations))
     end
 
-    create(unique_index(:users, [:organization_id]))
+    create_if_not_exists(unique_index(:users, [:organization_id]))
   end
 end

--- a/priv/repo/migrations/20190618121721_add_index_to_audit_logs_params_package_id.exs
+++ b/priv/repo/migrations/20190618121721_add_index_to_audit_logs_params_package_id.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.AddIndexToAuditLogsParamsPackageId do
   use Ecto.Migration
 
   def change do
-    create(
+    create_if_not_exists(
       index(
         :audit_logs,
         ["((params -> 'package' ->> 'id')::integer)"],

--- a/priv/repo/migrations/20190917171521_add_repo_to_package_dependants.exs
+++ b/priv/repo/migrations/20190917171521_add_repo_to_package_dependants.exs
@@ -5,7 +5,7 @@ defmodule Hexpm.RepoBase.Migrations.AddRepoToPackageDependants do
     execute("DROP MATERIALIZED VIEW IF EXISTS package_dependants")
 
     execute("""
-      CREATE MATERIALIZED VIEW package_dependants (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_dependants (
         name,
         repo,
         dependant_id) AS
@@ -23,6 +23,6 @@ defmodule Hexpm.RepoBase.Migrations.AddRepoToPackageDependants do
   end
 
   def down() do
-    execute("DROP MATERIALIZED VIEW package_dependants")
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_dependants")
   end
 end

--- a/priv/repo/migrations/20200416050611_add_short_urls_table.exs
+++ b/priv/repo/migrations/20200416050611_add_short_urls_table.exs
@@ -2,13 +2,13 @@ defmodule Hexpm.RepoBase.Migrations.AddShortUrlsTable do
   use Ecto.Migration
 
   def change do
-    create table(:short_urls) do
+    create_if_not_exists table(:short_urls) do
       add(:url, :text, null: false)
       add(:short_code, :string, null: false)
       timestamps(updated_at: false)
     end
 
-    create(index(:short_urls, [:url]))
-    create(unique_index(:short_urls, [:short_code]))
+    create_if_not_exists(index(:short_urls, [:url]))
+    create_if_not_exists(unique_index(:short_urls, [:short_code]))
   end
 end

--- a/priv/repo/migrations/20200605151334_add_package_reports_table.exs
+++ b/priv/repo/migrations/20200605151334_add_package_reports_table.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.AddPackageReportsTable do
   use Ecto.Migration
 
   def up() do
-    create table(:package_reports) do
+    create_if_not_exists table(:package_reports) do
       add(:description, :text, null: false)
       add(:state, :string, null: false)
       add(:package_id, references(:packages), null: false)
@@ -11,10 +11,10 @@ defmodule Hexpm.RepoBase.Migrations.AddPackageReportsTable do
       timestamps()
     end
 
-    create(index(:package_reports, [:package_id]))
+    create_if_not_exists(index(:package_reports, [:package_id]))
   end
 
   def down() do
-    drop(table("package_reports"))
+    drop_if_exists(table("package_reports"))
   end
 end

--- a/priv/repo/migrations/20200609095835_add_package_report_release_table.exs
+++ b/priv/repo/migrations/20200609095835_add_package_report_release_table.exs
@@ -2,18 +2,18 @@ defmodule Hexpm.RepoBase.Migrations.AddPackageReportReleaseTable do
   use Ecto.Migration
 
   def up() do
-    create table(:package_report_releases) do
+    create_if_not_exists table(:package_report_releases) do
       add(:package_report_id, references(:package_reports), null: false)
       add(:release_id, references(:releases), null: false)
 
       timestamps()
     end
 
-    create(index(:package_report_releases, [:package_report_id]))
-    create(index(:package_report_releases, [:release_id]))
+    create_if_not_exists(index(:package_report_releases, [:package_report_id]))
+    create_if_not_exists(index(:package_report_releases, [:release_id]))
   end
 
   def drop() do
-    drop(table("package_report_releases"))
+    drop_if_exists(table("package_report_releases"))
   end
 end

--- a/priv/repo/migrations/20200711092923_add_package_report_comments_table.exs
+++ b/priv/repo/migrations/20200711092923_add_package_report_comments_table.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.AddCommentsTable do
   use Ecto.Migration
 
   def up do
-    create table(:package_report_comments) do
+    create_if_not_exists table(:package_report_comments) do
       add(:text, :text, null: false)
       add(:author_id, references(:users), null: false)
       add(:package_report_id, references(:package_reports), null: false)
@@ -10,10 +10,10 @@ defmodule Hexpm.RepoBase.Migrations.AddCommentsTable do
       timestamps()
     end
 
-    create(index(:package_report_comments, [:package_report_id]))
+    create_if_not_exists(index(:package_report_comments, [:package_report_id]))
   end
 
   def down() do
-    drop(table("package_report_comments"))
+    drop_if_exists(table("package_report_comments"))
   end
 end

--- a/priv/repo/migrations/20200718042121_modify_unique_index_on_packages.exs
+++ b/priv/repo/migrations/20200718042121_modify_unique_index_on_packages.exs
@@ -11,7 +11,7 @@ defmodule Hexpm.RepoBase.Migrations.ModifyUniqueIndexOnPackages do
     end
 
     execute("""
-      CREATE MATERIALIZED VIEW package_dependants (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_dependants (
         name,
         repo,
         dependant_id) AS
@@ -27,9 +27,9 @@ defmodule Hexpm.RepoBase.Migrations.ModifyUniqueIndexOnPackages do
     execute("CREATE INDEX ON package_dependants (name, repo)")
     execute("CREATE UNIQUE INDEX ON package_dependants (name, repo, dependant_id)")
 
-    create(unique_index(:packages, [:repository_id, "(lower(name))"]))
+    create_if_not_exists(unique_index(:packages, [:repository_id, "(lower(name))"]))
 
-    create(index(:packages, [:repository_id, :name]))
+    create_if_not_exists(index(:packages, [:repository_id, :name]))
   end
 
   def down() do
@@ -43,7 +43,7 @@ defmodule Hexpm.RepoBase.Migrations.ModifyUniqueIndexOnPackages do
     end
 
     execute("""
-      CREATE MATERIALIZED VIEW package_dependants (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_dependants (
         name,
         repo,
         dependant_id) AS
@@ -59,6 +59,6 @@ defmodule Hexpm.RepoBase.Migrations.ModifyUniqueIndexOnPackages do
     execute("CREATE INDEX ON package_dependants (name, repo)")
     execute("CREATE UNIQUE INDEX ON package_dependants (name, repo, dependant_id)")
 
-    create(unique_index(:packages, [:repository_id, :name]))
+    create_if_not_exists(unique_index(:packages, [:repository_id, :name]))
   end
 end

--- a/priv/repo/migrations/20200718045909_modify_unique_index_on_organizations.exs
+++ b/priv/repo/migrations/20200718045909_modify_unique_index_on_organizations.exs
@@ -3,13 +3,13 @@ defmodule Hexpm.RepoBase.Migrations.ModifyUniqueIndexOnOrganizations do
 
   def up do
     drop_if_exists(index(:organizations, [:name]))
-    create(unique_index(:organizations, ["(lower(name))"]))
-    create(index(:organizations, [:name]))
+    create_if_not_exists(unique_index(:organizations, ["(lower(name))"]))
+    create_if_not_exists(index(:organizations, [:name]))
   end
 
   def down do
     drop_if_exists(index(:organizations, [:name]))
     drop_if_exists(index(:organizations, [:_lower_name]))
-    create(unique_index(:organizations, [:name]))
+    create_if_not_exists(unique_index(:organizations, [:name]))
   end
 end

--- a/priv/repo/migrations/20200718051728_modify_unique_index_on_repositories.exs
+++ b/priv/repo/migrations/20200718051728_modify_unique_index_on_repositories.exs
@@ -3,13 +3,13 @@ defmodule Hexpm.RepoBase.Migrations.ModifyUniqueIndexOnRepositories do
 
   def up do
     drop_if_exists(index(:repositories, [:name]))
-    create(unique_index(:repositories, ["(lower(name))"]))
-    create(index(:repositories, [:name]))
+    create_if_not_exists(unique_index(:repositories, ["(lower(name))"]))
+    create_if_not_exists(index(:repositories, [:name]))
   end
 
   def down do
     drop_if_exists(index(:repositories, [:name]))
     drop_if_exists(index(:repositories, [:_lower_name]))
-    create(unique_index(:repositories, [:name]))
+    create_if_not_exists(unique_index(:repositories, [:name]))
   end
 end

--- a/priv/repo/migrations/20211019235721_update_constraint_on_revoked_at.exs
+++ b/priv/repo/migrations/20211019235721_update_constraint_on_revoked_at.exs
@@ -5,17 +5,17 @@ defmodule Hexpm.RepoBase.Migrations.UpdateConstraintOnRevokedAt do
     execute("ALTER TABLE keys DROP CONSTRAINT keys_user_id_name_revoked_at_key")
 
     execute(
-      "CREATE UNIQUE INDEX keys_user_id_name_revoked_at_key ON keys (user_id, name) WHERE (revoked_at IS NULL)"
+      "CREATE UNIQUE INDEX IF NOT EXISTS keys_user_id_name_revoked_at_key ON keys (user_id, name) WHERE (revoked_at IS NULL)"
     )
 
     execute(
-      "CREATE UNIQUE INDEX keys_organization_id_name_revoked_at_key ON keys (organization_id, name) WHERE (revoked_at IS NULL)"
+      "CREATE UNIQUE INDEX IF NOT EXISTS keys_organization_id_name_revoked_at_key ON keys (organization_id, name) WHERE (revoked_at IS NULL)"
     )
   end
 
   def down do
-    execute("DROP INDEX keys_organization_id_name_revoked_at_key")
-    execute("DROP INDEX keys_user_id_name_revoked_at_key")
+    execute("DROP INDEX IF EXISTS keys_organization_id_name_revoked_at_key")
+    execute("DROP INDEX IF EXISTS keys_user_id_name_revoked_at_key")
 
     execute(
       "ALTER TABLE keys ADD CONSTRAINT keys_user_id_name_revoked_at_key UNIQUE (user_id, name, revoked_at)"

--- a/priv/repo/migrations/20220218173443_fixup_indexes.exs
+++ b/priv/repo/migrations/20220218173443_fixup_indexes.exs
@@ -2,26 +2,26 @@ defmodule Hexpm.RepoBase.Migrations.FixupIndexes do
   use Ecto.Migration
 
   def change do
-    drop(
+    drop_if_exists(
       index(:package_downloads, [:view, :downloads], name: "package_downloads_view_downloads_idx")
     )
 
-    drop(unique_index(:repositories, ["(lower(name))"]))
-    drop(index(:repositories, [:name]))
-    drop(unique_index(:organizations, ["(lower(name))"]))
-    drop(index(:organizations, [:name]))
-    drop(unique_index(:packages, [:repository_id, "(lower(name))"]))
-    drop(index(:packages, [:repository_id, :name]))
-    drop(index(:keys, [:public]))
-    drop(index(:package_owners, [:package_id], name: "package_owners_package_id_idx"))
+    drop_if_exists(unique_index(:repositories, ["(lower(name))"]))
+    drop_if_exists(index(:repositories, [:name]))
+    drop_if_exists(unique_index(:organizations, ["(lower(name))"]))
+    drop_if_exists(index(:organizations, [:name]))
+    drop_if_exists(unique_index(:packages, [:repository_id, "(lower(name))"]))
+    drop_if_exists(index(:packages, [:repository_id, :name]))
+    drop_if_exists(index(:keys, [:public]))
+    drop_if_exists(index(:package_owners, [:package_id], name: "package_owners_package_id_idx"))
 
-    create(index(:package_downloads, [:view]))
-    create(index(:package_downloads, ["downloads DESC NULLS LAST"]))
-    create(unique_index(:repositories, [:name]))
-    create(unique_index(:organizations, [:name]))
-    create(unique_index(:packages, [:repository_id, :name]))
-    create(index(:packages, [:name]))
-    create(index(:audit_logs, [:inserted_at]))
-    create(index(:package_owners, [:user_id]))
+    create_if_not_exists(index(:package_downloads, [:view]))
+    create_if_not_exists(index(:package_downloads, ["downloads DESC NULLS LAST"]))
+    create_if_not_exists(unique_index(:repositories, [:name]))
+    create_if_not_exists(unique_index(:organizations, [:name]))
+    create_if_not_exists(unique_index(:packages, [:repository_id, :name]))
+    create_if_not_exists(index(:packages, [:name]))
+    create_if_not_exists(index(:audit_logs, [:inserted_at]))
+    create_if_not_exists(index(:package_owners, [:user_id]))
   end
 end

--- a/priv/repo/migrations/20220219012733_add_downloads_package_id.exs
+++ b/priv/repo/migrations/20220219012733_add_downloads_package_id.exs
@@ -6,7 +6,7 @@ defmodule Hexpm.RepoBase.Migrations.AddDownloadsPackageId do
       add(:package_id, references(:packages, on_delete: :delete_all))
     end
 
-    create(index(:downloads, [:package_id]))
+    create_if_not_exists(index(:downloads, [:package_id]))
   end
 end
 

--- a/priv/repo/migrations/20221103004202_improve_package_name_index.exs
+++ b/priv/repo/migrations/20221103004202_improve_package_name_index.exs
@@ -2,13 +2,13 @@ defmodule Hexpm.RepoBase.Migrations.ImprovePackageNameIndex do
   use Ecto.Migration
 
   def up do
-    create(unique_index(:packages, [:repository_id, "name text_pattern_ops"]))
-    drop(unique_index(:packages, [:repository_id, :name]))
+    create_if_not_exists(unique_index(:packages, [:repository_id, "name text_pattern_ops"]))
+    drop_if_exists(unique_index(:packages, [:repository_id, :name]))
 
-    execute("DROP MATERIALIZED VIEW release_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS release_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW release_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS release_downloads (
         package_id,
         release_id,
         downloads) AS
@@ -21,13 +21,13 @@ defmodule Hexpm.RepoBase.Migrations.ImprovePackageNameIndex do
   end
 
   def down do
-    create(unique_index(:packages, [:repository_id, :name]))
-    drop(unique_index(:packages, [:repository_id, "name text_pattern_ops"]))
+    create_if_not_exists(unique_index(:packages, [:repository_id, :name]))
+    drop_if_exists(unique_index(:packages, [:repository_id, "name text_pattern_ops"]))
 
-    execute("DROP MATERIALIZED VIEW release_downloads")
+    execute("DROP MATERIALIZED VIEW IF EXISTS release_downloads")
 
     execute("""
-      CREATE MATERIALIZED VIEW release_downloads (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS release_downloads (
         release_id,
         downloads) AS
           SELECT release_id, SUM(downloads)

--- a/priv/repo/migrations/20221106173432_drop_unused_indexes.exs
+++ b/priv/repo/migrations/20221106173432_drop_unused_indexes.exs
@@ -10,8 +10,8 @@ defmodule Hexpm.RepoBase.Migrations.DropUnusedIndexes do
   end
 
   def down do
-    create(index(:sessions, ["((data->>'user_id')::integer)"]))
-    create(index(:short_urls, [:url]))
+    create_if_not_exists(index(:sessions, ["((data->>'user_id')::integer)"]))
+    create_if_not_exists(index(:short_urls, [:url]))
 
     execute("CREATE INDEX ON package_dependants (name)")
     execute("CREATE INDEX ON package_dependants (name, repo)")

--- a/priv/repo/migrations/20230510205035_remove_keys_revoked_at.exs
+++ b/priv/repo/migrations/20230510205035_remove_keys_revoked_at.exs
@@ -4,13 +4,21 @@ defmodule Hexpm.RepoBase.Migrations.RemoveKeysRevokedAt do
   def change do
     execute "UPDATE keys SET revoke_at = least(revoke_at, revoked_at)"
 
-    drop unique_index(:keys, [:user_id, :name], where: "revoked_at IS NULL", name: "keys_user_id_name_revoked_at_key")
-    drop unique_index(:keys, [:organization_id, :name], where: "revoked_at IS NULL", name: "keys_organization_id_name_revoked_at_key")
-    drop index(:keys, :name)
+    drop_if_exists unique_index(:keys, [:user_id, :name],
+                     where: "revoked_at IS NULL",
+                     name: "keys_user_id_name_revoked_at_key"
+                   )
 
-    create index(:keys, [:user_id, :name])
-    create index(:keys, [:organization_id, :name])
-    create index(:keys, [:public])
+    drop_if_exists unique_index(:keys, [:organization_id, :name],
+                     where: "revoked_at IS NULL",
+                     name: "keys_organization_id_name_revoked_at_key"
+                   )
+
+    drop_if_exists index(:keys, :name)
+
+    create_if_not_exists index(:keys, [:user_id, :name])
+    create_if_not_exists index(:keys, [:organization_id, :name])
+    create_if_not_exists index(:keys, [:public])
 
     alter table(:keys) do
       remove(:revoked_at, :timestamp)

--- a/priv/repo/migrations/20240604161405_add_package_searches.exs
+++ b/priv/repo/migrations/20240604161405_add_package_searches.exs
@@ -2,12 +2,13 @@ defmodule Hexpm.RepoBase.Migrations.AddPackageSearches do
   use Ecto.Migration
 
   def change do
-    create table(:package_searches) do
+    create_if_not_exists table(:package_searches) do
       add(:package_id, references(:packages))
       add(:term, :text, null: false)
       add(:frequency, :integer, default: 1)
       timestamps()
     end
-    create(unique_index(:package_searches, [:term]))
+
+    create_if_not_exists(unique_index(:package_searches, [:term]))
   end
 end

--- a/priv/repo/migrations/20250919152128_add_build_tools_index.exs
+++ b/priv/repo/migrations/20250919152128_add_build_tools_index.exs
@@ -2,7 +2,9 @@ defmodule Hexpm.RepoBase.Migrations.AddBuildToolsIndex do
   use Ecto.Migration
 
   def up do
-    execute("CREATE INDEX releases_meta_build_tools_idx ON releases USING GIN ((meta->'build_tools'));")
+    execute(
+      "CREATE INDEX IF NOT EXISTS releases_meta_build_tools_idx ON releases USING GIN ((meta->'build_tools'));"
+    )
   end
 
   def down do

--- a/priv/repo/migrations/20250923100001_create_oauth_clients.exs
+++ b/priv/repo/migrations/20250923100001_create_oauth_clients.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.CreateOauthClients do
   use Ecto.Migration
 
   def change do
-    create table(:oauth_clients, primary_key: false) do
+    create_if_not_exists table(:oauth_clients, primary_key: false) do
       add :client_id, :binary_id, primary_key: true
       add :client_secret, :string
       add :name, :string, null: false

--- a/priv/repo/migrations/20250923100002_create_oauth_sessions.exs
+++ b/priv/repo/migrations/20250923100002_create_oauth_sessions.exs
@@ -2,12 +2,13 @@ defmodule Hexpm.RepoBase.Migrations.CreateOauthSessions do
   use Ecto.Migration
 
   def change do
-    create table(:oauth_sessions) do
+    create_if_not_exists table(:oauth_sessions) do
       add :name, :string
       add :revoked_at, :utc_datetime_usec
       add :last_use, :map
 
       add :user_id, references(:users, on_delete: :delete_all), null: false
+
       add :client_id,
           references(:oauth_clients, column: :client_id, type: :binary_id, on_delete: :delete_all),
           null: false
@@ -15,8 +16,8 @@ defmodule Hexpm.RepoBase.Migrations.CreateOauthSessions do
       timestamps()
     end
 
-    create index(:oauth_sessions, [:user_id])
-    create index(:oauth_sessions, [:client_id])
-    create index(:oauth_sessions, [:revoked_at])
+    create_if_not_exists index(:oauth_sessions, [:user_id])
+    create_if_not_exists index(:oauth_sessions, [:client_id])
+    create_if_not_exists index(:oauth_sessions, [:revoked_at])
   end
 end

--- a/priv/repo/migrations/20250923100003_create_oauth_tokens.exs
+++ b/priv/repo/migrations/20250923100003_create_oauth_tokens.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.CreateOauthTokens do
   use Ecto.Migration
 
   def up do
-    create table(:oauth_tokens) do
+    create_if_not_exists table(:oauth_tokens) do
       add :jti, :text, null: false
       add :refresh_jti, :text
       add :token_type, :string, null: false, default: "bearer"
@@ -26,13 +26,13 @@ defmodule Hexpm.RepoBase.Migrations.CreateOauthTokens do
       timestamps()
     end
 
-    create unique_index(:oauth_tokens, [:jti])
-    create unique_index(:oauth_tokens, [:refresh_jti])
-    create index(:oauth_tokens, [:user_id])
-    create index(:oauth_tokens, [:client_id])
-    create index(:oauth_tokens, [:expires_at])
-    create index(:oauth_tokens, [:refresh_token_expires_at])
-    create index(:oauth_tokens, [:session_id])
+    create_if_not_exists unique_index(:oauth_tokens, [:jti])
+    create_if_not_exists unique_index(:oauth_tokens, [:refresh_jti])
+    create_if_not_exists index(:oauth_tokens, [:user_id])
+    create_if_not_exists index(:oauth_tokens, [:client_id])
+    create_if_not_exists index(:oauth_tokens, [:expires_at])
+    create_if_not_exists index(:oauth_tokens, [:refresh_token_expires_at])
+    create_if_not_exists index(:oauth_tokens, [:session_id])
   end
 
   def down do

--- a/priv/repo/migrations/20250923100004_create_authorization_codes.exs
+++ b/priv/repo/migrations/20250923100004_create_authorization_codes.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.CreateAuthorizationCodes do
   use Ecto.Migration
 
   def change do
-    create table(:authorization_codes) do
+    create_if_not_exists table(:authorization_codes) do
       add :code, :string, null: false
       add :redirect_uri, :string, null: false
       add :scopes, {:array, :string}, null: false, default: []
@@ -21,9 +21,9 @@ defmodule Hexpm.RepoBase.Migrations.CreateAuthorizationCodes do
       timestamps()
     end
 
-    create unique_index(:authorization_codes, [:code])
-    create index(:authorization_codes, [:user_id])
-    create index(:authorization_codes, [:client_id])
-    create index(:authorization_codes, [:expires_at])
+    create_if_not_exists unique_index(:authorization_codes, [:code])
+    create_if_not_exists index(:authorization_codes, [:user_id])
+    create_if_not_exists index(:authorization_codes, [:client_id])
+    create_if_not_exists index(:authorization_codes, [:expires_at])
   end
 end

--- a/priv/repo/migrations/20250923100005_create_device_codes.exs
+++ b/priv/repo/migrations/20250923100005_create_device_codes.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.RepoBase.Migrations.CreateDeviceCodes do
   use Ecto.Migration
 
   def change do
-    create table(:device_codes) do
+    create_if_not_exists table(:device_codes) do
       add :device_code, :string, null: false
       add :user_code, :string, null: false
       add :verification_uri, :string, null: false
@@ -23,10 +23,10 @@ defmodule Hexpm.RepoBase.Migrations.CreateDeviceCodes do
       timestamps()
     end
 
-    create unique_index(:device_codes, [:device_code])
-    create unique_index(:device_codes, [:user_code])
-    create index(:device_codes, [:expires_at])
-    create index(:device_codes, [:status])
-    create index(:device_codes, [:user_id])
+    create_if_not_exists unique_index(:device_codes, [:device_code])
+    create_if_not_exists unique_index(:device_codes, [:user_code])
+    create_if_not_exists index(:device_codes, [:expires_at])
+    create_if_not_exists index(:device_codes, [:status])
+    create_if_not_exists index(:device_codes, [:user_id])
   end
 end

--- a/priv/repo/migrations/20251004230016_create_user_providers.exs
+++ b/priv/repo/migrations/20251004230016_create_user_providers.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.Repo.Migrations.CreateUserProviders do
   use Ecto.Migration
 
   def change do
-    create table(:user_providers) do
+    create_if_not_exists table(:user_providers) do
       add :user_id, references(:users, on_delete: :delete_all), null: false
       add :provider, :string, null: false
       add :provider_uid, :string, null: false
@@ -12,7 +12,7 @@ defmodule Hexpm.Repo.Migrations.CreateUserProviders do
       timestamps(type: :utc_datetime_usec)
     end
 
-    create unique_index(:user_providers, [:provider, :provider_uid])
-    create index(:user_providers, [:user_id])
+    create_if_not_exists unique_index(:user_providers, [:provider, :provider_uid])
+    create_if_not_exists index(:user_providers, [:user_id])
   end
 end

--- a/priv/repo/migrations/20251005174900_add_oauth_token_to_audit_logs.exs
+++ b/priv/repo/migrations/20251005174900_add_oauth_token_to_audit_logs.exs
@@ -3,9 +3,9 @@ defmodule Hexpm.RepoBase.Migrations.AddOauthTokenToAuditLogs do
 
   def change do
     alter table(:audit_logs) do
-      add :oauth_token_id, references(:oauth_tokens, on_delete: :nilify_all)
+      add_if_not_exists :oauth_token_id, references(:oauth_tokens, on_delete: :nilify_all)
     end
 
-    create index(:audit_logs, [:oauth_token_id])
+    create_if_not_exists index(:audit_logs, [:oauth_token_id])
   end
 end

--- a/priv/repo/migrations/20251007175802_remove_parent_token_id_from_oauth_tokens.exs
+++ b/priv/repo/migrations/20251007175802_remove_parent_token_id_from_oauth_tokens.exs
@@ -3,13 +3,13 @@ defmodule Hexpm.RepoBase.Migrations.RemoveParentTokenIdFromOauthTokens do
 
   def up do
     alter table(:oauth_tokens) do
-      remove :parent_token_id
+      remove_if_exists :parent_token_id
     end
   end
 
   def down do
     alter table(:oauth_tokens) do
-      add :parent_token_id, references(:oauth_tokens, on_delete: :nothing)
+      add_if_not_exists :parent_token_id, references(:oauth_tokens, on_delete: :nothing)
     end
   end
 end

--- a/priv/repo/migrations/20251010135827_create_user_sessions.exs
+++ b/priv/repo/migrations/20251010135827_create_user_sessions.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.CreateUserSessions do
 
   def up do
     # Create unified user_sessions table
-    create table(:user_sessions) do
+    create_if_not_exists table(:user_sessions) do
       add :user_id, references(:users, on_delete: :delete_all), null: false
       add :type, :string, null: false
       add :name, :string
@@ -14,15 +14,16 @@ defmodule Hexpm.Repo.Migrations.CreateUserSessions do
       add :session_token, :binary
 
       # OAuth-specific fields
-      add :client_id, references(:oauth_clients, column: :client_id, type: :uuid, on_delete: :delete_all)
+      add :client_id,
+          references(:oauth_clients, column: :client_id, type: :uuid, on_delete: :delete_all)
 
       timestamps(type: :utc_datetime_usec)
     end
 
-    create index(:user_sessions, [:user_id])
-    create index(:user_sessions, [:type])
-    create index(:user_sessions, [:session_token])
-    create index(:user_sessions, [:client_id])
+    create_if_not_exists index(:user_sessions, [:user_id])
+    create_if_not_exists index(:user_sessions, [:type])
+    create_if_not_exists index(:user_sessions, [:session_token])
+    create_if_not_exists index(:user_sessions, [:client_id])
 
     # Migrate browser sessions from sessions table
     execute """
@@ -73,7 +74,7 @@ defmodule Hexpm.Repo.Migrations.CreateUserSessions do
 
     # Add new column to oauth_tokens
     alter table(:oauth_tokens) do
-      add :user_session_id, references(:user_sessions, on_delete: :nilify_all)
+      add_if_not_exists :user_session_id, references(:user_sessions, on_delete: :nilify_all)
     end
 
     # Update oauth_tokens to reference user_sessions
@@ -86,11 +87,11 @@ defmodule Hexpm.Repo.Migrations.CreateUserSessions do
 
     # Drop old session_id column from oauth_tokens
     alter table(:oauth_tokens) do
-      remove :session_id
+      remove_if_exists :session_id
     end
 
     # Drop oauth_sessions table
-    drop table(:oauth_sessions)
+    drop_if_exists table(:oauth_sessions)
 
     # Clean up sessions table - remove user sessions, keep only Plug session storage
     execute "DELETE FROM sessions WHERE data->>'user_id' IS NOT NULL"
@@ -98,18 +99,21 @@ defmodule Hexpm.Repo.Migrations.CreateUserSessions do
 
   def down do
     # Recreate oauth_sessions table
-    create table(:oauth_sessions) do
+    create_if_not_exists table(:oauth_sessions) do
       add :name, :string
       add :revoked_at, :utc_datetime_usec
       add :last_use, :jsonb
       add :user_id, references(:users, on_delete: :delete_all), null: false
-      add :client_id, references(:oauth_clients, column: :client_id, type: :uuid, on_delete: :delete_all), null: false
+
+      add :client_id,
+          references(:oauth_clients, column: :client_id, type: :uuid, on_delete: :delete_all),
+          null: false
 
       timestamps(type: :utc_datetime_usec)
     end
 
-    create index(:oauth_sessions, [:user_id])
-    create index(:oauth_sessions, [:client_id])
+    create_if_not_exists index(:oauth_sessions, [:user_id])
+    create_if_not_exists index(:oauth_sessions, [:client_id])
 
     # Migrate OAuth sessions back
     execute """
@@ -140,7 +144,7 @@ defmodule Hexpm.Repo.Migrations.CreateUserSessions do
 
     # Restore session_id column
     alter table(:oauth_tokens) do
-      add :session_id, references(:oauth_sessions, on_delete: :nilify_all)
+      add_if_not_exists :session_id, references(:oauth_sessions, on_delete: :nilify_all)
     end
 
     # Update oauth_tokens back
@@ -157,10 +161,10 @@ defmodule Hexpm.Repo.Migrations.CreateUserSessions do
 
     # Remove user_session_id column
     alter table(:oauth_tokens) do
-      remove :user_session_id
+      remove_if_exists :user_session_id
     end
 
     # Drop user_sessions table
-    drop table(:user_sessions)
+    drop_if_exists table(:user_sessions)
   end
 end

--- a/priv/repo/migrations/20251010172623_add_expires_at_to_user_sessions.exs
+++ b/priv/repo/migrations/20251010172623_add_expires_at_to_user_sessions.exs
@@ -4,7 +4,7 @@ defmodule Hexpm.Repo.Migrations.AddExpiresAtToUserSessions do
   def up do
     # Add expires_at column
     alter table(:user_sessions) do
-      add :expires_at, :utc_datetime_usec
+      add_if_not_exists :expires_at, :utc_datetime_usec
     end
 
     # Backfill OAuth sessions: use the earliest refresh_token_expires_at from their tokens
@@ -33,14 +33,14 @@ defmodule Hexpm.Repo.Migrations.AddExpiresAtToUserSessions do
     """
 
     # Add index for cleanup queries
-    create index(:user_sessions, [:expires_at])
+    create_if_not_exists index(:user_sessions, [:expires_at])
   end
 
   def down do
-    drop index(:user_sessions, [:expires_at])
+    drop_if_exists index(:user_sessions, [:expires_at])
 
     alter table(:user_sessions) do
-      remove :expires_at
+      remove_if_exists :expires_at
     end
   end
 end

--- a/priv/repo/migrations/20251020202843_add_seats_to_organizations.exs
+++ b/priv/repo/migrations/20251020202843_add_seats_to_organizations.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.RepoBase.Migrations.AddSeatsToOrganizations do
 
   def change do
     alter table(:organizations) do
-      add :billing_seats, :integer
+      add_if_not_exists :billing_seats, :integer
     end
   end
 end

--- a/priv/repo/migrations/20251023120000_add_optional_emails_to_users.exs
+++ b/priv/repo/migrations/20251023120000_add_optional_emails_to_users.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.Repo.Migrations.AddOptionalEmailsToUsers do
 
   def change do
     alter table(:users) do
-      add :optional_emails, :map
+      add_if_not_exists :optional_emails, :map
     end
   end
 end

--- a/priv/repo/migrations/20260202233553_add_refresh_token_hash_to_oauth_tokens.exs
+++ b/priv/repo/migrations/20260202233553_add_refresh_token_hash_to_oauth_tokens.exs
@@ -3,11 +3,11 @@ defmodule Hexpm.RepoBase.Migrations.AddRefreshTokenHashToOauthTokens do
 
   def change do
     alter table(:oauth_tokens) do
-      add :refresh_token_hash, :text
+      add_if_not_exists :refresh_token_hash, :text
     end
 
-    create unique_index(:oauth_tokens, [:refresh_token_hash],
-             where: "refresh_token_hash IS NOT NULL"
-           )
+    create_if_not_exists unique_index(:oauth_tokens, [:refresh_token_hash],
+                           where: "refresh_token_hash IS NOT NULL"
+                         )
   end
 end

--- a/priv/repo/migrations/20260203000536_add_user_delete_constraints.exs
+++ b/priv/repo/migrations/20260203000536_add_user_delete_constraints.exs
@@ -8,9 +8,19 @@ defmodule Hexpm.Repo.Migrations.AddUserDeleteConstraints do
 
     # Drop existing foreign key constraints
     execute("ALTER TABLE audit_logs DROP CONSTRAINT IF EXISTS audit_logs_actor_id_fkey")
-    execute("ALTER TABLE organization_users DROP CONSTRAINT IF EXISTS organization_users_user_id_fkey")
-    execute("ALTER TABLE package_reports DROP CONSTRAINT IF EXISTS package_reports_author_id_fkey")
-    execute("ALTER TABLE package_report_comments DROP CONSTRAINT IF EXISTS package_report_comments_author_id_fkey")
+
+    execute(
+      "ALTER TABLE organization_users DROP CONSTRAINT IF EXISTS organization_users_user_id_fkey"
+    )
+
+    execute(
+      "ALTER TABLE package_reports DROP CONSTRAINT IF EXISTS package_reports_author_id_fkey"
+    )
+
+    execute(
+      "ALTER TABLE package_report_comments DROP CONSTRAINT IF EXISTS package_report_comments_author_id_fkey"
+    )
+
     execute("ALTER TABLE password_resets DROP CONSTRAINT IF EXISTS password_resets_user_id_fkey")
     execute("ALTER TABLE releases DROP CONSTRAINT IF EXISTS releases_publisher_id_fkey")
 
@@ -57,7 +67,11 @@ defmodule Hexpm.Repo.Migrations.AddUserDeleteConstraints do
     execute("ALTER TABLE audit_logs DROP CONSTRAINT audit_logs_actor_id_fkey")
     execute("ALTER TABLE organization_users DROP CONSTRAINT organization_users_user_id_fkey")
     execute("ALTER TABLE package_reports DROP CONSTRAINT package_reports_author_id_fkey")
-    execute("ALTER TABLE package_report_comments DROP CONSTRAINT package_report_comments_author_id_fkey")
+
+    execute(
+      "ALTER TABLE package_report_comments DROP CONSTRAINT package_report_comments_author_id_fkey"
+    )
+
     execute("ALTER TABLE password_resets DROP CONSTRAINT password_resets_user_id_fkey")
     execute("ALTER TABLE releases DROP CONSTRAINT releases_publisher_id_fkey")
 

--- a/priv/repo/migrations/20260206130000_add_user_key_data_to_audit_logs.exs
+++ b/priv/repo/migrations/20260206130000_add_user_key_data_to_audit_logs.exs
@@ -3,8 +3,8 @@ defmodule Hexpm.Repo.Migrations.AddUserKeyDataToAuditLogs do
 
   def up() do
     alter table(:audit_logs) do
-      add :user_data, :map
-      add :key_data, :map
+      add_if_not_exists :user_data, :map
+      add_if_not_exists :key_data, :map
     end
 
     flush()
@@ -35,8 +35,8 @@ defmodule Hexpm.Repo.Migrations.AddUserKeyDataToAuditLogs do
 
   def down() do
     alter table(:audit_logs) do
-      remove :user_data
-      remove :key_data
+      remove_if_exists :user_data
+      remove_if_exists :key_data
     end
   end
 end

--- a/priv/repo/migrations/20260315120000_add_organization_id_to_sessions_and_tokens.exs
+++ b/priv/repo/migrations/20260315120000_add_organization_id_to_sessions_and_tokens.exs
@@ -3,17 +3,17 @@ defmodule Hexpm.RepoBase.Migrations.AddOrganizationIdToSessionsAndTokens do
 
   def change do
     alter table(:user_sessions) do
-      add :organization_id, references(:organizations, on_delete: :delete_all)
+      add_if_not_exists :organization_id, references(:organizations, on_delete: :delete_all)
       modify :user_id, :bigint, null: true, from: {:bigint, null: false}
     end
 
     alter table(:oauth_tokens) do
-      add :organization_id, references(:organizations, on_delete: :delete_all)
+      add_if_not_exists :organization_id, references(:organizations, on_delete: :delete_all)
       modify :user_id, :bigint, null: true, from: {:bigint, null: false}
     end
 
-    create index(:user_sessions, [:organization_id])
-    create index(:oauth_tokens, [:organization_id])
+    create_if_not_exists index(:user_sessions, [:organization_id])
+    create_if_not_exists index(:oauth_tokens, [:organization_id])
 
     create constraint(:user_sessions, :user_or_organization_required,
              check: "user_id IS NOT NULL OR organization_id IS NOT NULL"

--- a/priv/repo/migrations/20260325120000_drop_package_searches.exs
+++ b/priv/repo/migrations/20260325120000_drop_package_searches.exs
@@ -2,6 +2,6 @@ defmodule Hexpm.RepoBase.Migrations.DropPackageSearches do
   use Ecto.Migration
 
   def change do
-    drop table(:package_searches)
+    drop_if_exists table(:package_searches)
   end
 end

--- a/priv/repo/migrations/20260416120000_add_oauth_tokens_user_session_id_index.exs
+++ b/priv/repo/migrations/20260416120000_add_oauth_tokens_user_session_id_index.exs
@@ -2,6 +2,6 @@ defmodule Hexpm.RepoBase.Migrations.AddOauthTokensUserSessionIdIndex do
   use Ecto.Migration
 
   def change do
-    create index(:oauth_tokens, [:user_session_id], where: "revoked_at IS NULL")
+    create_if_not_exists index(:oauth_tokens, [:user_session_id], where: "revoked_at IS NULL")
   end
 end

--- a/priv/repo/migrations/20260417120000_optimize_audit_logs_indexes.exs
+++ b/priv/repo/migrations/20260417120000_optimize_audit_logs_indexes.exs
@@ -34,64 +34,64 @@ defmodule Hexpm.Repo.Migrations.OptimizeAuditLogsIndexes do
       )
     )
 
-    create(
+    create_if_not_exists(
       index(:audit_logs, [:user_id, "inserted_at DESC"],
         name: "audit_logs_user_id_inserted_at_index",
         concurrently: true
       )
     )
 
-    create(
+    create_if_not_exists(
       index(:audit_logs, [:organization_id, "inserted_at DESC"],
         name: "audit_logs_organization_id_inserted_at_index",
         concurrently: true
       )
     )
 
-    create(
+    create_if_not_exists(
       index(:audit_logs, ["((params -> 'package' ->> 'id')::integer)", "inserted_at DESC"],
         name: "audit_logs_params_package_id_inserted_at_index",
         concurrently: true
       )
     )
 
-    create(index(:audit_logs, [:key_id], concurrently: true))
+    create_if_not_exists(index(:audit_logs, [:key_id], concurrently: true))
   end
 
   def down() do
-    drop(index(:audit_logs, [:key_id], concurrently: true))
+    drop_if_exists(index(:audit_logs, [:key_id], concurrently: true))
 
-    drop(
+    drop_if_exists(
       index(:audit_logs, ["((params -> 'package' ->> 'id')::integer)", "inserted_at DESC"],
         name: "audit_logs_params_package_id_inserted_at_index",
         concurrently: true
       )
     )
 
-    drop(
+    drop_if_exists(
       index(:audit_logs, [:organization_id, "inserted_at DESC"],
         name: "audit_logs_organization_id_inserted_at_index",
         concurrently: true
       )
     )
 
-    drop(
+    drop_if_exists(
       index(:audit_logs, [:user_id, "inserted_at DESC"],
         name: "audit_logs_user_id_inserted_at_index",
         concurrently: true
       )
     )
 
-    create(index(:audit_logs, [:inserted_at], concurrently: true))
+    create_if_not_exists(index(:audit_logs, [:inserted_at], concurrently: true))
 
-    create(
+    create_if_not_exists(
       index(:audit_logs, ["((params -> 'package' ->> 'id')::integer)"],
         name: "audit_logs_params_package_id_index",
         concurrently: true
       )
     )
 
-    create(index(:audit_logs, [:organization_id], concurrently: true))
-    create(index(:audit_logs, [:user_id], concurrently: true))
+    create_if_not_exists(index(:audit_logs, [:organization_id], concurrently: true))
+    create_if_not_exists(index(:audit_logs, [:user_id], concurrently: true))
   end
 end

--- a/priv/repo/migrations/20260417130000_optimize_downloads_indexes.exs
+++ b/priv/repo/migrations/20260417130000_optimize_downloads_indexes.exs
@@ -5,14 +5,14 @@ defmodule Hexpm.Repo.Migrations.OptimizeDownloadsIndexes do
   @disable_migration_lock true
 
   def up() do
-    create(
+    create_if_not_exists(
       index(:downloads, [:package_id, :day],
         name: "downloads_package_id_day_idx",
         concurrently: true
       )
     )
 
-    create(
+    create_if_not_exists(
       index(:downloads, [:release_id, :day],
         name: "downloads_release_id_day_idx",
         concurrently: true
@@ -29,17 +29,20 @@ defmodule Hexpm.Repo.Migrations.OptimizeDownloadsIndexes do
   end
 
   def down() do
-    create(index(:downloads, [:package_id], concurrently: true))
-    create(index(:downloads, [:release_id], name: "downloads_release_id_idx", concurrently: true))
+    create_if_not_exists(index(:downloads, [:package_id], concurrently: true))
 
-    drop(
+    create_if_not_exists(
+      index(:downloads, [:release_id], name: "downloads_release_id_idx", concurrently: true)
+    )
+
+    drop_if_exists(
       index(:downloads, [:release_id, :day],
         name: "downloads_release_id_day_idx",
         concurrently: true
       )
     )
 
-    drop(
+    drop_if_exists(
       index(:downloads, [:package_id, :day],
         name: "downloads_package_id_day_idx",
         concurrently: true

--- a/priv/repo/migrations/20260417140000_drop_package_dependants_view.exs
+++ b/priv/repo/migrations/20260417140000_drop_package_dependants_view.exs
@@ -5,15 +5,15 @@ defmodule Hexpm.Repo.Migrations.DropPackageDependantsView do
   @disable_migration_lock true
 
   def up() do
-    execute("DROP MATERIALIZED VIEW package_dependants")
-    create(index(:requirements, [:dependency_id], concurrently: true))
+    execute("DROP MATERIALIZED VIEW IF EXISTS package_dependants")
+    create_if_not_exists(index(:requirements, [:dependency_id], concurrently: true))
   end
 
   def down() do
-    drop(index(:requirements, [:dependency_id], concurrently: true))
+    drop_if_exists(index(:requirements, [:dependency_id], concurrently: true))
 
     execute("""
-      CREATE MATERIALIZED VIEW package_dependants (
+      CREATE MATERIALIZED VIEW IF NOT EXISTS package_dependants (
         name,
         repo,
         dependant_id) AS

--- a/priv/repo/migrations/20260417153000_optimize_requirements_dependency_release_index.exs
+++ b/priv/repo/migrations/20260417153000_optimize_requirements_dependency_release_index.exs
@@ -6,11 +6,11 @@ defmodule Hexpm.Repo.Migrations.OptimizeRequirementsDependencyReleaseIndex do
 
   def up() do
     drop_if_exists(index(:requirements, [:dependency_id], concurrently: true))
-    create(index(:requirements, [:dependency_id, :release_id], concurrently: true))
+    create_if_not_exists(index(:requirements, [:dependency_id, :release_id], concurrently: true))
   end
 
   def down() do
     drop_if_exists(index(:requirements, [:dependency_id, :release_id], concurrently: true))
-    create(index(:requirements, [:dependency_id], concurrently: true))
+    create_if_not_exists(index(:requirements, [:dependency_id], concurrently: true))
   end
 end


### PR DESCRIPTION
## Summary
- Adds IF (NOT) EXISTS guards to every reversible DDL operation across all 84 affected migrations so a partially-applied migration (DDL ran, `schema_migrations` row missing — the failure mode that hit `20260417153000` in prod) can be safely re-run.
- Conversions:
  - `create(table|index|unique_index ...)` → `create_if_not_exists(...)`
  - `drop(table|index|unique_index ...)` → `drop_if_exists(...)`
  - `add :col` / `remove :col` inside `alter table` → `add_if_not_exists` / `remove_if_exists`
  - Raw SQL inside `execute(...)` heredocs: `CREATE TABLE`/`MATERIALIZED VIEW`/`INDEX` → `IF NOT EXISTS`; `DROP TABLE`/`MATERIALIZED VIEW`/`INDEX`/`COLUMN` and `ADD COLUMN` → `IF (NOT) EXISTS`.
- `ADD CONSTRAINT` and `MODIFY COLUMN` are left alone — Postgres has no native `IF (NOT) EXISTS` for those.