### PR TITLE
Show all licenses separated by comma

### DIFF
--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -344,24 +344,8 @@ defmodule HexpmWeb.Components.PackageLayout do
                       </p>
                       <div class="flex items-center gap-1.5 flex-wrap">
                         <p class="text-grey-700 dark:text-grey-100 font-bold">
-                          {List.first(@licenses)}
+                          {Enum.join(@licenses, ", ")}
                         </p>
-                        <%= if length(@licenses) > 1 do %>
-                          <div class="relative group">
-                            <span class="text-xs font-medium text-purple-600 dark:text-primary-300 cursor-default">
-                              +{length(@licenses) - 1} more
-                            </span>
-                            <div class="absolute bottom-full left-0 mb-1.5 hidden group-hover:block z-10">
-                              <div class="bg-grey-900 text-white text-xs rounded-lg px-3 py-2 whitespace-nowrap shadow-lg">
-                                <%= for license <- tl(@licenses) do %>
-                                  <p>{license}</p>
-                                <% end %>
-                                <div class="absolute top-full left-3 border-4 border-transparent border-t-grey-900">
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        <% end %>
                       </div>
                     </div>
                   <% end %>


### PR DESCRIPTION
Fixes #1500 

Changes the licenses in the package layout to show all separated by comma.

Here is an example of how the change handles many licenses: 
<img width="377" height="462" alt="Screenshot 2026-04-20 at 07 03 47" src="https://github.com/user-attachments/assets/be64d9a5-c602-4240-b75e-0bbd16123d22" />
