### PR TITLE
Remove unused session helpers

### DIFF
--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -280,29 +280,6 @@ defmodule Hexpm.UserSessions do
   end
 
   @doc """
-  Gets all active browser sessions for a user.
-  """
-  def all_browser_for_user(user) do
-    from(s in UserSession,
-      where: s.user_id == ^user.id and s.type == "browser" and is_nil(s.revoked_at),
-      order_by: [desc: s.inserted_at]
-    )
-    |> Repo.all()
-  end
-
-  @doc """
-  Gets all active OAuth sessions for a user.
-  """
-  def all_oauth_for_user(user) do
-    from(s in UserSession,
-      where: s.user_id == ^user.id and s.type == "oauth" and is_nil(s.revoked_at),
-      order_by: [desc: s.inserted_at],
-      preload: [:client]
-    )
-    |> Repo.all()
-  end
-
-  @doc """
   Revokes a session and all associated tokens (for OAuth sessions).
   """
   def revoke(session, revoke_at \\ nil, opts \\ [])


### PR DESCRIPTION
## Summary
- remove all_browser_for_user/1 and all_oauth_for_user/1 because they have no repo-local call sites
- keep all_for_user/1 as the active user session listing helper
- drop the dead API surface instead of fixing expiry behavior on unused code

## Testing
- MIX_ENV=test mix test test/hexpm/user_sessions_test.exs