### PR TITLE
Drop unused organizations.public column

### DIFF
--- a/priv/repo/migrations/20260419152629_drop_organizations_public.exs
+++ b/priv/repo/migrations/20260419152629_drop_organizations_public.exs
@@ -1,0 +1,9 @@
+defmodule Hexpm.Repo.Migrations.DropOrganizationsPublic do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organizations) do
+      remove(:public, :boolean, default: false, null: false)
+    end
+  end
+end


### PR DESCRIPTION
Leftover from the 2018 `repositories` → `organizations` rename. The 2022 commit that removed `Repository.public` (`f914d5d`) only touched the post-split `repositories` table — `organizations.public` survived but has been dead since.

- Not declared in the `Organization` Ecto schema (lib/hexpm/accounts/organization.ex:8–13).
- No code references it in hexpm, hexpm_billing, hexpm-ops, or hexdocs.
- Production data: 1,294 rows `false`, 1 row `true` (id=1, the hexpm org). Callers already use `Repository.id == 1` / `Organization.id == 1` for the same check.
- Dropping the column auto-drops `organizations_public_index` (also covered by #1509, where `drop_if_exists` makes the redundancy a no-op). 