### PR TITLE
Promote version selection to a header dropdown on package pages

### DIFF
--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -24,6 +24,8 @@ defmodule HexpmWeb.Components.PackageLayout do
 
   attr :package, :map, required: true
   attr :current_release, :map, default: nil
+  attr :all_releases, :list, default: []
+  attr :version_pinned?, :boolean, default: false
   attr :dependants_count, :integer, default: 0
   attr :versions_count, :integer, default: 0
   attr :repository_name, :string, required: true
@@ -111,14 +113,34 @@ defmodule HexpmWeb.Components.PackageLayout do
                 </a>
               </h1>
               <%= if @current_release do %>
-                <div class="bg-grey-200 dark:bg-grey-800 flex items-center gap-1.5 px-3 py-1 rounded-xl whitespace-nowrap">
-                  {HexpmWeb.ViewIcons.icon(:heroicon, "tag",
-                    class: "size-3.5 text-grey-500 dark:text-grey-300"
-                  )}
-                  <p class="text-grey-700 dark:text-grey-200 text-sm font-medium">
-                    v{@current_release.version}
-                  </p>
-                </div>
+                <details class="package-version-picker group relative">
+                  <summary class="select-none flex cursor-pointer list-none items-center gap-1.5 rounded-xl border border-grey-300 bg-grey-100 px-3 py-1 text-sm font-medium text-grey-700 transition-colors hover:border-grey-400 hover:bg-grey-200 dark:border-grey-600 dark:bg-grey-800 dark:text-grey-200 dark:hover:border-grey-500 dark:hover:bg-grey-700 [&::-webkit-details-marker]:hidden">
+                    {HexpmWeb.ViewIcons.icon(:heroicon, "tag",
+                      class: "size-3.5 text-grey-500 dark:text-grey-300"
+                    )}
+                    <span class="font-mono">{@current_release.version}</span>
+                    {HexpmWeb.ViewIcons.icon(:heroicon, "chevron-down",
+                      class:
+                        "size-3.5 text-grey-500 dark:text-grey-300 transition-transform group-open:rotate-180"
+                    )}
+                  </summary>
+
+                  <div class="absolute right-0 top-full z-20 mt-2 max-h-80 w-52 max-w-[calc(100vw-2rem)] overflow-y-auto overflow-x-hidden rounded-lg border border-grey-200 bg-white shadow-lg sm:left-0 sm:right-auto sm:w-64 dark:border-grey-700 dark:bg-grey-800">
+                    <%= for release <- @all_releases do %>
+                      <a
+                        href={path_for_tab(@active_tab, @package, release)}
+                        class={version_item_class(@current_release.version == release.version)}
+                      >
+                        <span class="select-none font-mono text-sm">{release.version}</span>
+                        <%= if release.retirement do %>
+                          <span class="inline-flex items-center rounded border border-yellow-300 bg-yellow-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-900 dark:border-yellow-700/60 dark:bg-yellow-900/30 dark:text-yellow-100">
+                            retired
+                          </span>
+                        <% end %>
+                      </a>
+                    <% end %>
+                  </div>
+                </details>
               <% end %>
             </div>
             <%= if @description do %>
@@ -525,12 +547,6 @@ defmodule HexpmWeb.Components.PackageLayout do
   defp dependents_path(package),
     do: "/packages/#{package.repository.name}/#{package.name}/dependents"
 
-  defp dependencies_path(%{repository: %{id: 1}} = package),
-    do: "/packages/#{package.name}/dependencies"
-
-  defp dependencies_path(package),
-    do: "/packages/#{package.repository.name}/#{package.name}/dependencies"
-
   defp advisories_path(%{repository: %{id: 1}} = package),
     do: "/packages/#{package.name}/advisories"
 
@@ -543,7 +559,7 @@ defmodule HexpmWeb.Components.PackageLayout do
         active: assigns.active_tab == :readme,
         icon: "document-text",
         label: "Readme",
-        path: ViewHelpers.path_for_package(assigns.package)
+        path: readme_path(assigns)
       },
       %{
         active: assigns.active_tab == :versions,
@@ -581,7 +597,7 @@ defmodule HexpmWeb.Components.PackageLayout do
         icon: "cube",
         label:
           "#{assigns.dependency_count} #{pluralize(assigns.dependency_count, "Dependency", "Dependencies")}",
-        path: dependencies_path(assigns.package)
+        path: dependencies_tab_path(assigns)
       }
     ]
   end
@@ -603,6 +619,19 @@ defmodule HexpmWeb.Components.PackageLayout do
     ]
   end
 
+  defp readme_path(%{version_pinned?: true, package: package, current_release: release})
+       when not is_nil(release),
+       do: ViewHelpers.path_for_release(package, release)
+
+  defp readme_path(%{package: package}), do: ViewHelpers.path_for_package(package)
+
+  defp dependencies_tab_path(%{version_pinned?: true, package: package, current_release: release})
+       when not is_nil(release),
+       do: ViewHelpers.path_for_dependencies(package, release)
+
+  defp dependencies_tab_path(%{package: package}),
+    do: ViewHelpers.path_for_dependencies(package)
+
   defp tab_class(true),
     do:
       "flex items-center gap-1 px-[15px] py-3 text-grey-900 dark:text-white font-medium border-b-2 border-primary-default dark:border-white -mb-px whitespace-nowrap"
@@ -621,4 +650,18 @@ defmodule HexpmWeb.Components.PackageLayout do
 
   defp pluralize(1, singular, _plural), do: singular
   defp pluralize(_count, _singular, plural), do: plural
+
+  defp path_for_tab(:dependencies, package, release),
+    do: ViewHelpers.path_for_dependencies(package, release)
+
+  defp path_for_tab(_tab, package, release),
+    do: ViewHelpers.path_for_release(package, release)
+
+  defp version_item_class(true),
+    do:
+      "flex items-center justify-between gap-3 px-3 py-2 bg-grey-100 dark:bg-grey-700/60 text-grey-900 dark:text-white"
+
+  defp version_item_class(false),
+    do:
+      "flex items-center justify-between gap-3 px-3 py-2 text-grey-700 dark:text-grey-200 hover:bg-grey-50 dark:hover:bg-grey-700/40 transition-colors"
 end

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -131,7 +131,7 @@ defmodule HexpmWeb.Components.PackageLayout do
                         href={path_for_tab(@active_tab, @package, release)}
                         class={version_item_class(@current_release.version == release.version)}
                       >
-                        <span class="select-none font-mono text-sm">{release.version}</span>
+                        <span class="font-mono text-sm">{release.version}</span>
                         <%= if release.retirement do %>
                           <span class="inline-flex items-center rounded border border-yellow-300 bg-yellow-100 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-yellow-900 dark:border-yellow-700/60 dark:bg-yellow-900/30 dark:text-yellow-100">
                             retired

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -577,15 +577,17 @@ defmodule HexpmWeb.Components.PackageLayout do
           label:
             "#{assigns.dependants_count} #{pluralize(assigns.dependants_count, "Dependant", "Dependants")}",
           path: dependents_path(assigns.package)
-        },
+        }
+      ] ++
+      advisories_tab(assigns) ++
+      [
         %{
           active: assigns.active_tab == :activity,
           icon: "clock",
           label: "Activity",
           path: audit_logs_path(assigns.package)
         }
-      ] ++
-      advisories_tab(assigns)
+      ]
   end
 
   defp dependency_tab(%{current_release: nil}), do: []

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -79,25 +79,39 @@ defmodule HexpmWeb.PackageController do
   end
 
   def dependencies(conn, params) do
+    params = fixup_params(params)
+
     access_package(conn, params, fn package, repositories ->
       releases = Releases.all(package)
-      current_release = current_release(releases)
 
-      dependants_count = Packages.count_dependants(repositories, package)
+      release =
+        if version = params["version"] do
+          matching_release(releases, version)
+        else
+          current_release(releases)
+        end
 
-      render(
-        conn,
-        "dependencies.html",
-        [
-          title: "Dependencies of #{package.name}",
-          container: "container",
-          package: package,
-          releases: releases,
-          current_release: current_release,
-          dependants_count: dependants_count,
-          repository_name: package.repository.name
-        ] ++ sidebar_assigns(package, releases, current_release)
-      )
+      if release do
+        release = preload_release(release)
+        dependants_count = Packages.count_dependants(repositories, package)
+
+        render(
+          conn,
+          "dependencies.html",
+          [
+            title: "Dependencies of #{package.name}",
+            container: "container",
+            package: package,
+            releases: releases,
+            current_release: release,
+            version_pinned?: params["version"] != nil,
+            dependants_count: dependants_count,
+            repository_name: package.repository.name
+          ] ++ sidebar_assigns(package, releases, release)
+        )
+      else
+        not_found(conn)
+      end
     end)
   end
 
@@ -241,8 +255,12 @@ defmodule HexpmWeb.PackageController do
   defp current_release(releases) do
     case Release.latest_version(releases, only_stable: true, unstable_fallback: true) do
       nil -> nil
-      release -> Releases.preload(release, [:requirements, :downloads, :publisher])
+      release -> preload_release(release)
     end
+  end
+
+  defp preload_release(release) do
+    Releases.preload(release, [:requirements, :downloads, :publisher])
   end
 
   defp access_package(conn, params, fun) do
@@ -339,7 +357,9 @@ defmodule HexpmWeb.PackageController do
         package: package,
         repository_name: repository.name,
         releases: releases,
+        all_releases: releases,
         current_release: release,
+        version_pinned?: type == :release,
         downloads: downloads,
         owners: owners,
         dependants: dependants,
@@ -399,7 +419,8 @@ defmodule HexpmWeb.PackageController do
       downloads: package_downloads,
       daily_graph: daily_graph,
       owners: owners,
-      versions_count: Enum.count(releases)
+      versions_count: Enum.count(releases),
+      all_releases: releases
     ]
   end
 

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -188,12 +188,13 @@ defmodule HexpmWeb.Router do
     get "/packages/:name/dependencies", PackageController, :dependencies
     get "/packages/:name/versions", PackageController, :versions
     get "/packages/:name/advisories", PackageController, :advisories
+    get "/packages/:name/:version/dependencies", PackageController, :dependencies
     get "/packages/:name/:version", PackageController, :show
     get "/packages/:repository/:name/audit-logs", PackageController, :audit_logs
     get "/packages/:repository/:name/dependents", PackageController, :dependents
-    get "/packages/:repository/:name/dependencies", PackageController, :dependencies
     get "/packages/:repository/:name/versions", PackageController, :versions
     get "/packages/:repository/:name/advisories", PackageController, :advisories
+    get "/packages/:repository/:name/:version/dependencies", PackageController, :dependencies
     get "/packages/:repository/:name/:version", PackageController, :show
 
     get "/blog", BlogController, :index

--- a/lib/hexpm_web/templates/package/advisories.html.heex
+++ b/lib/hexpm_web/templates/package/advisories.html.heex
@@ -1,5 +1,6 @@
 <.package_layout
   active_tab={:advisories}
+  all_releases={@all_releases}
   current_release={@current_release}
   daily_graph={@daily_graph}
   dependants_count={@dependants_count}

--- a/lib/hexpm_web/templates/package/audit_logs.html.heex
+++ b/lib/hexpm_web/templates/package/audit_logs.html.heex
@@ -1,5 +1,6 @@
 <.package_layout
   active_tab={:activity}
+  all_releases={@all_releases}
   current_release={@current_release}
   daily_graph={@daily_graph}
   dependants_count={@dependants_count}

--- a/lib/hexpm_web/templates/package/dependencies.html.heex
+++ b/lib/hexpm_web/templates/package/dependencies.html.heex
@@ -6,7 +6,9 @@ requirements_count = length(requirements) %>
 
 <.package_layout
   active_tab={:dependencies}
+  all_releases={@all_releases}
   current_release={@current_release}
+  version_pinned?={@version_pinned?}
   daily_graph={@daily_graph}
   dependants_count={@dependants_count}
   docs_html_url={@docs_html_url}

--- a/lib/hexpm_web/templates/package/dependents.html.heex
+++ b/lib/hexpm_web/templates/package/dependents.html.heex
@@ -1,5 +1,6 @@
 <.package_layout
   active_tab={:dependants}
+  all_releases={@all_releases}
   current_release={@current_release}
   daily_graph={@daily_graph}
   dependants_count={@dependants_count}

--- a/lib/hexpm_web/templates/package/show.html.heex
+++ b/lib/hexpm_web/templates/package/show.html.heex
@@ -2,7 +2,9 @@
 
 <.package_layout
   active_tab={:readme}
+  all_releases={@all_releases}
   current_release={@current_release}
+  version_pinned?={@version_pinned?}
   daily_graph={@daily_graph}
   dependants_count={@dependants_count}
   docs_html_url={@docs_html_url}

--- a/lib/hexpm_web/templates/package/versions.html.heex
+++ b/lib/hexpm_web/templates/package/versions.html.heex
@@ -18,6 +18,7 @@ version_rows =
 
 <.package_layout
   active_tab={:versions}
+  all_releases={@all_releases}
   current_release={@current_release}
   daily_graph={@daily_graph}
   dependants_count={@dependants_count}

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -52,6 +52,22 @@ defmodule HexpmWeb.ViewHelpers do
     ~p"/packages/#{package.repository}/#{package}/versions"
   end
 
+  def path_for_dependencies(%Package{repository_id: 1} = package) do
+    ~p"/packages/#{package}/dependencies"
+  end
+
+  def path_for_dependencies(%Package{} = package) do
+    ~p"/packages/#{package.repository}/#{package}/dependencies"
+  end
+
+  def path_for_dependencies(%Package{repository_id: 1} = package, %Release{} = release) do
+    ~p"/packages/#{package}/#{release}/dependencies"
+  end
+
+  def path_for_dependencies(%Package{} = package, %Release{} = release) do
+    ~p"/packages/#{package.repository}/#{package}/#{release}/dependencies"
+  end
+
   def html_url_for_package(%Package{repository_id: 1} = package) do
     url(~p"/packages/#{package}")
   end

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -369,6 +369,12 @@ defmodule HexpmWeb.PackageControllerTest do
       |> get("/packages/#{package3.name}/0.0.1")
       |> response(404)
     end
+
+    test "version-pinned page links Dependencies tab to versioned dependencies",
+         %{package1: package1} do
+      body = response(get(build_conn(), "/packages/#{package1.name}/0.0.1"), 200)
+      assert body =~ "/packages/#{package1.name}/0.0.1/dependencies"
+    end
   end
 
   describe "GET /packages/:repository/:name/:version" do
@@ -699,6 +705,19 @@ defmodule HexpmWeb.PackageControllerTest do
         build_conn()
         |> test_login(user1)
         |> get("/packages/#{repository1.name}/#{package3.name}/0.0.1/dependencies")
+
+      assert response(conn, 200) =~ "Dependencies of"
+    end
+
+    test "renders for repository/name unversioned dependencies", %{
+      package3: package3,
+      repository1: repository1,
+      user1: user1
+    } do
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> get("/packages/#{repository1.name}/#{package3.name}/dependencies")
 
       assert response(conn, 200) =~ "Dependencies of"
     end

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -677,6 +677,33 @@ defmodule HexpmWeb.PackageControllerTest do
     end
   end
 
+  describe "GET /packages/:name/:version/dependencies" do
+    test "renders dependencies page for the selected version", %{package1: package1} do
+      conn = get(build_conn(), "/packages/#{package1.name}/0.0.1/dependencies")
+      body = response(conn, 200)
+      assert body =~ "Dependencies of"
+      assert body =~ "gleam add #{package1.name}@0.0.1"
+    end
+
+    test "returns 404 when version does not exist", %{package1: package1} do
+      conn = get(build_conn(), "/packages/#{package1.name}/9.9.9/dependencies")
+      assert response(conn, 404)
+    end
+
+    test "renders for repository/name/version triple", %{
+      package3: package3,
+      repository1: repository1,
+      user1: user1
+    } do
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> get("/packages/#{repository1.name}/#{package3.name}/0.0.1/dependencies")
+
+      assert response(conn, 200) =~ "Dependencies of"
+    end
+  end
+
   defp escape(html) do
     {:safe, safe} = Phoenix.HTML.html_escape(html)
     IO.iodata_to_binary(safe)

--- a/test/hexpm_web/controllers/package_versions_controller_test.exs
+++ b/test/hexpm_web/controllers/package_versions_controller_test.exs
@@ -145,7 +145,7 @@ defmodule HexpmWeb.PackageVersionsControllerTest do
 
   defp release_link_texts(document, package_name) do
     document
-    |> Floki.find("a")
+    |> Floki.find("table tbody a")
     |> Enum.filter(fn link ->
       case Floki.attribute(link, "href") do
         [href] ->


### PR DESCRIPTION
* Replace the static version chip with a dropdown so the entire package page (Readme, Dependencies, Checksum, Dependency Config, Package Details) reflects the selected release.
* Adds a version-aware /packages/:name/:version/dependencies route, threads the chosen release through the sidebar assigns on Readme and Dependencies, and preserves the selected version when switching between version-scoped tabs. Package-scoped tabs (Versions, Dependants, Activity) still show the dropdown but selecting a version navigates to that version's Readme.

<img width="820" height="428" alt="Screenshot 2026-05-03 at 09 54 35" src="https://github.com/user-attachments/assets/83551211-9dd8-4a49-bc80-46f1f4d40200" />

<img width="820" height="428" alt="Screenshot 2026-05-03 at 09 54 40" src="https://github.com/user-attachments/assets/3d2cac84-976f-4918-9c93-f2d6d9b14a8b" />
