### PR TITLE
Optimize package index download sorts

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -156,6 +156,22 @@ defmodule Hexpm.Repository.Package do
     )
   end
 
+  def downloaded_package_ids(repositories, view, limit, offset) do
+    repository_ids = Enum.map(repositories, & &1.id)
+
+    from(
+      pd in PackageDownload,
+      join: p in Package,
+      on: p.id == pd.package_id,
+      where: pd.view == ^view,
+      where: p.repository_id in ^repository_ids,
+      order_by: [fragment("? DESC NULLS LAST", pd.downloads)],
+      limit: ^limit,
+      offset: ^offset,
+      select: pd.package_id
+    )
+  end
+
   def count_downloaded_dependants(repositories, dependency, view) do
     repository_ids = Enum.map(repositories, & &1.id)
 
@@ -171,6 +187,19 @@ defmodule Hexpm.Repository.Package do
     )
   end
 
+  def count_downloaded_packages(repositories, view) do
+    repository_ids = Enum.map(repositories, & &1.id)
+
+    from(
+      pd in PackageDownload,
+      join: p in Package,
+      on: p.id == pd.package_id,
+      where: pd.view == ^view,
+      where: p.repository_id in ^repository_ids,
+      select: count()
+    )
+  end
+
   def undownloaded_dependant_ids(repositories, dependency, view, limit, offset) do
     repository_ids = Enum.map(repositories, & &1.id)
 
@@ -179,6 +208,27 @@ defmodule Hexpm.Repository.Package do
       as: :package,
       where: p.repository_id in ^repository_ids,
       where: exists(dependency_exists_query(dependency.id)),
+      where:
+        not exists(
+          from(pd in PackageDownload,
+            where: pd.package_id == parent_as(:package).id,
+            where: pd.view == ^view
+          )
+        ),
+      order_by: p.id,
+      limit: ^limit,
+      offset: ^offset,
+      select: p.id
+    )
+  end
+
+  def undownloaded_package_ids(repositories, view, limit, offset) do
+    repository_ids = Enum.map(repositories, & &1.id)
+
+    from(
+      p in Package,
+      as: :package,
+      where: p.repository_id in ^repository_ids,
       where:
         not exists(
           from(pd in PackageDownload,

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -80,9 +80,13 @@ defmodule Hexpm.Repository.Packages do
   end
 
   def search(repositories, page, packages_per_page, query, sort, fields) do
-    Package.all(repositories, page, packages_per_page, query, sort, fields)
-    |> Repo.all()
-    |> attach_repositories(repositories)
+    if query == nil and sort in [:recent_downloads, :total_downloads] do
+      packages_by_downloads(repositories, page, packages_per_page, sort, fields)
+    else
+      Package.all(repositories, page, packages_per_page, query, sort, fields)
+      |> Repo.all()
+      |> attach_repositories(repositories)
+    end
   end
 
   def dependants(repositories, dependency, page, packages_per_page, sort, fields \\ nil) do
@@ -118,7 +122,7 @@ defmodule Hexpm.Repository.Packages do
   end
 
   defp dependants_by_downloads(repositories, dependency, page, packages_per_page, sort, fields) do
-    view = dependant_download_view(sort)
+    view = download_view(sort)
     offset = (page - 1) * packages_per_page
 
     downloaded_ids =
@@ -159,12 +163,45 @@ defmodule Hexpm.Repository.Packages do
         downloaded_ids
       end
 
-    load_dependants(repositories, package_ids, fields)
+    load_packages(repositories, package_ids, fields)
   end
 
-  defp load_dependants(_repositories, [], _fields), do: []
+  defp packages_by_downloads(repositories, page, packages_per_page, sort, fields) do
+    view = download_view(sort)
+    offset = (page - 1) * packages_per_page
 
-  defp load_dependants(repositories, package_ids, fields) do
+    downloaded_ids =
+      Package.downloaded_package_ids(repositories, view, packages_per_page, offset)
+      |> Repo.all()
+
+    remaining = packages_per_page - length(downloaded_ids)
+
+    package_ids =
+      if remaining > 0 do
+        downloaded_count =
+          if downloaded_ids == [] and offset > 0 do
+            Repo.one!(Package.count_downloaded_packages(repositories, view))
+          else
+            offset + length(downloaded_ids)
+          end
+
+        zero_download_offset = max(offset - downloaded_count, 0)
+
+        zero_download_ids =
+          Package.undownloaded_package_ids(repositories, view, remaining, zero_download_offset)
+          |> Repo.all()
+
+        downloaded_ids ++ zero_download_ids
+      else
+        downloaded_ids
+      end
+
+    load_packages(repositories, package_ids, fields)
+  end
+
+  defp load_packages(_repositories, [], _fields), do: []
+
+  defp load_packages(repositories, package_ids, fields) do
     packages =
       package_ids
       |> Package.by_ids(fields)
@@ -176,8 +213,8 @@ defmodule Hexpm.Repository.Packages do
     Enum.map(package_ids, &Map.fetch!(packages_by_id, &1))
   end
 
-  defp dependant_download_view(:recent_downloads), do: "recent"
-  defp dependant_download_view(:total_downloads), do: "all"
+  defp download_view(:recent_downloads), do: "recent"
+  defp download_view(:total_downloads), do: "all"
 
   def recent(repository, count) do
     Repo.all(Package.recent(repository, count))

--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -123,74 +123,41 @@ defmodule Hexpm.Repository.Packages do
 
   defp dependants_by_downloads(repositories, dependency, page, packages_per_page, sort, fields) do
     view = download_view(sort)
-    offset = (page - 1) * packages_per_page
 
-    downloaded_ids =
-      Package.downloaded_dependant_ids(
-        repositories,
-        dependency,
-        view,
-        packages_per_page,
-        offset
-      )
-      |> Repo.all()
-
-    remaining = packages_per_page - length(downloaded_ids)
-
-    package_ids =
-      if remaining > 0 do
-        downloaded_count =
-          if downloaded_ids == [] and offset > 0 do
-            Repo.one!(Package.count_downloaded_dependants(repositories, dependency, view))
-          else
-            offset + length(downloaded_ids)
-          end
-
-        zero_download_offset = max(offset - downloaded_count, 0)
-
-        zero_download_ids =
-          Package.undownloaded_dependant_ids(
-            repositories,
-            dependency,
-            view,
-            remaining,
-            zero_download_offset
-          )
-          |> Repo.all()
-
-        downloaded_ids ++ zero_download_ids
-      else
-        downloaded_ids
-      end
-
-    load_packages(repositories, package_ids, fields)
+    paginate_by_downloads(repositories, page, packages_per_page, fields,
+      downloaded: &Package.downloaded_dependant_ids(repositories, dependency, view, &1, &2),
+      count: fn -> Package.count_downloaded_dependants(repositories, dependency, view) end,
+      undownloaded: &Package.undownloaded_dependant_ids(repositories, dependency, view, &1, &2)
+    )
   end
 
   defp packages_by_downloads(repositories, page, packages_per_page, sort, fields) do
     view = download_view(sort)
+
+    paginate_by_downloads(repositories, page, packages_per_page, fields,
+      downloaded: &Package.downloaded_package_ids(repositories, view, &1, &2),
+      count: fn -> Package.count_downloaded_packages(repositories, view) end,
+      undownloaded: &Package.undownloaded_package_ids(repositories, view, &1, &2)
+    )
+  end
+
+  defp paginate_by_downloads(repositories, page, packages_per_page, fields, queries) do
     offset = (page - 1) * packages_per_page
 
-    downloaded_ids =
-      Package.downloaded_package_ids(repositories, view, packages_per_page, offset)
-      |> Repo.all()
-
+    downloaded_ids = Repo.all(queries[:downloaded].(packages_per_page, offset))
     remaining = packages_per_page - length(downloaded_ids)
 
     package_ids =
       if remaining > 0 do
         downloaded_count =
           if downloaded_ids == [] and offset > 0 do
-            Repo.one!(Package.count_downloaded_packages(repositories, view))
+            Repo.one!(queries[:count].())
           else
             offset + length(downloaded_ids)
           end
 
         zero_download_offset = max(offset - downloaded_count, 0)
-
-        zero_download_ids =
-          Package.undownloaded_package_ids(repositories, view, remaining, zero_download_offset)
-          |> Repo.all()
-
+        zero_download_ids = Repo.all(queries[:undownloaded].(remaining, zero_download_offset))
         downloaded_ids ++ zero_download_ids
       else
         downloaded_ids

--- a/priv/repo/migrations/20260421120000_add_package_downloads_browse_index.exs
+++ b/priv/repo/migrations/20260421120000_add_package_downloads_browse_index.exs
@@ -1,12 +1,16 @@
 defmodule Hexpm.Repo.Migrations.AddPackageDownloadsBrowseIndex do
   use Ecto.Migration
 
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
   def up() do
     create_if_not_exists(
       index(
         :package_downloads,
         [:view, "downloads DESC NULLS LAST", :package_id],
-        name: :package_downloads_view_downloads_package_id_idx
+        name: :package_downloads_view_downloads_package_id_idx,
+        concurrently: true
       )
     )
   end
@@ -16,7 +20,8 @@ defmodule Hexpm.Repo.Migrations.AddPackageDownloadsBrowseIndex do
       index(
         :package_downloads,
         [:view, "downloads DESC NULLS LAST", :package_id],
-        name: :package_downloads_view_downloads_package_id_idx
+        name: :package_downloads_view_downloads_package_id_idx,
+        concurrently: true
       )
     )
   end

--- a/priv/repo/migrations/20260421120000_add_package_downloads_browse_index.exs
+++ b/priv/repo/migrations/20260421120000_add_package_downloads_browse_index.exs
@@ -1,0 +1,23 @@
+defmodule Hexpm.Repo.Migrations.AddPackageDownloadsBrowseIndex do
+  use Ecto.Migration
+
+  def up() do
+    create_if_not_exists(
+      index(
+        :package_downloads,
+        [:view, "downloads DESC NULLS LAST", :package_id],
+        name: :package_downloads_view_downloads_package_id_idx
+      )
+    )
+  end
+
+  def down() do
+    drop_if_exists(
+      index(
+        :package_downloads,
+        [:view, "downloads DESC NULLS LAST", :package_id],
+        name: :package_downloads_view_downloads_package_id_idx
+      )
+    )
+  end
+end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -468,6 +468,39 @@ defmodule Hexpm.Repository.PackageTest do
              |> Enum.map(& &1.id)
   end
 
+  test "search packages by total downloads uses download order and repo scoping", %{
+    repository: repository
+  } do
+    private_repo = insert(:repository)
+    top = insert(:package, name: "top", repository_id: repository.id)
+    middle = insert(:package, name: "middle", repository_id: repository.id)
+    zero = insert(:package, name: "zero", repository_id: repository.id)
+    hidden = insert(:package, name: "hidden", repository_id: private_repo.id)
+
+    insert(:release,
+      package: top,
+      daily_downloads: [build(:download, package_id: top.id, downloads: 10)]
+    )
+
+    insert(:release,
+      package: middle,
+      daily_downloads: [build(:download, package_id: middle.id, downloads: 5)]
+    )
+
+    insert(:release, package: zero)
+
+    insert(:release,
+      package: hidden,
+      daily_downloads: [build(:download, package_id: hidden.id, downloads: 100)]
+    )
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [top.id, middle.id, zero.id] ==
+             Packages.search([repository], 1, 10, nil, :total_downloads, nil)
+             |> Enum.map(& &1.id)
+  end
+
   test "sort packages by recent downloads", %{repository: repository} do
     %{id: ecto_id} = insert(:package, repository_id: repository.id)
     %{id: phoenix_id} = insert(:package, repository_id: repository.id)
@@ -502,6 +535,29 @@ defmodule Hexpm.Repository.PackageTest do
     assert [decimal_id, ecto_id, phoenix_id] ==
              Package.all([repository], 1, 10, nil, :recent_downloads, nil)
              |> Repo.all()
+             |> Enum.map(& &1.id)
+  end
+
+  test "search packages by recent downloads paginates into zero-download packages", %{
+    repository: repository
+  } do
+    top = insert(:package, name: "top", repository_id: repository.id)
+    zero_one = insert(:package, name: "zero_one", repository_id: repository.id)
+    zero_two = insert(:package, name: "zero_two", repository_id: repository.id)
+
+    insert(:release,
+      package: top,
+      daily_downloads: [build(:download, package_id: top.id, downloads: 10)]
+    )
+
+    for package <- [zero_one, zero_two] do
+      insert(:release, package: package)
+    end
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [zero_two.id] ==
+             Packages.search([repository], 2, 2, nil, :recent_downloads, nil)
              |> Enum.map(& &1.id)
   end
 

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -561,6 +561,29 @@ defmodule Hexpm.Repository.PackageTest do
              |> Enum.map(& &1.id)
   end
 
+  test "search packages by recent downloads fills first page with zero-download packages", %{
+    repository: repository
+  } do
+    top = insert(:package, name: "top", repository_id: repository.id)
+    zero_one = insert(:package, name: "zero_one", repository_id: repository.id)
+    zero_two = insert(:package, name: "zero_two", repository_id: repository.id)
+
+    insert(:release,
+      package: top,
+      daily_downloads: [build(:download, package_id: top.id, downloads: 10)]
+    )
+
+    for package <- [zero_one, zero_two] do
+      insert(:release, package: package)
+    end
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [top.id, zero_one.id] ==
+             Packages.search([repository], 1, 2, nil, :recent_downloads, nil)
+             |> Enum.map(& &1.id)
+  end
+
   defp search_for(repository, search_term) do
     Package.all([repository], 1, 10, search_term, :name, nil)
     |> Repo.all()


### PR DESCRIPTION
## Summary
- special-case the HTML package browse path when there is no search term and the sort is recent or total downloads
- fetch ranked package ids from package_downloads first, then backfill zero-download packages only when a page under-fills, preserving the current NULLS LAST behavior
- add a supporting package_downloads browse index and regression coverage for repo scoping and late-page zero-download pagination

## Scope
- this changes Packages.search/6, which is what the HTML package index uses
- it intentionally does not change the API search_with_versions/5 path in this PR

## Testing
- MIX_ENV=test mix test test/hexpm/repository/package_test.exs
- MIX_ENV=test mix test test/hexpm_web/controllers/package_controller_test.exs