### PR TITLE
Display optional dependencies badge if at least one is present

### DIFF
--- a/lib/hexpm_web/templates/package/dependencies.html.heex
+++ b/lib/hexpm_web/templates/package/dependencies.html.heex
@@ -55,6 +55,7 @@ requirements_count = length(requirements) %>
                 <td class="px-5 py-3.5">
                   <a
                     href={ViewHelpers.path_for_package(req.repository, req.name)}
+                    title={if req.repository != "hexpm", do: "#{req.repository}/#{req.name}", else: req.name}
                     class="font-semibold text-grey-900 dark:text-grey-100 hover:text-purple-600 dark:hover:text-primary-300 transition-colors font-mono"
                   >
                     <%= if req.repository != "hexpm" do %>
@@ -70,7 +71,10 @@ requirements_count = length(requirements) %>
                 </td>
                 <td class="px-5 py-3.5">
                   <div class="flex flex-wrap items-center gap-1.5">
-                    <span class="font-mono text-grey-600 dark:text-grey-200 bg-grey-50 dark:bg-grey-900/60 px-2 py-0.5 rounded">
+                    <span
+                      title={req.requirement}
+                      class="font-mono text-grey-600 dark:text-grey-200 bg-grey-50 dark:bg-grey-900/60 px-2 py-0.5 rounded"
+                    >
                       {req.requirement}
                     </span>
                     <%= if req.optional do %>

--- a/lib/hexpm_web/templates/package/dependencies.html.heex
+++ b/lib/hexpm_web/templates/package/dependencies.html.heex
@@ -36,9 +36,15 @@ requirements_count = length(requirements) %>
       <% else %>
         <table class="w-full table-fixed text-sm">
           <colgroup>
-            <col class="w-2/5" />
-            <col class="w-3/5" />
-            <col class="w-px" />
+            <%= if Enum.any?(requirements, fn req -> req.optional end) do %>
+              <col class="w-2/5" />
+              <col class="w-2/5" />
+              <col class="w-1/5" />
+            <% else %>
+              <col class="w-2/5" />
+              <col class="w-3/5" />
+              <col class="w-px" />
+            <% end %>
           </colgroup>
           <thead>
             <tr class="bg-grey-50 dark:bg-grey-900/60 border-b border-grey-200 dark:border-grey-700">

--- a/lib/hexpm_web/templates/package/dependencies.html.heex
+++ b/lib/hexpm_web/templates/package/dependencies.html.heex
@@ -36,15 +36,8 @@ requirements_count = length(requirements) %>
       <% else %>
         <table class="w-full table-fixed text-sm">
           <colgroup>
-            <%= if Enum.any?(requirements, fn req -> req.optional end) do %>
-              <col class="w-2/5" />
-              <col class="w-2/5" />
-              <col class="w-1/5" />
-            <% else %>
-              <col class="w-2/5" />
-              <col class="w-3/5" />
-              <col class="w-px" />
-            <% end %>
+            <col class="w-3/5" />
+            <col class="w-2/5" />
           </colgroup>
           <thead>
             <tr class="bg-grey-50 dark:bg-grey-900/60 border-b border-grey-200 dark:border-grey-700">
@@ -53,9 +46,6 @@ requirements_count = length(requirements) %>
               </th>
               <th class="px-5 py-3 text-left text-xs font-semibold text-grey-500 dark:text-grey-300 uppercase tracking-wider">
                 Requirement
-              </th>
-              <th class="px-5 py-3">
-                <span class="sr-only">Status</span>
               </th>
             </tr>
           </thead>
@@ -79,14 +69,14 @@ requirements_count = length(requirements) %>
                   <% end %>
                 </td>
                 <td class="px-5 py-3.5">
-                  <span class="font-mono text-grey-600 dark:text-grey-200 bg-grey-50 dark:bg-grey-900/60 px-2 py-0.5 rounded">
-                    {req.requirement}
-                  </span>
-                </td>
-                <td class="px-5 py-3.5">
-                  <%= if req.optional do %>
-                    <.badge>optional</.badge>
-                  <% end %>
+                  <div class="flex flex-wrap items-center gap-1.5">
+                    <span class="font-mono text-grey-600 dark:text-grey-200 bg-grey-50 dark:bg-grey-900/60 px-2 py-0.5 rounded">
+                      {req.requirement}
+                    </span>
+                    <%= if req.optional do %>
+                      <.badge>optional</.badge>
+                    <% end %>
+                  </div>
                 </td>
               </tr>
             <% end %>

--- a/lib/hexpm_web/templates/package/dependencies.html.heex
+++ b/lib/hexpm_web/templates/package/dependencies.html.heex
@@ -55,7 +55,11 @@ requirements_count = length(requirements) %>
                 <td class="px-5 py-3.5">
                   <a
                     href={ViewHelpers.path_for_package(req.repository, req.name)}
-                    title={if req.repository != "hexpm", do: "#{req.repository}/#{req.name}", else: req.name}
+                    title={
+                      if req.repository != "hexpm",
+                        do: "#{req.repository}/#{req.name}",
+                        else: req.name
+                    }
                     class="font-semibold text-grey-900 dark:text-grey-100 hover:text-purple-600 dark:hover:text-primary-300 transition-colors font-mono"
                   >
                     <%= if req.repository != "hexpm" do %>


### PR DESCRIPTION
Optional badge was not being displayed on dependency pages:

<img width="631" height="324" alt="image" src="https://github.com/user-attachments/assets/02c7ac11-cf4d-4c60-a280-3ceccb5b24f0" />

This fixes that by shortening the second column if the third one is present:

<img width="628" height="325" alt="image" src="https://github.com/user-attachments/assets/babbd205-f11d-4ac2-871d-dbfeb1ef0e51" />
