### PR TITLE
Use round-numbered Y-axis labels with a single unit on downloads graph

### DIFF
--- a/lib/hexpm_web/components/chart.ex
+++ b/lib/hexpm_web/components/chart.ex
@@ -42,6 +42,7 @@ defmodule HexpmWeb.Components.Chart do
         </linearGradient>
       </defs>
       <%!-- Y-axis labels --%>
+      <% {max_label, _} = List.last(@y_axis_labels) %>
       <%= for {label, y} <- @y_axis_labels do %>
         <text
           x="72"
@@ -51,7 +52,7 @@ defmodule HexpmWeb.Components.Chart do
           font-size="22"
           font-family="ui-monospace, SFMono-Regular, monospace"
         >
-          {ViewHelpers.human_number_space(label)}
+          {ViewHelpers.chart_axis_label(label, max_label)}
         </text>
       <% end %>
       <%!-- Chart area --%>

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -268,6 +268,22 @@ defmodule HexpmWeb.ViewHelpers do
     end
   end
 
+  @doc """
+  Formats a chart axis label using a single unit chosen from `max` so
+  every label on a chart shares the same unit (e.g. all K, never mixing
+  bare numbers with K, or K with M).
+  """
+  def chart_axis_label(0, _max), do: "0"
+
+  def chart_axis_label(value, max) do
+    cond do
+      max >= 4_000_000_000 -> "#{div(value, 1_000_000_000)}B"
+      max >= 4_000_000 -> "#{div(value, 1_000_000)}M"
+      max >= 4_000 -> "#{div(value, 1_000)}K"
+      true -> "#{value}"
+    end
+  end
+
   defp do_human_number(int, max, digits, _unit) when is_integer(int) and digits <= max do
     human_number_space(int)
   end
@@ -455,15 +471,23 @@ defmodule HexpmWeb.ViewHelpers do
     ]
   end
 
+  defp rounded_max(max) when max <= 0, do: 5
+
   defp rounded_max(max) do
-    case max do
-      max when max > 1_000_000 -> max |> Kernel./(1_000_000) |> ceil |> Kernel.*(1_000_000)
-      max when max > 100_000 -> max |> Kernel./(100_000) |> ceil |> Kernel.*(100_000)
-      max when max > 10_000 -> max |> Kernel./(10_000) |> ceil |> Kernel.*(10_000)
-      max when max > 1_000 -> max |> Kernel./(1_000) |> ceil |> Kernel.*(1_000)
-      max when max > 100 -> 1_000
-      _ -> 100
-    end
+    rough_step = max / 5
+    pow = :math.pow(10, trunc(:math.log10(rough_step)))
+    fraction = rough_step / pow
+
+    nice_fraction =
+      cond do
+        fraction <= 1 -> 1
+        fraction <= 2 -> 2
+        fraction <= 5 -> 5
+        true -> 10
+      end
+
+    step = nice_fraction * pow
+    trunc(ceil(max / (step * 5)) * step * 5)
   end
 
   def main_repository?(%{repository_id: 1}), do: true

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -471,6 +471,22 @@ defmodule HexpmWeb.PackageControllerTest do
       assert current_page(second_document) == "2"
       assert normalized_text(second_document) =~ "101 total"
     end
+
+    test "computes daily_graph for sidebar", %{package1: package1} do
+      release = Hexpm.Repository.Releases.all(package1) |> List.first()
+
+      insert(:download,
+        package: package1,
+        release: release,
+        downloads: 42,
+        day: Date.utc_today() |> Date.add(-2)
+      )
+
+      conn = get(build_conn(), "/packages/#{package1.name}/audit-logs")
+      assert response(conn, 200)
+      assert conn.assigns.daily_graph != []
+      assert Enum.any?(conn.assigns.daily_graph, fn n -> n > 0 end)
+    end
   end
 
   describe "GET /packages/:repository/:name/audit-logs" do
@@ -506,6 +522,22 @@ defmodule HexpmWeb.PackageControllerTest do
     } do
       conn = get(build_conn(), "/packages/#{repository1.name}/#{package3.name}/versions")
       assert response(conn, 404)
+    end
+
+    test "computes daily_graph for sidebar", %{package1: package1} do
+      release = Hexpm.Repository.Releases.all(package1) |> List.first()
+
+      insert(:download,
+        package: package1,
+        release: release,
+        downloads: 42,
+        day: Date.utc_today() |> Date.add(-2)
+      )
+
+      conn = get(build_conn(), "/packages/#{package1.name}/versions")
+      assert response(conn, 200)
+      assert conn.assigns.daily_graph != []
+      assert Enum.any?(conn.assigns.daily_graph, fn n -> n > 0 end)
     end
   end
 
@@ -596,6 +628,22 @@ defmodule HexpmWeb.PackageControllerTest do
       conn = get(build_conn(), "/packages/#{repository1.name}/#{package3.name}/dependents")
       assert response(conn, 404)
     end
+
+    test "computes daily_graph for sidebar", %{package1: package1} do
+      release = Hexpm.Repository.Releases.all(package1) |> List.first()
+
+      insert(:download,
+        package: package1,
+        release: release,
+        downloads: 42,
+        day: Date.utc_today() |> Date.add(-2)
+      )
+
+      conn = get(build_conn(), "/packages/#{package1.name}/dependents")
+      assert response(conn, 200)
+      assert conn.assigns.daily_graph != []
+      assert Enum.any?(conn.assigns.daily_graph, fn n -> n > 0 end)
+    end
   end
 
   describe "GET /packages/:name/dependencies" do
@@ -610,6 +658,22 @@ defmodule HexpmWeb.PackageControllerTest do
     } do
       conn = get(build_conn(), "/packages/#{repository1.name}/#{package3.name}/dependencies")
       assert response(conn, 404)
+    end
+
+    test "computes daily_graph for sidebar", %{package1: package1} do
+      release = Hexpm.Repository.Releases.all(package1) |> List.first()
+
+      insert(:download,
+        package: package1,
+        release: release,
+        downloads: 42,
+        day: Date.utc_today() |> Date.add(-2)
+      )
+
+      conn = get(build_conn(), "/packages/#{package1.name}/dependencies")
+      assert response(conn, 200)
+      assert conn.assigns.daily_graph != []
+      assert Enum.any?(conn.assigns.daily_graph, fn n -> n > 0 end)
     end
   end
 


### PR DESCRIPTION
Replace the magnitude-bucketed `rounded_max` with a nice-number step (1/2/5 × 10^n) so the chart Y-axis lands on round values regardless of data magnitude. Add `chart_axis_label/2` that picks one unit (K/M/B) from the chart max so every label on a chart shares the same unit instead of mixing bare numbers with abbreviations.

Add regression tests covering the sidebar downloads graph across package sub-pages.