### PR TITLE
Optimize package_dependants delete trigger

### DIFF
--- a/priv/repo/migrations/20260420120000_optimize_package_dependants_delete_trigger.exs
+++ b/priv/repo/migrations/20260420120000_optimize_package_dependants_delete_trigger.exs
@@ -2,12 +2,14 @@ defmodule Hexpm.Repo.Migrations.OptimizePackageDependantsDeleteTrigger do
   use Ecto.Migration
 
   def up() do
-    create table(:package_dependants_deleted_releases, primary_key: false) do
-      add :backend_pid, :bigint, null: false
-      add :xact_id, :bigint, null: false
-      add :release_id, :integer, null: false
-      add :package_id, :integer, null: false
-    end
+    execute("""
+    CREATE UNLOGGED TABLE package_dependants_deleted_releases (
+      backend_pid bigint NOT NULL,
+      xact_id bigint NOT NULL,
+      release_id integer NOT NULL,
+      package_id integer NOT NULL
+    )
+    """)
 
     create unique_index(
              :package_dependants_deleted_releases,
@@ -24,8 +26,7 @@ defmodule Hexpm.Repo.Migrations.OptimizePackageDependantsDeleteTrigger do
         backend_pid, xact_id, release_id, package_id
       )
       VALUES (pg_backend_pid(), txid_current(), OLD.id, OLD.package_id)
-      ON CONFLICT (backend_pid, xact_id, release_id)
-        DO UPDATE SET package_id = EXCLUDED.package_id;
+      ON CONFLICT (backend_pid, xact_id, release_id) DO NOTHING;
       RETURN OLD;
     END;
     $$ LANGUAGE plpgsql;

--- a/priv/repo/migrations/20260420120000_optimize_package_dependants_delete_trigger.exs
+++ b/priv/repo/migrations/20260420120000_optimize_package_dependants_delete_trigger.exs
@@ -1,0 +1,125 @@
+defmodule Hexpm.Repo.Migrations.OptimizePackageDependantsDeleteTrigger do
+  use Ecto.Migration
+
+  def up() do
+    create table(:package_dependants_deleted_releases, primary_key: false) do
+      add :backend_pid, :bigint, null: false
+      add :xact_id, :bigint, null: false
+      add :release_id, :integer, null: false
+      add :package_id, :integer, null: false
+    end
+
+    create unique_index(
+             :package_dependants_deleted_releases,
+             [:backend_pid, :xact_id, :release_id]
+           )
+
+    execute("""
+    CREATE OR REPLACE FUNCTION package_dependants_cache_deleted_release() RETURNS trigger AS $$
+    BEGIN
+      -- requirements are deleted by ON DELETE CASCADE, and once that happens
+      -- the requirements trigger can no longer resolve release_id -> package_id
+      -- through releases. Cache the mapping before the release row disappears.
+      INSERT INTO package_dependants_deleted_releases (
+        backend_pid, xact_id, release_id, package_id
+      )
+      VALUES (pg_backend_pid(), txid_current(), OLD.id, OLD.package_id)
+      ON CONFLICT (backend_pid, xact_id, release_id)
+        DO UPDATE SET package_id = EXCLUDED.package_id;
+      RETURN OLD;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+    CREATE OR REPLACE FUNCTION package_dependants_cleanup_deleted_releases() RETURNS trigger AS $$
+    BEGIN
+      DELETE FROM package_dependants_deleted_releases cache
+      USING old_releases
+      WHERE cache.backend_pid = pg_backend_pid()
+        AND cache.xact_id = txid_current()
+        AND cache.release_id = old_releases.id;
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("""
+    CREATE OR REPLACE FUNCTION package_dependants_delete() RETURNS trigger AS $$
+    BEGIN
+      WITH affected AS (
+        SELECT DISTINCT
+          old_req.dependency_id,
+          COALESCE(rel.package_id, cache.package_id) AS package_id
+        FROM old_requirements old_req
+        LEFT JOIN releases rel ON rel.id = old_req.release_id
+        LEFT JOIN package_dependants_deleted_releases cache
+          ON cache.backend_pid = pg_backend_pid()
+         AND cache.xact_id = txid_current()
+         AND cache.release_id = old_req.release_id
+        WHERE COALESCE(rel.package_id, cache.package_id) IS NOT NULL
+      )
+      DELETE FROM package_dependants pd
+      USING affected
+      WHERE pd.dependency_id = affected.dependency_id
+        AND pd.package_id = affected.package_id
+        AND NOT EXISTS (
+          SELECT 1 FROM requirements req
+          JOIN releases rel ON rel.id = req.release_id
+          WHERE req.dependency_id = affected.dependency_id
+            AND rel.package_id = affected.package_id
+        );
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("DROP TRIGGER IF EXISTS package_dependants_before_release_delete ON releases")
+
+    execute("""
+    CREATE TRIGGER package_dependants_before_release_delete
+    BEFORE DELETE ON releases
+    FOR EACH ROW EXECUTE FUNCTION package_dependants_cache_deleted_release();
+    """)
+
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_release_delete ON releases")
+
+    execute("""
+    CREATE TRIGGER package_dependants_after_release_delete
+    AFTER DELETE ON releases
+    REFERENCING OLD TABLE AS old_releases
+    FOR EACH STATEMENT EXECUTE FUNCTION package_dependants_cleanup_deleted_releases();
+    """)
+  end
+
+  def down() do
+    execute("""
+    CREATE OR REPLACE FUNCTION package_dependants_delete() RETURNS trigger AS $$
+    BEGIN
+      DELETE FROM package_dependants pd
+      WHERE pd.dependency_id IN (SELECT DISTINCT dependency_id FROM old_requirements)
+        AND NOT EXISTS (
+          SELECT 1 FROM requirements req
+          JOIN releases rel ON rel.id = req.release_id
+          WHERE req.dependency_id = pd.dependency_id
+            AND rel.package_id = pd.package_id
+        );
+      RETURN NULL;
+    END;
+    $$ LANGUAGE plpgsql;
+    """)
+
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_release_delete ON releases")
+    execute("DROP TRIGGER IF EXISTS package_dependants_before_release_delete ON releases")
+    execute("DROP FUNCTION IF EXISTS package_dependants_cleanup_deleted_releases()")
+    execute("DROP FUNCTION IF EXISTS package_dependants_cache_deleted_release()")
+
+    drop_if_exists unique_index(:package_dependants_deleted_releases, [
+                     :backend_pid,
+                     :xact_id,
+                     :release_id
+                   ])
+
+    drop_if_exists table(:package_dependants_deleted_releases)
+  end
+end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.Repository.PackageTest do
   use Hexpm.DataCase
 
   alias Hexpm.Accounts.User
-  alias Hexpm.Repository.{Package, Packages, Repository}
+  alias Hexpm.Repository.{Package, Packages, Releases, Repository}
 
   setup do
     user = insert(:user)
@@ -357,6 +357,71 @@ defmodule Hexpm.Repository.PackageTest do
              |> Enum.map(& &1.id)
   end
 
+  test "reverting a release only removes affected dependant pairs", %{
+    repository: repository,
+    user: user
+  } do
+    dependency = %{
+      insert(:package, name: "dependency", repository_id: repository.id)
+      | repository: repository
+    }
+
+    survivor = %{
+      insert(:package, name: "survivor", repository_id: repository.id)
+      | repository: repository
+    }
+
+    doomed = %{
+      insert(:package, name: "doomed", repository_id: repository.id)
+      | repository: repository
+    }
+
+    shared_packages =
+      for index <- 1..4 do
+        insert(:package, name: "shared#{index}", repository_id: repository.id)
+      end
+
+    survivor_release_one = %{
+      insert(:release, package: survivor, version: "1.0.0")
+      | package: survivor
+    }
+
+    survivor_release_two = %{
+      insert(:release, package: survivor, version: "2.0.0")
+      | package: survivor
+    }
+
+    doomed_release = %{insert(:release, package: doomed, version: "1.0.0") | package: doomed}
+
+    for package <- shared_packages do
+      release = insert(:release, package: package, version: "1.0.0")
+      insert(:requirement, release: release, dependency: dependency, requirement: "~> 1.0")
+    end
+
+    for release <- [survivor_release_one, survivor_release_two, doomed_release] do
+      insert(:requirement, release: release, dependency: dependency, requirement: "~> 1.0")
+    end
+
+    assert 6 = Package.count_dependants([repository], dependency) |> Repo.one!()
+
+    assert ["doomed", "shared1", "shared2", "shared3", "shared4", "survivor"] =
+             dependant_names(repository, dependency)
+
+    assert :ok = Releases.revert(doomed, doomed_release, audit: audit_data(user))
+
+    assert 5 = Package.count_dependants([repository], dependency) |> Repo.one!()
+
+    assert ["shared1", "shared2", "shared3", "shared4", "survivor"] =
+             dependant_names(repository, dependency)
+
+    assert :ok = Releases.revert(survivor, survivor_release_one, audit: audit_data(user))
+
+    assert 5 = Package.count_dependants([repository], dependency) |> Repo.one!()
+
+    assert ["shared1", "shared2", "shared3", "shared4", "survivor"] =
+             dependant_names(repository, dependency)
+  end
+
   test "depends search can return private packages if caller passes a broad repository list", %{
     repository: repository
   } do
@@ -507,6 +572,12 @@ defmodule Hexpm.Repository.PackageTest do
 
   defp search_for(repository, search_term) do
     Package.all([repository], 1, 10, search_term, :name, nil)
+    |> Repo.all()
+    |> Enum.map(& &1.name)
+  end
+
+  defp dependant_names(repository, dependency) do
+    Package.dependants([repository], dependency, 1, 20, :name, nil)
     |> Repo.all()
     |> Enum.map(& &1.name)
   end


### PR DESCRIPTION
## Summary
- cache deleted release package ids during release deletes so the requirements trigger can still resolve affected pairs during cascades
- narrow package_dependants cleanup to only the affected dependency/package pairs instead of scanning every dependant for a dependency
- add a regression covering release revert when many packages share a dependency and one package has multiple dependent releases

## Testing
- MIX_ENV=test mix test test/hexpm/repository/package_test.exs