### PR TITLE
Use EXISTS for docs sitemap packages

### DIFF
--- a/lib/hexpm/repository/sitemaps.ex
+++ b/lib/hexpm/repository/sitemaps.ex
@@ -15,13 +15,19 @@ defmodule Hexpm.Repository.Sitemaps do
     packages =
       from(
         p in Package,
-        join: r in assoc(p, :releases),
+        as: :package,
         order_by: p.name,
         where: p.repository_id == 1,
         where: not is_nil(p.docs_updated_at),
-        where: r.has_docs,
-        select: {p.name, p.docs_updated_at},
-        distinct: true
+        where:
+          exists(
+            from(r in Release,
+              where: r.package_id == parent_as(:package).id,
+              where: r.has_docs,
+              select: 1
+            )
+          ),
+        select: {p.name, p.docs_updated_at}
       )
       |> Repo.all()
 

--- a/test/hexpm_web/controllers/sitemap_controller_test.exs
+++ b/test/hexpm_web/controllers/sitemap_controller_test.exs
@@ -31,6 +31,21 @@ defmodule HexpmWeb.SitemapControllerTest do
     assert response(conn, 200) == expected
   end
 
+  test "GET /docs_sitemap.xml keeps one entry when a package has multiple docs releases", %{
+    package: package
+  } do
+    insert(:release, package: package, version: "0.2.0", has_docs: true)
+
+    conn = get(build_conn(), "/docs_sitemap.xml")
+
+    expected =
+      "docs_sitemap.xml"
+      |> read_fixture()
+      |> String.replace("{package}", package.name)
+
+    assert response(conn, 200) == expected
+  end
+
   test "GET /preview_sitemap.xml", %{package: package} do
     conn = get(build_conn(), "/preview_sitemap.xml")
     assert response(conn, 200) =~ "/preview/#{package.name}/0.1.0/sitemap.xml"


### PR DESCRIPTION
## Summary
- rewrite the docs sitemap package query to use EXISTS instead of joining releases and deduplicating
- keep the rendered output unchanged while letting the database filter on doc-bearing releases more directly
- add a regression showing that multiple docs releases still produce a single sitemap entry for a package

## Testing
- MIX_ENV=test mix test test/hexpm_web/controllers/sitemap_controller_test.exs