### PR TITLE
Add package_dependants table maintained via triggers

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -228,12 +228,12 @@ defmodule Hexpm.Repository.Package do
   end
 
   def count_dependants(repositories, dependency) do
-    dependant_ids = dependant_ids_query(dependency.id)
+    repository_ids = Enum.map(repositories, & &1.id)
 
     from(
-      p in assoc(repositories, :packages),
-      as: :package,
-      where: p.id in subquery(dependant_ids),
+      pd in PackageDependant,
+      where: pd.dependency_id == ^dependency.id,
+      where: pd.dependant_repository_id in ^repository_ids,
       select: count()
     )
   end
@@ -372,14 +372,12 @@ defmodule Hexpm.Repository.Package do
         from(p in query,
           where:
             exists(
-              from(req in Requirement,
-                join: rel in Release,
-                on: rel.id == req.release_id,
+              from(pd in PackageDependant,
                 join: dep in Package,
-                on: dep.id == req.dependency_id,
+                on: dep.id == pd.dependency_id,
                 join: repo in Repository,
                 on: repo.id == dep.repository_id,
-                where: rel.package_id == parent_as(:package).id,
+                where: pd.package_id == parent_as(:package).id,
                 where: dep.name == ^package,
                 where: repo.name == ^repository
               )
@@ -390,12 +388,10 @@ defmodule Hexpm.Repository.Package do
         from(p in query,
           where:
             exists(
-              from(req in Requirement,
-                join: rel in Release,
-                on: rel.id == req.release_id,
+              from(pd in PackageDependant,
                 join: dep in Package,
-                on: dep.id == req.dependency_id,
-                where: rel.package_id == parent_as(:package).id,
+                on: dep.id == pd.dependency_id,
+                where: pd.package_id == parent_as(:package).id,
                 where: dep.name == ^search
               )
             )
@@ -421,20 +417,16 @@ defmodule Hexpm.Repository.Package do
   end
 
   defp dependant_ids_query(dependency_id) do
-    from(req in Requirement,
-      join: rel in Release,
-      on: rel.id == req.release_id,
-      where: req.dependency_id == ^dependency_id,
-      select: rel.package_id
+    from(pd in PackageDependant,
+      where: pd.dependency_id == ^dependency_id,
+      select: pd.package_id
     )
   end
 
   defp dependency_exists_query(dependency_id) do
-    from(r in Release,
-      join: req in Requirement,
-      on: req.release_id == r.id,
-      where: r.package_id == parent_as(:package).id,
-      where: req.dependency_id == ^dependency_id
+    from(pd in PackageDependant,
+      where: pd.dependency_id == ^dependency_id,
+      where: pd.package_id == parent_as(:package).id
     )
   end
 

--- a/lib/hexpm/repository/package_dependant.ex
+++ b/lib/hexpm/repository/package_dependant.ex
@@ -1,0 +1,9 @@
+defmodule Hexpm.Repository.PackageDependant do
+  use Hexpm.Schema
+
+  schema "package_dependants" do
+    belongs_to :dependency, Package
+    belongs_to :package, Package
+    belongs_to :dependant_repository, Repository
+  end
+end

--- a/lib/hexpm/shared.ex
+++ b/lib/hexpm/shared.ex
@@ -26,6 +26,7 @@ defmodule Hexpm.Shared do
         Repository.Installs,
         Repository.Owners,
         Repository.Package,
+        Repository.PackageDependant,
         Repository.PackageDownload,
         Repository.PackageMetadata,
         Repository.PackageOwner,

--- a/priv/repo/migrations/20260419014711_add_package_dependants_table.exs
+++ b/priv/repo/migrations/20260419014711_add_package_dependants_table.exs
@@ -17,12 +17,18 @@ defmodule Hexpm.Repo.Migrations.AddPackageDependantsTable do
     execute("""
     CREATE OR REPLACE FUNCTION package_dependants_insert() RETURNS trigger AS $$
     BEGIN
+      -- ON CONFLICT DO UPDATE (no-op SET) takes a row-level lock on the
+      -- existing (dependency_id, package_id) row, which serializes against
+      -- a concurrent DELETE trigger's NOT EXISTS check on the same row.
+      -- Without this, a publish + revert race on the same (package, dep)
+      -- can leave a stale row missing from package_dependants.
       INSERT INTO package_dependants (dependency_id, package_id, dependant_repository_id)
       SELECT NEW.dependency_id, rel.package_id, p.repository_id
       FROM releases rel
       JOIN packages p ON p.id = rel.package_id
       WHERE rel.id = NEW.release_id
-      ON CONFLICT DO NOTHING;
+      ON CONFLICT (dependency_id, package_id)
+        DO UPDATE SET package_id = EXCLUDED.package_id;
       RETURN NEW;
     END;
     $$ LANGUAGE plpgsql;

--- a/priv/repo/migrations/20260419014711_add_package_dependants_table.exs
+++ b/priv/repo/migrations/20260419014711_add_package_dependants_table.exs
@@ -1,0 +1,81 @@
+defmodule Hexpm.Repo.Migrations.AddPackageDependantsTable do
+  use Ecto.Migration
+
+  def up() do
+    create_if_not_exists table(:package_dependants) do
+      add :dependency_id, references(:packages, on_delete: :delete_all), null: false
+      add :package_id, references(:packages, on_delete: :delete_all), null: false
+      add :dependant_repository_id, references(:repositories, on_delete: :delete_all), null: false
+    end
+
+    create_if_not_exists unique_index(:package_dependants, [:dependency_id, :package_id])
+
+    create_if_not_exists index(:package_dependants, [:dependency_id, :dependant_repository_id],
+                           include: [:package_id]
+                         )
+
+    execute("""
+    CREATE OR REPLACE FUNCTION package_dependants_insert() RETURNS trigger AS $$
+    BEGIN
+      INSERT INTO package_dependants (dependency_id, package_id, dependant_repository_id)
+      SELECT NEW.dependency_id, rel.package_id, p.repository_id
+      FROM releases rel
+      JOIN packages p ON p.id = rel.package_id
+      WHERE rel.id = NEW.release_id
+      ON CONFLICT DO NOTHING;
+      RETURN NEW;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+    CREATE OR REPLACE FUNCTION package_dependants_delete() RETURNS trigger AS $$
+    BEGIN
+      DELETE FROM package_dependants pd
+      WHERE pd.dependency_id IN (SELECT DISTINCT dependency_id FROM old_requirements)
+        AND NOT EXISTS (
+          SELECT 1 FROM requirements req
+          JOIN releases rel ON rel.id = req.release_id
+          WHERE req.dependency_id = pd.dependency_id
+            AND rel.package_id = pd.package_id
+        );
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_requirement_insert ON requirements")
+
+    execute("""
+    CREATE TRIGGER package_dependants_after_requirement_insert
+    AFTER INSERT ON requirements
+    FOR EACH ROW EXECUTE FUNCTION package_dependants_insert();
+    """)
+
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_requirement_delete ON requirements")
+
+    execute("""
+    CREATE TRIGGER package_dependants_after_requirement_delete
+    AFTER DELETE ON requirements
+    REFERENCING OLD TABLE AS old_requirements
+    FOR EACH STATEMENT EXECUTE FUNCTION package_dependants_delete();
+    """)
+
+    execute("""
+    INSERT INTO package_dependants (dependency_id, package_id, dependant_repository_id)
+    SELECT DISTINCT req.dependency_id, p.id, p.repository_id
+    FROM requirements req
+    JOIN releases rel ON rel.id = req.release_id
+    JOIN packages p ON p.id = rel.package_id
+    ON CONFLICT DO NOTHING
+    """)
+  end
+
+  def down() do
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_requirement_delete ON requirements")
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_requirement_insert ON requirements")
+    execute("DROP FUNCTION IF EXISTS package_dependants_delete()")
+    execute("DROP FUNCTION IF EXISTS package_dependants_insert()")
+    drop_if_exists table(:package_dependants)
+  end
+end


### PR DESCRIPTION
## Summary
- Introduces a denormalized `package_dependants(dependency_id, package_id, dependant_repository_id)` table maintained automatically by `AFTER INSERT/DELETE` triggers on `requirements`, so it stays consistent regardless of how requirements are inserted (publish flow, factories, scripts).
- Rewrites `count_dependants`, `dependants`, `downloaded_dependant_ids`, `count_downloaded_dependants`, `undownloaded_dependant_ids`, and `search_param("depends")` to use the new table — index-only lookups instead of joining `requirements` + `releases` (+ packages + repositories).
- Measured against prod data for `jason` (62k requirements, 3,200 dependants in hexpm):
  - `count_dependants`: ~186-371 ms → <1 ms
  - `downloaded_dependant_ids` (dependants page download sort): ~45 ms → ~1 ms
  - `Packages.search("depends:hexpm:jason")`: ~75 ms → ~25 ms
- Covering index `(dependency_id, dependant_repository_id) INCLUDE (package_id)` supports `count_dependants` directly. Unique `(dependency_id, package_id)` index supports the `EXISTS` subqueries used by the other paths.
- Backfill runs as part of the migration via `INSERT ... ON CONFLICT DO NOTHING`.
- Different from the dropped `package_dependants` materialized view: maintained incrementally per requirement-row rather than via full `REFRESH`, so there's no per-publish bulk recompute cost and no staleness window.