### PR TITLE
Sort typeahead suggestions by downloads within each match tier

### DIFF
--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -241,8 +241,12 @@ defmodule Hexpm.Repository.Packages do
   def suggest(_repository, "", _limit), do: []
 
   def suggest(repository, term, limit) when is_binary(term) do
-    term = String.trim(term)
-    do_suggest(repository, term, limit)
+    term
+    |> String.trim()
+    |> case do
+      term when byte_size(term) < 3 -> []
+      term -> do_suggest(repository, term, limit)
+    end
   end
 
   defp do_suggest(_repository, "", _limit), do: []
@@ -260,7 +264,7 @@ defmodule Hexpm.Repository.Packages do
     |> where([p], p.repository_id == ^repository.id)
     |> add_suggest_joins()
     |> add_suggest_search_where(substr, tsquery)
-    |> add_suggest_order_by(pkg_part, prefix, substr, tsquery)
+    |> add_suggest_order_by(pkg_part, prefix, substr)
     |> add_suggest_select(tsquery)
     |> limit(^limit)
     |> Repo.all()
@@ -309,7 +313,7 @@ defmodule Hexpm.Repository.Packages do
     where(
       query,
       [p],
-      fragment("lower(?) LIKE ?", p.name, ^substr) or
+      like(p.name, ^substr) or
         fragment(
           "to_tsvector('english', regexp_replace((?->'description')::text, '/', ' ')) @@ to_tsquery('english', ?)",
           p.meta,
@@ -318,11 +322,14 @@ defmodule Hexpm.Repository.Packages do
     )
   end
 
-  defp add_suggest_order_by(query, pkg_part, prefix, substr, tsquery) do
+  defp add_suggest_order_by(query, pkg_part, prefix, substr) do
     # Name-match tiers are exclusive so each package falls into exactly one band:
-    #   exact  → 3.0  (lower(name) = term)
-    #   prefix → 2.0  (lower(name) LIKE term%)
-    #   substr → 1.0  (lower(name) LIKE %term%)
+    #   exact       → 3.0  (name LIKE term)
+    #   prefix      → 2.0  (name LIKE term%)
+    #   substr      → 1.0  (name LIKE %term%)
+    #   desc-only   → 0.5  (matched via full-text search, not name)
+    # Downloads use an uncapped logarithm so popular packages rank higher within
+    # each tier (e.g. "ecto" surfaces above other "ect*" prefix matches).
     order_by(
       query,
       [p, r, d],
@@ -330,19 +337,12 @@ defmodule Hexpm.Repository.Packages do
         fragment(
           """
           (CASE
-            WHEN lower(?) = ?        THEN 3.0
-            WHEN lower(?) LIKE ?     THEN 2.0
-            WHEN lower(?) LIKE ?     THEN 1.0
-            ELSE 0.0
+            WHEN ? LIKE ?           THEN 3.0
+            WHEN ? LIKE ?           THEN 2.0
+            WHEN ? LIKE ?           THEN 1.0
+            ELSE 0.5
           END) +
-          (LEAST(5.0, ln(1 + COALESCE(?, 0))) * 0.2) +
-          (COALESCE(
-            ts_rank_cd(
-              to_tsvector('english', regexp_replace((?->'description')::text, '/', ' ')),
-              to_tsquery('english', ?)
-            ),
-            0.0
-          ) * 0.4)
+          (ln(1 + COALESCE(?, 0)) * 0.1)
           """,
           p.name,
           ^pkg_part,
@@ -350,9 +350,7 @@ defmodule Hexpm.Repository.Packages do
           ^prefix,
           p.name,
           ^substr,
-          d.downloads,
-          p.meta,
-          ^tsquery
+          d.downloads
         ),
       asc: p.name
     )

--- a/test/hexpm/repository/packages_suggest_test.exs
+++ b/test/hexpm/repository/packages_suggest_test.exs
@@ -1,5 +1,5 @@
 defmodule Hexpm.Repository.PackagesSuggestTest do
-  use Hexpm.DataCase, async: true
+  use Hexpm.DataCase
 
   alias Hexpm.Repository.Packages
 
@@ -10,11 +10,13 @@ defmodule Hexpm.Repository.PackagesSuggestTest do
   end
 
   describe "suggest/3" do
-    test "returns empty list for empty string", %{repository: repository} do
+    test "returns empty list for fewer than 3 characters", %{repository: repository} do
       insert(:package, name: "ecto", repository_id: repository.id)
 
       assert [] == Packages.suggest(repository, "")
       assert [] == Packages.suggest(repository, "   ")
+      assert [] == Packages.suggest(repository, "ec")
+      assert [] == Packages.suggest(repository, "e")
     end
 
     test "returns exact match first", %{repository: repository} do
@@ -78,18 +80,16 @@ defmodule Hexpm.Repository.PackagesSuggestTest do
       assert description_string =~ ~r/<strong>ecto<\/strong>/i
     end
 
-    test "is case insensitive", %{repository: repository} do
-      ecto = insert(:package, name: "Ecto", repository_id: repository.id)
-      phoenix = insert(:package, name: "Phoenix", repository_id: repository.id)
+    test "matches regardless of search term case", %{repository: repository} do
+      ecto = insert(:package, name: "ecto", repository_id: repository.id)
+      phoenix = insert(:package, name: "phoenix", repository_id: repository.id)
 
       insert(:release, package: ecto)
       insert(:release, package: phoenix)
 
-      results = Packages.suggest(repository, "ecto")
-      assert "Ecto" in names(results)
-
-      results = Packages.suggest(repository, "ECTO")
-      assert "Ecto" in names(results)
+      assert "ecto" in names(Packages.suggest(repository, "ecto"))
+      assert "ecto" in names(Packages.suggest(repository, "ECTO"))
+      assert "ecto" in names(Packages.suggest(repository, "Ecto"))
     end
 
     test "respects repository scoping", %{repository: repository} do
@@ -168,21 +168,43 @@ defmodule Hexpm.Repository.PackagesSuggestTest do
     end
 
     test "orders by relevance and downloads", %{repository: repository} do
-      # Create packages with different download counts
-      high_downloads = insert(:package, name: "ecto_high", repository_id: repository.id)
+      # Names are chosen so alphabetical order is the reverse of expected download order:
+      # "ecto_zzz" > "ecto_aaa" by downloads, but "ecto_aaa" < "ecto_zzz" alphabetically.
+      # This proves downloads drive the ranking, not the fallback name sort.
+      recent_day = Date.utc_today() |> Date.add(-7)
+      high_downloads = insert(:package, name: "ecto_zzz", repository_id: repository.id)
       exact_match = insert(:package, name: "ecto", repository_id: repository.id)
-      low_downloads = insert(:package, name: "ecto_low", repository_id: repository.id)
+      low_downloads = insert(:package, name: "ecto_aaa", repository_id: repository.id)
 
-      insert(:release, package: high_downloads)
-      insert(:release, package: exact_match)
-      insert(:release, package: low_downloads)
+      insert(:release,
+        package: high_downloads,
+        daily_downloads: [
+          build(:download, package_id: high_downloads.id, downloads: 1_000_000, day: recent_day)
+        ]
+      )
 
-      # Add downloads (would need PackageDownload view refresh in real scenario)
-      # For now, just verify the structure
+      insert(:release,
+        package: exact_match,
+        daily_downloads: [
+          build(:download, package_id: exact_match.id, downloads: 500_000, day: recent_day)
+        ]
+      )
+
+      insert(:release,
+        package: low_downloads,
+        daily_downloads: [
+          build(:download, package_id: low_downloads.id, downloads: 500, day: recent_day)
+        ]
+      )
+
+      :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload, concurrently: false)
+
       results = Packages.suggest(repository, "ecto")
 
-      # Exact match should be first
+      # Exact name match ("ecto") ranks first despite fewer downloads than "ecto_zzz"
       assert hd(names(results)) == "ecto"
+      # Within the prefix-match tier, higher downloads rank first (not alphabetical)
+      assert names(results) == ["ecto", "ecto_zzz", "ecto_aaa"]
     end
 
     test "name_html wraps matched portion in a mark element", %{repository: repository} do
@@ -194,16 +216,13 @@ defmodule Hexpm.Repository.PackagesSuggestTest do
       assert name_html == "<mark>ecto</mark>"
     end
 
-    test "name_html match is case-insensitive and preserves original casing", %{
-      repository: repository
-    } do
-      insert(:package, name: "EctoSQL", repository_id: repository.id)
+    test "name_html highlights the matched portion", %{repository: repository} do
+      insert(:package, name: "ecto_sql", repository_id: repository.id)
 
       [result] = Packages.suggest(repository, "ecto")
 
       assert {:safe, name_html} = result.name_html
-      # Original casing preserved; matched portion wrapped in <mark>
-      assert name_html == "<mark>Ecto</mark>SQL"
+      assert name_html == "<mark>ecto</mark>_sql"
     end
 
     test "description_html does not pass raw HTML tags from descriptions", %{


### PR DESCRIPTION
### Fixes #1567.

My first implementation of the search typeahead was not sorting results by downloads. Searching for `ect` returned `ecto`, `ecto_sql`, `ecto_commons`, etc. in effectively arbitrary order because the scoring formula capped the download contribution too aggressively:

```sql
(LEAST(5.0, ln(1 + COALESCE(downloads, 0))) * 0.2)
```

`e^5 ≈ 148`, so any package with more than ~150 downloads receives the maximum score of `1.0`. Since almost every published package exceeds that threshold, all candidates in the same name-match tier (exact/prefix/substring) received identical download scores and fell back to alphabetical ordering.

I should have done the math.

### Fix

Remove the `LEAST(5.0, …)` cap and reduce the multiplier to `0.1`:

```sql
(ln(1 + COALESCE(downloads, 0)) * 0.1)
```

This lets the logarithm scale continuously with actual download counts, so `ecto` (millions of weekly downloads) naturally surfaces above `ecto_commons` (thousands of weekly downloads) within the prefix-match tier.

The `0.1` multiplier keeps download weight below the `1.0`-point gap between tiers (exact → prefix → substring), so name-match quality still takes precedence — an exact match like `ecto` will not be buried by a hugely popular prefix match, unless the exact-match package has essentially zero downloads.