### PR TITLE
Add release task to purge expired database records

### DIFF
--- a/lib/hexpm/oauth/device_codes.ex
+++ b/lib/hexpm/oauth/device_codes.ex
@@ -197,22 +197,6 @@ defmodule Hexpm.OAuth.DeviceCodes do
   end
 
   @doc """
-  Cleans up expired device codes.
-  This should be called periodically to remove old records.
-  """
-  def cleanup_expired do
-    now = DateTime.utc_now()
-
-    from(dc in DeviceCode,
-      where: dc.expires_at < ^now and dc.status == "pending"
-    )
-    |> Repo.update_all(set: [status: "expired", updated_at: now])
-  end
-
-  # Alias for compatibility
-  def cleanup_expired_device_codes, do: cleanup_expired()
-
-  @doc """
   Generates a cryptographically secure device code.
   Returns a 32-character base64url encoded string.
   """

--- a/lib/hexpm/oauth/tokens.ex
+++ b/lib/hexpm/oauth/tokens.ex
@@ -408,19 +408,6 @@ defmodule Hexpm.OAuth.Tokens do
     Enum.all?(required_scopes, &(&1 in token_scopes))
   end
 
-  @doc """
-  Cleans up expired OAuth tokens.
-  This should be called periodically to remove old records.
-  """
-  def cleanup_expired_tokens do
-    now = DateTime.utc_now()
-
-    from(t in Token,
-      where: t.expires_at < ^now and is_nil(t.revoked_at)
-    )
-    |> Repo.delete_all()
-  end
-
   defp extract_jti_for_type(claims, :access) do
     case claims do
       %{"jti" => jti} -> {:ok, jti}

--- a/lib/hexpm/release_tasks.ex
+++ b/lib/hexpm/release_tasks.ex
@@ -1,5 +1,5 @@
 defmodule Hexpm.ReleaseTasks do
-  alias Hexpm.ReleaseTasks.{CheckNames, Stats}
+  alias Hexpm.ReleaseTasks.{CheckNames, PurgeExpiredRecords, Stats}
   require Logger
 
   @start_apps [
@@ -82,6 +82,17 @@ defmodule Hexpm.ReleaseTasks do
     task(&Stats.run/0)
 
     Logger.info("[task] Finished stats")
+    stop()
+  end
+
+  def purge_expired_records() do
+    start_apps(@start_apps)
+    Logger.info("[task] Running purge_expired_records")
+    start_repo()
+
+    task(&PurgeExpiredRecords.run/0)
+
+    Logger.info("[task] Finished purge_expired_records")
     stop()
   end
 

--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -3,8 +3,9 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
   require Logger
 
   @repos Application.compile_env!(:hexpm, :ecto_repos)
-  @short_lived_retention_days 30
-  @long_lived_retention_days 90
+  @retention_days 90
+  # Plug session cookies have a 30-day max_age; rows older than that are unreachable.
+  @plug_session_retention_days 30
 
   def run() do
     Enum.each(@repos, fn repo ->
@@ -13,10 +14,10 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
 
       purge_authorization_codes(repo)
       purge_device_codes(repo)
-      purge_password_resets(repo)
       purge_oauth_tokens(repo)
       purge_user_sessions(repo)
-      purge_sessions(repo)
+      purge_plug_sessions(repo)
+      purge_password_resets(repo)
       purge_keys(repo)
     end)
   end
@@ -25,9 +26,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
     {count, _} =
       repo.delete_all(
         from(ac in Hexpm.OAuth.AuthorizationCode,
-          where:
-            ac.expires_at <
-              fragment("NOW() - make_interval(days => ?)", @short_lived_retention_days)
+          where: ac.expires_at < fragment("NOW()")
         )
       )
 
@@ -38,38 +37,18 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
     {count, _} =
       repo.delete_all(
         from(dc in Hexpm.OAuth.DeviceCode,
-          where:
-            dc.expires_at <
-              fragment("NOW() - make_interval(days => ?)", @short_lived_retention_days)
+          where: dc.expires_at < fragment("NOW()")
         )
       )
 
     Logger.info("[task] Purged #{count} expired device codes")
   end
 
-  defp purge_password_resets(repo) do
-    {count, _} =
-      repo.delete_all(
-        from(pr in Hexpm.Accounts.PasswordReset,
-          where:
-            pr.inserted_at <
-              fragment("NOW() - make_interval(days => ?)", @short_lived_retention_days)
-        )
-      )
-
-    Logger.info("[task] Purged #{count} expired password resets")
-  end
-
   defp purge_oauth_tokens(repo) do
     {count, _} =
       repo.delete_all(
         from(t in Hexpm.OAuth.Token,
-          where:
-            t.expires_at <
-              fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days) or
-              (not is_nil(t.revoked_at) and
-                 t.revoked_at <
-                   fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days))
+          where: t.expires_at < fragment("NOW()") or not is_nil(t.revoked_at)
         )
       )
 
@@ -81,29 +60,36 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
       repo.delete_all(
         from(us in Hexpm.UserSession,
           where:
-            (not is_nil(us.expires_at) and
-               us.expires_at <
-                 fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days)) or
-              (not is_nil(us.revoked_at) and
-                 us.revoked_at <
-                   fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days))
+            (not is_nil(us.expires_at) and us.expires_at < fragment("NOW()")) or
+              not is_nil(us.revoked_at)
         )
       )
 
     Logger.info("[task] Purged #{count} expired/revoked user sessions")
   end
 
-  defp purge_sessions(repo) do
+  defp purge_plug_sessions(repo) do
     {count, _} =
       repo.delete_all(
         from(s in Hexpm.PlugSession,
           where:
             s.updated_at <
-              fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days)
+              fragment("NOW() - make_interval(days => ?)", @plug_session_retention_days)
         )
       )
 
     Logger.info("[task] Purged #{count} stale plug sessions")
+  end
+
+  defp purge_password_resets(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(pr in Hexpm.Accounts.PasswordReset,
+          where: pr.inserted_at < fragment("NOW() - make_interval(days => ?)", @retention_days)
+        )
+      )
+
+    Logger.info("[task] Purged #{count} expired password resets")
   end
 
   defp purge_keys(repo) do
@@ -112,8 +98,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
         from(k in Hexpm.Accounts.Key,
           where:
             not is_nil(k.revoke_at) and
-              k.revoke_at <
-                fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days)
+              k.revoke_at < fragment("NOW() - make_interval(days => ?)", @retention_days)
         )
       )
 

--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -1,0 +1,122 @@
+defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
+  import Ecto.Query, only: [from: 2]
+  require Logger
+
+  @repos Application.compile_env!(:hexpm, :ecto_repos)
+  @short_lived_retention_days 30
+  @long_lived_retention_days 90
+
+  def run() do
+    Enum.each(@repos, fn repo ->
+      app = Keyword.get(repo.config(), :otp_app)
+      Logger.info("[task] Purging expired records for #{app}")
+
+      purge_authorization_codes(repo)
+      purge_device_codes(repo)
+      purge_password_resets(repo)
+      purge_oauth_tokens(repo)
+      purge_user_sessions(repo)
+      purge_sessions(repo)
+      purge_keys(repo)
+    end)
+  end
+
+  defp purge_authorization_codes(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(ac in Hexpm.OAuth.AuthorizationCode,
+          where:
+            ac.expires_at <
+              fragment("NOW() - make_interval(days => ?)", @short_lived_retention_days)
+        )
+      )
+
+    Logger.info("[task] Purged #{count} expired authorization codes")
+  end
+
+  defp purge_device_codes(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(dc in Hexpm.OAuth.DeviceCode,
+          where:
+            dc.expires_at <
+              fragment("NOW() - make_interval(days => ?)", @short_lived_retention_days)
+        )
+      )
+
+    Logger.info("[task] Purged #{count} expired device codes")
+  end
+
+  defp purge_password_resets(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(pr in Hexpm.Accounts.PasswordReset,
+          where:
+            pr.inserted_at <
+              fragment("NOW() - make_interval(days => ?)", @short_lived_retention_days)
+        )
+      )
+
+    Logger.info("[task] Purged #{count} expired password resets")
+  end
+
+  defp purge_oauth_tokens(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(t in Hexpm.OAuth.Token,
+          where:
+            t.expires_at <
+              fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days) or
+              (not is_nil(t.revoked_at) and
+                 t.revoked_at <
+                   fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days))
+        )
+      )
+
+    Logger.info("[task] Purged #{count} expired/revoked OAuth tokens")
+  end
+
+  defp purge_user_sessions(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(us in Hexpm.UserSession,
+          where:
+            (not is_nil(us.expires_at) and
+               us.expires_at <
+                 fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days)) or
+              (not is_nil(us.revoked_at) and
+                 us.revoked_at <
+                   fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days))
+        )
+      )
+
+    Logger.info("[task] Purged #{count} expired/revoked user sessions")
+  end
+
+  defp purge_sessions(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(s in Hexpm.PlugSession,
+          where:
+            s.updated_at <
+              fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days)
+        )
+      )
+
+    Logger.info("[task] Purged #{count} stale plug sessions")
+  end
+
+  defp purge_keys(repo) do
+    {count, _} =
+      repo.delete_all(
+        from(k in Hexpm.Accounts.Key,
+          where:
+            not is_nil(k.revoke_at) and
+              k.revoke_at <
+                fragment("NOW() - make_interval(days => ?)", @long_lived_retention_days)
+        )
+      )
+
+    Logger.info("[task] Purged #{count} revoked keys")
+  end
+end

--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -16,9 +16,8 @@ defmodule Hexpm.UserSessions do
 
   ## Session Expiration
 
-  All sessions expire after 30 days of creation (non-sliding window). Sessions
-  are automatically cleaned up by calling `cleanup_expired_sessions/0` periodically
-  via a scheduled job (e.g., cron, Oban, Quantum).
+  All sessions expire after 30 days of creation (non-sliding window). Expired
+  rows are deleted by `Hexpm.ReleaseTasks.PurgeExpiredRecords`.
 
   ## Last Use Tracking
 
@@ -487,22 +486,5 @@ defmodule Hexpm.UserSessions do
 
   defp owner_filter(%Hexpm.Accounts.Organization{} = org) do
     Ecto.Query.dynamic([s], s.organization_id == ^org.id)
-  end
-
-  @doc """
-  Cleans up expired sessions by deleting them from the database.
-
-  This function should be called periodically (e.g., daily) via a scheduled job
-  such as cron, Oban, or Quantum to prevent accumulation of expired records.
-
-  Returns `{count, nil}` where count is the number of deleted sessions.
-  """
-  def cleanup_expired_sessions do
-    now = DateTime.utc_now()
-
-    from(s in UserSession,
-      where: s.expires_at < ^now
-    )
-    |> Repo.delete_all()
   end
 end

--- a/test/hexpm/oauth/device_flow_test.exs
+++ b/test/hexpm/oauth/device_flow_test.exs
@@ -327,30 +327,4 @@ defmodule Hexpm.OAuth.DeviceFlowTest do
                DeviceCodes.get_device_code_for_verification(device_code.user_code)
     end
   end
-
-  describe "cleanup_expired_device_codes/0" do
-    test "marks expired pending device codes as expired" do
-      # Create expired device code
-      client = create_test_client()
-      conn = create_mock_conn()
-      {:ok, response} = DeviceCodes.initiate_device_authorization(conn, client.client_id, ["api"])
-      device_code = Repo.get_by(DeviceCode, device_code: response.device_code)
-
-      past_time = DateTime.add(DateTime.utc_now(), -3600, :second)
-      Repo.update!(DeviceCode.changeset(device_code, %{expires_at: past_time}))
-
-      # Create non-expired device code
-      client2 = create_test_client("Client 2")
-
-      {:ok, _response2} =
-        DeviceCodes.initiate_device_authorization(conn, client2.client_id, ["api"])
-
-      # Run cleanup
-      assert {1, nil} = DeviceCodes.cleanup_expired_device_codes()
-
-      # Verify only expired code was updated
-      updated_device_code = Repo.get(DeviceCode, device_code.id)
-      assert updated_device_code.status == "expired"
-    end
-  end
 end

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -1,0 +1,291 @@
+defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.ReleaseTasks.PurgeExpiredRecords
+
+  defp days_ago(days) do
+    DateTime.add(DateTime.utc_now(), -days * 86400, :second)
+  end
+
+  defp truncated_days_ago(days) do
+    days_ago(days) |> DateTime.truncate(:second)
+  end
+
+  defp naive_days_ago(days) do
+    NaiveDateTime.utc_now()
+    |> NaiveDateTime.add(-days * 86400, :second)
+    |> NaiveDateTime.truncate(:second)
+  end
+
+  describe "purge authorization codes" do
+    test "deletes expired codes older than 30 days" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      expired =
+        Repo.insert!(%Hexpm.OAuth.AuthorizationCode{
+          code: "expired-code",
+          redirect_uri: "https://example.com/callback",
+          scopes: ["api"],
+          expires_at: truncated_days_ago(31),
+          code_challenge: "challenge",
+          code_challenge_method: "S256",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      active =
+        Repo.insert!(%Hexpm.OAuth.AuthorizationCode{
+          code: "active-code",
+          redirect_uri: "https://example.com/callback",
+          scopes: ["api"],
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(600, :second) |> DateTime.truncate(:second),
+          code_challenge: "challenge2",
+          code_challenge_method: "S256",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.OAuth.AuthorizationCode, expired.id)
+      assert Repo.get(Hexpm.OAuth.AuthorizationCode, active.id)
+    end
+  end
+
+  describe "purge device codes" do
+    test "deletes expired codes older than 30 days" do
+      client = insert(:oauth_client)
+
+      expired =
+        Repo.insert!(%Hexpm.OAuth.DeviceCode{
+          device_code: "expired-device",
+          user_code: "EXPR1234",
+          verification_uri: "https://hex.pm/device",
+          expires_at: days_ago(31),
+          client_id: client.client_id
+        })
+
+      active =
+        Repo.insert!(%Hexpm.OAuth.DeviceCode{
+          device_code: "active-device",
+          user_code: "ACTV5678",
+          verification_uri: "https://hex.pm/device",
+          expires_at: DateTime.add(DateTime.utc_now(), 600, :second),
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.OAuth.DeviceCode, expired.id)
+      assert Repo.get(Hexpm.OAuth.DeviceCode, active.id)
+    end
+  end
+
+  describe "purge password resets" do
+    test "deletes resets older than 30 days" do
+      user = insert(:user)
+
+      old =
+        Repo.insert!(%Hexpm.Accounts.PasswordReset{
+          key: "old-key",
+          primary_email: "old@example.com",
+          user_id: user.id,
+          inserted_at: days_ago(31)
+        })
+
+      recent =
+        Repo.insert!(%Hexpm.Accounts.PasswordReset{
+          key: "new-key",
+          primary_email: "new@example.com",
+          user_id: user.id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.Accounts.PasswordReset, old.id)
+      assert Repo.get(Hexpm.Accounts.PasswordReset, recent.id)
+    end
+  end
+
+  describe "purge oauth tokens" do
+    test "deletes expired tokens older than 90 days" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      expired =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "expired-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at: truncated_days_ago(91),
+          grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      recent_expired =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "recent-expired-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at: truncated_days_ago(60),
+          grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.OAuth.Token, expired.id)
+      assert Repo.get(Hexpm.OAuth.Token, recent_expired.id)
+    end
+
+    test "deletes revoked tokens older than 90 days" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      revoked =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "revoked-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at: truncated_days_ago(91),
+          revoked_at: truncated_days_ago(91),
+          grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      recent_revoked =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "recent-revoked-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at:
+            DateTime.utc_now() |> DateTime.add(86400, :second) |> DateTime.truncate(:second),
+          revoked_at: truncated_days_ago(60),
+          grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.OAuth.Token, revoked.id)
+      assert Repo.get(Hexpm.OAuth.Token, recent_revoked.id)
+    end
+  end
+
+  describe "purge user sessions" do
+    test "deletes expired sessions older than 90 days" do
+      user = insert(:user)
+
+      expired =
+        Repo.insert!(%Hexpm.UserSession{
+          type: "browser",
+          name: "expired session",
+          session_token: :crypto.strong_rand_bytes(32),
+          expires_at: days_ago(91),
+          user_id: user.id
+        })
+
+      recent =
+        Repo.insert!(%Hexpm.UserSession{
+          type: "browser",
+          name: "recent session",
+          session_token: :crypto.strong_rand_bytes(32),
+          expires_at: days_ago(60),
+          user_id: user.id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.UserSession, expired.id)
+      assert Repo.get(Hexpm.UserSession, recent.id)
+    end
+
+    test "deletes revoked sessions older than 90 days" do
+      user = insert(:user)
+
+      revoked =
+        Repo.insert!(%Hexpm.UserSession{
+          type: "browser",
+          name: "revoked session",
+          session_token: :crypto.strong_rand_bytes(32),
+          revoked_at: days_ago(91),
+          user_id: user.id
+        })
+
+      recent_revoked =
+        Repo.insert!(%Hexpm.UserSession{
+          type: "browser",
+          name: "recent revoked session",
+          session_token: :crypto.strong_rand_bytes(32),
+          revoked_at: days_ago(60),
+          user_id: user.id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.UserSession, revoked.id)
+      assert Repo.get(Hexpm.UserSession, recent_revoked.id)
+    end
+
+    test "keeps sessions with no expiry or revocation" do
+      user = insert(:user)
+
+      active =
+        Repo.insert!(%Hexpm.UserSession{
+          type: "browser",
+          name: "active session",
+          session_token: :crypto.strong_rand_bytes(32),
+          user_id: user.id
+        })
+
+      PurgeExpiredRecords.run()
+
+      assert Repo.get(Hexpm.UserSession, active.id)
+    end
+  end
+
+  describe "purge plug sessions" do
+    test "deletes sessions inactive for more than 90 days" do
+      stale =
+        Repo.insert!(%Hexpm.PlugSession{
+          token: :crypto.strong_rand_bytes(32),
+          data: %{},
+          inserted_at: naive_days_ago(91),
+          updated_at: naive_days_ago(91)
+        })
+
+      recent =
+        Repo.insert!(%Hexpm.PlugSession{
+          token: :crypto.strong_rand_bytes(32),
+          data: %{}
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.PlugSession, stale.id)
+      assert Repo.get(Hexpm.PlugSession, recent.id)
+    end
+  end
+
+  describe "purge keys" do
+    test "deletes keys revoked more than 90 days ago" do
+      user = insert(:user)
+
+      revoked = insert(:key, user: user, revoke_at: days_ago(91))
+      recent_revoked = insert(:key, user: user, revoke_at: days_ago(60))
+      active = insert(:key, user: user)
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.Accounts.Key, revoked.id)
+      assert Repo.get(Hexpm.Accounts.Key, recent_revoked.id)
+      assert Repo.get(Hexpm.Accounts.Key, active.id)
+    end
+  end
+end

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -3,13 +3,23 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
 
   alias Hexpm.ReleaseTasks.PurgeExpiredRecords
 
-  defp days_ago(days) do
-    DateTime.add(DateTime.utc_now(), -days * 86400, :second)
+  defp seconds_ago(seconds) do
+    DateTime.add(DateTime.utc_now(), -seconds, :second)
   end
 
-  defp truncated_days_ago(days) do
-    days_ago(days) |> DateTime.truncate(:second)
+  defp seconds_from_now(seconds) do
+    DateTime.add(DateTime.utc_now(), seconds, :second)
   end
+
+  defp truncated_seconds_ago(seconds) do
+    seconds_ago(seconds) |> DateTime.truncate(:second)
+  end
+
+  defp truncated_seconds_from_now(seconds) do
+    seconds_from_now(seconds) |> DateTime.truncate(:second)
+  end
+
+  defp days_ago(days), do: seconds_ago(days * 86400)
 
   defp naive_days_ago(days) do
     NaiveDateTime.utc_now()
@@ -18,7 +28,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
   end
 
   describe "purge authorization codes" do
-    test "deletes expired codes older than 30 days" do
+    test "deletes any expired code" do
       user = insert(:user)
       client = insert(:oauth_client)
 
@@ -27,7 +37,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           code: "expired-code",
           redirect_uri: "https://example.com/callback",
           scopes: ["api"],
-          expires_at: truncated_days_ago(31),
+          expires_at: truncated_seconds_ago(60),
           code_challenge: "challenge",
           code_challenge_method: "S256",
           user_id: user.id,
@@ -39,8 +49,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           code: "active-code",
           redirect_uri: "https://example.com/callback",
           scopes: ["api"],
-          expires_at:
-            DateTime.utc_now() |> DateTime.add(600, :second) |> DateTime.truncate(:second),
+          expires_at: truncated_seconds_from_now(600),
           code_challenge: "challenge2",
           code_challenge_method: "S256",
           user_id: user.id,
@@ -55,7 +64,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
   end
 
   describe "purge device codes" do
-    test "deletes expired codes older than 30 days" do
+    test "deletes any expired code" do
       client = insert(:oauth_client)
 
       expired =
@@ -63,7 +72,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           device_code: "expired-device",
           user_code: "EXPR1234",
           verification_uri: "https://hex.pm/device",
-          expires_at: days_ago(31),
+          expires_at: seconds_ago(60),
           client_id: client.client_id
         })
 
@@ -72,7 +81,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           device_code: "active-device",
           user_code: "ACTV5678",
           verification_uri: "https://hex.pm/device",
-          expires_at: DateTime.add(DateTime.utc_now(), 600, :second),
+          expires_at: seconds_from_now(600),
           client_id: client.client_id
         })
 
@@ -83,34 +92,8 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
     end
   end
 
-  describe "purge password resets" do
-    test "deletes resets older than 30 days" do
-      user = insert(:user)
-
-      old =
-        Repo.insert!(%Hexpm.Accounts.PasswordReset{
-          key: "old-key",
-          primary_email: "old@example.com",
-          user_id: user.id,
-          inserted_at: days_ago(31)
-        })
-
-      recent =
-        Repo.insert!(%Hexpm.Accounts.PasswordReset{
-          key: "new-key",
-          primary_email: "new@example.com",
-          user_id: user.id
-        })
-
-      PurgeExpiredRecords.run()
-
-      refute Repo.get(Hexpm.Accounts.PasswordReset, old.id)
-      assert Repo.get(Hexpm.Accounts.PasswordReset, recent.id)
-    end
-  end
-
   describe "purge oauth tokens" do
-    test "deletes expired tokens older than 90 days" do
+    test "deletes any expired token" do
       user = insert(:user)
       client = insert(:oauth_client)
 
@@ -119,18 +102,18 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           jti: "expired-jti",
           token_type: "bearer",
           scopes: ["api"],
-          expires_at: truncated_days_ago(91),
+          expires_at: truncated_seconds_ago(60),
           grant_type: "authorization_code",
           user_id: user.id,
           client_id: client.client_id
         })
 
-      recent_expired =
+      active =
         Repo.insert!(%Hexpm.OAuth.Token{
-          jti: "recent-expired-jti",
+          jti: "active-jti",
           token_type: "bearer",
           scopes: ["api"],
-          expires_at: truncated_days_ago(60),
+          expires_at: truncated_seconds_from_now(86400),
           grant_type: "authorization_code",
           user_id: user.id,
           client_id: client.client_id
@@ -139,10 +122,10 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
       PurgeExpiredRecords.run()
 
       refute Repo.get(Hexpm.OAuth.Token, expired.id)
-      assert Repo.get(Hexpm.OAuth.Token, recent_expired.id)
+      assert Repo.get(Hexpm.OAuth.Token, active.id)
     end
 
-    test "deletes revoked tokens older than 90 days" do
+    test "deletes any revoked token" do
       user = insert(:user)
       client = insert(:oauth_client)
 
@@ -151,21 +134,8 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           jti: "revoked-jti",
           token_type: "bearer",
           scopes: ["api"],
-          expires_at: truncated_days_ago(91),
-          revoked_at: truncated_days_ago(91),
-          grant_type: "authorization_code",
-          user_id: user.id,
-          client_id: client.client_id
-        })
-
-      recent_revoked =
-        Repo.insert!(%Hexpm.OAuth.Token{
-          jti: "recent-revoked-jti",
-          token_type: "bearer",
-          scopes: ["api"],
-          expires_at:
-            DateTime.utc_now() |> DateTime.add(86400, :second) |> DateTime.truncate(:second),
-          revoked_at: truncated_days_ago(60),
+          expires_at: truncated_seconds_from_now(86400),
+          revoked_at: truncated_seconds_ago(60),
           grant_type: "authorization_code",
           user_id: user.id,
           client_id: client.client_id
@@ -174,12 +144,11 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
       PurgeExpiredRecords.run()
 
       refute Repo.get(Hexpm.OAuth.Token, revoked.id)
-      assert Repo.get(Hexpm.OAuth.Token, recent_revoked.id)
     end
   end
 
   describe "purge user sessions" do
-    test "deletes expired sessions older than 90 days" do
+    test "deletes any expired session" do
       user = insert(:user)
 
       expired =
@@ -187,26 +156,26 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           type: "browser",
           name: "expired session",
           session_token: :crypto.strong_rand_bytes(32),
-          expires_at: days_ago(91),
+          expires_at: seconds_ago(60),
           user_id: user.id
         })
 
-      recent =
+      active =
         Repo.insert!(%Hexpm.UserSession{
           type: "browser",
-          name: "recent session",
+          name: "active session",
           session_token: :crypto.strong_rand_bytes(32),
-          expires_at: days_ago(60),
+          expires_at: seconds_from_now(86400),
           user_id: user.id
         })
 
       PurgeExpiredRecords.run()
 
       refute Repo.get(Hexpm.UserSession, expired.id)
-      assert Repo.get(Hexpm.UserSession, recent.id)
+      assert Repo.get(Hexpm.UserSession, active.id)
     end
 
-    test "deletes revoked sessions older than 90 days" do
+    test "deletes any revoked session" do
       user = insert(:user)
 
       revoked =
@@ -214,23 +183,13 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           type: "browser",
           name: "revoked session",
           session_token: :crypto.strong_rand_bytes(32),
-          revoked_at: days_ago(91),
-          user_id: user.id
-        })
-
-      recent_revoked =
-        Repo.insert!(%Hexpm.UserSession{
-          type: "browser",
-          name: "recent revoked session",
-          session_token: :crypto.strong_rand_bytes(32),
-          revoked_at: days_ago(60),
+          revoked_at: seconds_ago(60),
           user_id: user.id
         })
 
       PurgeExpiredRecords.run()
 
       refute Repo.get(Hexpm.UserSession, revoked.id)
-      assert Repo.get(Hexpm.UserSession, recent_revoked.id)
     end
 
     test "keeps sessions with no expiry or revocation" do
@@ -251,13 +210,13 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
   end
 
   describe "purge plug sessions" do
-    test "deletes sessions inactive for more than 90 days" do
+    test "deletes sessions inactive for more than 30 days" do
       stale =
         Repo.insert!(%Hexpm.PlugSession{
           token: :crypto.strong_rand_bytes(32),
           data: %{},
-          inserted_at: naive_days_ago(91),
-          updated_at: naive_days_ago(91)
+          inserted_at: naive_days_ago(31),
+          updated_at: naive_days_ago(31)
         })
 
       recent =
@@ -270,6 +229,32 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
 
       refute Repo.get(Hexpm.PlugSession, stale.id)
       assert Repo.get(Hexpm.PlugSession, recent.id)
+    end
+  end
+
+  describe "purge password resets" do
+    test "deletes resets older than 90 days" do
+      user = insert(:user)
+
+      old =
+        Repo.insert!(%Hexpm.Accounts.PasswordReset{
+          key: "old-key",
+          primary_email: "old@example.com",
+          user_id: user.id,
+          inserted_at: days_ago(91)
+        })
+
+      recent =
+        Repo.insert!(%Hexpm.Accounts.PasswordReset{
+          key: "new-key",
+          primary_email: "new@example.com",
+          user_id: user.id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.Accounts.PasswordReset, old.id)
+      assert Repo.get(Hexpm.Accounts.PasswordReset, recent.id)
     end
   end
 

--- a/test/hexpm/user_sessions_test.exs
+++ b/test/hexpm/user_sessions_test.exs
@@ -653,41 +653,6 @@ defmodule Hexpm.UserSessionsTest do
 
       refute Hexpm.UserSession.active?(revoked_session)
     end
-
-    test "cleanup_expired_sessions deletes expired sessions" do
-      user = insert(:user)
-
-      # Create 3 active sessions
-      for i <- 1..3 do
-        UserSessions.create_browser_session(user, name: "Active #{i}", audit: audit_data(user))
-      end
-
-      # Create 2 expired sessions
-      expired_ids =
-        for i <- 1..2 do
-          {:ok, session, _token} =
-            UserSessions.create_browser_session(user,
-              name: "Expired #{i}",
-              audit: audit_data(user)
-            )
-
-          past_time = DateTime.add(DateTime.utc_now(), -3600, :second)
-          Repo.update!(Hexpm.UserSession.changeset(session, %{expires_at: past_time}))
-          session.id
-        end
-
-      # Run cleanup
-      {deleted_count, _} = UserSessions.cleanup_expired_sessions()
-      assert deleted_count == 2
-
-      # Verify expired sessions were deleted
-      Enum.each(expired_ids, fn id ->
-        assert Repo.get(Hexpm.UserSession, id) == nil
-      end)
-
-      # Verify active sessions still exist
-      assert UserSessions.count_for_user(user) == 3
-    end
   end
 
   describe "OAuth token expiration" do


### PR DESCRIPTION
Adds `Hexpm.ReleaseTasks.purge_expired_records/0` and a `PurgeExpiredRecords` module that deletes accumulated stale rows from seven tables on a single pass.

**Retention rules:**

| Table | Cutoff |
|---|---|
| `authorization_codes` | `expires_at < NOW()` |
| `device_codes` | `expires_at < NOW()` |
| `oauth_tokens` | `expires_at < NOW()` OR `revoked_at IS NOT NULL` |
| `user_sessions` | `expires_at < NOW()` OR `revoked_at IS NOT NULL` |
| `sessions` (Plug session store) | `updated_at < NOW() - 30d` (cookie `max_age`) |
| `password_resets` | `inserted_at < NOW() - 90d` |
| `keys` | `revoke_at IS NOT NULL AND revoke_at < NOW() - 90d` |

**Why this is needed (production today, no cleanup ever runs):**

- `oauth_tokens`: 1,043,452 rows; 100% of `client_credentials` are expired, ~419 MB.
- `user_sessions`: 1,066,387 rows; 99.7% expired, ~480 MB.

**Also removed**: `UserSessions.cleanup_expired_sessions/0`, `Tokens.cleanup_expired_tokens/0`, `DeviceCodes.cleanup_expired/0`, and `cleanup_expired_device_codes/0`. They were never called outside of tests; `PurgeExpiredRecords` is the single entry point now.

Companion ops PR (k8s nightly CronJob): hexpm/hexpm-ops#122.