### PR TITLE
Improve advisory dedup display: alias links and reference type merging

### DIFF
--- a/lib/hexpm/security/advisories.ex
+++ b/lib/hexpm/security/advisories.ex
@@ -140,10 +140,19 @@ defmodule Hexpm.Security.Advisories do
   end
 
   defp display_aliases(primary, advisories) do
+    advisory_ids = MapSet.new(advisories, & &1.id)
+
     advisories
     |> Enum.flat_map(&display_identifiers/1)
     |> Enum.uniq()
     |> Enum.reject(&(&1 == primary.id))
+    |> Enum.map(fn id ->
+      if MapSet.member?(advisory_ids, id) do
+        %{id: id, url: "https://osv.dev/vulnerability/#{URI.encode(id)}"}
+      else
+        %{id: id, url: nil}
+      end
+    end)
   end
 
   defp display_group_key(advisory) do
@@ -179,7 +188,11 @@ defmodule Hexpm.Security.Advisories do
   defp uniq_references(advisories) do
     advisories
     |> Enum.flat_map(&loaded_assoc(&1.references))
-    |> Enum.uniq_by(&{&1.type, &1.url})
+    |> Enum.group_by(& &1.url)
+    |> Enum.map(fn {url, refs} ->
+      types = refs |> Enum.map(& &1.type) |> Enum.uniq()
+      %{url: url, types: types}
+    end)
   end
 
   defp uniq_affected_versions(advisories) do

--- a/lib/hexpm_web/templates/package/advisories.html.heex
+++ b/lib/hexpm_web/templates/package/advisories.html.heex
@@ -38,10 +38,20 @@
                   >
                     {advisory.id}
                   </a>
-                  <%= for alias_id <- aliases do %>
-                    <span class="text-grey-400 dark:text-grey-400 text-xs font-mono">
-                      {alias_id}
-                    </span>
+                  <%= for alias <- aliases do %>
+                    <%= if alias.url do %>
+                      <a
+                        href={alias.url}
+                        class="text-grey-400 dark:text-grey-400 text-xs font-mono hover:text-purple-600 dark:hover:text-primary-300 transition-colors"
+                        rel="nofollow"
+                      >
+                        {alias.id}
+                      </a>
+                    <% else %>
+                      <span class="text-grey-400 dark:text-grey-400 text-xs font-mono">
+                        {alias.id}
+                      </span>
+                    <% end %>
                   <% end %>
                 </div>
                 <p class="text-grey-700 dark:text-grey-300 text-sm mt-1">{advisory.summary}</p>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -301,7 +301,8 @@ Hexpm.Repo.transaction(fn ->
       %{
         type: "WEB",
         url: "https://github.com/phoenixframework/phoenix/security/advisories/GHSA-628h-q48j-jr6q"
-      }
+      },
+      %{type: "WEB", url: "https://cna.erlef.org/cves/CVE-2026-32689.html"}
     ],
     affected: [
       %{

--- a/test/hexpm/security/advisories_test.exs
+++ b/test/hexpm/security/advisories_test.exs
@@ -236,6 +236,57 @@ defmodule Hexpm.Security.AdvisoriesTest do
              ])
   end
 
+  test "group_for_display merges references by URL and accumulates types" do
+    refs_a = [
+      %{type: "WEB", url: "https://example.com/advisory"},
+      %{type: "ADVISORY", url: "https://shared.example.com/1"}
+    ]
+
+    refs_b = [
+      %{type: "FIX", url: "https://shared.example.com/1"},
+      %{type: "WEB", url: "https://other.example.com/2"}
+    ]
+
+    [merged] =
+      Advisories.group_for_display([
+        %Advisory{id: "GHSA-aaaa-1111-bbbb", aliases: ["CVE-2026-0001"], references: refs_a},
+        %Advisory{id: "GHSA-cccc-2222-dddd", aliases: ["CVE-2026-0001"], references: refs_b}
+      ])
+
+    by_url = Map.new(merged.references, &{&1.url, &1.types})
+
+    assert map_size(by_url) == 3
+    assert by_url["https://example.com/advisory"] == ["WEB"]
+    assert by_url["https://shared.example.com/1"] == ["ADVISORY", "FIX"]
+    assert by_url["https://other.example.com/2"] == ["WEB"]
+  end
+
+  test "group_for_display aliases: links advisory IDs to osv.dev, plain strings have no URL" do
+    [merged] =
+      Advisories.group_for_display([
+        %Advisory{
+          id: "GHSA-aaaa-1111-bbbb",
+          aliases: ["CVE-2026-0001"],
+          references: [],
+          affected_versions: []
+        },
+        %Advisory{
+          id: "GHSA-cccc-2222-dddd",
+          aliases: ["CVE-2026-0001"],
+          references: [],
+          affected_versions: []
+        }
+      ])
+
+    # GHSA-cccc-2222-dddd was a separate advisory → gets an osv.dev URL
+    advisory_alias = Enum.find(merged.aliases, &(&1.id == "GHSA-cccc-2222-dddd"))
+    assert advisory_alias.url == "https://osv.dev/vulnerability/GHSA-cccc-2222-dddd"
+
+    # CVE-2026-0001 is only a plain alias string → no URL
+    cve_alias = Enum.find(merged.aliases, &(&1.id == "CVE-2026-0001"))
+    assert cve_alias.url == nil
+  end
+
   test "upsert skips sync for unchanged advisories", %{package: package} do
     record =
       record("GHSA-skip", "oidcc",


### PR DESCRIPTION
When grouping advisories for display, alias IDs that correspond to a separate advisory in the group now link to osv.dev instead of rendering as plain text. References with the same URL from different sources are merged into a single entry with all types accumulated, rather than being deduplicated by (type, url) pair.