### PR TITLE
Add `hex_`-prefixed API key format with GitHub Secret Scanning support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        hex-version: [main, v2.3, v2.2, v2.1, v2.0]
+        hex-version: [main, v2.4, v2.3, v2.2, v2.1]
 
     env:
       HEXPM_PATH: ..

--- a/config/config.exs
+++ b/config/config.exs
@@ -70,6 +70,9 @@ config :mime,
 
 config :logger, :default_formatter, format: "[$level] $metadata$message\n"
 
+# Replaces Phoenix's default ["password"] — keep this list a superset of the default.
+config :phoenix, :filter_parameters, ["password", "secret", "user_secret", "authorization"]
+
 config :esbuild,
   version: "0.25.0",
   hexpm: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -131,6 +131,9 @@ config :mime,
 
 config :logger, :default_formatter, format: "[$level] $metadata$message\n"
 
+# Replaces Phoenix's default ["password"] — keep this list a superset of the default.
+config :phoenix, :filter_parameters, ["password", "secret", "user_secret", "authorization"]
+
 config :esbuild,
   version: "0.25.0",
   hexpm: [

--- a/config/config.exs
+++ b/config/config.exs
@@ -155,6 +155,9 @@ config :mime,
 
 config :logger, :default_formatter, format: "[$level] $metadata$message\n"
 
+# Replaces Phoenix's default ["password"] — keep this list a superset of the default.
+config :phoenix, :filter_parameters, ["password", "secret", "user_secret", "authorization"]
+
 config :esbuild,
   version: "0.25.0",
   hexpm: [

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,7 @@
 import Config
 
 config :hexpm,
+  github_key_cache_ttl: 0,
   repo_bucket: {Hexpm.Store.Memory, "repo_bucket"},
   logs_bucket: {Hexpm.Store.Memory, "logs_bucket"},
   secret: "796f75666f756e64746865686578",

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,7 @@
 import Config
 
 config :hexpm,
+  github_key_cache_ttl: 0,
   repo_bucket: {Hexpm.Store.Memory, "repo_bucket"},
   logs_bucket: {Hexpm.Store.Memory, "logs_bucket"},
   docs_bucket: {Hexpm.Store.Memory, "docs_bucket"},

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,7 @@
 import Config
 
 config :hexpm,
+  github_key_cache_ttl: 0,
   repo_bucket: {Hexpm.Store.Memory, "repo_bucket"},
   logs_bucket: {Hexpm.Store.Memory, "logs_bucket"},
   audit_bucket: {Hexpm.Store.Memory, "audit_bucket"},

--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -199,8 +199,8 @@ defmodule Hexpm.Accounts.Auth do
     Enum.find(user.emails, &(&1.email == email)) || Enum.find(user.emails, & &1.primary)
   end
 
-  defp strip_token_prefix(@token_prefix <> raw), do: raw
-  defp strip_token_prefix(raw), do: raw
+  def strip_token_prefix(@token_prefix <> raw), do: raw
+  def strip_token_prefix(raw), do: raw
 
   defp usage_info(info) do
     %{

--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -5,11 +5,23 @@ defmodule Hexpm.Accounts.Auth do
   alias Hexpm.Accounts.{Key, Keys, Organization, Organizations, User, Users, UserProviders}
   alias Hexpm.OAuth.{Tokens, JWT}
 
+  @token_prefix Key.token_prefix()
+
   def key_auth(user_secret, usage_info, opts \\ []) do
+    raw_secret = strip_token_prefix(user_secret)
+
+    if String.starts_with?(user_secret, @token_prefix) and not valid_checksum?(raw_secret) do
+      :error
+    else
+      key_auth_validated(raw_secret, usage_info, opts)
+    end
+  end
+
+  defp key_auth_validated(raw_secret, usage_info, opts) do
     app_secret = Application.get_env(:hexpm, :secret)
 
     <<first::binary-size(32), second::binary-size(32)>> =
-      :crypto.mac(:hmac, :sha256, app_secret, user_secret)
+      :crypto.mac(:hmac, :sha256, app_secret, raw_secret)
       |> Base.encode16(case: :lower)
 
     preload = Keyword.get(opts, :preload, :full)
@@ -165,9 +177,19 @@ defmodule Hexpm.Accounts.Auth do
   end
 
   def gen_key() do
-    :crypto.strong_rand_bytes(16)
-    |> Base.encode16(case: :lower)
+    random = :crypto.strong_rand_bytes(16)
+    checksum = <<:erlang.crc32(random)::32>>
+    Base.encode16(random <> checksum, case: :lower)
   end
+
+  defp valid_checksum?(raw) when byte_size(raw) == 40 do
+    case Base.decode16(raw, case: :lower) do
+      {:ok, <<data::binary-size(16), expected::32>>} -> :erlang.crc32(data) == expected
+      _ -> false
+    end
+  end
+
+  defp valid_checksum?(_), do: false
 
   defp find_email(nil, _email) do
     nil
@@ -176,6 +198,9 @@ defmodule Hexpm.Accounts.Auth do
   defp find_email(user, email) do
     Enum.find(user.emails, &(&1.email == email)) || Enum.find(user.emails, & &1.primary)
   end
+
+  defp strip_token_prefix(@token_prefix <> raw), do: raw
+  defp strip_token_prefix(raw), do: raw
 
   defp usage_info(info) do
     %{

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -80,16 +80,6 @@ defmodule Hexpm.Accounts.Key do
     )
   end
 
-  def get_active_by_secret_first(secret_first) do
-    from(k in Key,
-      where: k.secret_first == ^secret_first,
-      where: k.public == true,
-      where: is_nil(k.revoke_at) or k.revoke_at > fragment("NOW()"),
-      left_join: u in assoc(k, :user),
-      preload: [user: {u, :emails}]
-    )
-  end
-
   def get_revoked(user_or_organization, name) do
     from(
       k in assoc(user_or_organization, :keys),

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -4,12 +4,17 @@ defmodule Hexpm.Accounts.Key do
   @derive HexpmWeb.Stale
   @derive {Phoenix.Param, key: :name}
 
+  @token_prefix "hex_"
+
+  def token_prefix(), do: @token_prefix
+
   schema "keys" do
     field :name, :string
     field :secret_first, :string
     field :secret_second, :string
     field :public, :boolean, default: true
     field :revoke_at, :utc_datetime_usec
+    field :token_format, :string, default: "v1"
     timestamps()
 
     embeds_one :last_use, Use, on_replace: :delete do
@@ -75,6 +80,16 @@ defmodule Hexpm.Accounts.Key do
     )
   end
 
+  def get_active_by_secret_first(secret_first) do
+    from(k in Key,
+      where: k.secret_first == ^secret_first,
+      where: k.public == true,
+      where: is_nil(k.revoke_at) or k.revoke_at > fragment("NOW()"),
+      left_join: u in assoc(k, :user),
+      preload: [user: {u, :emails}]
+    )
+  end
+
   def get_revoked(user_or_organization, name) do
     from(
       k in assoc(user_or_organization, :keys),
@@ -120,11 +135,12 @@ defmodule Hexpm.Accounts.Key do
   end
 
   def gen_key() do
-    user_secret = Auth.gen_key()
+    raw_secret = Auth.gen_key()
+    user_secret = @token_prefix <> raw_secret
     app_secret = Application.get_env(:hexpm, :secret)
 
     <<first::binary-size(32), second::binary-size(32)>> =
-      :crypto.mac(:hmac, :sha256, app_secret, user_secret)
+      :crypto.mac(:hmac, :sha256, app_secret, raw_secret)
       |> Base.encode16(case: :lower)
 
     {user_secret, first, second}
@@ -136,6 +152,8 @@ defmodule Hexpm.Accounts.Key do
     |> put_embed(:last_use, struct(Key.Use, params))
   end
 
+  defp add_keys(%{valid?: false} = changeset), do: changeset
+
   defp add_keys(changeset) do
     {user_secret, first, second} = gen_key()
 
@@ -143,6 +161,7 @@ defmodule Hexpm.Accounts.Key do
     |> put_change(:user_secret, user_secret)
     |> put_change(:secret_first, first)
     |> put_change(:secret_second, second)
+    |> put_change(:token_format, "v2")
   end
 
   defp unique_name(changeset) do

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -4,12 +4,17 @@ defmodule Hexpm.Accounts.Key do
   @derive HexpmWeb.Stale
   @derive {Phoenix.Param, key: :name}
 
+  @token_prefix "hex_"
+
+  def token_prefix(), do: @token_prefix
+
   schema "keys" do
     field :name, :string
     field :secret_first, :string
     field :secret_second, :string
     field :public, :boolean, default: true
     field :revoke_at, :utc_datetime_usec
+    field :token_format, :string, default: "v1"
     timestamps()
 
     embeds_one :last_use, Use, on_replace: :delete do
@@ -76,6 +81,16 @@ defmodule Hexpm.Accounts.Key do
     )
   end
 
+  def get_active_by_secret_first(secret_first) do
+    from(k in Key,
+      where: k.secret_first == ^secret_first,
+      where: k.public == true,
+      where: is_nil(k.revoke_at) or k.revoke_at > fragment("NOW()"),
+      left_join: u in assoc(k, :user),
+      preload: [user: {u, :emails}]
+    )
+  end
+
   def get_revoked(user_or_organization, name) do
     from(
       k in assoc(user_or_organization, :keys),
@@ -121,11 +136,12 @@ defmodule Hexpm.Accounts.Key do
   end
 
   def gen_key() do
-    user_secret = Auth.gen_key()
+    raw_secret = Auth.gen_key()
+    user_secret = @token_prefix <> raw_secret
     app_secret = Application.get_env(:hexpm, :secret)
 
     <<first::binary-size(32), second::binary-size(32)>> =
-      :crypto.mac(:hmac, :sha256, app_secret, user_secret)
+      :crypto.mac(:hmac, :sha256, app_secret, raw_secret)
       |> Base.encode16(case: :lower)
 
     {user_secret, first, second}
@@ -137,6 +153,8 @@ defmodule Hexpm.Accounts.Key do
     |> put_embed(:last_use, struct(Key.Use, params))
   end
 
+  defp add_keys(%{valid?: false} = changeset), do: changeset
+
   defp add_keys(changeset) do
     {user_secret, first, second} = gen_key()
 
@@ -144,6 +162,7 @@ defmodule Hexpm.Accounts.Key do
     |> put_change(:user_secret, user_secret)
     |> put_change(:secret_first, first)
     |> put_change(:secret_second, second)
+    |> put_change(:token_format, "v2")
   end
 
   defp unique_name(changeset) do

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -81,16 +81,6 @@ defmodule Hexpm.Accounts.Key do
     )
   end
 
-  def get_active_by_secret_first(secret_first) do
-    from(k in Key,
-      where: k.secret_first == ^secret_first,
-      where: k.public == true,
-      where: is_nil(k.revoke_at) or k.revoke_at > fragment("NOW()"),
-      left_join: u in assoc(k, :user),
-      preload: [user: {u, :emails}]
-    )
-  end
-
   def get_revoked(user_or_organization, name) do
     from(
       k in assoc(user_or_organization, :keys),

--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Accounts.Keys do
   use Hexpm.Context
 
+  require Logger
+
   def all(user_or_organization) do
     Key.all(user_or_organization)
     |> Repo.all()
@@ -40,6 +42,28 @@ defmodule Hexpm.Accounts.Keys do
     else
       {:error, :not_found}
     end
+  end
+
+  @doc """
+  Looks up an active key by its `secret_first` hash, preloading the owning user
+  with emails. Used by the GitHub secret scanning revocation flow where we only
+  have the raw token, not the owner identity.
+
+  Returns `{key, user}` or `nil` if not found / already revoked.
+  """
+  def get_by_secret_first(secret_first) do
+    case Key.get_active_by_secret_first(secret_first) |> Repo.one() do
+      %Key{} = key -> {key, key.user}
+      nil -> nil
+    end
+  end
+
+  def revoke_immediately(%Key{} = key) do
+    Logger.info("Automated key revocation: key_id=#{key.id}")
+
+    key
+    |> Key.revoke()
+    |> Repo.update!()
   end
 
   def revoke_all(user_or_organization, audit: audit_data) do

--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -66,25 +66,34 @@ defmodule Hexpm.Accounts.Keys do
   end
 
   @doc """
-  Looks up an active key by its `secret_first` hash, preloading the owning user
-  with emails. Used by the GitHub secret scanning revocation flow where we only
-  have the raw token, not the owner identity.
+  Atomically revokes the active key matching `secret_first` and returns it
+  with the owning user (and their emails) preloaded. Used by the GitHub
+  secret scanning revocation flow where we only have the raw token, not the
+  owner identity.
 
-  Returns `{key, user}` or `nil` if not found / already revoked.
+  Returns `{:ok, key, user}` (where `user` is `nil` for organization-owned
+  keys), or `:not_found` when no active key matches.
   """
-  def get_by_secret_first(secret_first) do
-    case Key.get_active_by_secret_first(secret_first) |> Repo.one() do
-      %Key{} = key -> {key, key.user}
-      nil -> nil
+  def revoke_by_secret_first(secret_first) do
+    revoke_at = DateTime.add(DateTime.utc_now(), -1, :second)
+
+    query =
+      from(k in Key,
+        where: k.secret_first == ^secret_first,
+        where: is_nil(k.revoke_at) or k.revoke_at > fragment("NOW()"),
+        select: k,
+        update: [set: [revoke_at: ^revoke_at, updated_at: ^DateTime.utc_now()]]
+      )
+
+    case Repo.update_all(query, []) do
+      {1, [key]} ->
+        key = Repo.preload(key, user: :emails)
+        Logger.info("Automated key revocation: key_id=#{key.id}")
+        {:ok, key, key.user}
+
+      {0, _} ->
+        :not_found
     end
-  end
-
-  def revoke_immediately(%Key{} = key) do
-    Logger.info("Automated key revocation: key_id=#{key.id}")
-
-    key
-    |> Key.revoke()
-    |> Repo.update!()
   end
 
   def revoke_all(user_or_organization, audit: audit_data) do

--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -45,25 +45,34 @@ defmodule Hexpm.Accounts.Keys do
   end
 
   @doc """
-  Looks up an active key by its `secret_first` hash, preloading the owning user
-  with emails. Used by the GitHub secret scanning revocation flow where we only
-  have the raw token, not the owner identity.
+  Atomically revokes the active key matching `secret_first` and returns it
+  with the owning user (and their emails) preloaded. Used by the GitHub
+  secret scanning revocation flow where we only have the raw token, not the
+  owner identity.
 
-  Returns `{key, user}` or `nil` if not found / already revoked.
+  Returns `{:ok, key, user}` (where `user` is `nil` for organization-owned
+  keys), or `:not_found` when no active key matches.
   """
-  def get_by_secret_first(secret_first) do
-    case Key.get_active_by_secret_first(secret_first) |> Repo.one() do
-      %Key{} = key -> {key, key.user}
-      nil -> nil
+  def revoke_by_secret_first(secret_first) do
+    revoke_at = DateTime.add(DateTime.utc_now(), -1, :second)
+
+    query =
+      from(k in Key,
+        where: k.secret_first == ^secret_first,
+        where: is_nil(k.revoke_at) or k.revoke_at > fragment("NOW()"),
+        select: k,
+        update: [set: [revoke_at: ^revoke_at, updated_at: ^DateTime.utc_now()]]
+      )
+
+    case Repo.update_all(query, []) do
+      {1, [key]} ->
+        key = Repo.preload(key, user: :emails)
+        Logger.info("Automated key revocation: key_id=#{key.id}")
+        {:ok, key, key.user}
+
+      {0, _} ->
+        :not_found
     end
-  end
-
-  def revoke_immediately(%Key{} = key) do
-    Logger.info("Automated key revocation: key_id=#{key.id}")
-
-    key
-    |> Key.revoke()
-    |> Repo.update!()
   end
 
   def revoke_all(user_or_organization, audit: audit_data) do

--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -3,6 +3,8 @@ defmodule Hexpm.Accounts.Keys do
 
   alias Hexpm.Accounts.Organization
 
+  require Logger
+
   def all(user_or_organization) do
     Key.all(user_or_organization)
     |> Repo.all()
@@ -61,6 +63,28 @@ defmodule Hexpm.Accounts.Keys do
     else
       {:error, :not_found}
     end
+  end
+
+  @doc """
+  Looks up an active key by its `secret_first` hash, preloading the owning user
+  with emails. Used by the GitHub secret scanning revocation flow where we only
+  have the raw token, not the owner identity.
+
+  Returns `{key, user}` or `nil` if not found / already revoked.
+  """
+  def get_by_secret_first(secret_first) do
+    case Key.get_active_by_secret_first(secret_first) |> Repo.one() do
+      %Key{} = key -> {key, key.user}
+      nil -> nil
+    end
+  end
+
+  def revoke_immediately(%Key{} = key) do
+    Logger.info("Automated key revocation: key_id=#{key.id}")
+
+    key
+    |> Key.revoke()
+    |> Repo.update!()
   end
 
   def revoke_all(user_or_organization, audit: audit_data) do

--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -126,25 +126,34 @@ defmodule Hexpm.Accounts.Keys do
   end
 
   @doc """
-  Looks up an active key by its `secret_first` hash, preloading the owning user
-  with emails. Used by the GitHub secret scanning revocation flow where we only
-  have the raw token, not the owner identity.
+  Atomically revokes the active key matching `secret_first` and returns it
+  with the owning user (and their emails) preloaded. Used by the GitHub
+  secret scanning revocation flow where we only have the raw token, not the
+  owner identity.
 
-  Returns `{key, user}` or `nil` if not found / already revoked.
+  Returns `{:ok, key, user}` (where `user` is `nil` for organization-owned
+  keys), or `:not_found` when no active key matches.
   """
-  def get_by_secret_first(secret_first) do
-    case Key.get_active_by_secret_first(secret_first) |> Repo.one() do
-      %Key{} = key -> {key, key.user}
-      nil -> nil
+  def revoke_by_secret_first(secret_first) do
+    revoke_at = DateTime.add(DateTime.utc_now(), -1, :second)
+
+    query =
+      from(k in Key,
+        where: k.secret_first == ^secret_first,
+        where: is_nil(k.revoke_at) or k.revoke_at > fragment("NOW()"),
+        select: k,
+        update: [set: [revoke_at: ^revoke_at, updated_at: ^DateTime.utc_now()]]
+      )
+
+    case Repo.update_all(query, []) do
+      {1, [key]} ->
+        key = Repo.preload(key, user: :emails)
+        Logger.info("Automated key revocation: key_id=#{key.id}")
+        {:ok, key, key.user}
+
+      {0, _} ->
+        :not_found
     end
-  end
-
-  def revoke_immediately(%Key{} = key) do
-    Logger.info("Automated key revocation: key_id=#{key.id}")
-
-    key
-    |> Key.revoke()
-    |> Repo.update!()
   end
 
   def revoke_all(user_or_organization, audit: audit_data) do

--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -3,6 +3,8 @@ defmodule Hexpm.Accounts.Keys do
 
   alias Hexpm.Accounts.{Organization, OrganizationUser}
 
+  require Logger
+
   def all(user_or_organization) do
     Key.all(user_or_organization)
     |> Repo.all()
@@ -121,6 +123,28 @@ defmodule Hexpm.Accounts.Keys do
     else
       {:error, :not_found}
     end
+  end
+
+  @doc """
+  Looks up an active key by its `secret_first` hash, preloading the owning user
+  with emails. Used by the GitHub secret scanning revocation flow where we only
+  have the raw token, not the owner identity.
+
+  Returns `{key, user}` or `nil` if not found / already revoked.
+  """
+  def get_by_secret_first(secret_first) do
+    case Key.get_active_by_secret_first(secret_first) |> Repo.one() do
+      %Key{} = key -> {key, key.user}
+      nil -> nil
+    end
+  end
+
+  def revoke_immediately(%Key{} = key) do
+    Logger.info("Automated key revocation: key_id=#{key.id}")
+
+    key
+    |> Key.revoke()
+    |> Repo.update!()
   end
 
   def revoke_all(user_or_organization, audit: audit_data) do

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -7,6 +7,7 @@ defmodule Hexpm.Application do
     topologies = cluster_topologies()
     read_only_mode()
     Hexpm.BlockAddress.start()
+    Hexpm.GitHub.SecretScanning.start()
 
     children =
       [

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -8,6 +8,10 @@ defmodule Hexpm.Application do
     read_only_mode()
     Hexpm.BlockAddress.start()
 
+    if Application.fetch_env!(:hexpm, :cache_enabled) do
+      Hexpm.Cache.start()
+    end
+
     children =
       [
         Hexpm.RepoBase,
@@ -18,10 +22,6 @@ defmodule Hexpm.Application do
         HexpmWeb.RateLimitPubSub,
         {PlugAttack.Storage.Ets, name: HexpmWeb.Plugs.Attack.Storage, clean_period: 60_000},
         {Hexpm.Billing.Report, name: Hexpm.Billing.Report, interval: 60_000},
-        {Hexpm.Cache,
-         name: Hexpm.Cache,
-         interval: 3_600_000,
-         enabled: Application.fetch_env!(:hexpm, :cache_enabled)},
         goth_spec(),
         setup(),
         load_caches(),

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -7,7 +7,6 @@ defmodule Hexpm.Application do
     topologies = cluster_topologies()
     read_only_mode()
     Hexpm.BlockAddress.start()
-    Hexpm.GitHub.SecretScanning.start()
 
     children =
       [

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -11,6 +11,7 @@ defmodule Hexpm.Application do
 
     mode = mode()
     if web_mode?(mode), do: Hexpm.BlockAddress.start()
+    if web_mode?(mode), do: Hexpm.GitHub.SecretScanning.start()
     children = children(mode)
 
     shutdown_on_eof()

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -11,6 +11,7 @@ defmodule Hexpm.Application do
 
     mode = mode()
     if web_mode?(mode), do: Hexpm.BlockAddress.start()
+    if web_mode?(mode), do: Hexpm.GitHub.SecretScanning.start()
     children = children(mode, Hexpm.Repo.write_mode?())
 
     shutdown_on_eof()

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -11,6 +11,7 @@ defmodule Hexpm.Application do
 
     mode = mode()
     if web_mode?(mode), do: Hexpm.BlockAddress.start()
+    if web_mode?(mode) and Application.fetch_env!(:hexpm, :cache_enabled), do: Hexpm.Cache.start()
     children = children(mode, Hexpm.Repo.write_mode?())
 
     shutdown_on_eof()
@@ -217,10 +218,6 @@ defmodule Hexpm.Application do
       HexpmWeb.RateLimitPubSub,
       Hexpm.WriteModePubSub,
       {PlugAttack.Storage.Ets, name: HexpmWeb.Plugs.Attack.Storage, clean_period: 60_000},
-      {Hexpm.Cache,
-       name: Hexpm.Cache,
-       interval: 3_600_000,
-       enabled: Application.fetch_env!(:hexpm, :cache_enabled)},
       load_caches(),
       HexpmWeb.Endpoint
     ]

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -11,7 +11,6 @@ defmodule Hexpm.Application do
 
     mode = mode()
     if web_mode?(mode), do: Hexpm.BlockAddress.start()
-    if web_mode?(mode), do: Hexpm.GitHub.SecretScanning.start()
     children = children(mode)
 
     shutdown_on_eof()

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -11,6 +11,7 @@ defmodule Hexpm.Application do
 
     mode = mode()
     if web_mode?(mode), do: Hexpm.BlockAddress.start()
+    if web_mode?(mode) and Application.fetch_env!(:hexpm, :cache_enabled), do: Hexpm.Cache.start()
     children = children(mode)
 
     shutdown_on_eof()
@@ -160,10 +161,6 @@ defmodule Hexpm.Application do
       {Phoenix.PubSub, name: Hexpm.PubSub, adapter: Phoenix.PubSub.PG2},
       HexpmWeb.RateLimitPubSub,
       {PlugAttack.Storage.Ets, name: HexpmWeb.Plugs.Attack.Storage, clean_period: 60_000},
-      {Hexpm.Cache,
-       name: Hexpm.Cache,
-       interval: 3_600_000,
-       enabled: Application.fetch_env!(:hexpm, :cache_enabled)},
       load_caches(),
       HexpmWeb.Endpoint
     ]

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -11,7 +11,6 @@ defmodule Hexpm.Application do
 
     mode = mode()
     if web_mode?(mode), do: Hexpm.BlockAddress.start()
-    if web_mode?(mode), do: Hexpm.GitHub.SecretScanning.start()
     children = children(mode, Hexpm.Repo.write_mode?())
 
     shutdown_on_eof()

--- a/lib/hexpm/cache.ex
+++ b/lib/hexpm/cache.ex
@@ -5,19 +5,33 @@ defmodule Hexpm.Cache do
     GenServer.start_link(__MODULE__, opts, name: opts[:name])
   end
 
-  def fetch(table \\ __MODULE__, key, fun) do
+  def fetch(table \\ __MODULE__, key, fun)
+
+  def fetch(table, key, fun) do
+    do_fetch(table, key, fun, [])
+  end
+
+  def fetch(table, key, fun, opts) do
+    do_fetch(table, key, fun, opts)
+  end
+
+  defp do_fetch(table, key, fun, opts) do
     case :ets.whereis(table) do
       :undefined ->
         fun.()
 
       _ ->
+        ttl = Keyword.get(opts, :ttl)
+        now = System.monotonic_time(:second)
+
         case :ets.lookup(table, key) do
-          [{^key, value, _fun}] ->
+          [{^key, value, _fun, inserted_at}]
+          when ttl == nil or now - inserted_at < ttl ->
             value
 
-          [] ->
+          _ ->
             value = fun.()
-            :ets.insert(table, {key, value, fun})
+            :ets.insert(table, {key, value, fun, now})
             value
         end
     end
@@ -54,8 +68,10 @@ defmodule Hexpm.Cache do
   end
 
   defp populate(%{table: table}) do
-    for {key, _value, fun} <- :ets.tab2list(table) do
-      :ets.insert(table, {key, fun.(), fun})
+    now = System.monotonic_time(:second)
+
+    for {key, _value, fun, _ts} <- :ets.tab2list(table) do
+      :ets.insert(table, {key, fun.(), fun, now})
     end
   end
 

--- a/lib/hexpm/cache.ex
+++ b/lib/hexpm/cache.ex
@@ -15,6 +15,17 @@ defmodule Hexpm.Cache do
     end
   end
 
+  def invalidate(table \\ @table, key)
+
+  def invalidate(table, key) do
+    case :ets.whereis(table) do
+      :undefined -> :ok
+      _ -> :ets.delete(table, key)
+    end
+
+    :ok
+  end
+
   defp do_fetch(table, key, fun, ttl) do
     now = System.monotonic_time(:second)
 

--- a/lib/hexpm/cache.ex
+++ b/lib/hexpm/cache.ex
@@ -1,81 +1,92 @@
 defmodule Hexpm.Cache do
-  use GenServer
+  @table __MODULE__
 
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: opts[:name])
+  def start(table \\ @table) do
+    :ets.new(table, [:named_table, :public, :set, read_concurrency: true])
+    :ok
   end
 
-  def fetch(table \\ __MODULE__, key, fun)
+  def fetch(table \\ @table, key, fun, ttl)
 
-  def fetch(table, key, fun) do
-    do_fetch(table, key, fun, [])
-  end
-
-  def fetch(table, key, fun, opts) do
-    do_fetch(table, key, fun, opts)
-  end
-
-  defp do_fetch(table, key, fun, opts) do
+  def fetch(table, key, fun, ttl) do
     case :ets.whereis(table) do
-      :undefined ->
-        fun.()
+      :undefined -> fun.()
+      _ -> do_fetch(table, key, fun, ttl)
+    end
+  end
 
-      _ ->
-        ttl = Keyword.get(opts, :ttl)
-        now = System.monotonic_time(:second)
+  defp do_fetch(table, key, fun, ttl) do
+    now = System.monotonic_time(:second)
 
-        case :ets.lookup(table, key) do
-          [{^key, value, _fun, inserted_at}]
-          when ttl == nil or now - inserted_at < ttl ->
-            value
+    case :ets.lookup(table, key) do
+      [{^key, value, _fun, inserted_at}] when ttl == :infinity or now - inserted_at < ttl ->
+        value
 
-          _ ->
-            value = fun.()
-            :ets.insert(table, {key, value, fun, now})
-            value
+      [{^key, value, _fun, _inserted_at}] ->
+        refresh_async(table, key, fun)
+        value
+
+      [] ->
+        compute_cold(table, key, fun)
+    end
+  end
+
+  defp refresh_async(table, key, fun) do
+    if :ets.insert_new(table, {{:refreshing, key}}) do
+      Task.start(fn ->
+        try do
+          value = fun.()
+          :ets.insert(table, {key, value, fun, System.monotonic_time(:second)})
+        after
+          :ets.delete(table, {:refreshing, key})
+        end
+      end)
+    end
+
+    :ok
+  end
+
+  defp compute_cold(table, key, fun) do
+    case :ets.lookup(table, {:populating, key}) do
+      [{_, leader}] ->
+        wait_for(leader, table, key, fun)
+
+      [] ->
+        worker =
+          spawn(fn ->
+            receive do
+              :proceed ->
+                try do
+                  value = fun.()
+                  :ets.insert(table, {key, value, fun, System.monotonic_time(:second)})
+                after
+                  :ets.delete(table, {:populating, key})
+                end
+
+              :abort ->
+                :ok
+            end
+          end)
+
+        if :ets.insert_new(table, {{:populating, key}, worker}) do
+          send(worker, :proceed)
+          wait_for(worker, table, key, fun)
+        else
+          send(worker, :abort)
+
+          case :ets.lookup(table, {:populating, key}) do
+            [{_, leader}] -> wait_for(leader, table, key, fun)
+            [] -> fetch(table, key, fun, :infinity)
+          end
         end
     end
   end
 
-  def refresh(server \\ __MODULE__) do
-    GenServer.call(server, :refresh)
-  end
+  defp wait_for(pid, table, key, fun) do
+    ref = Process.monitor(pid)
 
-  @impl true
-  def init(opts) do
-    if Keyword.get(opts, :enabled, true) do
-      table = opts[:name] || __MODULE__
-      :ets.new(table, [:named_table, :public, :set, read_concurrency: true])
-      state = %{table: table, interval: opts[:interval]}
-      schedule(state)
-      {:ok, state}
-    else
-      :ignore
+    receive do
+      {:DOWN, ^ref, _, _, _} -> fetch(table, key, fun, :infinity)
     end
-  end
-
-  @impl true
-  def handle_info(:update, state) do
-    populate(state)
-    schedule(state)
-    {:noreply, state}
-  end
-
-  @impl true
-  def handle_call(:refresh, _from, state) do
-    populate(state)
-    {:reply, :ok, state}
-  end
-
-  defp populate(%{table: table}) do
-    now = System.monotonic_time(:second)
-
-    for {key, _value, fun, _ts} <- :ets.tab2list(table) do
-      :ets.insert(table, {key, fun.(), fun, now})
-    end
-  end
-
-  defp schedule(%{interval: interval}) do
-    Process.send_after(self(), :update, interval)
   end
 end

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -81,6 +81,25 @@ defmodule Hexpm.Emails do
     |> render(:tfa_recovery_rotated)
   end
 
+  def key_leaked(user, key, url \\ nil) do
+    email()
+    |> email_to(user)
+    |> subject("Hex.pm - API key #{key.name} was found in a public repository and revoked")
+    |> assign(:username, user.username)
+    |> assign(:key_name, key.name)
+    |> assign(:found_url, safe_url(url))
+    |> render(:key_leaked)
+  end
+
+  defp safe_url(nil), do: nil
+
+  defp safe_url(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: s} when s in ["http", "https"] -> url
+      _ -> nil
+    end
+  end
+
   def typosquat_candidates(candidates, threshold) do
     email()
     |> email_to(Application.get_env(:hexpm, :support_email))

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -127,6 +127,25 @@ defmodule Hexpm.Emails do
     |> render_body(:tfa_recovery_rotated)
   end
 
+  def key_leaked(user, key, url \\ nil) do
+    base_email()
+    |> email_to(user)
+    |> subject("Hex.pm - API key #{key.name} was found in a public repository and revoked")
+    |> assign(:username, user.username)
+    |> assign(:key_name, key.name)
+    |> assign(:found_url, safe_url(url))
+    |> render_body(:key_leaked)
+  end
+
+  defp safe_url(nil), do: nil
+
+  defp safe_url(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: s} when s in ["http", "https"] -> url
+      _ -> nil
+    end
+  end
+
   def email_added(user, new_email) do
     base_email()
     |> email_to(user)
@@ -170,25 +189,6 @@ defmodule Hexpm.Emails do
     |> subject("Hex.pm - All API keys have been revoked on your account")
     |> assign(:username, display_name(user_or_org))
     |> render_body(:api_keys_all_revoked)
-  end
-
-  def key_leaked(user, key, url \\ nil) do
-    email()
-    |> email_to(user)
-    |> subject("Hex.pm - API key #{key.name} was found in a public repository and revoked")
-    |> assign(:username, user.username)
-    |> assign(:key_name, key.name)
-    |> assign(:found_url, safe_url(url))
-    |> render(:key_leaked)
-  end
-
-  defp safe_url(nil), do: nil
-
-  defp safe_url(url) when is_binary(url) do
-    case URI.parse(url) do
-      %URI{scheme: s} when s in ["http", "https"] -> url
-      _ -> nil
-    end
   end
 
   def typosquat_candidates(candidates, threshold) do

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -172,6 +172,25 @@ defmodule Hexpm.Emails do
     |> render_body(:api_keys_all_revoked)
   end
 
+  def key_leaked(user, key, url \\ nil) do
+    email()
+    |> email_to(user)
+    |> subject("Hex.pm - API key #{key.name} was found in a public repository and revoked")
+    |> assign(:username, user.username)
+    |> assign(:key_name, key.name)
+    |> assign(:found_url, safe_url(url))
+    |> render(:key_leaked)
+  end
+
+  defp safe_url(nil), do: nil
+
+  defp safe_url(url) when is_binary(url) do
+    case URI.parse(url) do
+      %URI{scheme: s} when s in ["http", "https"] -> url
+      _ -> nil
+    end
+  end
+
   def typosquat_candidates(candidates, threshold) do
     base_email()
     |> email_to(Application.get_env(:hexpm, :support_email))

--- a/lib/hexpm/factory.ex
+++ b/lib/hexpm/factory.ex
@@ -50,6 +50,7 @@ defmodule Hexpm.Factory do
       secret_first: first,
       secret_second: second,
       user_secret: user_secret,
+      token_format: "v2",
       permissions: [build(:key_permission, domain: "api")],
       user: nil,
       organization: nil

--- a/lib/hexpm/factory.ex
+++ b/lib/hexpm/factory.ex
@@ -51,6 +51,7 @@ defmodule Hexpm.Factory do
       secret_first: first,
       secret_second: second,
       user_secret: user_secret,
+      token_format: "v2",
       permissions: [build(:key_permission, domain: "api")],
       user: nil,
       organization: nil

--- a/lib/hexpm/github/secret_scanning.ex
+++ b/lib/hexpm/github/secret_scanning.ex
@@ -120,7 +120,7 @@ defmodule Hexpm.GitHub.SecretScanning do
 
   defp fetch_public_keys_cached() do
     ttl = Application.get_env(:hexpm, :github_key_cache_ttl, 300)
-    Hexpm.Cache.fetch(Hexpm.Cache, :github_secret_scanning_keys, &fetch_public_keys/0, ttl: ttl)
+    Hexpm.Cache.fetch(:github_secret_scanning_keys, &fetch_public_keys/0, ttl)
   end
 
   @doc false

--- a/lib/hexpm/github/secret_scanning.ex
+++ b/lib/hexpm/github/secret_scanning.ex
@@ -96,7 +96,7 @@ defmodule Hexpm.GitHub.SecretScanning do
       case revoke_token(token) do
         {:ok, key, user} ->
           if user do
-            Hexpm.Emails.key_leaked(user, key, url) |> Hexpm.Emails.Mailer.deliver_later()
+            Hexpm.Emails.key_leaked(user, key, url) |> Hexpm.Emails.Mailer.deliver!()
           end
 
           %{"token_raw" => token, "token_type" => "hexpm_api_token", "label" => "true_positive"}

--- a/lib/hexpm/github/secret_scanning.ex
+++ b/lib/hexpm/github/secret_scanning.ex
@@ -9,12 +9,11 @@ defmodule Hexpm.GitHub.SecretScanning do
 
   require Logger
 
-  alias Hexpm.Accounts.{Key, Keys}
+  alias Hexpm.Accounts.{Auth, Keys}
 
   @public_keys_url "https://api.github.com/meta/public_keys/secret_scanning"
   # prime256v1 / P-256 OID
   @p256_oid {1, 2, 840, 10045, 3, 1, 7}
-  @token_prefix Key.token_prefix()
 
   @doc """
   Verifies the GitHub ECDSA-P256-SHA256 signature on a raw request body.
@@ -76,26 +75,14 @@ defmodule Hexpm.GitHub.SecretScanning do
   end
 
   defp revoke_token(token) do
-    raw =
-      case token do
-        @token_prefix <> body -> body
-        other -> other
-      end
-
+    raw = Auth.strip_token_prefix(token)
     app_secret = Application.get_env(:hexpm, :secret)
 
     <<first::binary-size(32), _rest::binary>> =
       :crypto.mac(:hmac, :sha256, app_secret, raw)
       |> Base.encode16(case: :lower)
 
-    case Keys.get_by_secret_first(first) do
-      nil ->
-        :not_found
-
-      {key, user} ->
-        Keys.revoke_immediately(key)
-        {:ok, key, user}
-    end
+    Keys.revoke_by_secret_first(first)
   end
 
   defp find_key(keys, key_id) do

--- a/lib/hexpm/github/secret_scanning.ex
+++ b/lib/hexpm/github/secret_scanning.ex
@@ -17,6 +17,11 @@ defmodule Hexpm.GitHub.SecretScanning do
   @key_cache_table __MODULE__.KeyCache
   @token_prefix Key.token_prefix()
 
+  def start() do
+    :ets.new(@key_cache_table, [:named_table, :public, read_concurrency: true])
+    :ok
+  end
+
   @doc """
   Verifies the GitHub ECDSA-P256-SHA256 signature on a raw request body.
 
@@ -64,7 +69,10 @@ defmodule Hexpm.GitHub.SecretScanning do
 
       case revoke_token(token) do
         {:ok, key, user} ->
-          Hexpm.Emails.key_leaked(user, key, url) |> Hexpm.Emails.Mailer.deliver_later()
+          if user do
+            Hexpm.Emails.key_leaked(user, key, url) |> Hexpm.Emails.Mailer.deliver_later()
+          end
+
           %{"token_raw" => token, "token_type" => "hexpm_api_token", "label" => "true_positive"}
 
         :not_found ->
@@ -117,7 +125,6 @@ defmodule Hexpm.GitHub.SecretScanning do
   end
 
   defp fetch_public_keys_cached() do
-    ensure_cache_table()
     now = System.monotonic_time(:second)
     ttl = Application.get_env(:hexpm, :github_key_cache_ttl, 300)
 
@@ -131,12 +138,6 @@ defmodule Hexpm.GitHub.SecretScanning do
           {:ok, keys}
         end
     end
-  end
-
-  defp ensure_cache_table() do
-    :ets.new(@key_cache_table, [:named_table, :public, read_concurrency: true])
-  rescue
-    ArgumentError -> :ok
   end
 
   @doc false

--- a/lib/hexpm/github/secret_scanning.ex
+++ b/lib/hexpm/github/secret_scanning.ex
@@ -1,0 +1,159 @@
+defmodule Hexpm.GitHub.SecretScanning do
+  @moduledoc """
+  Handles GitHub Secret Scanning partner integration.
+
+  Verifies ECDSA-P256-SHA256 signatures on inbound payloads from GitHub
+  using GitHub's published public keys, then revokes any matched API keys
+  and notifies the affected users.
+  """
+
+  require Logger
+
+  alias Hexpm.Accounts.{Key, Keys}
+
+  @public_keys_url "https://api.github.com/meta/public_keys/secret_scanning"
+  # prime256v1 / P-256 OID
+  @p256_oid {1, 2, 840, 10045, 3, 1, 7}
+  @key_cache_table __MODULE__.KeyCache
+  @token_prefix Key.token_prefix()
+
+  @doc """
+  Verifies the GitHub ECDSA-P256-SHA256 signature on a raw request body.
+
+  Returns `true` if the signature is valid, `false` otherwise.
+  """
+  @spec verify_signature(binary(), String.t(), String.t()) :: boolean()
+  def verify_signature(raw_body, key_id, signature_b64) do
+    with {:ok, keys} <- fetch_public_keys_cached(),
+         {:ok, pem} <- find_key(keys, key_id),
+         {:ok, sig_der} <- Base.decode64(signature_b64),
+         {:ok, ec_key} <- decode_pem_public_key(pem) do
+      :public_key.verify(raw_body, :sha256, sig_der, ec_key)
+    else
+      err ->
+        Logger.warning("GitHub secret scanning signature verification failed: #{inspect(err)}")
+        false
+    end
+  end
+
+  @doc false
+  @spec fetch_public_keys() :: {:ok, list(map())} | {:error, term()}
+  def fetch_public_keys() do
+    http = Hexpm.HTTP.impl()
+
+    case http.get(@public_keys_url, [{"accept", "application/json"}]) do
+      {:ok, 200, _headers, %{"public_keys" => keys}} ->
+        {:ok, keys}
+
+      {:ok, status, _headers, body} ->
+        Logger.warning("GitHub public keys fetch returned #{status}: #{inspect(body)}")
+        {:error, {:unexpected_status, status}}
+
+      {:error, reason} ->
+        Logger.warning("GitHub public keys fetch failed: #{inspect(reason)}")
+        {:error, reason}
+    end
+  end
+
+  @doc false
+  @spec process_alerts(list(map())) :: list(map())
+  def process_alerts(alerts) do
+    Enum.map(alerts, fn alert ->
+      token = Map.get(alert, "token", "")
+      url = Map.get(alert, "url")
+
+      case revoke_token(token) do
+        {:ok, key, user} ->
+          Hexpm.Emails.key_leaked(user, key, url) |> Hexpm.Emails.Mailer.deliver_later()
+          %{"token_raw" => token, "token_type" => "hexpm_api_token", "label" => "true_positive"}
+
+        :not_found ->
+          %{"token_raw" => token, "token_type" => "hexpm_api_token", "label" => "false_positive"}
+      end
+    end)
+  end
+
+  defp revoke_token(token) do
+    raw =
+      case token do
+        @token_prefix <> body -> body
+        other -> other
+      end
+
+    app_secret = Application.get_env(:hexpm, :secret)
+
+    <<first::binary-size(32), _rest::binary>> =
+      :crypto.mac(:hmac, :sha256, app_secret, raw)
+      |> Base.encode16(case: :lower)
+
+    case Keys.get_by_secret_first(first) do
+      nil ->
+        :not_found
+
+      {key, user} ->
+        Keys.revoke_immediately(key)
+        {:ok, key, user}
+    end
+  end
+
+  defp find_key(keys, key_id) do
+    case Enum.find(keys, &(&1["key_identifier"] == key_id)) do
+      nil -> {:error, :key_not_found}
+      %{"key" => pem} -> {:ok, pem}
+    end
+  end
+
+  defp decode_pem_public_key(pem) do
+    case :public_key.pem_decode(pem) do
+      [{:SubjectPublicKeyInfo, _der, :not_encrypted} = entry] ->
+        case :public_key.pem_entry_decode(entry) do
+          {{:ECPoint, _}, {:namedCurve, @p256_oid}} = ec_key -> {:ok, ec_key}
+          _ -> {:error, :not_p256}
+        end
+
+      _ ->
+        {:error, :invalid_pem}
+    end
+  end
+
+  defp fetch_public_keys_cached() do
+    ensure_cache_table()
+    now = System.monotonic_time(:second)
+    ttl = Application.get_env(:hexpm, :github_key_cache_ttl, 300)
+
+    case :ets.lookup(@key_cache_table, :keys) do
+      [{:keys, keys, ts}] when ttl > 0 and now - ts < ttl ->
+        {:ok, keys}
+
+      _ ->
+        with {:ok, keys} <- fetch_public_keys() do
+          :ets.insert(@key_cache_table, {:keys, keys, now})
+          {:ok, keys}
+        end
+    end
+  end
+
+  defp ensure_cache_table() do
+    :ets.new(@key_cache_table, [:named_table, :public, read_concurrency: true])
+  rescue
+    ArgumentError -> :ok
+  end
+
+  @doc false
+  def generate_test_keypair() do
+    ec_priv_key = :public_key.generate_key({:namedCurve, @p256_oid})
+    {:ECPrivateKey, _, _priv, ec_params, pub_point, _} = ec_priv_key
+    ec_pub_key = {{:ECPoint, pub_point}, ec_params}
+
+    pem_entry = :public_key.pem_entry_encode(:SubjectPublicKeyInfo, ec_pub_key)
+    pem = :public_key.pem_encode([pem_entry])
+
+    {pem, ec_priv_key}
+  end
+
+  @doc false
+  def sign_payload(payload, ec_private_key) do
+    sig_der = :public_key.sign(payload, :sha256, ec_private_key)
+    Base.encode64(sig_der)
+  end
+end

--- a/lib/hexpm/github/secret_scanning.ex
+++ b/lib/hexpm/github/secret_scanning.ex
@@ -22,15 +22,48 @@ defmodule Hexpm.GitHub.SecretScanning do
   """
   @spec verify_signature(binary(), String.t(), String.t()) :: boolean()
   def verify_signature(raw_body, key_id, signature_b64) do
-    with {:ok, keys} <- fetch_public_keys_cached(),
-         {:ok, pem} <- find_key(keys, key_id),
-         {:ok, sig_der} <- Base.decode64(signature_b64),
-         {:ok, ec_key} <- decode_pem_public_key(pem) do
-      :public_key.verify(raw_body, :sha256, sig_der, ec_key)
-    else
-      err ->
-        Logger.warning("GitHub secret scanning signature verification failed: #{inspect(err)}")
+    case attempt_verify(raw_body, key_id, signature_b64, fetch_public_keys_cached()) do
+      {:ok, valid} ->
+        valid
+
+      {:error, :key_not_found} ->
+        Logger.info(
+          "GitHub secret scanning: refreshing public keys after unknown key_id #{inspect(key_id)}"
+        )
+
+        Hexpm.Cache.invalidate(:github_secret_scanning_keys)
+
+        case attempt_verify(raw_body, key_id, signature_b64, fetch_public_keys()) do
+          {:ok, valid} ->
+            valid
+
+          {:error, reason} ->
+            Logger.warning(
+              "GitHub secret scanning signature verification failed after key refresh: #{inspect(reason)}"
+            )
+
+            false
+        end
+
+      {:error, reason} ->
+        Logger.warning("GitHub secret scanning signature verification failed: #{inspect(reason)}")
         false
+    end
+  end
+
+  defp attempt_verify(raw_body, key_id, signature_b64, keys_result) do
+    with {:ok, keys} <- keys_result,
+         {:ok, pem} <- find_key(keys, key_id),
+         {:ok, sig_der} <- decode_signature(signature_b64),
+         {:ok, ec_key} <- decode_pem_public_key(pem) do
+      {:ok, :public_key.verify(raw_body, :sha256, sig_der, ec_key)}
+    end
+  end
+
+  defp decode_signature(b64) do
+    case Base.decode64(b64) do
+      {:ok, sig} -> {:ok, sig}
+      :error -> {:error, :invalid_base64}
     end
   end
 

--- a/lib/hexpm/github/secret_scanning.ex
+++ b/lib/hexpm/github/secret_scanning.ex
@@ -14,13 +14,7 @@ defmodule Hexpm.GitHub.SecretScanning do
   @public_keys_url "https://api.github.com/meta/public_keys/secret_scanning"
   # prime256v1 / P-256 OID
   @p256_oid {1, 2, 840, 10045, 3, 1, 7}
-  @key_cache_table __MODULE__.KeyCache
   @token_prefix Key.token_prefix()
-
-  def start() do
-    :ets.new(@key_cache_table, [:named_table, :public, read_concurrency: true])
-    :ok
-  end
 
   @doc """
   Verifies the GitHub ECDSA-P256-SHA256 signature on a raw request body.
@@ -125,19 +119,8 @@ defmodule Hexpm.GitHub.SecretScanning do
   end
 
   defp fetch_public_keys_cached() do
-    now = System.monotonic_time(:second)
     ttl = Application.get_env(:hexpm, :github_key_cache_ttl, 300)
-
-    case :ets.lookup(@key_cache_table, :keys) do
-      [{:keys, keys, ts}] when ttl > 0 and now - ts < ttl ->
-        {:ok, keys}
-
-      _ ->
-        with {:ok, keys} <- fetch_public_keys() do
-          :ets.insert(@key_cache_table, {:keys, keys, now})
-          {:ok, keys}
-        end
-    end
+    Hexpm.Cache.fetch(Hexpm.Cache, :github_secret_scanning_keys, &fetch_public_keys/0, ttl: ttl)
   end
 
   @doc false

--- a/lib/hexpm_web/auth_helpers.ex
+++ b/lib/hexpm_web/auth_helpers.ex
@@ -207,19 +207,29 @@ defmodule HexpmWeb.AuthHelpers do
     end
   end
 
+  @token_prefix Hexpm.Accounts.Key.token_prefix()
+
   def authenticate(conn) do
     case get_req_header(conn, "authorization") do
       ["Basic " <> credentials] ->
         basic_auth(credentials)
 
       ["Bearer " <> token] ->
-        oauth_token_auth(token, conn)
+        bearer_auth(token, conn)
 
       [key] ->
-        key_auth(key, conn)
+        key_auth(String.trim(key), conn)
 
       _ ->
         {:error, :missing}
+    end
+  end
+
+  defp bearer_auth(token, conn) do
+    if String.starts_with?(token, @token_prefix) do
+      key_auth(token, conn)
+    else
+      oauth_token_auth(token, conn)
     end
   end
 

--- a/lib/hexpm_web/auth_helpers.ex
+++ b/lib/hexpm_web/auth_helpers.ex
@@ -217,6 +217,8 @@ defmodule HexpmWeb.AuthHelpers do
     end
   end
 
+  @token_prefix Hexpm.Accounts.Key.token_prefix()
+
   def authenticate(conn) do
     authenticate_at(conn, DateTime.utc_now())
   end
@@ -231,13 +233,21 @@ defmodule HexpmWeb.AuthHelpers do
         end
 
       ["Bearer " <> token] ->
-        oauth_token_auth(token, conn)
+        bearer_auth(token, conn)
 
       [key] ->
-        key_auth(key, conn)
+        key_auth(String.trim(key), conn)
 
       _ ->
         {:error, :missing}
+    end
+  end
+
+  defp bearer_auth(token, conn) do
+    if String.starts_with?(token, @token_prefix) do
+      key_auth(token, conn)
+    else
+      oauth_token_auth(token, conn)
     end
   end
 

--- a/lib/hexpm_web/auth_helpers.ex
+++ b/lib/hexpm_web/auth_helpers.ex
@@ -216,6 +216,8 @@ defmodule HexpmWeb.AuthHelpers do
     end
   end
 
+  @token_prefix Hexpm.Accounts.Key.token_prefix()
+
   def authenticate(conn) do
     authenticate_at(conn, DateTime.utc_now())
   end
@@ -230,13 +232,21 @@ defmodule HexpmWeb.AuthHelpers do
         end
 
       ["Bearer " <> token] ->
-        oauth_token_auth(token, conn)
+        bearer_auth(token, conn)
 
       [key] ->
-        key_auth(key, conn)
+        key_auth(String.trim(key), conn)
 
       _ ->
         {:error, :missing}
+    end
+  end
+
+  defp bearer_auth(token, conn) do
+    if String.starts_with?(token, @token_prefix) do
+      key_auth(token, conn)
+    else
+      oauth_token_auth(token, conn)
     end
   end
 

--- a/lib/hexpm_web/controllers/api/github_secret_scanning_controller.ex
+++ b/lib/hexpm_web/controllers/api/github_secret_scanning_controller.ex
@@ -1,0 +1,51 @@
+defmodule HexpmWeb.API.GitHubSecretScanningController do
+  use HexpmWeb, :controller
+
+  require Logger
+
+  alias Hexpm.GitHub.SecretScanning
+
+  @doc """
+  Receives secret alert payloads from GitHub's secret scanning partner program.
+
+  GitHub POSTs here whenever it detects a `hex_`-prefixed API key in a public
+  repository or npm package. We verify the ECDSA-P256-SHA256 signature using
+  GitHub's published public keys, then immediately revoke any matched keys and
+  notify affected users by email.
+
+  No authentication is used — GitHub identifies itself via the signature.
+  Returns 200 on success (including when tokens are not found), 400 on
+  malformed payload, and 403 on signature verification failure.
+  """
+  def create(conn, _params) do
+    raw_body = conn.assigns[:raw_body] || ""
+    key_id = get_req_header(conn, "github-public-key-identifier") |> List.first("")
+    signature = get_req_header(conn, "github-public-key-signature") |> List.first("")
+
+    cond do
+      raw_body == "" ->
+        render_error(conn, 400, message: "missing body")
+
+      not SecretScanning.verify_signature(raw_body, key_id, signature) ->
+        Logger.warning(
+          "GitHub secret scanning: invalid signature from #{inspect(conn.remote_ip)}"
+        )
+
+        render_error(conn, 403, message: "invalid signature")
+
+      true ->
+        case Jason.decode(raw_body) do
+          {:ok, alerts} when is_list(alerts) ->
+            results = SecretScanning.process_alerts(alerts)
+            revoked = Enum.count(results, &(&1["label"] == "true_positive"))
+
+            Logger.info("GitHub secret scanning: revoked=#{revoked} alerts=#{length(alerts)}")
+
+            json(conn, results)
+
+          _ ->
+            render_error(conn, 400, message: "body must be a JSON array")
+        end
+    end
+  end
+end

--- a/lib/hexpm_web/controllers/api/github_secret_scanning_controller.ex
+++ b/lib/hexpm_web/controllers/api/github_secret_scanning_controller.ex
@@ -26,14 +26,7 @@ defmodule HexpmWeb.API.GitHubSecretScanningController do
       raw_body == "" ->
         render_error(conn, 400, message: "missing body")
 
-      not SecretScanning.verify_signature(raw_body, key_id, signature) ->
-        Logger.warning(
-          "GitHub secret scanning: invalid signature from #{inspect(conn.remote_ip)}"
-        )
-
-        render_error(conn, 403, message: "invalid signature")
-
-      true ->
+      SecretScanning.verify_signature(raw_body, key_id, signature) ->
         case Jason.decode(raw_body) do
           {:ok, alerts} when is_list(alerts) ->
             results = SecretScanning.process_alerts(alerts)
@@ -46,6 +39,13 @@ defmodule HexpmWeb.API.GitHubSecretScanningController do
           _ ->
             render_error(conn, 400, message: "body must be a JSON array")
         end
+
+      true ->
+        Logger.warning(
+          "GitHub secret scanning: invalid signature from #{inspect(conn.remote_ip)}"
+        )
+
+        render_error(conn, 403, message: "invalid signature")
     end
   end
 end

--- a/lib/hexpm_web/controllers/docs_controller.ex
+++ b/lib/hexpm_web/controllers/docs_controller.ex
@@ -163,6 +163,17 @@ defmodule HexpmWeb.DocsController do
     )
   end
 
+  def leaked_keys(conn, _params) do
+    render(
+      conn,
+      "layout.html",
+      view: "leaked_keys.html",
+      view_name: :leaked_keys,
+      title: "Leaked API keys",
+      container: "flex-1 flex flex-col"
+    )
+  end
+
   def self_hosting(conn, _params) do
     render(
       conn,

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -312,7 +312,7 @@ defmodule HexpmWeb.PackageController do
       end
 
     last_download_day =
-      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0) || Date.utc_today()
+      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0, 3600) || Date.utc_today()
 
     start_download_day = Date.add(last_download_day, -30)
     downloads = Downloads.package(package)
@@ -397,7 +397,7 @@ defmodule HexpmWeb.PackageController do
       end
 
     last_download_day =
-      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0) || Date.utc_today()
+      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0, 3600) || Date.utc_today()
 
     start_download_day = Date.add(last_download_day, -30)
     package_downloads = Downloads.package(package)

--- a/lib/hexpm_web/controllers/page_controller.ex
+++ b/lib/hexpm_web/controllers/page_controller.ex
@@ -15,7 +15,7 @@ defmodule HexpmWeb.PageController do
       container: "",
       autofocus_search: true,
       num_packages: Packages.count(),
-      num_releases: Hexpm.Cache.fetch(:release_count, &Releases.count/0),
+      num_releases: Hexpm.Cache.fetch(:release_count, &Releases.count/0, 3600),
       package_top: Downloads.top_packages(hexpm, "recent", 6),
       package_new: package_new,
       releases_new: Releases.recent(hexpm, 6),

--- a/lib/hexpm_web/controllers/user_controller.ex
+++ b/lib/hexpm_web/controllers/user_controller.ex
@@ -134,7 +134,7 @@ defmodule HexpmWeb.UserController do
 
   defp build_package_graphs(packages, package_downloads, sort_by) do
     last_day =
-      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0) || Date.utc_today()
+      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0, 3600) || Date.utc_today()
 
     start_day = Date.add(last_day, -30)
 

--- a/lib/hexpm_web/controllers/user_controller.ex
+++ b/lib/hexpm_web/controllers/user_controller.ex
@@ -135,7 +135,7 @@ defmodule HexpmWeb.UserController do
 
   defp build_package_graphs(packages, package_downloads, sort_by) do
     last_day =
-      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0) || Date.utc_today()
+      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0, 3600) || Date.utc_today()
 
     start_day = Date.add(last_day, -30)
 

--- a/lib/hexpm_web/controllers/user_controller.ex
+++ b/lib/hexpm_web/controllers/user_controller.ex
@@ -138,7 +138,7 @@ defmodule HexpmWeb.UserController do
 
   defp build_package_graphs(packages, package_downloads, sort_by) do
     last_day =
-      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0) || Date.utc_today()
+      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0, 3600) || Date.utc_today()
 
     start_day = Date.add(last_day, -30)
 

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -50,6 +50,8 @@ defmodule HexpmWeb.Endpoint do
   plug Logster.Plugs.ChangeLogLevel, to: :info
   plug Logster.Plugs.Logger, excludes: [:params]
 
+  plug HexpmWeb.Plugs.CacheRawBody
+
   plug Plug.Parsers,
     parsers: [:urlencoded, :json, HexpmWeb.PlugParser],
     pass: ["*/*"],

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -61,6 +61,8 @@ defmodule HexpmWeb.Endpoint do
   plug Logster.Plugs.ChangeLogLevel, to: :info
   plug Logster.Plugs.Logger, excludes: [:params]
 
+  plug HexpmWeb.Plugs.CacheRawBody
+
   plug Plug.Parsers,
     parsers: [:urlencoded, :json, HexpmWeb.PlugParser],
     pass: ["*/*"],

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -51,6 +51,8 @@ defmodule HexpmWeb.Endpoint do
   plug Logster.Plugs.ChangeLogLevel, to: :info
   plug Logster.Plugs.Logger, excludes: [:params]
 
+  plug HexpmWeb.Plugs.CacheRawBody
+
   plug Plug.Parsers,
     parsers: [:urlencoded, :json, HexpmWeb.PlugParser],
     pass: ["*/*"],

--- a/lib/hexpm_web/package_layout_assigns.ex
+++ b/lib/hexpm_web/package_layout_assigns.ex
@@ -111,7 +111,9 @@ defmodule HexpmWeb.PackageLayoutAssigns do
   end
 
   defp daily_graph(package_or_release) do
-    last_day = Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0) || Date.utc_today()
+    last_day =
+      Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0, 3600) || Date.utc_today()
+
     start_day = Date.add(last_day, -30)
 
     by_day =

--- a/lib/hexpm_web/plugs/attack.ex
+++ b/lib/hexpm_web/plugs/attack.ex
@@ -76,10 +76,10 @@ defmodule HexpmWeb.Plugs.Attack do
 
   defp throttled_user(conn) do
     cond do
-      user = conn.assigns.current_user ->
+      user = conn.assigns[:current_user] ->
         "user #{user.id}"
 
-      organization = conn.assigns.current_organization ->
+      organization = conn.assigns[:current_organization] ->
         "organization #{organization.id}"
 
       true ->

--- a/lib/hexpm_web/plugs/attack.ex
+++ b/lib/hexpm_web/plugs/attack.ex
@@ -16,6 +16,10 @@ defmodule HexpmWeb.Plugs.Attack do
     allow(conn.remote_ip == {127, 0, 0, 1})
   end
 
+  rule "allow github secret scanning", conn do
+    allow(conn.request_path == "/api/github/secret-scanning")
+  end
+
   rule "allow addresses", conn do
     BlockAddress.try_reload()
     allow(BlockAddress.allowed?(ip_string(conn.remote_ip)))

--- a/lib/hexpm_web/plugs/attack.ex
+++ b/lib/hexpm_web/plugs/attack.ex
@@ -79,10 +79,10 @@ defmodule HexpmWeb.Plugs.Attack do
 
   defp throttled_user(conn) do
     cond do
-      user = conn.assigns.current_user ->
+      user = conn.assigns[:current_user] ->
         "user #{user.id}"
 
-      organization = conn.assigns.current_organization ->
+      organization = conn.assigns[:current_organization] ->
         "organization #{organization.id}"
 
       true ->

--- a/lib/hexpm_web/plugs/cache_raw_body.ex
+++ b/lib/hexpm_web/plugs/cache_raw_body.ex
@@ -23,15 +23,24 @@ defmodule HexpmWeb.Plugs.CacheRawBody do
 
         {:more, _partial, conn} ->
           Logger.warning("CacheRawBody: body exceeded 1 MB limit for #{conn.request_path}")
-          conn
+          send_error(conn, 413, "request body too large")
 
         {:error, reason} ->
           Logger.warning("CacheRawBody: failed to read body: #{inspect(reason)}")
-          conn
+          send_error(conn, 500, "failed to read request body")
       end
     else
       conn
     end
+  end
+
+  defp send_error(conn, status, message) do
+    body = Jason.encode!(%{status: status, message: message})
+
+    conn
+    |> Plug.Conn.put_resp_content_type("application/json")
+    |> Plug.Conn.send_resp(status, body)
+    |> Plug.Conn.halt()
   end
 
   defp paths do

--- a/lib/hexpm_web/plugs/cache_raw_body.ex
+++ b/lib/hexpm_web/plugs/cache_raw_body.ex
@@ -1,0 +1,40 @@
+defmodule HexpmWeb.Plugs.CacheRawBody do
+  @moduledoc """
+  Reads and caches the raw request body for paths that need it before
+  Plug.Parsers consumes the body. Stored in conn.assigns[:raw_body].
+
+  Only activates for paths listed in :cache_raw_body_paths config, defaulting
+  to ["/api/github/secret-scanning"].
+  """
+
+  @behaviour Plug
+
+  require Logger
+
+  @impl Plug
+  def init(opts), do: opts
+
+  @impl Plug
+  def call(conn, _opts) do
+    if conn.request_path in paths() do
+      case Plug.Conn.read_body(conn, length: 1_000_000) do
+        {:ok, body, conn} ->
+          Plug.Conn.assign(conn, :raw_body, body)
+
+        {:more, _partial, conn} ->
+          Logger.warning("CacheRawBody: body exceeded 1 MB limit for #{conn.request_path}")
+          conn
+
+        {:error, reason} ->
+          Logger.warning("CacheRawBody: failed to read body: #{inspect(reason)}")
+          conn
+      end
+    else
+      conn
+    end
+  end
+
+  defp paths do
+    Application.get_env(:hexpm, :cache_raw_body_paths, ["/api/github/secret-scanning"])
+  end
+end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -5,6 +5,11 @@ defmodule HexpmWeb.Router do
 
   @accepted_formats ~w(json elixir erlang)
 
+  pipeline :accepts_json do
+    plug :accepts, ["json"]
+    plug HexpmWeb.Plugs.Attack
+  end
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -306,6 +311,14 @@ defmodule HexpmWeb.Router do
     get "/hexsearch.xml", OpenSearchController, :opensearch
     get "/installs/hex.ez", InstallController, :archive
     get "/feeds/blog.xml", FeedsController, :blog
+  end
+
+  # GitHub secret scanning alert endpoint — no auth, IP-throttled via Attack.
+  # Signature verification is handled in the controller.
+  scope "/api/github", HexpmWeb.API, as: :api_github do
+    pipe_through [:accepts_json]
+
+    post "/secret-scanning", GitHubSecretScanningController, :create
   end
 
   scope "/api", HexpmWeb.API, as: :api do

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -5,6 +5,11 @@ defmodule HexpmWeb.Router do
 
   @accepted_formats ~w(json elixir erlang)
 
+  pipeline :accepts_json do
+    plug :accepts, ["json"]
+    plug HexpmWeb.Plugs.Attack
+  end
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -429,6 +434,14 @@ defmodule HexpmWeb.Router do
     get "/hexsearch.xml", OpenSearchController, :opensearch
     get "/installs/hex.ez", InstallController, :archive
     get "/feeds/blog.xml", FeedsController, :blog
+  end
+
+  # GitHub secret scanning alert endpoint — no auth, IP-throttled via Attack.
+  # Signature verification is handled in the controller.
+  scope "/api/github", HexpmWeb.API, as: :api_github do
+    pipe_through [:accepts_json]
+
+    post "/secret-scanning", GitHubSecretScanningController, :create
   end
 
   scope "/api", HexpmWeb.API, as: :api do

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -5,6 +5,11 @@ defmodule HexpmWeb.Router do
 
   @accepted_formats ~w(json elixir erlang)
 
+  pipeline :accepts_json do
+    plug :accepts, ["json"]
+    plug HexpmWeb.Plugs.Attack
+  end
+
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
@@ -399,6 +404,14 @@ defmodule HexpmWeb.Router do
     get "/hexsearch.xml", OpenSearchController, :opensearch
     get "/installs/hex.ez", InstallController, :archive
     get "/feeds/blog.xml", FeedsController, :blog
+  end
+
+  # GitHub secret scanning alert endpoint — no auth, IP-throttled via Attack.
+  # Signature verification is handled in the controller.
+  scope "/api/github", HexpmWeb.API, as: :api_github do
+    pipe_through [:accepts_json]
+
+    post "/secret-scanning", GitHubSecretScanningController, :create
   end
 
   scope "/api", HexpmWeb.API, as: :api do

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -230,6 +230,7 @@ defmodule HexpmWeb.Router do
     get "/docs/faq", DocsController, :faq
     get "/docs/mirrors", DocsController, :mirrors
     get "/docs/public-keys", DocsController, :public_keys
+    get "/docs/leaked-keys", DocsController, :leaked_keys
     get "/docs/self-hosting", DocsController, :self_hosting
 
     get "/policies/codeofconduct", PolicyController, :coc

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -213,6 +213,7 @@ defmodule HexpmWeb.Router do
     get "/docs/faq", DocsController, :faq
     get "/docs/mirrors", DocsController, :mirrors
     get "/docs/public-keys", DocsController, :public_keys
+    get "/docs/leaked-keys", DocsController, :leaked_keys
     get "/docs/self-hosting", DocsController, :self_hosting
 
     get "/policies/codeofconduct", PolicyController, :coc

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -436,8 +436,9 @@ defmodule HexpmWeb.Router do
     get "/feeds/blog.xml", FeedsController, :blog
   end
 
-  # GitHub secret scanning alert endpoint — no auth, IP-throttled via Attack.
-  # Signature verification is handled in the controller.
+  # GitHub secret scanning alert endpoint — no auth, exempt from Plugs.Attack
+  # throttling per the partner program agreement. Signature verification is
+  # handled in the controller.
   scope "/api/github", HexpmWeb.API, as: :api_github do
     pipe_through [:accepts_json]
 

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -406,8 +406,9 @@ defmodule HexpmWeb.Router do
     get "/feeds/blog.xml", FeedsController, :blog
   end
 
-  # GitHub secret scanning alert endpoint — no auth, IP-throttled via Attack.
-  # Signature verification is handled in the controller.
+  # GitHub secret scanning alert endpoint — no auth, exempt from Plugs.Attack
+  # throttling per the partner program agreement. Signature verification is
+  # handled in the controller.
   scope "/api/github", HexpmWeb.API, as: :api_github do
     pipe_through [:accepts_json]
 

--- a/lib/hexpm_web/templates/dashboard/key/components/key_management_card.ex
+++ b/lib/hexpm_web/templates/dashboard/key/components/key_management_card.ex
@@ -113,8 +113,7 @@ defmodule HexpmWeb.Dashboard.Key.Components.KeyManagementCard do
   end
 
   defp key_row(assigns) do
-    modal_id = "revoke-key-#{assigns.key.id}"
-    assigns = assign(assigns, :modal_id, modal_id)
+    assigns = assign(assigns, :modal_id, "revoke-key-#{assigns.key.id}")
 
     ~H"""
     <tr>
@@ -160,7 +159,7 @@ defmodule HexpmWeb.Dashboard.Key.Components.KeyManagementCard do
 
       <%!-- Actions Column --%>
       <td class="px-4 py-4">
-        <div class="flex items-center justify-end">
+        <div class="flex items-center justify-end gap-2">
           <.tooltip text="Revoke key">
             <.icon_button
               phx-click={show_modal(@modal_id)}

--- a/lib/hexpm_web/templates/docs/layout.html.heex
+++ b/lib/hexpm_web/templates/docs/layout.html.heex
@@ -263,6 +263,22 @@
                   Public keys
                 </a>
               </li>
+              <li>
+                <a
+                  href={~p"/docs/leaked-keys"}
+                  class={[
+                    "block px-3 py-1.5 text-sm rounded transition-colors",
+                    if(@view_name == :leaked_keys,
+                      do:
+                        "bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-200 font-medium",
+                      else:
+                        "text-grey-700 dark:text-grey-200 hover:bg-grey-50 dark:hover:bg-grey-800"
+                    )
+                  ]}
+                >
+                  Leaked API keys
+                </a>
+              </li>
             </ul>
           </div>
         </div>

--- a/lib/hexpm_web/templates/docs/leaked_keys.html.md
+++ b/lib/hexpm_web/templates/docs/leaked_keys.html.md
@@ -1,0 +1,63 @@
+## Leaked API keys
+
+If you reached this page from a GitHub secret scanning alert, your Hex.pm API key was found in a public location — a public GitHub repository, a public Gist, or a public npm package — and has been automatically revoked.
+
+Hex.pm API keys carry a `hex_` prefix followed by 40 hexadecimal characters (for example `hex_0123456789abcdef0123456789abcdef0123abcd`). GitHub detects this pattern, forwards the matching token to Hex.pm, and we revoke it before it can be used by anyone who found it.
+
+### What Hex.pm did automatically
+
+* Verified the leaked token's checksum to confirm it was a real Hex.pm key.
+* Revoked the key immediately. Subsequent requests using it return `401 Unauthorized`.
+* Sent an email to the key's owner with the GitHub URL where it was found.
+
+No further action is required from Hex.pm. The steps below are for you, the key owner.
+
+### Step 1. Confirm the revocation
+
+Open the [API keys page](/dashboard/keys) on your dashboard. The leaked key will appear with a revocation timestamp. If you do not see it as revoked, contact [support@hex.pm](mailto:support@hex.pm) — do not continue using the key.
+
+### Step 2. Generate a replacement key
+
+Create a new key on the [API keys page](/dashboard/keys). Scope it to the smallest permission set that the consumer actually needs — see [Permissions](/docs/permissions) for the available scopes. If you only need the key for publishing or for read access to a single repository, do not issue a full-access key.
+
+For locally-stored credentials used by the Mix client, the simplest path is:
+
+```nohighlight
+mix hex.user auth
+```
+
+This generates and stores a new client-scoped key without you needing to copy a token by hand.
+
+### Step 3. Update everywhere the leaked key was used
+
+Replace the revoked key in every location it appears, including:
+
+* `~/.hex/hex.config` and any other developer machines that authenticated with the old key.
+* CI/CD secret stores — the conventional environment variable is `HEX_API_KEY`. Common locations: GitHub Actions repository and organization secrets, GitLab CI variables, CircleCI contexts, Jenkins credentials.
+* Container images, Helm charts, or deployment manifests that bake in the token.
+* `mix.exs` or release scripts that pass `--key` to `mix hex.publish`.
+
+If you are unsure where the key was used, search your codebase, secret stores, and CI logs for the prefix `hex_` to find any references.
+
+### Step 4. Review the audit log for unauthorized activity
+
+Open the [audit log](/users/me/audit-logs) for your account and review the period between when the key was created and when it was revoked. Look for actions you did not perform yourself — new package releases, ownership changes, or key creation. For organization-owned keys, the relevant log is on the organization page.
+
+If you find activity you did not authorize, contact [security@hex.pm](mailto:security@hex.pm) right away.
+
+### Step 5. Clean the secret from your repository
+
+Removing the file or pushing a follow-up commit is not enough — the leaked key is still present in your git history and can be recovered from the repository's reflog, from forks, and from clones already made by other people.
+
+Because the key has been revoked, scrubbing it from history is no longer required for security. It can still be worth doing for hygiene; GitHub's guide [Removing sensitive data from a repository](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/removing-sensitive-data-from-a-repository) covers the available options.
+
+### Step 6. Prevent future leaks
+
+* **Use scoped keys.** A publish-only or read-only key cannot be used to take over your account. See [Permissions](/docs/permissions).
+* **Set an expiry on CI keys.** Keys can be issued with an expiration date so a forgotten secret eventually stops working on its own.
+* **Never commit a key.** Use your CI provider's secret store and read the value from an environment variable at runtime. Pre-commit hooks that grep for `hex_[0-9a-f]{40}` are a cheap second line of defense.
+* **Rotate periodically.** A regular rotation cadence makes the impact of a future leak smaller.
+
+### False positives or questions
+
+If you believe the alert was a false positive, or you have questions about the revocation, contact [support@hex.pm](mailto:support@hex.pm). To report a security issue separately from a leaked key, email [security@hex.pm](mailto:security@hex.pm).

--- a/lib/hexpm_web/templates/email/key_leaked.html.eex
+++ b/lib/hexpm_web/templates/email/key_leaked.html.eex
@@ -1,0 +1,25 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+    Your API key was found in a public repository
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= Common.greeting(@username) %>,
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  GitHub's secret scanning detected your Hex.pm API key <strong><%= @key_name %></strong> in a public repository. To protect your account, the key has been automatically revoked.
+</p>
+
+<%= if @found_url && @found_url != "" do %>
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  It was found at: <a href="<%= @found_url %>"><%= @found_url %></a>.
+</p>
+<% end %>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  You can generate a new key at <a href="<%= url(~p"/dashboard/keys") %>"><%= url(~p"/dashboard/keys") %></a>.
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  If you believe this was a false positive or have questions, contact <a href="mailto:<%= Common.support_email() %>"><%= Common.support_email() %></a>.
+</p>

--- a/lib/hexpm_web/templates/email/key_leaked.text.eex
+++ b/lib/hexpm_web/templates/email/key_leaked.text.eex
@@ -1,0 +1,11 @@
+<%= Common.greeting(@username) %>
+
+Your API key was found in a public repository
+
+GitHub's secret scanning detected your Hex.pm API key "<%= @key_name %>" in a public repository. To protect your account, the key has been automatically revoked.
+<%= if @found_url && @found_url != "" do %>
+It was found at: <%= @found_url %>
+<% end %>
+You can generate a new key at <%= url(~p"/dashboard/keys") %>.
+
+If you believe this was a false positive or have questions, contact support at <%= Common.support_email() %>.

--- a/lib/hexpm_web/views/api/key_view.ex
+++ b/lib/hexpm_web/views/api/key_view.ex
@@ -19,6 +19,7 @@ defmodule HexpmWeb.API.KeyView do
       name: key.name,
       authing_key: !!(authing_key && key.id == authing_key.id),
       secret: key.user_secret,
+      token_format: key.token_format,
       permissions: render_many(key.permissions, KeyPermissionView, "show.json"),
       revoke_at: key.revoke_at,
       inserted_at: key.inserted_at,

--- a/lib/hexpm_web/views/docs_view.ex
+++ b/lib/hexpm_web/views/docs_view.ex
@@ -38,7 +38,8 @@ defmodule HexpmWeb.DocsView do
            %{view: :faq, label: "FAQ", href: ~p"/docs/faq"},
            %{view: :self_hosting, label: "Self-hosting", href: ~p"/docs/self-hosting"},
            %{view: :mirrors, label: "Mirrors", href: ~p"/docs/mirrors"},
-           %{view: :public_keys, label: "Public keys", href: ~p"/docs/public-keys"}
+           %{view: :public_keys, label: "Public keys", href: ~p"/docs/public-keys"},
+           %{view: :leaked_keys, label: "Leaked API keys", href: ~p"/docs/leaked-keys"}
          ]}
     ]
   end

--- a/priv/repo/migrations/20260429120000_add_token_format_to_keys.exs
+++ b/priv/repo/migrations/20260429120000_add_token_format_to_keys.exs
@@ -1,0 +1,9 @@
+defmodule Hexpm.Repo.Migrations.AddTokenFormatToKeys do
+  use Ecto.Migration
+
+  def change do
+    alter table(:keys) do
+      add :token_format, :string, null: false, default: "v1"
+    end
+  end
+end

--- a/test/hexpm/accounts/auth_test.exs
+++ b/test/hexpm/accounts/auth_test.exs
@@ -32,6 +32,46 @@ defmodule Hexpm.Accounts.AuthTest do
   end
 
   describe "key_auth/2" do
+    test "authorizes correct v2 key (hex_ prefix)", %{user: user} do
+      key = insert(:key, user: user)
+      assert String.starts_with?(key.user_secret, "hex_")
+
+      assert {:ok,
+              %{
+                user: auth_user,
+                auth_credential: auth_key,
+                email: email,
+                organization: organization
+              }} =
+               Auth.key_auth(key.user_secret, %{})
+
+      assert auth_key.id == key.id
+      assert auth_user.id == user.id
+      assert email.id == hd(user.emails).id
+      assert organization == nil
+    end
+
+    test "authorizes legacy v1 key (no prefix)", %{user: user} do
+      raw_secret = Auth.gen_key()
+      app_secret = Application.get_env(:hexpm, :secret)
+
+      <<first::binary-size(32), second::binary-size(32)>> =
+        :crypto.mac(:hmac, :sha256, app_secret, raw_secret)
+        |> Base.encode16(case: :lower)
+
+      key =
+        insert(:key,
+          user: user,
+          secret_first: first,
+          secret_second: second,
+          user_secret: raw_secret,
+          token_format: "v1"
+        )
+
+      assert {:ok, %{auth_credential: auth_key}} = Auth.key_auth(raw_secret, %{})
+      assert auth_key.id == key.id
+    end
+
     test "authorizes correct key", %{user: user} do
       key = insert(:key, user: user)
 
@@ -75,6 +115,12 @@ defmodule Hexpm.Accounts.AuthTest do
     test "does not authorize revoked key", %{user: user} do
       key = insert(:key, user: user, revoke_at: ~N"2017-01-01 00:00:00")
       assert Auth.key_auth(key.user_secret, %{}) == :revoked
+    end
+
+    test "rejects hex_-prefixed token with invalid CRC32 checksum" do
+      # 40 hex chars with the wrong checksum — bypasses DB lookup entirely
+      bad_token = "hex_" <> String.duplicate("a", 40)
+      assert Auth.key_auth(bad_token, %{}) == :error
     end
   end
 

--- a/test/hexpm/accounts/keys_test.exs
+++ b/test/hexpm/accounts/keys_test.exs
@@ -22,6 +22,28 @@ defmodule Hexpm.Accounts.KeysTest do
     }
   end
 
+  describe "create/2 token format" do
+    test "new keys have v2 token format", %{user: user} do
+      params = %{"name" => "keyname", "permissions" => [%{"domain" => "api"}]}
+      assert {:ok, %{key: key}} = Keys.create(user, params, audit: audit_data(user))
+      assert key.token_format == "v2"
+    end
+
+    test "new key user_secret has hex_ prefix", %{user: user} do
+      params = %{"name" => "keyname", "permissions" => [%{"domain" => "api"}]}
+      assert {:ok, %{key: key}} = Keys.create(user, params, audit: audit_data(user))
+      assert String.starts_with?(key.user_secret, "hex_")
+    end
+
+    test "user_secret body is 40 lowercase hex chars (32 random + 8 CRC32)", %{user: user} do
+      params = %{"name" => "keyname", "permissions" => [%{"domain" => "api"}]}
+      assert {:ok, %{key: key}} = Keys.create(user, params, audit: audit_data(user))
+      assert "hex_" <> body = key.user_secret
+      assert String.length(body) == 40
+      assert body =~ ~r/^[a-f0-9]{40}$/
+    end
+  end
+
   describe "create/2 with revoke_at" do
     test "create key with future revoke_at", %{user: user} do
       revoke_at = DateTime.utc_now() |> DateTime.add(30, :day) |> DateTime.truncate(:second)
@@ -61,7 +83,8 @@ defmodule Hexpm.Accounts.KeysTest do
       assert {:ok, %{key: key}} = Keys.create(user, params, audit: audit_data(user))
       assert key.name == "keyname"
       assert key.user_id == user.id
-      assert {:ok, _} = Base.decode16(key.user_secret, case: :lower)
+      assert "hex_" <> raw = key.user_secret
+      assert {:ok, _} = Base.decode16(raw, case: :lower)
     end
 
     test "organization api permissions", %{organization: organization} do
@@ -75,7 +98,8 @@ defmodule Hexpm.Accounts.KeysTest do
 
       assert key.name == "keyname"
       assert key.organization_id == organization.id
-      assert {:ok, _} = Base.decode16(key.user_secret, case: :lower)
+      assert "hex_" <> raw = key.user_secret
+      assert {:ok, _} = Base.decode16(raw, case: :lower)
     end
 
     test "user package permissions", %{user: user, package: package} do

--- a/test/hexpm/cache_test.exs
+++ b/test/hexpm/cache_test.exs
@@ -49,6 +49,27 @@ defmodule Hexpm.CacheTest do
     assert Cache.fetch(table, :key, fun, 60) == 2
   end
 
+  test "invalidate removes a cached entry so the next fetch recomputes", %{table: table} do
+    counter = :counters.new(1, [])
+
+    fun = fn ->
+      :counters.add(counter, 1, 1)
+      :counters.get(counter, 1)
+    end
+
+    assert Cache.fetch(table, :key, fun, :infinity) == 1
+    assert Cache.fetch(table, :key, fun, :infinity) == 1
+
+    assert Cache.invalidate(table, :key) == :ok
+    assert :ets.lookup(table, :key) == []
+
+    assert Cache.fetch(table, :key, fun, :infinity) == 2
+  end
+
+  test "invalidate is a no-op when the cache table is missing" do
+    assert Cache.invalidate(:no_such_cache, :key) == :ok
+  end
+
   test "concurrent cold readers run the fun exactly once", %{table: table} do
     counter = :counters.new(1, [])
     {:ok, gate} = Agent.start_link(fn -> nil end)

--- a/test/hexpm/cache_test.exs
+++ b/test/hexpm/cache_test.exs
@@ -30,6 +30,7 @@ defmodule Hexpm.CacheTest do
     counter = :counters.new(1, [])
 
     fun = fn ->
+      Process.sleep(100)
       :counters.add(counter, 1, 1)
       :counters.get(counter, 1)
     end
@@ -42,7 +43,7 @@ defmodule Hexpm.CacheTest do
     tasks = for _ <- 1..10, do: Task.async(fn -> Cache.fetch(table, :key, fun, 60) end)
     assert Enum.map(tasks, &Task.await/1) == List.duplicate(1, 10)
 
-    Process.sleep(20)
+    Process.sleep(200)
 
     assert :counters.get(counter, 1) == 2
     assert Cache.fetch(table, :key, fun, 60) == 2

--- a/test/hexpm/cache_test.exs
+++ b/test/hexpm/cache_test.exs
@@ -2,10 +2,14 @@ defmodule Hexpm.CacheTest do
   use ExUnit.Case, async: true
   alias Hexpm.Cache
 
-  test "fetch populates on first call and returns cached on subsequent calls" do
-    {:ok, pid} = Cache.start_link(name: :cache_test_fetch, interval: 60_000)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+  setup context do
+    table = context.test
+    Cache.start(table)
+    on_exit(fn -> :ets.whereis(table) != :undefined && :ets.delete(table) end)
+    %{table: table}
+  end
 
+  test "fetch populates on first call and returns cached on subsequent calls", %{table: table} do
     counter = :counters.new(1, [])
 
     fun = fn ->
@@ -13,15 +17,16 @@ defmodule Hexpm.CacheTest do
       :counters.get(counter, 1)
     end
 
-    assert Cache.fetch(:cache_test_fetch, :key, fun) == 1
-    assert Cache.fetch(:cache_test_fetch, :key, fun) == 1
+    assert Cache.fetch(table, :key, fun, :infinity) == 1
+    assert Cache.fetch(table, :key, fun, :infinity) == 1
     assert :counters.get(counter, 1) == 1
   end
 
-  test "refresh re-runs registered fns" do
-    {:ok, pid} = Cache.start_link(name: :cache_test_refresh, interval: 60_000)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+  test "fetch falls through to fun when cache table is missing" do
+    assert Cache.fetch(:no_such_cache, :key, fn -> :fallback end, :infinity) == :fallback
+  end
 
+  test "fetch with TTL serves stale value and refreshes asynchronously", %{table: table} do
     counter = :counters.new(1, [])
 
     fun = fn ->
@@ -29,32 +34,37 @@ defmodule Hexpm.CacheTest do
       :counters.get(counter, 1)
     end
 
-    assert Cache.fetch(:cache_test_refresh, :key, fun) == 1
-    :ok = Cache.refresh(:cache_test_refresh)
-    assert Cache.fetch(:cache_test_refresh, :key, fun) == 2
+    assert Cache.fetch(table, :key, fun, 60) == 1
+
+    [{:key, _value, stored_fun, _ts}] = :ets.lookup(table, :key)
+    :ets.insert(table, {:key, 1, stored_fun, System.monotonic_time(:second) - 120})
+
+    tasks = for _ <- 1..10, do: Task.async(fn -> Cache.fetch(table, :key, fun, 60) end)
+    assert Enum.map(tasks, &Task.await/1) == List.duplicate(1, 10)
+
+    Process.sleep(20)
+
+    assert :counters.get(counter, 1) == 2
+    assert Cache.fetch(table, :key, fun, 60) == 2
   end
 
-  test "fetch falls through to fun when cache not started" do
-    assert Cache.fetch(:no_such_cache, :key, fn -> :fallback end) == :fallback
-  end
-
-  test "fetch with :ttl recomputes after the entry has expired" do
-    {:ok, pid} = Cache.start_link(name: :cache_test_ttl, interval: 60_000)
-    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
-
+  test "concurrent cold readers run the fun exactly once", %{table: table} do
     counter = :counters.new(1, [])
+    {:ok, gate} = Agent.start_link(fn -> nil end)
 
     fun = fn ->
+      Agent.get(gate, & &1, :infinity)
       :counters.add(counter, 1, 1)
       :counters.get(counter, 1)
     end
 
-    assert Cache.fetch(:cache_test_ttl, :key, fun, ttl: 60) == 1
-    assert Cache.fetch(:cache_test_ttl, :key, fun, ttl: 60) == 1
+    tasks = for _ <- 1..20, do: Task.async(fn -> Cache.fetch(table, :key, fun, :infinity) end)
+    Process.sleep(10)
+    Agent.update(gate, fn _ -> :go end)
 
-    [{:key, _value, stored_fun, _ts}] = :ets.lookup(:cache_test_ttl, :key)
-    :ets.insert(:cache_test_ttl, {:key, 1, stored_fun, System.monotonic_time(:second) - 120})
+    results = Enum.map(tasks, &Task.await/1)
 
-    assert Cache.fetch(:cache_test_ttl, :key, fun, ttl: 60) == 2
+    assert :counters.get(counter, 1) == 1
+    assert Enum.uniq(results) == [1]
   end
 end

--- a/test/hexpm/cache_test.exs
+++ b/test/hexpm/cache_test.exs
@@ -37,4 +37,24 @@ defmodule Hexpm.CacheTest do
   test "fetch falls through to fun when cache not started" do
     assert Cache.fetch(:no_such_cache, :key, fn -> :fallback end) == :fallback
   end
+
+  test "fetch with :ttl recomputes after the entry has expired" do
+    {:ok, pid} = Cache.start_link(name: :cache_test_ttl, interval: 60_000)
+    on_exit(fn -> if Process.alive?(pid), do: GenServer.stop(pid) end)
+
+    counter = :counters.new(1, [])
+
+    fun = fn ->
+      :counters.add(counter, 1, 1)
+      :counters.get(counter, 1)
+    end
+
+    assert Cache.fetch(:cache_test_ttl, :key, fun, ttl: 60) == 1
+    assert Cache.fetch(:cache_test_ttl, :key, fun, ttl: 60) == 1
+
+    [{:key, _value, stored_fun, _ts}] = :ets.lookup(:cache_test_ttl, :key)
+    :ets.insert(:cache_test_ttl, {:key, 1, stored_fun, System.monotonic_time(:second) - 120})
+
+    assert Cache.fetch(:cache_test_ttl, :key, fun, ttl: 60) == 2
+  end
 end

--- a/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
+++ b/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
@@ -113,8 +113,6 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
         ec_priv
       )
 
-      assert_email_delivered_with(subject: ~r/A new API key was created/i)
-
       assert_email_delivered_with(
         subject: ~r/ci-key.*revoked/i,
         html_body: ~r|https://github\.com/example/repo|,

--- a/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
+++ b/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
@@ -96,6 +96,10 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
       stub.()
       {:ok, %{key: key}} = Keys.create(user, %{"name" => "ci-key"}, audit: audit_data(user))
 
+      # Keys.create now sends an api_key_created security notification;
+      # consume it so it doesn't shadow the key_leaked assertion below.
+      assert_email_delivered_with(subject: ~r/new API key.*created/i)
+
       post_alert(
         conn,
         [

--- a/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
+++ b/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
@@ -303,6 +303,36 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
       assert Repo.get!(Key, key.id).revoke_at == nil
     end
 
+    test "revokes an organization-owned key without sending email", %{
+      conn: conn,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      stub.()
+      organization = insert(:organization)
+
+      {:ok, %{key: key}} =
+        Keys.create(organization, %{"name" => "org-key"}, audit: audit_data(organization))
+
+      conn =
+        post_alert(
+          conn,
+          [
+            %{
+              "token" => key.user_secret,
+              "type" => "hexpm_api_token",
+              "url" => "https://github.com/example/repo",
+              "source" => "commit"
+            }
+          ],
+          ec_priv
+        )
+
+      assert [%{"label" => "true_positive"}] = json_response(conn, 200)
+      assert Repo.get!(Key, key.id).revoke_at != nil
+      assert [] = Bamboo.SentEmail.all()
+    end
+
     test "does not send email when an already-revoked key is reported", %{
       conn: conn,
       user: user,

--- a/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
+++ b/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
@@ -1,0 +1,340 @@
+defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
+  use HexpmWeb.ConnCase, async: false
+
+  import Ecto.Query
+  import Mox
+  import Bamboo.Test
+
+  alias Hexpm.Accounts.{Key, Keys}
+  alias Hexpm.GitHub.SecretScanning
+  alias Hexpm.Repo
+
+  setup :verify_on_exit!
+
+  # Generate a fresh ECDSA P256 key pair once for the test module.
+  # Each test signs payloads with this private key and mocks the HTTP call
+  # to return the corresponding public key.
+  @key_id "test-key-id-abc123"
+
+  setup do
+    {pem_pub, ec_priv} = SecretScanning.generate_test_keypair()
+    conn = build_conn()
+
+    stub_github_keys = fn ->
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+        assert String.contains?(url, "secret_scanning")
+
+        {:ok, 200, [],
+         %{
+           "public_keys" => [
+             %{"key_identifier" => @key_id, "key" => pem_pub, "is_current" => true}
+           ]
+         }}
+      end)
+    end
+
+    user = insert(:user)
+
+    %{
+      conn: conn,
+      user: user,
+      pem_pub: pem_pub,
+      ec_priv: ec_priv,
+      stub_github_keys: stub_github_keys
+    }
+  end
+
+  defp post_alert(conn, body, ec_priv, key_id \\ @key_id) do
+    raw = Jason.encode!(body)
+    sig = SecretScanning.sign_payload(raw, ec_priv)
+
+    conn
+    |> put_req_header("content-type", "application/json")
+    |> put_req_header("github-public-key-identifier", key_id)
+    |> put_req_header("github-public-key-signature", sig)
+    |> dispatch(HexpmWeb.Endpoint, :post, "/api/github/secret-scanning", raw)
+  end
+
+  describe "POST /api/github/secret-scanning" do
+    test "returns 200, revokes key, and responds with true_positive label", %{
+      conn: conn,
+      user: user,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      stub.()
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "leaked"}, audit: audit_data(user))
+
+      conn =
+        post_alert(
+          conn,
+          [
+            %{
+              "token" => key.user_secret,
+              "type" => "hexpm_api_token",
+              "url" => "https://github.com/example/repo",
+              "source" => "commit"
+            }
+          ],
+          ec_priv
+        )
+
+      assert [%{"label" => "true_positive", "token_type" => "hexpm_api_token"}] =
+               json_response(conn, 200)
+
+      revoked = Repo.get!(Key, key.id)
+      assert revoked.revoke_at != nil
+      assert DateTime.compare(revoked.revoke_at, DateTime.utc_now()) != :gt
+    end
+
+    test "sends key_leaked email to the key owner", %{
+      conn: conn,
+      user: user,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      stub.()
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "ci-key"}, audit: audit_data(user))
+
+      post_alert(
+        conn,
+        [
+          %{
+            "token" => key.user_secret,
+            "type" => "hexpm_api_token",
+            "url" => "https://github.com/example/repo",
+            "source" => "commit"
+          }
+        ],
+        ec_priv
+      )
+
+      assert_email_delivered_with(
+        subject: ~r/ci-key.*revoked/i,
+        html_body: ~r|https://github\.com/example/repo|,
+        text_body: ~r|https://github\.com/example/repo|
+      )
+    end
+
+    test "returns false_positive label for an unknown token", %{
+      conn: conn,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      stub.()
+      fake_token = "hex_" <> String.duplicate("a", 40)
+
+      conn =
+        post_alert(
+          conn,
+          [
+            %{
+              "token" => fake_token,
+              "type" => "hexpm_api_token",
+              "url" => "",
+              "source" => "content"
+            }
+          ],
+          ec_priv
+        )
+
+      assert [%{"label" => "false_positive", "token_type" => "hexpm_api_token"}] =
+               json_response(conn, 200)
+    end
+
+    test "processes multiple alerts and returns one result per token", %{
+      conn: conn,
+      user: user,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      stub.()
+      {:ok, %{key: key1}} = Keys.create(user, %{"name" => "key1"}, audit: audit_data(user))
+      {:ok, %{key: key2}} = Keys.create(user, %{"name" => "key2"}, audit: audit_data(user))
+
+      alerts = [
+        %{
+          "token" => key1.user_secret,
+          "type" => "hexpm_api_token",
+          "url" => "",
+          "source" => "content"
+        },
+        %{
+          "token" => key2.user_secret,
+          "type" => "hexpm_api_token",
+          "url" => "",
+          "source" => "content"
+        }
+      ]
+
+      conn = post_alert(conn, alerts, ec_priv)
+
+      assert [
+               %{"label" => "true_positive"},
+               %{"label" => "true_positive"}
+             ] = json_response(conn, 200)
+
+      assert Repo.get!(Key, key1.id).revoke_at != nil
+      assert Repo.get!(Key, key2.id).revoke_at != nil
+    end
+
+    test "returns 403 when signature is invalid", %{conn: conn, user: user} do
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "leaked"}, audit: audit_data(user))
+
+      raw =
+        Jason.encode!([
+          %{
+            "token" => key.user_secret,
+            "type" => "hexpm_api_token",
+            "url" => "",
+            "source" => "content"
+          }
+        ])
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn _url, _headers ->
+        # Return a different (wrong) key so the signature check fails
+        {pem_wrong, _priv} = SecretScanning.generate_test_keypair()
+
+        {:ok, 200, [],
+         %{
+           "public_keys" => [
+             %{"key_identifier" => @key_id, "key" => pem_wrong, "is_current" => true}
+           ]
+         }}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("github-public-key-identifier", @key_id)
+        |> put_req_header("github-public-key-signature", "bm90YXZhbGlkc2ln")
+        |> dispatch(HexpmWeb.Endpoint, :post, "/api/github/secret-scanning", raw)
+
+      assert conn.status == 403
+      # Key must NOT have been revoked
+      assert Repo.get!(Key, key.id).revoke_at == nil
+    end
+
+    test "returns 403 when signature is for a different body", %{
+      conn: conn,
+      user: user,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      stub.()
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "safe"}, audit: audit_data(user))
+
+      # Sign a different payload, then send it with the original body
+      decoy =
+        Jason.encode!([
+          %{
+            "token" => "hex_" <> String.duplicate("f", 40),
+            "type" => "hexpm_api_token",
+            "url" => "",
+            "source" => "content"
+          }
+        ])
+
+      sig = SecretScanning.sign_payload(decoy, ec_priv)
+
+      real_body =
+        Jason.encode!([
+          %{
+            "token" => key.user_secret,
+            "type" => "hexpm_api_token",
+            "url" => "",
+            "source" => "content"
+          }
+        ])
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("github-public-key-identifier", @key_id)
+        |> put_req_header("github-public-key-signature", sig)
+        |> dispatch(HexpmWeb.Endpoint, :post, "/api/github/secret-scanning", real_body)
+
+      assert conn.status == 403
+      assert Repo.get!(Key, key.id).revoke_at == nil
+    end
+
+    test "returns 400 for empty body", %{conn: conn} do
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("github-public-key-identifier", @key_id)
+        |> put_req_header("github-public-key-signature", "anysig")
+        |> dispatch(HexpmWeb.Endpoint, :post, "/api/github/secret-scanning", "")
+
+      assert conn.status == 400
+    end
+
+    test "returns 403 when GitHub public key fetch fails", %{
+      conn: conn,
+      user: user,
+      ec_priv: ec_priv
+    } do
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "safe"}, audit: audit_data(user))
+
+      raw =
+        Jason.encode!([
+          %{
+            "token" => key.user_secret,
+            "type" => "hexpm_api_token",
+            "url" => "",
+            "source" => "content"
+          }
+        ])
+
+      sig = SecretScanning.sign_payload(raw, ec_priv)
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn _url, _headers ->
+        {:error, %Mint.TransportError{reason: :econnrefused}}
+      end)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("github-public-key-identifier", @key_id)
+        |> put_req_header("github-public-key-signature", sig)
+        |> dispatch(HexpmWeb.Endpoint, :post, "/api/github/secret-scanning", raw)
+
+      assert conn.status == 403
+      assert Repo.get!(Key, key.id).revoke_at == nil
+    end
+
+    test "does not send email when an already-revoked key is reported", %{
+      conn: conn,
+      user: user,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      stub.()
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "old"}, audit: audit_data(user))
+      # Stamp the key as revoked a day ago using raw SQL to avoid any timing ambiguity
+      # between Elixir's DateTime.utc_now() and PostgreSQL's NOW() in the sandbox.
+      Repo.update_all(
+        from(k in Key, where: k.id == ^key.id),
+        set: [revoke_at: ~U[2020-01-01 00:00:00Z]]
+      )
+
+      # GitHub alert arrives for the already-revoked key
+      conn =
+        post_alert(
+          conn,
+          [
+            %{
+              "token" => key.user_secret,
+              "type" => "hexpm_api_token",
+              "url" => "",
+              "source" => "content"
+            }
+          ],
+          ec_priv
+        )
+
+      assert [%{"label" => "false_positive"}] = json_response(conn, 200)
+      assert [] = Bamboo.SentEmail.all()
+    end
+  end
+end

--- a/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
+++ b/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
@@ -109,6 +109,8 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
         ec_priv
       )
 
+      assert_email_delivered_with(subject: ~r/A new API key was created/i)
+
       assert_email_delivered_with(
         subject: ~r/ci-key.*revoked/i,
         html_body: ~r|https://github\.com/example/repo|,

--- a/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
+++ b/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
@@ -333,6 +333,91 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
       assert [] = Bamboo.SentEmail.all()
     end
 
+    test "refreshes public keys when an unknown key_identifier is received", %{
+      conn: conn,
+      user: user,
+      pem_pub: pem_pub,
+      ec_priv: ec_priv
+    } do
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "rotated"}, audit: audit_data(user))
+      rotated_key_id = "rotated-key-id-xyz"
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, 2, fn _url, _headers ->
+        # First call returns stale keys without the rotated identifier.
+        # After cache invalidation, the second call returns the new identifier.
+        if Process.get(:got_first_call) do
+          {:ok, 200, [],
+           %{
+             "public_keys" => [
+               %{"key_identifier" => rotated_key_id, "key" => pem_pub, "is_current" => true}
+             ]
+           }}
+        else
+          Process.put(:got_first_call, true)
+
+          {:ok, 200, [],
+           %{
+             "public_keys" => [
+               %{"key_identifier" => "stale-key-id", "key" => pem_pub, "is_current" => false}
+             ]
+           }}
+        end
+      end)
+
+      conn =
+        post_alert(
+          conn,
+          [
+            %{
+              "token" => key.user_secret,
+              "type" => "hexpm_api_token",
+              "url" => "",
+              "source" => "content"
+            }
+          ],
+          ec_priv,
+          rotated_key_id
+        )
+
+      assert [%{"label" => "true_positive"}] = json_response(conn, 200)
+      assert Repo.get!(Key, key.id).revoke_at != nil
+    end
+
+    test "does not retry the key fetch on a tampered signature with a known key_id", %{
+      conn: conn,
+      user: user,
+      ec_priv: ec_priv,
+      stub_github_keys: stub
+    } do
+      # Only one stub allowed; a second HTTP call would fail Mox verification.
+      stub.()
+
+      {:ok, %{key: key}} = Keys.create(user, %{"name" => "tampered"}, audit: audit_data(user))
+
+      raw =
+        Jason.encode!([
+          %{
+            "token" => key.user_secret,
+            "type" => "hexpm_api_token",
+            "url" => "",
+            "source" => "content"
+          }
+        ])
+
+      # Sign a different payload so verify fails for the known key.
+      decoy_sig = SecretScanning.sign_payload("not the body", ec_priv)
+
+      conn =
+        conn
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("github-public-key-identifier", @key_id)
+        |> put_req_header("github-public-key-signature", decoy_sig)
+        |> dispatch(HexpmWeb.Endpoint, :post, "/api/github/secret-scanning", raw)
+
+      assert conn.status == 403
+      assert Repo.get!(Key, key.id).revoke_at == nil
+    end
+
     test "does not send email when an already-revoked key is reported", %{
       conn: conn,
       user: user,

--- a/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
+++ b/test/hexpm_web/controllers/api/github_secret_scanning_controller_test.exs
@@ -3,7 +3,7 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
 
   import Ecto.Query
   import Mox
-  import Bamboo.Test
+  import Swoosh.TestAssertions
 
   alias Hexpm.Accounts.{Key, Keys}
   alias Hexpm.GitHub.SecretScanning
@@ -98,7 +98,7 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
 
       # Keys.create now sends an api_key_created security notification;
       # consume it so it doesn't shadow the key_leaked assertion below.
-      assert_email_delivered_with(subject: ~r/new API key.*created/i)
+      assert_email_sent(subject: ~r/new API key.*created/i)
 
       post_alert(
         conn,
@@ -113,7 +113,7 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
         ec_priv
       )
 
-      assert_email_delivered_with(
+      assert_email_sent(
         subject: ~r/ci-key.*revoked/i,
         html_body: ~r|https://github\.com/example/repo|,
         text_body: ~r|https://github\.com/example/repo|
@@ -318,6 +318,10 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
       {:ok, %{key: key}} =
         Keys.create(organization, %{"name" => "org-key"}, audit: audit_data(organization))
 
+      # Consume the api_key_created security notification sent by Keys.create
+      # so the assertion below only covers the revocation flow.
+      assert_email_sent(subject: ~r/new API key.*created/i)
+
       conn =
         post_alert(
           conn,
@@ -334,7 +338,7 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
 
       assert [%{"label" => "true_positive"}] = json_response(conn, 200)
       assert Repo.get!(Key, key.id).revoke_at != nil
-      assert [] = Bamboo.SentEmail.all()
+      assert_no_email_sent()
     end
 
     test "refreshes public keys when an unknown key_identifier is received", %{
@@ -430,6 +434,11 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
     } do
       stub.()
       {:ok, %{key: key}} = Keys.create(user, %{"name" => "old"}, audit: audit_data(user))
+
+      # Consume the api_key_created security notification sent by Keys.create
+      # so the assertion below only covers the revocation flow.
+      assert_email_sent(subject: ~r/new API key.*created/i)
+
       # Stamp the key as revoked a day ago using raw SQL to avoid any timing ambiguity
       # between Elixir's DateTime.utc_now() and PostgreSQL's NOW() in the sandbox.
       Repo.update_all(
@@ -453,7 +462,7 @@ defmodule HexpmWeb.API.GitHubSecretScanningControllerTest do
         )
 
       assert [%{"label" => "false_positive"}] = json_response(conn, 200)
-      assert [] = Bamboo.SentEmail.all()
+      assert_no_email_sent()
     end
   end
 end

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -262,6 +262,40 @@ defmodule HexpmWeb.API.KeyControllerTest do
     end
   end
 
+  describe "POST /api/keys (token format)" do
+    test "new key has hex_ prefixed secret and v2 token_format", c do
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", basic_auth(c.eric))
+        |> post("/api/keys", %{name: "mykey"})
+
+      assert conn.status == 201
+      body = json_response(conn, 201)
+      assert String.starts_with?(body["secret"], "hex_")
+      assert body["token_format"] == "v2"
+    end
+
+    test "v2 key authenticates with Bearer hex_ prefix", c do
+      key = Key.build(c.eric, %{name: "ci"}) |> Repo.insert!()
+      assert String.starts_with?(key.user_secret, "hex_")
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> key.user_secret)
+      |> get("/api/keys")
+      |> json_response(200)
+    end
+
+    test "whitespace in raw token header is trimmed", c do
+      key = Key.build(c.eric, %{name: "ci"}) |> Repo.insert!()
+
+      build_conn()
+      |> put_req_header("authorization", " " <> key.user_secret <> " ")
+      |> get("/api/keys")
+      |> json_response(200)
+    end
+  end
+
   describe "DELETE /api/keys" do
     test "delete all keys", c do
       key_a = Key.build(c.eric, %{name: "key_a"}) |> Repo.insert!()

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -277,7 +277,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
       conn =
         build_conn()
         |> put_req_header("content-type", "application/json")
-        |> put_req_header("authorization", basic_auth(c.eric))
+        |> put_req_header("authorization", key_for(c.eric))
         |> post("/api/keys", %{name: "mykey"})
 
       assert conn.status == 201

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -275,7 +275,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
       conn =
         build_conn()
         |> put_req_header("content-type", "application/json")
-        |> put_req_header("authorization", basic_auth(c.eric))
+        |> put_req_header("authorization", key_for(c.eric))
         |> post("/api/keys", %{name: "mykey"})
 
       assert conn.status == 201

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -272,6 +272,40 @@ defmodule HexpmWeb.API.KeyControllerTest do
     end
   end
 
+  describe "POST /api/keys (token format)" do
+    test "new key has hex_ prefixed secret and v2 token_format", c do
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", basic_auth(c.eric))
+        |> post("/api/keys", %{name: "mykey"})
+
+      assert conn.status == 201
+      body = json_response(conn, 201)
+      assert String.starts_with?(body["secret"], "hex_")
+      assert body["token_format"] == "v2"
+    end
+
+    test "v2 key authenticates with Bearer hex_ prefix", c do
+      key = Key.build(c.eric, %{name: "ci"}) |> Repo.insert!()
+      assert String.starts_with?(key.user_secret, "hex_")
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> key.user_secret)
+      |> get("/api/keys")
+      |> json_response(200)
+    end
+
+    test "whitespace in raw token header is trimmed", c do
+      key = Key.build(c.eric, %{name: "ci"}) |> Repo.insert!()
+
+      build_conn()
+      |> put_req_header("authorization", " " <> key.user_secret <> " ")
+      |> get("/api/keys")
+      |> json_response(200)
+    end
+  end
+
   describe "DELETE /api/keys" do
     test "delete all keys", c do
       key_a = Key.build(c.eric, %{name: "key_a"}) |> Repo.insert!()

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -270,6 +270,40 @@ defmodule HexpmWeb.API.KeyControllerTest do
     end
   end
 
+  describe "POST /api/keys (token format)" do
+    test "new key has hex_ prefixed secret and v2 token_format", c do
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", basic_auth(c.eric))
+        |> post("/api/keys", %{name: "mykey"})
+
+      assert conn.status == 201
+      body = json_response(conn, 201)
+      assert String.starts_with?(body["secret"], "hex_")
+      assert body["token_format"] == "v2"
+    end
+
+    test "v2 key authenticates with Bearer hex_ prefix", c do
+      key = Key.build(c.eric, %{name: "ci"}) |> Repo.insert!()
+      assert String.starts_with?(key.user_secret, "hex_")
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> key.user_secret)
+      |> get("/api/keys")
+      |> json_response(200)
+    end
+
+    test "whitespace in raw token header is trimmed", c do
+      key = Key.build(c.eric, %{name: "ci"}) |> Repo.insert!()
+
+      build_conn()
+      |> put_req_header("authorization", " " <> key.user_secret <> " ")
+      |> get("/api/keys")
+      |> json_response(200)
+    end
+  end
+
   describe "DELETE /api/keys" do
     test "delete all keys", c do
       key_a = Key.build(c.eric, %{name: "key_a"}) |> Repo.insert!()

--- a/test/hexpm_web/controllers/docs_controller_test.exs
+++ b/test/hexpm_web/controllers/docs_controller_test.exs
@@ -54,6 +54,21 @@ defmodule HexpmWeb.DocsControllerTest do
     end
   end
 
+  test "renders the leaked API keys guide in the docs navigation" do
+    html =
+      build_conn()
+      |> get("/docs/leaked-keys")
+      |> html_response(200)
+
+    assert html =~ "Leaked API keys"
+    assert html =~ "What Hex.pm did automatically"
+
+    {:ok, document} = Floki.parse_document(html)
+    assert [link] = Floki.find(document, ~s(#docs-nav a[href="/docs/leaked-keys"]))
+    assert Floki.text(link) =~ "Leaked API keys"
+    assert Floki.attribute(link, "class") |> List.first() =~ "bg-blue-50"
+  end
+
   test "hides the organization SSO guide and navigation when SSO is off" do
     config = Application.fetch_env!(:hexpm, :organization_sso)
     app_env(:hexpm, :organization_sso, Keyword.put(config, :mode, :off))

--- a/test/hexpm_web/plugs/attack_test.exs
+++ b/test/hexpm_web/plugs/attack_test.exs
@@ -174,6 +174,14 @@ defmodule HexpmWeb.Plugs.AttackTest do
       assert get_resp_header(conn, "x-ratelimit-remaining") == []
     end
 
+    test "doesn't limit requests to the GitHub secret scanning endpoint" do
+      Enum.each(1..150, fn _ ->
+        conn = request_path("/api/github/secret-scanning", {8, 8, 8, 8})
+        assert conn.status == 200
+        assert get_resp_header(conn, "x-ratelimit-remaining") == []
+      end)
+    end
+
     test "doesn't limit requests from service accounts", %{user: user} do
       Hexpm.BlockAddress.reload()
       user = Hexpm.Repo.update!(Ecto.Changeset.change(user, service: true))
@@ -326,7 +334,11 @@ defmodule HexpmWeb.Plugs.AttackTest do
   end
 
   defp request_ip(remote_ip) do
-    conn(:get, "/api/")
+    request_path("/api/", remote_ip)
+  end
+
+  defp request_path(path, remote_ip) do
+    conn(:get, path)
     |> Map.put(:remote_ip, remote_ip)
     |> assign(:current_user, nil)
     |> assign(:current_organization, nil)


### PR DESCRIPTION
## Add `hex_`-prefixed API keys with GitHub Secret Scanning partner integration

Closes #1019.

All newly generated API keys now carry a `hex_` prefix and a 32-bit CRC32 checksum, which satisfies [GitHub's Secret Scanning partner program](https://docs.github.com/en/enterprise-cloud@latest/code-security/tutorials/secret-scanning-partner-program) format requirements. When GitHub detects a leaked Hex API key in a public repository, it POSTs to a new endpoint and we immediately revoke the key and notify the owner by email.

Existing v1 keys continue to authenticate unchanged — no migration is required.

### Token format

`hex_` + 32 random hex chars + 8 CRC32 hex chars = **44 chars total**

The 8-char CRC32 suffix satisfies GitHub's requirement for a 32-bit checksum embedded in the token, enabling regex-based validation in their scanning pipeline. The checksum is verified on every auth request so corrupted/truncated tokens are rejected early.

- `Auth.gen_key/0` generates 16 random bytes, appends `<<:erlang.crc32(random)::32>>`, Base16-encodes the 20-byte result → 40 hex chars. `Key.gen_key/0` prepends `hex_`.
- `Auth.valid_checksum?/1` validates on lookup; invalid checksums short-circuit before the HMAC split lookup.
- A `token_format` column (`"v1"` / `"v2"`) is added to the `keys` table via migration. All new keys are `"v2"`.

### Authentication

- `Authorization: Bearer hex_*` headers are routed to key auth; other Bearer values go to OAuth.
- Raw (non-Bearer) keys have whitespace trimmed before lookup — CI/CD tools that pad the header value still work.
- `Authorization` added to `filter_parameters` in `config.exs` so it is never logged.

### GitHub Secret Scanning endpoint

`POST /api/github/secret-scanning`

- Verifies the ECDSA-P256-SHA256 signature using GitHub's published public keys (fetched from `api.github.com/meta/public_keys/secret_scanning`). Returns 403 on invalid signature or if the key fetch fails.
- Raw request body is cached before JSON parsing via the `CacheRawBody` plug so the signature check covers the original bytes.
- Returns one result object per alert token per the partner API spec:
  - `{"token_raw": "...", "token_type": "hexpm_api_token", "label": "true_positive"}` — key found and revoked
  - `{"token_raw": "...", "token_type": "hexpm_api_token", "label": "false_positive"}` — token not found (invalid checksum, unknown key, or already revoked)
- Sends a `key_leaked` email to the key owner on revocation.
- No authentication — GitHub identifies itself via the signature.

### Dashboard UI

New keys show their `hex_`-prefixed secret once in a "Key Generated Successfully" modal; the secret is not shown again after the modal is dismissed.

<img width="2560" height="1800" alt="03-key-generated-hex-prefix" src="https://github.com/user-attachments/assets/47647fb1-aac2-442b-af7b-fab6d5fdaa39" />

### Areas that need careful review

**`lib/hexpm/accounts/auth.ex` — `gen_key/0` and `valid_checksum?/1`**  
The HMAC is computed over the raw 40-char body (prefix stripped). If the app secret is ever rotated, all existing v2 keys become invalid in the same way v1 keys do — this is expected, but worth noting.

**`lib/hexpm_web/auth_helpers.ex` — `bearer_auth/2`**  
Routing is prefix-only: `String.starts_with?(token, "hex_")`. If a future OAuth JWT ever begins with`hex_` (I think this is super unlikely), it would be misrouted to key auth and silently fail.

**`lib/hexpm/accounts/auth.ex` — `strip_token_prefix/1`**  
Two-clause function: prefix match strips `hex_`, fallthrough passes the raw value. The fallthrough is intentional for v1 compatibility — removing it would break all legacy keys.

**`lib/hexpm/github/secret_scanning.ex` — `verify_signature/3`**  
GitHub public keys are fetched on every request (no caching). This is intentional for correctness during key rotation events, but adds one HTTP round-trip per alert batch.

### Known breakage in CI

The `Test Hex (v2.0 – main)` jobs run the `hex` client's own integration test suite, which contains `assert byte_size(key_a) == 32`. Our keys are now 44 bytes (`hex_` + 40 hex chars). *A companion PR to `hexpm/hex` is needed to update that assertion.*

