### PR TITLE
Decode `'` entity before syntax highlighting in README code blocks

### DIFF
--- a/lib/hexpm_web/controllers/readme_controller.ex
+++ b/lib/hexpm_web/controllers/readme_controller.ex
@@ -151,6 +151,7 @@ defmodule HexpmWeb.ReadmeController do
     |> String.replace("&lt;", "<")
     |> String.replace("&gt;", ">")
     |> String.replace("&quot;", "\"")
+    |> String.replace("&#39;", "'")
   end
 
   defp send_no_readme(conn) do

--- a/test/hexpm_web/controllers/readme_controller_test.exs
+++ b/test/hexpm_web/controllers/readme_controller_test.exs
@@ -229,6 +229,23 @@ defmodule HexpmWeb.ReadmeControllerTest do
       assert conn.resp_body =~ "puts"
     end
 
+    test "decodes single quotes in highlighted code blocks", %{package: package} do
+      mock_file_list_and_readme(
+        package.name,
+        "1.0.0",
+        "README.md",
+        "```erlang\n{'div', []}.\n```"
+      )
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ ~s|class="ss">&#39;div&#39;|
+    end
+
     test "preserves newlines in unhighlighted code blocks", %{package: package} do
       mock_file_list_and_readme(
         package.name,


### PR DESCRIPTION
`unescape_html/1` in the README pipeline decoded `&amp; &lt; &gt; &quot;` but missed `&#39;`. Makeup lib then received the literal entity and escaped its `&`, so the source contained `&amp;#39;`, which the browser decoded to a visible `&#39;` instead of `'`.

- Erlang atom `{'div', ...}` displays as `{&#39;div&#39;, ...}`:

<img width="1038" height="754" alt="image" src="https://github.com/user-attachments/assets/61c1e4dd-6557-42cd-9c07-b885cd5ef7ab" />

Examples from https://hex.pm/packages/arizona.