### PR TITLE
Split full API scope for OAuth consent

### DIFF
--- a/lib/hexpm/oauth/clients.ex
+++ b/lib/hexpm/oauth/clients.ex
@@ -76,8 +76,13 @@ defmodule Hexpm.OAuth.Clients do
   """
   def supports_scopes?(%Client{allowed_scopes: allowed_scopes}, requested_scopes) do
     Enum.all?(requested_scopes, fn scope ->
-      scope in allowed_scopes or resource_scope_allowed_by_base?(scope, allowed_scopes)
+      scope in allowed_scopes or api_scope_allowed_by_full_api?(scope, allowed_scopes) or
+        resource_scope_allowed_by_base?(scope, allowed_scopes)
     end)
+  end
+
+  defp api_scope_allowed_by_full_api?(scope, allowed_scopes) do
+    scope in ["api:read", "api:write"] and "api" in allowed_scopes
   end
 
   # Check if a resource-specific scope (e.g., "docs:acme") is allowed

--- a/lib/hexpm/oauth/device_codes.ex
+++ b/lib/hexpm/oauth/device_codes.ex
@@ -2,6 +2,7 @@ defmodule Hexpm.OAuth.DeviceCodes do
   use Hexpm.Context
 
   alias Hexpm.OAuth.{DeviceCode, Token, Tokens}
+  alias Hexpm.Permissions
   alias Hexpm.UserSessions
 
   @default_device_code_expiry_seconds 10 * 60
@@ -13,6 +14,7 @@ defmodule Hexpm.OAuth.DeviceCodes do
   for the client to display to the user.
   """
   def initiate_device_authorization(conn, client_id, scopes, opts \\ []) do
+    scopes = Permissions.expand_api_scope(scopes)
     device_code = generate_device_code()
     user_code = generate_user_code()
     expires_at = DateTime.add(DateTime.utc_now(), @default_device_code_expiry_seconds, :second)

--- a/lib/hexpm/permissions.ex
+++ b/lib/hexpm/permissions.ex
@@ -66,6 +66,19 @@ defmodule Hexpm.Permissions do
     end
   end
 
+  @doc """
+  Expands the full API scope into the granular API scopes used for interactive
+  authorization.
+  """
+  def expand_api_scope(scopes) when is_list(scopes) do
+    scopes
+    |> Enum.flat_map(fn
+      "api" -> ["api:read", "api:write"]
+      scope -> [scope]
+    end)
+    |> Enum.uniq()
+  end
+
   defp valid_scope?(scope) do
     case String.split(scope, ":", parts: 2) do
       [scope_name] ->

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -396,7 +396,10 @@ defmodule HexpmWeb.API.OAuthController do
 
   defp validate_scopes(client, scope_string)
        when is_binary(scope_string) or is_nil(scope_string) do
-    scopes = String.split(scope_string || "", " ", trim: true)
+    scopes =
+      (scope_string || "")
+      |> String.split(" ", trim: true)
+      |> Hexpm.Permissions.expand_api_scope()
 
     if Clients.supports_scopes?(client, scopes) do
       {:ok, scopes}

--- a/lib/hexpm_web/controllers/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/oauth_controller.ex
@@ -179,7 +179,10 @@ defmodule HexpmWeb.OAuthController do
 
   defp validate_scopes(client, scope_string)
        when is_binary(scope_string) or is_nil(scope_string) do
-    scopes = String.split(scope_string || "", " ", trim: true)
+    scopes =
+      (scope_string || "")
+      |> String.split(" ", trim: true)
+      |> Permissions.expand_api_scope()
 
     if Clients.supports_scopes?(client, scopes) do
       {:ok, scopes}

--- a/lib/hexpm_web/views/shared_authorization_view.ex
+++ b/lib/hexpm_web/views/shared_authorization_view.ex
@@ -102,6 +102,7 @@ defmodule HexpmWeb.SharedAuthorizationView do
             name="selected_scopes[]"
             value={@scope}
             checked={@checked}
+            disabled={@disabled}
             class="scope-checkbox"
           />
           <div class="scope-content">

--- a/test/hexpm/oauth/clients_test.exs
+++ b/test/hexpm/oauth/clients_test.exs
@@ -28,8 +28,16 @@ defmodule Hexpm.OAuth.ClientsTest do
       assert Clients.supports_scopes?(client, ["api:read", "api:write"])
     end
 
+    test "treats api as allowing granular api scopes" do
+      client = %Client{allowed_scopes: ["api"]}
+
+      assert Clients.supports_scopes?(client, ["api:read"])
+      assert Clients.supports_scopes?(client, ["api:write"])
+      assert Clients.supports_scopes?(client, ["api:read", "api:write"])
+    end
+
     test "returns false when any requested scope is not allowed" do
-      client = %Client{allowed_scopes: ["api", "api:read"]}
+      client = %Client{allowed_scopes: ["api:read"]}
 
       refute Clients.supports_scopes?(client, ["api:write"])
       refute Clients.supports_scopes?(client, ["api", "repositories"])

--- a/test/hexpm/oauth/device_flow_test.exs
+++ b/test/hexpm/oauth/device_flow_test.exs
@@ -44,7 +44,7 @@ defmodule Hexpm.OAuth.DeviceFlowTest do
 
       assert response.client_id == client.client_id
       assert response.status == "pending"
-      assert response.scopes == ["api"]
+      assert response.scopes == ["api:read", "api:write"]
     end
 
     test "creates device code with custom scopes" do

--- a/test/hexpm/permissions_test.exs
+++ b/test/hexpm/permissions_test.exs
@@ -42,6 +42,20 @@ defmodule Hexpm.PermissionsTest do
     end
   end
 
+  describe "expand_api_scope/1" do
+    test "expands full api scope into read and write scopes" do
+      assert Permissions.expand_api_scope(["api", "repositories"]) == [
+               "api:read",
+               "api:write",
+               "repositories"
+             ]
+    end
+
+    test "keeps explicit api scopes without duplicates" do
+      assert Permissions.expand_api_scope(["api:read", "api"]) == ["api:read", "api:write"]
+    end
+  end
+
   describe "resource-specific package scopes" do
     setup do
       repository = %{name: "hexpm"}

--- a/test/hexpm_web/controllers/api/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/oauth_controller_test.exs
@@ -38,6 +38,9 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["verification_uri_complete"]
       assert response["expires_in"] in 599..600
       assert response["interval"] == 5
+
+      device_code = Repo.get_by(Hexpm.OAuth.DeviceCode, device_code: response["device_code"])
+      assert device_code.scopes == ["api:read", "api:write"]
     end
 
     test "handles multiple scopes", %{client: client} do
@@ -195,7 +198,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["access_token"]
       assert response["token_type"] == "bearer"
       assert response["expires_in"] > 0
-      assert response["scope"] == "api"
+      assert response["scope"] == "api:read api:write"
     end
 
     test "returns error for invalid grant type", %{client: client, response: response} do
@@ -301,7 +304,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["refresh_token"]
       assert response["token_type"] == "bearer"
       assert response["expires_in"] > 0
-      assert response["scope"] == "api"
+      assert response["scope"] == "api:read api:write"
 
       # New tokens should be different
       refute response["access_token"] == refresh_token

--- a/test/hexpm_web/controllers/device_controller_test.exs
+++ b/test/hexpm_web/controllers/device_controller_test.exs
@@ -246,8 +246,8 @@ defmodule HexpmWeb.DeviceControllerTest do
     end
 
     test "shows error for already processed device code", %{user: user, client: client} do
-      {response, _device_code} = create_device_code(client)
-      DeviceCodes.authorize_device(response.user_code, user, ["api"])
+      {response, device_code} = create_device_code(client)
+      DeviceCodes.authorize_device(response.user_code, user, device_code.scopes)
 
       conn = login_user(build_conn(), user)
 
@@ -370,7 +370,7 @@ defmodule HexpmWeb.DeviceControllerTest do
       conn =
         post(conn, ~p"/oauth/device/authorize", %{
           "action" => "authorize",
-          "selected_scopes" => ["api"]
+          "selected_scopes" => ["api:read", "api:write"]
         })
 
       assert redirected_to(conn, 302) == "/"
@@ -381,6 +381,30 @@ defmodule HexpmWeb.DeviceControllerTest do
       updated_device_code = Repo.get(DeviceCode, device_code.id)
       assert updated_device_code.status == "authorized"
       assert updated_device_code.user_id == user.id
+    end
+
+    test "authorizes api request with read scope without 2FA", %{
+      user: user,
+      client: client
+    } do
+      {_response, device_code} = create_device_code(client)
+      conn = login_with_verified_code(build_conn(), user, device_code.user_code)
+
+      conn =
+        post(conn, ~p"/oauth/device/authorize", %{
+          "action" => "authorize",
+          "selected_scopes" => ["api:read"]
+        })
+
+      assert redirected_to(conn, 302) == "/"
+
+      token =
+        Repo.get_by(Hexpm.OAuth.Token,
+          grant_type: "urn:ietf:params:oauth:grant-type:device_code",
+          grant_reference: device_code.device_code
+        )
+
+      assert token.scopes == ["api:read"]
     end
 
     test "authorizes with selected scopes", %{user: user, client: client} do
@@ -420,7 +444,7 @@ defmodule HexpmWeb.DeviceControllerTest do
       conn =
         post(conn, ~p"/oauth/device/authorize", %{
           "action" => "authorize",
-          "selected_scopes" => ["api"]
+          "selected_scopes" => ["api:write"]
         })
 
       assert html_response(conn, 200) =~ "Two-factor authentication is required"
@@ -498,7 +522,7 @@ defmodule HexpmWeb.DeviceControllerTest do
       conn =
         post(conn, ~p"/oauth/device/authorize", %{
           "action" => "authorize",
-          "selected_scopes" => ["api"]
+          "selected_scopes" => ["api:read", "api:write"]
         })
 
       assert redirected_to(conn) == "/"
@@ -640,7 +664,7 @@ defmodule HexpmWeb.DeviceControllerTest do
       conn =
         post(conn, ~p"/oauth/device/authorize", %{
           "action" => "authorize",
-          "selected_scopes" => ["api", "repositories"]
+          "selected_scopes" => ["api:read", "api:write", "repositories"]
         })
 
       assert redirected_to(conn) == "/"

--- a/test/hexpm_web/controllers/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/oauth_controller_test.exs
@@ -92,6 +92,26 @@ defmodule HexpmWeb.OAuthControllerTest do
       assert html =~ "repositories"
     end
 
+    test "expands full api scope on authorization page", %{client: client} do
+      user = insert(:user)
+      conn = login_user(build_conn(), user)
+
+      conn =
+        get(conn, ~p"/oauth/authorize", %{
+          "client_id" => client.client_id,
+          "redirect_uri" => "https://example.com/callback",
+          "scope" => "api repositories",
+          "state" => "test_state",
+          "code_challenge" => "challenge123",
+          "code_challenge_method" => "S256"
+        })
+
+      html = html_response(conn, 200)
+      assert html =~ "api:read"
+      assert html =~ "api:write"
+      assert html =~ "repositories"
+    end
+
     test "CSP form-action includes redirect URI origin", %{client: client} do
       user = insert(:user)
       conn = login_user(build_conn(), user)
@@ -164,6 +184,27 @@ defmodule HexpmWeb.OAuthControllerTest do
       # Verify authorization code was created with only selected scopes
       auth_code = Repo.get_by(Hexpm.OAuth.AuthorizationCode, client_id: client.client_id)
       assert auth_code
+      assert auth_code.scopes == ["api:read", "repositories"]
+    end
+
+    test "approves read scope from full api request without 2FA", %{client: client, user: user} do
+      conn = login_user(build_conn(), user)
+
+      conn =
+        post(conn, ~p"/oauth/authorize", %{
+          "client_id" => client.client_id,
+          "redirect_uri" => "https://example.com/callback",
+          "scope" => "api repositories",
+          "state" => "test_state",
+          "code_challenge" => "challenge123",
+          "code_challenge_method" => "S256",
+          "action" => "approve",
+          "selected_scopes" => ["api:read", "repositories"]
+        })
+
+      assert redirected_to(conn) =~ "https://example.com/callback?code="
+
+      auth_code = Repo.get_by(Hexpm.OAuth.AuthorizationCode, client_id: client.client_id)
       assert auth_code.scopes == ["api:read", "repositories"]
     end
 

--- a/test/hexpm_web/controllers/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/oauth_controller_test.exs
@@ -110,6 +110,13 @@ defmodule HexpmWeb.OAuthControllerTest do
       assert html =~ "api:read"
       assert html =~ "api:write"
       assert html =~ "repositories"
+
+      assert {:ok, document} = Floki.parse_document(html)
+
+      assert [{"input", attrs, _}] =
+               Floki.find(document, ~s(input[value="api:write"][name="selected_scopes[]"]))
+
+      assert {"disabled", "disabled"} in attrs
     end
 
     test "CSP form-action includes redirect URI origin", %{client: client} do


### PR DESCRIPTION
Split OAuth requests for the full `api` scope into `api:read` and `api:write` during interactive consent.

This lets users without 2FA approve read-only API access while `api:write` remains blocked until 2FA is enabled.