### PR TITLE
Show only latest-release dependants on package pages

### DIFF
--- a/lib/hexpm/repository/package_dependants.ex
+++ b/lib/hexpm/repository/package_dependants.ex
@@ -1,0 +1,98 @@
+defmodule Hexpm.Repository.PackageDependants do
+  import Ecto.Query
+
+  alias Hexpm.Repo
+  alias Hexpm.Repository.{Package, PackageDependant, Release, Requirement}
+
+  @lock_class_id 0xD3D3
+  @backfill_batch_size 1000
+
+  def recompute_for_package(repo, package) do
+    take_lock(repo, package.id)
+
+    releases = repo.all(from(r in Release, where: r.package_id == ^package.id))
+
+    latest = Release.latest_version(releases, only_stable: true, unstable_fallback: true)
+
+    sync_rows(repo, package, latest)
+
+    {:ok, latest}
+  end
+
+  def backfill() do
+    backfill(0)
+  end
+
+  defp backfill(after_id) do
+    packages =
+      from(p in Package,
+        where: p.id > ^after_id,
+        order_by: p.id,
+        limit: @backfill_batch_size
+      )
+      |> Repo.all()
+
+    case packages do
+      [] ->
+        :ok
+
+      packages ->
+        Enum.each(packages, fn package ->
+          {:ok, _} = Repo.transaction(fn -> recompute_for_package(Repo, package) end)
+        end)
+
+        backfill(List.last(packages).id)
+    end
+  end
+
+  defp sync_rows(repo, package, nil) do
+    repo.delete_all(from(pd in PackageDependant, where: pd.package_id == ^package.id))
+  end
+
+  defp sync_rows(repo, package, latest) do
+    dependency_ids =
+      repo.all(
+        from(req in Requirement, where: req.release_id == ^latest.id, select: req.dependency_id)
+      )
+
+    delete_stale_rows(repo, package, dependency_ids)
+    insert_missing_rows(repo, package, dependency_ids)
+  end
+
+  defp delete_stale_rows(repo, package, []) do
+    repo.delete_all(from(pd in PackageDependant, where: pd.package_id == ^package.id))
+  end
+
+  defp delete_stale_rows(repo, package, dependency_ids) do
+    repo.delete_all(
+      from(pd in PackageDependant,
+        where: pd.package_id == ^package.id and pd.dependency_id not in ^dependency_ids
+      )
+    )
+  end
+
+  defp insert_missing_rows(_repo, _package, []), do: :ok
+
+  defp insert_missing_rows(repo, package, dependency_ids) do
+    entries =
+      Enum.map(dependency_ids, fn dependency_id ->
+        %{
+          dependency_id: dependency_id,
+          package_id: package.id,
+          dependant_repository_id: package.repository_id
+        }
+      end)
+
+    repo.insert_all(PackageDependant, entries, on_conflict: :nothing)
+    :ok
+  end
+
+  defp take_lock(repo, package_id) do
+    if Application.get_env(:hexpm, :skip_advisory_locks, false) do
+      :ok
+    else
+      repo.query!("SELECT pg_advisory_xact_lock($1, $2)", [@lock_class_id, package_id])
+      :ok
+    end
+  end
+end

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -52,6 +52,9 @@ defmodule Hexpm.Repository.Releases do
     |> Multi.run(:matched_advisories, fn repo, %{release: release} ->
       Hexpm.Security.Advisories.affect_release_with_existing_advisories(repo, release)
     end)
+    |> Multi.run(:package_dependants, fn repo, %{package: package} ->
+      PackageDependants.recompute_for_package(repo, package)
+    end)
     |> audit_publish(audit_data)
     |> Repo.transaction(timeout: @publish_timeout)
     |> publish_result(user, body)
@@ -78,8 +81,15 @@ defmodule Hexpm.Repository.Releases do
     |> audit_revert(audit_data, package, release)
     |> Multi.run(:release_count, &release_count/2)
     |> Multi.run(:package, &maybe_delete_package/2)
+    |> Multi.run(:package_dependants, &recompute_package_dependants/2)
     |> Repo.transaction(timeout: @publish_timeout)
     |> revert_result()
+  end
+
+  defp recompute_package_dependants(_repo, %{release_count: 0}), do: {:ok, :skipped}
+
+  defp recompute_package_dependants(repo, %{package: package}) do
+    PackageDependants.recompute_for_package(repo, package)
   end
 
   def revert_docs(release, audit: audit_data) do

--- a/lib/hexpm/shared.ex
+++ b/lib/hexpm/shared.ex
@@ -27,6 +27,7 @@ defmodule Hexpm.Shared do
         Repository.Owners,
         Repository.Package,
         Repository.PackageDependant,
+        Repository.PackageDependants,
         Repository.PackageDownload,
         Repository.PackageMetadata,
         Repository.PackageOwner,

--- a/priv/repo/migrations/20260511000000_drop_package_dependants_triggers.exs
+++ b/priv/repo/migrations/20260511000000_drop_package_dependants_triggers.exs
@@ -1,0 +1,22 @@
+defmodule Hexpm.Repo.Migrations.DropPackageDependantsTriggers do
+  use Ecto.Migration
+
+  def up() do
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_requirement_insert ON requirements")
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_requirement_delete ON requirements")
+    execute("DROP TRIGGER IF EXISTS package_dependants_before_release_delete ON releases")
+    execute("DROP TRIGGER IF EXISTS package_dependants_after_release_delete ON releases")
+
+    execute("DROP FUNCTION IF EXISTS package_dependants_insert()")
+    execute("DROP FUNCTION IF EXISTS package_dependants_delete()")
+    execute("DROP FUNCTION IF EXISTS package_dependants_cache_deleted_release()")
+    execute("DROP FUNCTION IF EXISTS package_dependants_cleanup_deleted_releases()")
+
+    drop_if_exists table(:package_dependants_deleted_releases)
+  end
+
+  def down() do
+    raise Ecto.MigrationError,
+      message: "this migration is irreversible; the trigger-based maintenance has been retired"
+  end
+end

--- a/test/hexpm/repository/package_dependants_test.exs
+++ b/test/hexpm/repository/package_dependants_test.exs
@@ -1,0 +1,175 @@
+defmodule Hexpm.Repository.PackageDependantsTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.Repository.{Package, PackageDependant, PackageDependants}
+
+  setup do
+    repository = insert(:repository)
+    %{repository: repository}
+  end
+
+  defp dependant_names(repository, dependency) do
+    Package.dependants([repository], dependency, 1, 20, :name, nil)
+    |> Repo.all()
+    |> Enum.map(& &1.name)
+  end
+
+  defp row_count(package_id) do
+    Repo.aggregate(
+      from(pd in PackageDependant, where: pd.package_id == ^package_id),
+      :count
+    )
+  end
+
+  test "creates rows for the latest release's dependencies", %{repository: repository} do
+    dep_a = insert(:package, name: "dep_a", repository_id: repository.id)
+    dep_b = insert(:package, name: "dep_b", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    rel = insert(:release, package: dependant, version: "1.0.0")
+    insert(:requirement, release: rel, dependency: dep_a, requirement: "~> 1.0")
+    insert(:requirement, release: rel, dependency: dep_b, requirement: "~> 1.0")
+
+    {:ok, latest} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert latest.version == Version.parse!("1.0.0")
+    assert ["dependant"] = dependant_names(repository, dep_a)
+    assert ["dependant"] = dependant_names(repository, dep_b)
+  end
+
+  test "only the latest release's deps are reflected", %{repository: repository} do
+    dep_a = insert(:package, name: "dep_a", repository_id: repository.id)
+    dep_b = insert(:package, name: "dep_b", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    old_release = insert(:release, package: dependant, version: "1.0.0")
+    insert(:requirement, release: old_release, dependency: dep_a, requirement: "~> 1.0")
+
+    new_release = insert(:release, package: dependant, version: "2.0.0")
+    insert(:requirement, release: new_release, dependency: dep_b, requirement: "~> 1.0")
+
+    {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert [] = dependant_names(repository, dep_a)
+    assert ["dependant"] = dependant_names(repository, dep_b)
+  end
+
+  test "is idempotent", %{repository: repository} do
+    dep = insert(:package, name: "dep", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    rel = insert(:release, package: dependant, version: "1.0.0")
+    insert(:requirement, release: rel, dependency: dep, requirement: "~> 1.0")
+
+    {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+    {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert row_count(dependant.id) == 1
+  end
+
+  test "removes stale rows when the latest release drops a dep", %{repository: repository} do
+    dep = insert(:package, name: "dep", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    old_release = insert(:release, package: dependant, version: "1.0.0")
+    insert(:requirement, release: old_release, dependency: dep, requirement: "~> 1.0")
+
+    {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+    assert ["dependant"] = dependant_names(repository, dep)
+
+    insert(:release, package: dependant, version: "2.0.0")
+
+    {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert [] = dependant_names(repository, dep)
+  end
+
+  test "falls back to latest pre-release when no stable release exists", %{
+    repository: repository
+  } do
+    dep_a = insert(:package, name: "dep_a", repository_id: repository.id)
+    dep_b = insert(:package, name: "dep_b", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    rc1 = insert(:release, package: dependant, version: "1.0.0-rc.1")
+    insert(:requirement, release: rc1, dependency: dep_a, requirement: "~> 1.0")
+
+    rc2 = insert(:release, package: dependant, version: "1.0.0-rc.2")
+    insert(:requirement, release: rc2, dependency: dep_b, requirement: "~> 1.0")
+
+    {:ok, latest} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert latest.version == Version.parse!("1.0.0-rc.2")
+    assert [] = dependant_names(repository, dep_a)
+    assert ["dependant"] = dependant_names(repository, dep_b)
+  end
+
+  test "prefers latest stable over latest pre-release", %{repository: repository} do
+    stable_dep = insert(:package, name: "stable_dep", repository_id: repository.id)
+    pre_dep = insert(:package, name: "pre_dep", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    stable = insert(:release, package: dependant, version: "1.0.0")
+    insert(:requirement, release: stable, dependency: stable_dep, requirement: "~> 1.0")
+
+    pre = insert(:release, package: dependant, version: "2.0.0-rc.1")
+    insert(:requirement, release: pre, dependency: pre_dep, requirement: "~> 1.0")
+
+    {:ok, latest} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert latest.version == Version.parse!("1.0.0")
+    assert ["dependant"] = dependant_names(repository, stable_dep)
+    assert [] = dependant_names(repository, pre_dep)
+  end
+
+  test "uses the dependant's repository_id on inserted rows", %{repository: repository} do
+    private_repo = insert(:repository)
+    dep = insert(:package, name: "dep", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: private_repo.id)
+
+    rel = insert(:release, package: dependant, version: "1.0.0")
+    insert(:requirement, release: rel, dependency: dep, requirement: "~> 1.0")
+
+    {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    row = Repo.one!(from pd in PackageDependant, where: pd.package_id == ^dependant.id)
+    assert row.dependant_repository_id == private_repo.id
+  end
+
+  test "returns :ok with nil and deletes rows when package has no releases", %{
+    repository: repository
+  } do
+    dep = insert(:package, name: "dep", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    Repo.insert!(%PackageDependant{
+      dependency_id: dep.id,
+      package_id: dependant.id,
+      dependant_repository_id: repository.id
+    })
+
+    {:ok, latest} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert latest == nil
+    assert row_count(dependant.id) == 0
+  end
+
+  test "retired releases still count as latest", %{repository: repository} do
+    dep = insert(:package, name: "dep", repository_id: repository.id)
+    dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+    rel =
+      insert(:release,
+        package: dependant,
+        version: "1.0.0",
+        retirement: %{reason: "deprecated", message: "no longer supported"}
+      )
+
+    insert(:requirement, release: rel, dependency: dep, requirement: "~> 1.0")
+
+    {:ok, latest} = PackageDependants.recompute_for_package(Repo, dependant)
+
+    assert latest.version == Version.parse!("1.0.0")
+    assert ["dependant"] = dependant_names(repository, dep)
+  end
+end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -262,9 +262,11 @@ defmodule Hexpm.Repository.PackageTest do
 
     rel = insert(:release, package: ecto)
     insert(:requirement, release: rel, dependency: poison, requirement: "~> 1.0")
+    recompute_dependants(ecto)
     rel = insert(:release, package: phoenix)
     insert(:requirement, release: rel, dependency: poison, requirement: "~> 1.0")
     insert(:requirement, release: rel, dependency: ecto, requirement: "~> 1.0")
+    recompute_dependants(phoenix)
 
     assert ["ecto", "phoenix"] = search_for(repository, "depends:#{repository.name}:poison")
 
@@ -284,9 +286,11 @@ defmodule Hexpm.Repository.PackageTest do
 
     rel = insert(:release, package: ecto)
     insert(:requirement, release: rel, dependency: poison, requirement: "~> 1.0")
+    recompute_dependants(ecto)
     rel = insert(:release, package: phoenix)
     insert(:requirement, release: rel, dependency: poison, requirement: "~> 1.0")
     insert(:requirement, release: rel, dependency: ecto, requirement: "~> 1.0")
+    recompute_dependants(phoenix)
 
     assert ["phoenix"] = search_for(repository, "depends:#{repository.name}:poison")
   end
@@ -299,8 +303,10 @@ defmodule Hexpm.Repository.PackageTest do
 
     rel = insert(:release, package: ecto)
     insert(:requirement, release: rel, dependency: poison, requirement: "~> 1.0")
+    recompute_dependants(ecto)
     rel = insert(:release, package: phoenix)
     insert(:requirement, release: rel, dependency: poison, requirement: "~> 1.0")
+    recompute_dependants(phoenix)
 
     assert 1 = Package.count_dependants([repository], poison) |> Repo.one!()
 
@@ -345,6 +351,7 @@ defmodule Hexpm.Repository.PackageTest do
     for package <- [top, middle, zero, hidden] do
       rel = Repo.one!(assoc(package, :releases))
       insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+      recompute_dependants(package)
     end
 
     :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
@@ -374,6 +381,7 @@ defmodule Hexpm.Repository.PackageTest do
     for package <- [top, zero_one, zero_two] do
       rel = Repo.one!(assoc(package, :releases))
       insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+      recompute_dependants(package)
     end
 
     :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
@@ -383,7 +391,49 @@ defmodule Hexpm.Repository.PackageTest do
              |> Enum.map(& &1.id)
   end
 
-  test "reverting a release only removes affected dependant pairs", %{
+  test "reverting the latest release falls back to the previous latest's deps", %{
+    repository: repository,
+    user: user
+  } do
+    dependency_a = %{
+      insert(:package, name: "dependency_a", repository_id: repository.id)
+      | repository: repository
+    }
+
+    dependency_b = %{
+      insert(:package, name: "dependency_b", repository_id: repository.id)
+      | repository: repository
+    }
+
+    dependant = %{
+      insert(:package, name: "dependant", repository_id: repository.id)
+      | repository: repository
+    }
+
+    release_one = %{
+      insert(:release, package: dependant, version: "1.0.0")
+      | package: dependant
+    }
+
+    release_two = %{
+      insert(:release, package: dependant, version: "2.0.0")
+      | package: dependant
+    }
+
+    insert(:requirement, release: release_one, dependency: dependency_a, requirement: "~> 1.0")
+    insert(:requirement, release: release_two, dependency: dependency_b, requirement: "~> 1.0")
+    recompute_dependants(dependant)
+
+    assert ["dependant"] = dependant_names(repository, dependency_b)
+    assert [] = dependant_names(repository, dependency_a)
+
+    assert :ok = Releases.revert(dependant, release_two, audit: audit_data(user))
+
+    assert [] = dependant_names(repository, dependency_b)
+    assert ["dependant"] = dependant_names(repository, dependency_a)
+  end
+
+  test "reverting a non-latest release does not change dependants", %{
     repository: repository,
     user: user
   } do
@@ -392,60 +442,59 @@ defmodule Hexpm.Repository.PackageTest do
       | repository: repository
     }
 
-    survivor = %{
-      insert(:package, name: "survivor", repository_id: repository.id)
+    dependant = %{
+      insert(:package, name: "dependant", repository_id: repository.id)
       | repository: repository
     }
 
-    doomed = %{
-      insert(:package, name: "doomed", repository_id: repository.id)
+    release_one = %{
+      insert(:release, package: dependant, version: "1.0.0")
+      | package: dependant
+    }
+
+    release_two = %{
+      insert(:release, package: dependant, version: "2.0.0")
+      | package: dependant
+    }
+
+    insert(:requirement, release: release_one, dependency: dependency, requirement: "~> 1.0")
+    insert(:requirement, release: release_two, dependency: dependency, requirement: "~> 1.0")
+    recompute_dependants(dependant)
+
+    assert ["dependant"] = dependant_names(repository, dependency)
+
+    assert :ok = Releases.revert(dependant, release_one, audit: audit_data(user))
+
+    assert ["dependant"] = dependant_names(repository, dependency)
+  end
+
+  test "reverting the only release removes the dependant entry", %{
+    repository: repository,
+    user: user
+  } do
+    dependency = %{
+      insert(:package, name: "dependency", repository_id: repository.id)
       | repository: repository
     }
 
-    shared_packages =
-      for index <- 1..4 do
-        insert(:package, name: "shared#{index}", repository_id: repository.id)
-      end
-
-    survivor_release_one = %{
-      insert(:release, package: survivor, version: "1.0.0")
-      | package: survivor
+    dependant = %{
+      insert(:package, name: "dependant", repository_id: repository.id)
+      | repository: repository
     }
 
-    survivor_release_two = %{
-      insert(:release, package: survivor, version: "2.0.0")
-      | package: survivor
+    release = %{
+      insert(:release, package: dependant, version: "1.0.0")
+      | package: dependant
     }
 
-    doomed_release = %{insert(:release, package: doomed, version: "1.0.0") | package: doomed}
+    insert(:requirement, release: release, dependency: dependency, requirement: "~> 1.0")
+    recompute_dependants(dependant)
 
-    for package <- shared_packages do
-      release = insert(:release, package: package, version: "1.0.0")
-      insert(:requirement, release: release, dependency: dependency, requirement: "~> 1.0")
-    end
+    assert ["dependant"] = dependant_names(repository, dependency)
 
-    for release <- [survivor_release_one, survivor_release_two, doomed_release] do
-      insert(:requirement, release: release, dependency: dependency, requirement: "~> 1.0")
-    end
+    assert :ok = Releases.revert(dependant, release, audit: audit_data(user))
 
-    assert 6 = Package.count_dependants([repository], dependency) |> Repo.one!()
-
-    assert ["doomed", "shared1", "shared2", "shared3", "shared4", "survivor"] =
-             dependant_names(repository, dependency)
-
-    assert :ok = Releases.revert(doomed, doomed_release, audit: audit_data(user))
-
-    assert 5 = Package.count_dependants([repository], dependency) |> Repo.one!()
-
-    assert ["shared1", "shared2", "shared3", "shared4", "survivor"] =
-             dependant_names(repository, dependency)
-
-    assert :ok = Releases.revert(survivor, survivor_release_one, audit: audit_data(user))
-
-    assert 5 = Package.count_dependants([repository], dependency) |> Repo.one!()
-
-    assert ["shared1", "shared2", "shared3", "shared4", "survivor"] =
-             dependant_names(repository, dependency)
+    assert [] = dependant_names(repository, dependency)
   end
 
   test "depends search can return private packages if caller passes a broad repository list", %{
@@ -460,9 +509,11 @@ defmodule Hexpm.Repository.PackageTest do
 
     rel = insert(:release, package: public_match, version: "1.0.0")
     insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+    recompute_dependants(public_match)
 
     rel = insert(:release, package: private_match, version: "1.0.0")
     insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+    recompute_dependants(private_match)
 
     assert ["private_match", "public_match"] =
              Packages.search(

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -181,9 +181,11 @@ defmodule HexpmWeb.PackageControllerTest do
 
       rel = insert(:release, package: visible, version: "1.0.0")
       insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+      recompute_dependants(visible)
 
       rel = insert(:release, package: hidden, version: "1.0.0")
       insert(:requirement, release: rel, dependency: dependency, requirement: "~> 1.0")
+      recompute_dependants(hidden)
 
       search = URI.encode_www_form("depends:#{repository1.name}:#{dependency.name}")
 
@@ -212,9 +214,11 @@ defmodule HexpmWeb.PackageControllerTest do
 
       rel = insert(:release, package: visible, version: "1.0.0")
       insert(:requirement, release: rel, dependency: hidden_dependency, requirement: "~> 1.0")
+      recompute_dependants(visible)
 
       rel = insert(:release, package: hidden, version: "1.0.0")
       insert(:requirement, release: rel, dependency: hidden_dependency, requirement: "~> 1.0")
+      recompute_dependants(hidden)
 
       search = URI.encode_www_form("depends:#{repository2.name}:#{hidden_dependency.name}")
 
@@ -739,6 +743,7 @@ defmodule HexpmWeb.PackageControllerTest do
       )
 
     insert(:requirement, release: release, dependency: package, requirement: "~> 0.0.1")
+    recompute_dependants(dependant)
   end
 
   # Tabs render in both the mobile (<details>) and desktop nav, so a single href

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -130,4 +130,11 @@ defmodule Hexpm.TestHelpers do
   def default_requirement(name, requirement) do
     %{"name" => name, "app" => name, "requirement" => requirement, "optional" => false}
   end
+
+  def recompute_dependants(package) do
+    {:ok, _} =
+      Hexpm.Repository.PackageDependants.recompute_for_package(Hexpm.Repo, package)
+
+    package
+  end
 end


### PR DESCRIPTION
The dependants page listed any package that ever depended on a package in any historical release, which surprised users seeing dependants whose current release no longer has the requirement. npm, RubyGems, and crates.io all expose only the latest-version view; this brings hexpm in line.

Replace the Postgres trigger-based maintenance of `package_dependants` with Elixir code hooked into `Releases.publish/8` and `Releases.revert/2`. A row exists iff the latest release (per
`Release.latest_version/2` with `only_stable: true, unstable_fallback: true`) of the dependant package has a requirement on the target. Retire and unretire remain no-ops because retirement does not affect "latest".

Per-package `pg_advisory_xact_lock` serializes concurrent publish/revert on the same package. `mix hexpm.backfill_package_dependants` rebuilds the table from the new semantics; the migration drops the four triggers, four trigger functions, and the `package_dependants_deleted_releases` cache table.

Closes #1537