### PR TITLE
Add indexes required by the nightly cleanup cron

### DIFF
--- a/priv/repo/migrations/20260419051646_add_cleanup_cascade_indexes.exs
+++ b/priv/repo/migrations/20260419051646_add_cleanup_cascade_indexes.exs
@@ -1,0 +1,61 @@
+defmodule Hexpm.Repo.Migrations.AddCleanupCascadeIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up() do
+    # Required for the nightly purge of plug sessions. The table has 100M+ rows
+    # and the cleanup query filters on updated_at; without an index this would
+    # seq-scan the entire heap.
+    create_if_not_exists(
+      index(:sessions, [:updated_at],
+        name: :sessions_updated_at_index,
+        concurrently: true
+      )
+    )
+
+    # Replace the partial oauth_tokens(user_session_id) WHERE revoked_at IS NULL
+    # index with a non-partial one. The partial cannot be matched by the FK
+    # cascade UPDATE that fires on user_sessions DELETE (the cascade has no
+    # revoked_at predicate), forcing a seq scan that is prohibitively slow on
+    # the bloated heap during bulk cleanup.
+    create_if_not_exists(
+      index(:oauth_tokens, [:user_session_id],
+        name: :oauth_tokens_user_session_id_full_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:oauth_tokens, [:user_session_id],
+        name: :oauth_tokens_user_session_id_index,
+        concurrently: true
+      )
+    )
+
+    # Drop the ad-hoc index created during the initial production cleanup;
+    # superseded by oauth_tokens_user_session_id_full_index above.
+    execute("DROP INDEX CONCURRENTLY IF EXISTS oauth_tokens_user_session_id_full_idx")
+  end
+
+  def down() do
+    execute(
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS oauth_tokens_user_session_id_index ON oauth_tokens (user_session_id) WHERE revoked_at IS NULL"
+    )
+
+    drop_if_exists(
+      index(:oauth_tokens, [:user_session_id],
+        name: :oauth_tokens_user_session_id_full_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:sessions, [:updated_at],
+        name: :sessions_updated_at_index,
+        concurrently: true
+      )
+    )
+  end
+end

--- a/priv/repo/migrations/20260419051646_add_cleanup_cascade_indexes.exs
+++ b/priv/repo/migrations/20260419051646_add_cleanup_cascade_indexes.exs
@@ -5,9 +5,6 @@ defmodule Hexpm.Repo.Migrations.AddCleanupCascadeIndexes do
   @disable_migration_lock true
 
   def up() do
-    # Required for the nightly purge of plug sessions. The table has 100M+ rows
-    # and the cleanup query filters on updated_at; without an index this would
-    # seq-scan the entire heap.
     create_if_not_exists(
       index(:sessions, [:updated_at],
         name: :sessions_updated_at_index,
@@ -15,11 +12,6 @@ defmodule Hexpm.Repo.Migrations.AddCleanupCascadeIndexes do
       )
     )
 
-    # Replace the partial oauth_tokens(user_session_id) WHERE revoked_at IS NULL
-    # index with a non-partial one. The partial cannot be matched by the FK
-    # cascade UPDATE that fires on user_sessions DELETE (the cascade has no
-    # revoked_at predicate), forcing a seq scan that is prohibitively slow on
-    # the bloated heap during bulk cleanup.
     create_if_not_exists(
       index(:oauth_tokens, [:user_session_id],
         name: :oauth_tokens_user_session_id_full_index,
@@ -34,8 +26,6 @@ defmodule Hexpm.Repo.Migrations.AddCleanupCascadeIndexes do
       )
     )
 
-    # Drop the ad-hoc index created during the initial production cleanup;
-    # superseded by oauth_tokens_user_session_id_full_index above.
     execute("DROP INDEX CONCURRENTLY IF EXISTS oauth_tokens_user_session_id_full_idx")
   end
 


### PR DESCRIPTION
Two indexes the purge job (#1507) needs to be feasible:

- **`sessions_updated_at_index`** — `sessions(updated_at)`. The Plug session store has 100M+ rows; without an index on `updated_at` the cleanup query seq-scans the entire 16 GB heap.

- **`oauth_tokens_user_session_id_full_index`** — `oauth_tokens(user_session_id)` non-partial. Replaces the existing partial `WHERE revoked_at IS NULL` index. When `user_sessions` rows are deleted, Postgres fires a FK SET NULL cascade `UPDATE oauth_tokens SET user_session_id = NULL WHERE user_session_id = $1` per row — and that statement has no `revoked_at` predicate, so the planner cannot match the partial index. The cascade falls back to a seq scan over the 420 MB `oauth_tokens` heap, which times out under any non-trivial cleanup volume. The partial index is dropped because the new full index covers all use cases (including the app queries that filter on `is_nil(revoked_at)`) and steady-state cardinality is roughly equal anyway.

Also drops `oauth_tokens_user_session_id_full_idx` (ad-hoc index created in prod during the initial bulk cleanup, superseded by the named index above).

Both indexes built `CONCURRENTLY` with `@disable_ddl_transaction true`.