### PR TITLE
Drop unused indexes

### DIFF
--- a/priv/repo/migrations/20260419071136_drop_more_unused_indexes.exs
+++ b/priv/repo/migrations/20260419071136_drop_more_unused_indexes.exs
@@ -1,4 +1,4 @@
-defmodule Hexpm.Repo.Migrations.DropUnusedIndexes do
+defmodule Hexpm.Repo.Migrations.DropMoreUnusedIndexes do
   use Ecto.Migration
 
   @disable_ddl_transaction true
@@ -53,9 +53,51 @@ defmodule Hexpm.Repo.Migrations.DropUnusedIndexes do
         concurrently: true
       )
     )
+
+    drop_if_exists(
+      index(:oauth_tokens, [:client_id],
+        name: :oauth_tokens_client_id_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:oauth_tokens, [:organization_id],
+        name: :oauth_tokens_organization_id_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:user_sessions, [:client_id],
+        name: :user_sessions_client_id_index,
+        concurrently: true
+      )
+    )
   end
 
   def down() do
+    create_if_not_exists(
+      index(:user_sessions, [:client_id],
+        name: :user_sessions_client_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:oauth_tokens, [:organization_id],
+        name: :oauth_tokens_organization_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:oauth_tokens, [:client_id],
+        name: :oauth_tokens_client_id_index,
+        concurrently: true
+      )
+    )
+
     create_if_not_exists(
       index(:authorization_codes, [:user_id],
         name: :authorization_codes_user_id_index,

--- a/priv/repo/migrations/20260419071136_drop_unused_indexes.exs
+++ b/priv/repo/migrations/20260419071136_drop_unused_indexes.exs
@@ -1,0 +1,108 @@
+defmodule Hexpm.Repo.Migrations.DropUnusedIndexes do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up() do
+    drop_if_exists(
+      index(:sessions, ["((data->>'user_id')::integer)"],
+        name: :sessions__data__user_id__integer_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:package_downloads, [:view],
+        name: :package_downloads_view_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:organizations, [:public],
+        name: :organizations_public_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:blocked_addresses, [:ip],
+        name: :blocked_addresses_ip_idx,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:oauth_tokens, [:refresh_token_expires_at],
+        name: :oauth_tokens_refresh_token_expires_at_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:device_codes, [:user_id],
+        name: :device_codes_user_id_index,
+        concurrently: true
+      )
+    )
+
+    drop_if_exists(
+      index(:authorization_codes, [:user_id],
+        name: :authorization_codes_user_id_index,
+        concurrently: true
+      )
+    )
+  end
+
+  def down() do
+    create_if_not_exists(
+      index(:authorization_codes, [:user_id],
+        name: :authorization_codes_user_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:device_codes, [:user_id],
+        name: :device_codes_user_id_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:oauth_tokens, [:refresh_token_expires_at],
+        name: :oauth_tokens_refresh_token_expires_at_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:blocked_addresses, [:ip],
+        name: :blocked_addresses_ip_idx,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:organizations, [:public],
+        name: :organizations_public_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:package_downloads, [:view],
+        name: :package_downloads_view_index,
+        concurrently: true
+      )
+    )
+
+    create_if_not_exists(
+      index(:sessions, ["((data->>'user_id')::integer)"],
+        name: :sessions__data__user_id__integer_index,
+        concurrently: true
+      )
+    )
+  end
+end


### PR DESCRIPTION
Drops 10 unused indexes from the post-cleanup snapshot. Each has 0 idx_scans over a 42-hour window in production and no live code path queries by the indexed column.

| Index | Size |
|---|---:|
| `sessions__data__user_id__integer_index` | 101 MB |
| `package_downloads_view_index` | 2.1 MB |
| `organizations_public_index` | 32 KB |
| `blocked_addresses_ip_idx` | 64 KB |
| `oauth_tokens_refresh_token_expires_at_index` | 16 KB |
| `oauth_tokens_client_id_index` | 16 KB |
| `oauth_tokens_organization_id_index` | 16 KB |
| `device_codes_user_id_index` | 16 KB |
| `user_sessions_client_id_index` | 48 KB |
| `authorization_codes_user_id_index` | 8 KB |

`sessions__data__user_id__integer_index` accounts for almost all of the reclaim. Plug sessions are only looked up by primary key (`HexpmWeb.Session.get/3`) or purged in bulk by `updated_at` — nothing queries by `(data->>'user_id')::integer`. Password reset revokes `user_sessions`/oauth tokens, not plug sessions.

The three `*_client_id` / `*_organization_id` indexes only protect the FK ON DELETE CASCADE path on `oauth_clients` / `organizations`. Neither parent is deleted in production (`Hexpm.OAuth.Clients.delete/1` is defined but never called from app code; org deletes don't happen). Kept `audit_logs_key_id_index` because the nightly key purge does fire its `ON DELETE SET NULL` cascade.

Migration uses `CREATE/DROP INDEX CONCURRENTLY` with `@disable_ddl_transaction true`, and `down/0` recreates each index. Filename slug differs from the 2022 `drop_unused_indexes` migration to avoid an Ecto duplicate-name check.