### PR TITLE
Validate licenses against SPDX on package updates

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -82,7 +82,7 @@ defmodule Hexpm.Repository.Package do
     cast(package, params, [])
     # A release publish should always update the package's updated_at
     |> force_change(:updated_at, DateTime.utc_now())
-    |> cast_embed(:meta, with: &PackageMetadata.update_changeset(&1, &2, package), required: true)
+    |> cast_embed(:meta, with: &PackageMetadata.changeset(&1, &2, package), required: true)
     |> validate_metadata_name()
   end
 

--- a/lib/hexpm/repository/package_metadata.ex
+++ b/lib/hexpm/repository/package_metadata.ex
@@ -12,14 +12,10 @@ defmodule Hexpm.Repository.PackageMetadata do
   end
 
   def changeset(meta, params, package) do
-    update_changeset(meta, params, package)
-    |> validate_licenses(package)
-  end
-
-  def update_changeset(meta, params, package) do
     cast(meta, params, ~w(description licenses links maintainers extra)a)
     |> validate_required_meta(package)
     |> validate_links()
+    |> validate_licenses(package)
   end
 
   defp validate_required_meta(changeset, package) do

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -48,7 +48,7 @@ defmodule Hexpm.Repository.PackageTest do
     assert package.meta.description == "updated"
   end
 
-  test "update package with invalid license", %{user: user, repository: repository} do
+  test "update private package with invalid license", %{user: user, repository: repository} do
     package =
       Package.build(repository, user, pkg_meta(%{name: "ecto", description: "original"}))
       |> Hexpm.Repo.insert!()
@@ -63,6 +63,32 @@ defmodule Hexpm.Repository.PackageTest do
 
     package = Hexpm.Repo.get_by(Package, name: "ecto")
     assert package.meta.description == "updated"
+  end
+
+  test "validate invalid license on update for public package", %{
+    user: user,
+    public_repository: repository
+  } do
+    repository = %{repository | id: 1}
+
+    package =
+      Package.build(
+        repository,
+        user,
+        pkg_meta(%{name: "ecto", description: "original", licenses: ["Apache-2.0"]})
+      )
+      |> Hexpm.Repo.insert!()
+
+    changeset =
+      Package.update(package, %{
+        "meta" => %{
+          "description" => "updated",
+          "licenses" => ["Invalid-Lic", "Apache-2.0"]
+        }
+      })
+
+    assert changeset.errors == []
+    assert [licenses: {"invalid license \"Invalid-Lic\"", []}] = changeset.changes.meta.errors
   end
 
   test "validate invalid license for public package", %{


### PR DESCRIPTION
License validation was only run on initial package creation, so legacy packages could keep publishing releases with non-SPDX identifiers indefinitely. Apply the same SPDX check on every metadata update.

Closes #1550