### PR TITLE
Add partial indexes for device-code and org session lookups

### DIFF
--- a/priv/repo/migrations/20260419034605_add_session_token_partial_indexes.exs
+++ b/priv/repo/migrations/20260419034605_add_session_token_partial_indexes.exs
@@ -1,0 +1,41 @@
+defmodule Hexpm.Repo.Migrations.AddSessionTokenPartialIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up() do
+    create_if_not_exists(
+      index(:oauth_tokens, [:grant_reference, :client_id],
+        name: :oauth_tokens_device_code_lookup_idx,
+        where:
+          "grant_type = 'urn:ietf:params:oauth:grant-type:device_code' AND revoked_at IS NULL",
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:user_sessions, [:organization_id, :expires_at],
+        name: :user_sessions_organization_id_expires_at_active_idx,
+        where: "revoked_at IS NULL",
+        concurrently: true
+      )
+    )
+  end
+
+  def down() do
+    drop_if_exists(
+      index(:oauth_tokens, [:grant_reference, :client_id],
+        name: :oauth_tokens_device_code_lookup_idx,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:user_sessions, [:organization_id, :expires_at],
+        name: :user_sessions_organization_id_expires_at_active_idx,
+        concurrently: true
+      )
+    )
+  end
+end


### PR DESCRIPTION
Two narrow partial indexes, both built `CONCURRENTLY`:

- **`oauth_tokens_device_code_lookup_idx`** — `(grant_reference, client_id) WHERE grant_type = 'urn:ietf:params:oauth:grant-type:device_code' AND revoked_at IS NULL`. Targets `DeviceCodes.get_device_token/1`. Production currently picks the broad `oauth_tokens_user_session_id_index` partial and filters out ~91k rows per lookup; with this index, the lookup becomes a deterministic single-row hit. Index covers ~181 active rows.

- **`user_sessions_organization_id_expires_at_active_idx`** — `(organization_id, expires_at) WHERE revoked_at IS NULL`. Targets the per-organization session-limit count in `Hexpm.UserSessions.count_sessions/1`. Current BitmapAnd over `organization_id` and `expires_at` scans 100k+ index entries to return ~10 rows (~17 ms on the largest org); the partial index reduces this to a sub-ms lookup. Covers ~175k active rows out of ~1M.

Follow-up candidate not in this PR: a symmetric `(user_id, expires_at) WHERE revoked_at IS NULL` partial index — the user-scoped version of the same query is hotter (≈2× call volume) but was outside the scoped plan; can be added separately if PR-2 verification looks good.