### PR TITLE
Display custom license 'LicenseRef-foo' as 'foo (custom)'

### DIFF
--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -421,7 +421,7 @@ defmodule HexpmWeb.Components.PackageLayout do
                         </p>
                         <div class="flex items-center gap-1.5 flex-wrap">
                           <p class="text-grey-700 dark:text-grey-100 font-bold">
-                            {Enum.join(@licenses, ", ")}
+                            {Enum.map_join(@licenses, ", ", &display_license/1)}
                           </p>
                         </div>
                       </div>
@@ -677,4 +677,7 @@ defmodule HexpmWeb.Components.PackageLayout do
   defp version_item_class(false),
     do:
       "flex items-center justify-between gap-3 px-3 py-2 text-grey-700 dark:text-grey-200 hover:bg-grey-50 dark:hover:bg-grey-700/40 transition-colors"
+
+  defp display_license("LicenseRef-" <> license_name), do: "#{license_name} (custom)"
+  defp display_license(license), do: license
 end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -92,7 +92,7 @@ Hexpm.Repo.transaction(fn ->
       meta:
         build(
           :package_metadata,
-          licenses: ["Apache-2.0", "MIT"],
+          licenses: ["Apache-2.0", "MIT", "LicenseRef-Journey"],
           links: %{
             "Github" => "http://example.com/github",
             "Documentation" => "http://example.com/documentation"


### PR DESCRIPTION
@ericmj  thank you for the prompt fix for https://github.com/hexpm/hexpm/issues/1561 

Following up on this, I noticed that custom licenses, when rendered on the package page, include the full canonical SPDX string, including the prefix (e.g. `LicenseRef-Journey`):

<img width="283" height="92" alt="image" src="https://github.com/user-attachments/assets/53e15975-91c2-4c60-ba6b-5bf655a6c8d5" />

Here is an update that replaces the SPDX prefix'ed version with a human-friendly string (`Journey (custom)`):

<img width="697" height="863" alt="image" src="https://github.com/user-attachments/assets/6af69cc4-2f2d-4677-8069-c2f0c95ab1bb" />

(Also contemplating `(user-defined)`  vs `(custom)`, and maybe making the match case insensitive.)
 
Curious what you think , and thank you!

(feel free to close if not useful, ofc)