### PR TITLE
Require api:read on authorization, refine api:write description, fix tooltip clipping

### DIFF
--- a/assets/css/tooltip.css
+++ b/assets/css/tooltip.css
@@ -1,4 +1,6 @@
-/* Tooltip component using data-tooltip attribute */
+/* Tooltip component using data-tooltip attribute.
+   Uses position: fixed so it can escape ancestor overflow contexts.
+   The --tooltip-x / --tooltip-y custom properties are set by JS on hover/focus. */
 
 .tooltip {
   position: relative;
@@ -8,10 +10,10 @@
 /* Tooltip text */
 .tooltip:before {
   content: attr(data-tooltip);
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translate(-50%, -8px);
+  position: fixed;
+  top: var(--tooltip-y, 0);
+  left: var(--tooltip-x, 0);
+  transform: translate(-50%, calc(-100% - 8px));
   background-color: #1f2937;
   color: #ffffff;
   font-size: 12px;
@@ -28,10 +30,10 @@
 /* Tooltip arrow */
 .tooltip:after {
   content: '';
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  transform: translate(-50%, -4px);
+  position: fixed;
+  top: var(--tooltip-y, 0);
+  left: var(--tooltip-x, 0);
+  transform: translate(-50%, -8px);
   border: 4px solid transparent;
   border-top-color: #1f2937;
   opacity: 0;

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -49,6 +49,29 @@ if (document.getElementById("username")) {
   document.getElementById("code").focus();
 }
 
+// Position CSS tooltips with viewport-relative coordinates so they can escape
+// ancestor overflow containers (the .tooltip pseudo-elements use position: fixed).
+function positionTooltip(el) {
+  const rect = el.getBoundingClientRect();
+  el.style.setProperty("--tooltip-x", `${rect.left + rect.width / 2}px`);
+  el.style.setProperty("--tooltip-y", `${rect.top}px`);
+}
+
+document.addEventListener("mouseover", function (e) {
+  if (!(e.target instanceof Element)) return;
+  const tooltip = e.target.closest(".tooltip");
+  if (!tooltip) return;
+  const from = e.relatedTarget instanceof Element ? e.relatedTarget.closest(".tooltip") : null;
+  if (from === tooltip) return;
+  positionTooltip(tooltip);
+});
+
+document.addEventListener("focusin", function (e) {
+  if (!(e.target instanceof Element)) return;
+  const tooltip = e.target.closest(".tooltip");
+  if (tooltip) positionTooltip(tooltip);
+});
+
 // Auto-format device verification code input
 const userCodeInput = document.getElementById("user_code");
 if (userCodeInput) {

--- a/lib/hexpm/permissions.ex
+++ b/lib/hexpm/permissions.ex
@@ -585,7 +585,7 @@ defmodule Hexpm.Permissions do
         "Read-only access to your Hex account and packages. Allows viewing packages, account information, organizations, and audit logs. Cannot modify any data."
 
       "api:write" ->
-        "Read and write access to your Hex account and packages. Includes: publish, unpublish, retire, and unretire packages; manage package owners; manage API keys."
+        "Write access to your Hex account and packages. Includes: publish, unpublish, retire, and unretire packages; manage package owners; manage API keys."
 
       "repositories" ->
         "Access to fetch packages from all private repositories you belong to. Does not grant ability to publish packages or modify repository settings."

--- a/lib/hexpm_web/views/shared_authorization_view.ex
+++ b/lib/hexpm_web/views/shared_authorization_view.ex
@@ -82,13 +82,15 @@ defmodule HexpmWeb.SharedAuthorizationView do
     description = Permissions.scope_description(assigns.scope)
     requires_2fa = assigns.scope in ["api", "api:write"]
     has_2fa = User.tfa_enabled?(assigns.current_user)
-    disabled = requires_2fa and not has_2fa
-    checked = not disabled
+    required = assigns.scope == "api:read"
+    disabled = required or (requires_2fa and not has_2fa)
+    checked = required or not disabled
 
     assigns =
       assign(assigns,
         description: description,
         requires_2fa: requires_2fa,
+        required: required,
         checked: checked,
         disabled: disabled
       )
@@ -105,11 +107,18 @@ defmodule HexpmWeb.SharedAuthorizationView do
             disabled={@disabled}
             class="scope-checkbox"
           />
+          <input :if={@required} type="hidden" name="selected_scopes[]" value={@scope} />
           <div class="scope-content">
             <div class="scope-header">
               <code class="scope-name">
                 {@scope}
               </code>
+              <span
+                :if={@required}
+                class="scope-required"
+              >
+                Required
+              </span>
               <span
                 :if={@requires_2fa}
                 class="scope-requires-2fa"
@@ -126,8 +135,10 @@ defmodule HexpmWeb.SharedAuthorizationView do
     <% else %>
       <li class="flex items-start gap-3 py-2">
         <label class={[
-          "flex items-start gap-3 cursor-pointer",
-          @disabled && "opacity-60 cursor-not-allowed"
+          "flex items-start gap-3",
+          @disabled && "cursor-not-allowed",
+          !@disabled && "cursor-pointer",
+          @disabled && !@required && "opacity-60"
         ]}>
           <input
             type="checkbox"
@@ -137,9 +148,16 @@ defmodule HexpmWeb.SharedAuthorizationView do
             disabled={@disabled}
             class="scope-checkbox mt-1 h-4 w-4 rounded border-grey-300 text-primary-600 focus:ring-primary-500"
           />
+          <input :if={@required} type="hidden" name="selected_scopes[]" value={@scope} />
           <div>
             <div class="flex items-center gap-2">
               <code class="text-sm font-semibold text-grey-900">{@scope}</code>
+              <span
+                :if={@required}
+                class="inline-flex items-center rounded-full bg-grey-100 px-2 py-0.5 text-xs font-medium text-grey-700"
+              >
+                Required
+              </span>
               <span
                 :if={@requires_2fa}
                 class="inline-flex items-center rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800"

--- a/test/hexpm/permissions_test.exs
+++ b/test/hexpm/permissions_test.exs
@@ -281,7 +281,7 @@ defmodule Hexpm.PermissionsTest do
     test "provides descriptions for all basic scopes" do
       assert Permissions.scope_description("api") =~ "Complete access"
       assert Permissions.scope_description("api:read") =~ "Read-only access"
-      assert Permissions.scope_description("api:write") =~ "Read and write access"
+      assert Permissions.scope_description("api:write") =~ "Write access"
       assert Permissions.scope_description("repositories") =~ "private repositories"
       # package and docs are no longer simple scopes - they require resources
     end


### PR DESCRIPTION
- Make api:read always checked and disabled on the OAuth device/web authorization page, with a hidden input so the value still submits.
- Drop "Read and" from the api:write scope description.
- Switch tooltips to position: fixed driven by JS-set CSS variables so they escape ancestor overflow contexts (e.g. the sessions table).