### PR TITLE
fix: Use proper plurals for dependency and dependant counts

### DIFF
--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -67,6 +67,10 @@ defmodule HexpmWeb.Components.PackageLayout do
       )
       |> assign(:this_version_downloads, version_downloads(assigns))
       |> assign(:package_reports_enabled, @package_reports_enabled)
+      |> assign(
+        :dependency_count,
+        assigns.current_release && Enum.count(assigns.current_release.requirements || [])
+      )
 
     ~H"""
     <div class="bg-grey-50 dark:bg-grey-950 min-h-screen">
@@ -166,7 +170,9 @@ defmodule HexpmWeb.Components.PackageLayout do
                   class={tab_class(@active_tab == :dependencies)}
                 >
                   {HexpmWeb.ViewIcons.icon(:heroicon, "document", class: "size-4.5")}
-                  <span>{Enum.count(@current_release.requirements || [])} Dependencies</span>
+                  <span>
+                    {@dependency_count} {pluralize(@dependency_count, "Dependency", "Dependencies")}
+                  </span>
                 </a>
               <% end %>
               <a
@@ -174,7 +180,9 @@ defmodule HexpmWeb.Components.PackageLayout do
                 class={tab_class(@active_tab == :dependants)}
               >
                 {HexpmWeb.ViewIcons.icon(:heroicon, "document", class: "size-4.5")}
-                <span>{@dependants_count} Dependants</span>
+                <span>
+                  {@dependants_count} {pluralize(@dependants_count, "Dependant", "Dependants")}
+                </span>
               </a>
               <a
                 href={audit_logs_path(@package)}
@@ -497,4 +505,7 @@ defmodule HexpmWeb.Components.PackageLayout do
   defp tab_class(false),
     do:
       "flex items-center gap-1 px-[18px] py-3 text-grey-500 dark:text-grey-300 font-medium hover:text-grey-700 dark:hover:text-grey-200 transition-colors whitespace-nowrap"
+
+  defp pluralize(1, singular, _plural), do: singular
+  defp pluralize(_count, _singular, plural), do: plural
 end

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -232,7 +232,38 @@ defmodule HexpmWeb.PackageControllerTest do
   describe "GET /packages/:name" do
     test "show package", %{package1: package1} do
       conn = get(build_conn(), "/packages/#{package1.name}")
-      assert response(conn, 200) =~ escape(~s({:#{package1.name}, "~> 0.0.2"}))
+      html = response(conn, 200)
+
+      assert html =~ escape(~s({:#{package1.name}, "~> 0.0.2"}))
+
+      assert {:ok, document} = Floki.parse_document(html)
+      assert link_text(document, "/packages/#{package1.name}/dependents") == "0 Dependants"
+      assert link_text(document, "/packages/#{package1.name}/dependencies") == "0 Dependencies"
+    end
+
+    test "show package uses singular dependant label for one dependant", %{package1: package1} do
+      add_dependant(package1, "single_dependant")
+
+      html =
+        build_conn()
+        |> get("/packages/#{package1.name}")
+        |> html_response(200)
+
+      assert {:ok, document} = Floki.parse_document(html)
+      assert link_text(document, "/packages/#{package1.name}/dependents") == "1 Dependant"
+    end
+
+    test "show package uses plural dependant label for multiple dependants", %{package1: package1} do
+      add_dependant(package1, "first_dependant")
+      add_dependant(package1, "second_dependant")
+
+      html =
+        build_conn()
+        |> get("/packages/#{package1.name}")
+        |> html_response(200)
+
+      assert {:ok, document} = Floki.parse_document(html)
+      assert link_text(document, "/packages/#{package1.name}/dependents") == "2 Dependants"
     end
 
     test "package name is case sensitive", %{package1: package1} do
@@ -453,5 +484,26 @@ defmodule HexpmWeb.PackageControllerTest do
   defp escape(html) do
     {:safe, safe} = Phoenix.HTML.html_escape(html)
     IO.iodata_to_binary(safe)
+  end
+
+  defp add_dependant(package, name) do
+    dependant = insert(:package, name: name, repository_id: package.repository_id)
+
+    release =
+      insert(
+        :release,
+        package: dependant,
+        meta: build(:release_metadata, app: dependant.name)
+      )
+
+    insert(:requirement, release: release, dependency: package, requirement: "~> 0.0.1")
+  end
+
+  defp link_text(document, href) do
+    document
+    |> Floki.find(~s(a[href="#{href}"]))
+    |> Floki.text(sep: " ")
+    |> String.replace(~r/\s+/, " ")
+    |> String.trim()
   end
 end


### PR DESCRIPTION
This fixes the `/packages/:name` view to use the singular in tab labels when a package has 1 dependency or 1 dependant.

| Before | After |
|--------|------|
|  <img width="463" height="88" alt="image" src="https://github.com/user-attachments/assets/ebc330d6-b9d5-4d6a-af37-61bc5a32a281" /> |   <img width="459" height="79" alt="image" src="https://github.com/user-attachments/assets/83182200-eb0e-441a-b09a-526d77d1a161" /> |