### PR TITLE
Redesign packages filtering UI

### DIFF
--- a/lib/hexpm_web/live/package_live/filter_sidebar.ex
+++ b/lib/hexpm_web/live/package_live/filter_sidebar.ex
@@ -1,6 +1,8 @@
 defmodule HexpmWeb.PackageLive.FilterSidebar do
   use Phoenix.Component
 
+  alias Phoenix.LiveView.JS
+
   import HexpmWeb.ViewIcons, only: [icon: 3]
 
   alias Hexpm.Repository.Package.SearchQuery
@@ -10,79 +12,263 @@ defmodule HexpmWeb.PackageLive.FilterSidebar do
   attr :query, SearchQuery, required: true
 
   def sidebar(assigns) do
-    assigns = assign(assigns, :build_tools, @build_tools)
+    assigns =
+      assigns
+      |> assign(:build_tools, @build_tools)
+      |> assign(:active_count, active_count(assigns.query))
 
     ~H"""
-    <aside id="filter-sidebar" class="w-full md:w-60 shrink-0 hidden md:block" aria-label="Filters">
-      <div class="bg-grey-50 dark:bg-grey-800 rounded-xl p-5 space-y-5">
-        <form phx-change="filter_change" id="filter-form" class="space-y-5">
-          <h3 class="text-grey-700 dark:text-grey-200 text-sm font-semibold uppercase tracking-wide">
-            Filters
-          </h3>
-
-          <fieldset>
-            <legend class="text-grey-700 dark:text-grey-200 text-sm font-semibold mb-3">
-              Build tool
-            </legend>
-            <div class="relative">
-              <select
-                name="build_tool"
-                class="w-full h-9 pl-3 pr-8 text-sm bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-900 dark:text-grey-100 focus:outline-none focus:ring-1 focus:border-primary-600 focus:ring-primary-600 dark:focus:border-primary-400 dark:focus:ring-primary-400 cursor-pointer appearance-none"
-              >
-                <option value="" selected={is_nil(@query.build_tool)}>Any</option>
-                <option
-                  :for={tool <- @build_tools}
-                  value={tool}
-                  selected={@query.build_tool == tool}
-                >
-                  {tool}
-                </option>
-              </select>
-              <div class="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none text-grey-400 dark:text-grey-300">
-                {icon(:heroicon, "chevron-down", width: 15, height: 15)}
-              </div>
-            </div>
-          </fieldset>
-
-          <fieldset>
-            <legend class="text-grey-700 dark:text-grey-200 text-sm font-semibold mb-3">
-              Depends on
-            </legend>
-            <input
-              type="text"
-              name="depends"
-              value={@query.depends || ""}
-              placeholder="package name"
-              phx-debounce="300"
-              class="w-full h-9 px-3 text-sm bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-900 dark:text-grey-100 placeholder:text-grey-400 dark:placeholder:text-grey-400 focus:outline-none focus:ring-1 focus:border-primary-600 focus:ring-primary-600 dark:focus:border-primary-400 dark:focus:ring-primary-400"
-            />
-          </fieldset>
-
-          <fieldset>
-            <legend class="text-grey-700 dark:text-grey-200 text-sm font-semibold mb-3">
-              Updated after
-            </legend>
-            <input
-              type="date"
-              name="updated_after"
-              value={date_value(@query.updated_after)}
-              class="w-full h-9 px-3 text-sm bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-900 dark:text-grey-100 focus:outline-none focus:ring-1 focus:border-primary-600 focus:ring-primary-600 dark:focus:border-primary-400 dark:focus:ring-primary-400"
-            />
-          </fieldset>
-        </form>
-
-        <div class="pt-4 border-t border-grey-200 dark:border-grey-600">
-          <button
-            type="button"
-            phx-click="clear_filters"
-            class="w-full inline-flex items-center justify-center h-9 px-3 text-sm font-medium text-grey-700 dark:text-grey-200 bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg hover:bg-grey-100 dark:hover:bg-grey-600 transition-colors"
-          >
-            Clear all
-          </button>
-        </div>
+    <aside
+      class="hidden md:block w-full md:w-[264px] md:shrink-0 md:self-start md:sticky md:top-6"
+      aria-label="Filters"
+    >
+      <div class="bg-white dark:bg-grey-800 border border-grey-100 dark:border-grey-700 rounded-xl p-5">
+        <.filter_header active_count={@active_count} />
+        <.filter_form
+          id="filter-form"
+          query={@query}
+          build_tools={@build_tools}
+        />
+        <.filter_actions />
       </div>
     </aside>
     """
+  end
+
+  attr :query, SearchQuery, required: true
+
+  def mobile_sheet(assigns) do
+    assigns =
+      assigns
+      |> assign(:build_tools, @build_tools)
+      |> assign(:active_count, active_count(assigns.query))
+
+    ~H"""
+    <div
+      id="filter-sheet"
+      class="md:hidden fixed inset-0 z-40 hidden flex-col"
+      aria-hidden="true"
+    >
+      <button
+        type="button"
+        aria-label="Close filters"
+        class="flex-1 bg-grey-900/45"
+        phx-click={close_sheet()}
+      >
+      </button>
+      <div class="bg-white dark:bg-grey-800 rounded-t-[20px] shadow-[0_-8px_24px_rgba(3,9,19,0.16)] pt-2 pb-6 flex flex-col max-h-[85%]">
+        <div class="w-9 h-1 rounded-full bg-grey-200 dark:bg-grey-600 mx-auto mt-1.5 mb-1"></div>
+        <div class="flex items-center justify-between px-4 pt-2.5 pb-3.5 border-b border-grey-100 dark:border-grey-700">
+          <.filter_eyebrow active_count={@active_count} />
+          <button
+            type="button"
+            aria-label="Close filters"
+            class="w-8 h-8 rounded-lg inline-flex items-center justify-center text-grey-500 dark:text-grey-300 hover:bg-grey-50 dark:hover:bg-grey-700 transition-colors"
+            phx-click={close_sheet()}
+          >
+            {icon(:heroicon, "x-mark", width: 18, height: 18)}
+          </button>
+        </div>
+
+        <div class="overflow-y-auto px-4 pt-4 pb-1">
+          <.filter_form
+            id="filter-form-mobile"
+            query={@query}
+            build_tools={@build_tools}
+          />
+        </div>
+
+        <div class="flex gap-2 px-4 pt-3.5 border-t border-grey-100 dark:border-grey-700 mt-2">
+          <button
+            type="button"
+            phx-click="clear_filters"
+            class="flex-1 h-11 rounded-lg border-[1.5px] border-grey-900 dark:border-grey-100 bg-transparent text-grey-900 dark:text-grey-100 text-sm font-medium hover:bg-grey-900 hover:text-white dark:hover:bg-grey-100 dark:hover:text-grey-900 transition-colors"
+          >
+            Clear all
+          </button>
+          <button
+            type="button"
+            class="flex-[2] h-11 rounded-lg border-0 bg-blue-600 text-white text-sm font-semibold hover:bg-blue-700 transition-colors"
+            phx-click={close_sheet()}
+          >
+            Show results
+          </button>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :active_count, :integer, required: true
+
+  defp filter_header(assigns) do
+    ~H"""
+    <div class="flex items-center justify-between gap-2 pb-4 mb-4 border-b border-grey-100 dark:border-grey-700">
+      <.filter_eyebrow active_count={@active_count} />
+    </div>
+    """
+  end
+
+  attr :active_count, :integer, required: true
+
+  defp filter_eyebrow(assigns) do
+    ~H"""
+    <div class="flex items-baseline gap-2">
+      <span class="text-tiny font-semibold uppercase tracking-[0.08em] text-grey-400 dark:text-grey-300">
+        Filters
+      </span>
+      <span
+        :if={@active_count > 0}
+        class="text-tiny font-semibold text-primary-700 dark:text-primary-200 bg-primary-50 dark:bg-primary-900/30 border border-primary-100 dark:border-primary-800 px-2 py-0.5 rounded-full tabular-nums"
+      >
+        {@active_count} active
+      </span>
+    </div>
+    """
+  end
+
+  attr :id, :string, required: true
+  attr :query, SearchQuery, required: true
+  attr :build_tools, :list, required: true
+
+  defp filter_form(assigns) do
+    ~H"""
+    <form phx-change="filter_change" id={@id}>
+      <div class="mb-[18px]">
+        <label
+          class="flex items-center justify-between gap-2 text-small font-semibold text-grey-600 dark:text-grey-200 mb-1.5"
+          for={"#{@id}-build-tool"}
+        >
+          Build tool
+        </label>
+        <div class="relative">
+          <select
+            id={"#{@id}-build-tool"}
+            name="build_tool"
+            class="w-full h-9 pl-3 pr-8 text-small bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-700 dark:text-grey-100 cursor-pointer appearance-none focus:outline-none focus:border-primary-600 focus:ring-[3px] focus:ring-primary-100 dark:focus:ring-primary-900/40 transition-[border-color,box-shadow] duration-150"
+          >
+            <option value="" selected={is_nil(@query.build_tool)}>Any</option>
+            <option
+              :for={tool <- @build_tools}
+              value={tool}
+              selected={@query.build_tool == tool}
+            >
+              {tool}
+            </option>
+          </select>
+          <div class="absolute right-2.5 top-1/2 -translate-y-1/2 pointer-events-none text-grey-400 dark:text-grey-300">
+            {icon(:heroicon, "chevron-down", width: 14, height: 14)}
+          </div>
+        </div>
+      </div>
+
+      <div class="mb-[18px]">
+        <label
+          class="flex items-center justify-between gap-2 text-small font-semibold text-grey-600 dark:text-grey-200 mb-1.5"
+          for={"#{@id}-depends"}
+        >
+          Depends on
+        </label>
+        <div class="relative">
+          <span class="absolute left-2.5 top-1/2 -translate-y-1/2 pointer-events-none text-grey-300 dark:text-grey-400">
+            {icon(:heroicon, "magnifying-glass", width: 14, height: 14)}
+          </span>
+          <input
+            id={"#{@id}-depends"}
+            type="text"
+            name="depends"
+            value={@query.depends || ""}
+            placeholder="package name"
+            phx-debounce="300"
+            class="w-full h-9 pl-[34px] pr-3 text-small bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-700 dark:text-grey-100 placeholder:text-grey-300 dark:placeholder:text-grey-400 focus:outline-none focus:border-primary-600 focus:ring-[3px] focus:ring-primary-100 dark:focus:ring-primary-900/40 transition-[border-color,box-shadow] duration-150"
+          />
+        </div>
+      </div>
+
+      <div class="mb-5">
+        <label
+          class="flex items-center justify-between gap-2 text-small font-semibold text-grey-600 dark:text-grey-200 mb-1.5"
+          for={"#{@id}-updated-after"}
+        >
+          <span>Updated after</span>
+          <span class="text-tiny font-normal text-grey-400 dark:text-grey-300">last release</span>
+        </label>
+        <input
+          id={"#{@id}-updated-after"}
+          type="date"
+          name="updated_after"
+          value={date_value(@query.updated_after)}
+          class="w-full h-9 px-3 text-small bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-700 dark:text-grey-100 tabular-nums focus:outline-none focus:border-primary-600 focus:ring-[3px] focus:ring-primary-100 dark:focus:ring-primary-900/40 transition-[border-color,box-shadow] duration-150"
+        />
+      </div>
+    </form>
+    """
+  end
+
+  defp filter_actions(assigns) do
+    ~H"""
+    <div class="flex gap-2 pt-4 border-t border-grey-100 dark:border-grey-700">
+      <button
+        id="clear-filters"
+        type="button"
+        phx-click="clear_filters"
+        class="flex-1 h-9 rounded-lg border-[1.5px] border-grey-900 dark:border-grey-100 bg-transparent text-grey-900 dark:text-grey-100 text-small font-medium hover:bg-grey-900 hover:text-white dark:hover:bg-grey-100 dark:hover:text-grey-900 transition-colors"
+      >
+        Clear all
+      </button>
+    </div>
+    """
+  end
+
+  @doc """
+  JS command to open the mobile filter sheet.
+  """
+  def open_sheet(js \\ %JS{}) do
+    js
+    |> JS.remove_class("hidden", to: "#filter-sheet")
+    |> JS.add_class("flex", to: "#filter-sheet")
+    |> JS.set_attribute({"aria-hidden", "false"}, to: "#filter-sheet")
+  end
+
+  @doc """
+  JS command to close the mobile filter sheet.
+  """
+  def close_sheet(js \\ %JS{}) do
+    js
+    |> JS.add_class("hidden", to: "#filter-sheet")
+    |> JS.remove_class("flex", to: "#filter-sheet")
+    |> JS.set_attribute({"aria-hidden", "true"}, to: "#filter-sheet")
+  end
+
+  @doc """
+  Returns the number of active filters on a SearchQuery.
+  """
+  def active_count(%SearchQuery{} = q) do
+    [q.build_tool, q.depends, q.updated_after]
+    |> Enum.count(&(not is_nil(&1)))
+  end
+
+  @doc """
+  Returns the list of active filter chips as `{label, key, value}` tuples for
+  rendering an "Active" chip strip. Each chip exposes the filter `key` so the
+  parent LiveView can clear that filter individually.
+  """
+  def active_chips(%SearchQuery{} = q) do
+    [
+      {"build tool", "build_tool", q.build_tool},
+      {"depends on", "depends", q.depends},
+      {"updated after", "updated_after", format_date(q.updated_after)}
+    ]
+    |> Enum.reject(fn {_, _, v} -> is_nil(v) end)
+  end
+
+  defp format_date(nil), do: nil
+
+  defp format_date(iso8601) do
+    case DateTime.from_iso8601(iso8601) do
+      {:ok, dt, _} -> Date.to_iso8601(DateTime.to_date(dt))
+      _ -> iso8601
+    end
   end
 
   defp date_value(nil), do: ""

--- a/lib/hexpm_web/live/package_live/index.ex
+++ b/lib/hexpm_web/live/package_live/index.ex
@@ -3,11 +3,20 @@ defmodule HexpmWeb.PackageLive.Index do
 
   import HexpmWeb.PackageView, only: [downloads_for_package: 2]
   import HexpmWeb.PackageLive.FilterSidebar
+  import HexpmWeb.ViewIcons, only: [icon: 3]
 
   alias Hexpm.Repository.Package.SearchQuery
 
   @packages_per_page 30
   @sort_params ~w(name recent_downloads total_downloads inserted_at updated_at)
+  @sort_options [
+    {"Recent downloads", "recent_downloads"},
+    {"Total downloads", "total_downloads"},
+    {"Recently updated", "updated_at"},
+    {"Recently created", "inserted_at"},
+    {"Name (A–Z)", "name"}
+  ]
+
   @impl true
   def mount(_params, _session, socket) do
     organizations = Users.all_organizations(socket.assigns.current_user)
@@ -19,7 +28,8 @@ defmodule HexpmWeb.PackageLive.Index do
         container: "container",
         live_search: true,
         per_page: @packages_per_page,
-        repositories: repositories
+        repositories: repositories,
+        sort_options: @sort_options
       )
 
     {:ok, socket}
@@ -79,125 +89,194 @@ defmodule HexpmWeb.PackageLive.Index do
     ~H"""
     <%!-- Package Index Page --%>
     <div class="bg-white dark:bg-grey-950 min-h-dvh">
-      <div class="max-w-7xl mx-auto px-4 py-8 lg:py-12">
-        <%!-- Header --%>
-        <div class="mb-8">
-          <h1 class="text-grey-900 dark:text-grey-100 text-4xl font-bold mb-2">
+      <%!-- Header --%>
+      <header class="bg-white dark:bg-grey-950 border-b border-grey-100 dark:border-grey-700 pt-14 pb-6">
+        <div class="max-w-7xl mx-auto px-4">
+          <h1 class="text-h2 font-bold tracking-[-0.02em] text-grey-900 dark:text-grey-100 m-0">
             Packages
           </h1>
-          <p class="text-grey-600 dark:text-grey-300 text-lg">
+          <p class="mt-2 text-body text-grey-500 dark:text-grey-300">
             Browse and discover packages for the Erlang ecosystem
           </p>
         </div>
+      </header>
 
-        <button
-          type="button"
-          phx-click={
-            Phoenix.LiveView.JS.toggle(to: "#filter-sidebar")
-            |> Phoenix.LiveView.JS.toggle_attribute({"aria-expanded", "true", "false"})
-          }
-          aria-expanded="false"
-          aria-controls="filter-sidebar"
-          class="md:hidden mb-4 inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-grey-700 dark:text-grey-200 bg-grey-50 dark:bg-grey-800 border border-grey-200 dark:border-grey-600 rounded-lg hover:bg-grey-100 dark:hover:bg-grey-700 transition-colors"
-        >
-          <svg class="size-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z"
-            />
-          </svg>
-          Filters
-        </button>
-        <div class="flex flex-col md:flex-row gap-6">
-          <.sidebar query={@search_query} />
-          <div class="flex-1 min-w-0">
-            <%!-- Exact Match Section --%>
-            <%= if @exact_match do %>
-              <div class="mb-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl p-6">
-                <div class="flex items-center gap-2 mb-4">
-                  <svg
-                    class="size-5 text-green-600"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                    />
-                  </svg>
-                  <h3 class="text-green-900 dark:text-green-200 font-semibold text-lg">
-                    Exact Match
-                  </h3>
-                </div>
-                <ul class="bg-white dark:bg-grey-800 rounded-lg overflow-hidden divide-y divide-grey-200 dark:divide-grey-700">
-                  {HexpmWeb.PackageView.render("_package.html",
-                    exact_match?: true,
-                    package: @exact_match,
-                    package_downloads: downloads_for_package(@exact_match, @downloads),
-                    view: @sort
-                  )}
-                </ul>
+      <main class="max-w-7xl mx-auto px-4 pt-8 pb-20">
+        <%!-- Mobile sticky toolbar --%>
+        <div class="md:hidden sticky top-0 z-20 -mx-4 px-4 py-2.5 mb-3 bg-white/95 dark:bg-grey-900/95 backdrop-blur border-b border-grey-100 dark:border-grey-700 flex items-center gap-2">
+          <button
+            type="button"
+            phx-click={open_sheet()}
+            class="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg border-[1.5px] border-grey-900 dark:border-grey-100 bg-transparent text-grey-900 dark:text-grey-100 text-small font-medium hover:bg-grey-900 hover:text-white dark:hover:bg-grey-100 dark:hover:text-grey-900 transition-colors"
+          >
+            {icon(:heroicon, "funnel", width: 14, height: 14)} Filters
+            <span
+              :if={active_count(@search_query) > 0}
+              class="text-tiny font-semibold text-white bg-primary-600 px-1.5 py-px rounded-full tabular-nums leading-[1.45]"
+            >
+              {active_count(@search_query)}
+            </span>
+          </button>
+          <div class="flex-1"></div>
+          <form phx-change="sort_change" class="inline-flex">
+            <label for="sort-select-mobile" class="sr-only">Sort</label>
+            <div class="relative">
+              <select
+                id="sort-select-mobile"
+                name="sort"
+                class="appearance-none h-9 pl-3 pr-8 text-small font-medium bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-600 dark:text-grey-200 cursor-pointer focus:outline-none focus:border-primary-600 focus:ring-[3px] focus:ring-primary-100 dark:focus:ring-primary-900/40 transition-[border-color,box-shadow] duration-150"
+              >
+                <option
+                  :for={{label, value} <- @sort_options}
+                  value={value}
+                  selected={to_string(@sort) == value}
+                >
+                  Sort: {label}
+                </option>
+              </select>
+              <div class="absolute right-2.5 top-1/2 -translate-y-1/2 pointer-events-none text-grey-400 dark:text-grey-300">
+                {icon(:heroicon, "chevron-down", width: 12, height: 12)}
               </div>
-            <% end %>
+            </div>
+          </form>
+        </div>
+
+        <%!-- Mobile active filter chips --%>
+        <div
+          :if={active_count(@search_query) > 0}
+          class="md:hidden flex flex-wrap gap-1.5 items-center mb-4"
+        >
+          <span class="text-tiny font-semibold uppercase tracking-[0.08em] text-grey-400 dark:text-grey-300 mr-1">
+            Active
+          </span>
+          <span
+            :for={{label, key, value} <- active_chips(@search_query)}
+            class="inline-flex items-center gap-1.5 h-[26px] pl-2.5 pr-1.5 text-caption font-medium bg-primary-50 dark:bg-primary-900/30 border border-primary-100 dark:border-primary-800 text-primary-700 dark:text-primary-200 rounded-full"
+          >
+            <span class="opacity-65">{label}:</span> {value}
+            <button
+              type="button"
+              aria-label={"Remove #{label} filter"}
+              phx-click="remove_filter"
+              phx-value-key={key}
+              class="w-4 h-4 rounded-full inline-flex items-center justify-center hover:bg-primary-100 dark:hover:bg-primary-800 transition-colors"
+            >
+              {icon(:heroicon, "x-mark", width: 10, height: 10)}
+            </button>
+          </span>
+        </div>
+
+        <div class="md:grid md:grid-cols-[264px_1fr] md:gap-8">
+          <%!-- Desktop filter sidebar --%>
+          <.sidebar query={@search_query} />
+
+          <%!-- Results column --%>
+          <div class="min-w-0">
+            <%!-- Exact Match Section --%>
+            <div
+              :if={@exact_match}
+              class="mb-6 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-xl p-6"
+            >
+              <div class="flex items-center gap-2 mb-4">
+                {icon(:heroicon, "check-circle", class: "size-5 text-green-600")}
+                <h3 class="text-green-900 dark:text-green-200 font-semibold text-lg">
+                  Exact Match
+                </h3>
+              </div>
+              <ul class="bg-white dark:bg-grey-800 rounded-lg overflow-hidden divide-y divide-grey-100 dark:divide-grey-700">
+                {HexpmWeb.PackageView.render("_package.html",
+                  exact_match?: true,
+                  package: @exact_match,
+                  package_downloads: downloads_for_package(@exact_match, @downloads),
+                  view: @sort
+                )}
+              </ul>
+            </div>
 
             <%!-- No Results --%>
-            <%= if !@exact_match and @packages == [] do %>
-              <div class="bg-grey-50 dark:bg-grey-800 rounded-xl p-12 text-center">
-                <svg
-                  class="mx-auto size-16 text-grey-300 mb-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                  />
-                </svg>
-                <h3 class="text-grey-900 dark:text-grey-100 text-2xl font-semibold mb-2">
-                  No Results Found
-                </h3>
-                <p class="text-grey-600 dark:text-grey-300">
-                  Try adjusting your search
-                </p>
-              </div>
-            <% end %>
+            <div
+              :if={!@exact_match and @packages == []}
+              class="bg-grey-50 dark:bg-grey-800 rounded-xl p-12 text-center"
+            >
+              {icon(:heroicon, "magnifying-glass", class: "mx-auto size-16 text-grey-300 mb-4")}
+              <h3 class="text-grey-900 dark:text-grey-100 text-2xl font-semibold mb-2">
+                No Results Found
+              </h3>
+              <p class="text-grey-600 dark:text-grey-300">
+                Try adjusting your search
+              </p>
+            </div>
 
-            <%!-- Package List --%>
-            <%= if @packages != [] do %>
-              <%!-- Results Header with Sort Selector --%>
-              <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 mb-6">
+            <%!-- Package list --%>
+            <div :if={@packages != []}>
+              <%!-- Desktop results header with sort --%>
+              <div class="hidden md:flex items-end justify-between gap-6 mb-4">
                 <div>
-                  <h2 class="text-grey-900 dark:text-grey-100 text-2xl font-semibold">
+                  <h2 class="text-[28px] leading-tight font-bold tracking-[-0.01em] text-grey-900 dark:text-grey-100 m-0">
                     {if @exact_match, do: "Search Results", else: "All Packages"}
                   </h2>
-                  <div class="flex items-center gap-3 mt-1">
-                    <p class="text-grey-600 dark:text-grey-300 whitespace-nowrap">
-                      {@package_count} {if @package_count == 1, do: "package", else: "packages"} found
-                    </p>
-                    <% total_pages = ceil(@package_count / @per_page) %>
-                    <%= if total_pages > 1 do %>
-                      <span class="text-grey-400 dark:text-grey-300">•</span>
-                      <p class="text-grey-600 dark:text-grey-300 font-medium whitespace-nowrap">
-                        Page {@page} of {total_pages}
-                      </p>
-                    <% end %>
+                  <div class="text-small text-grey-500 dark:text-grey-300 mt-1.5">
+                    <strong class="text-grey-700 dark:text-grey-100 font-semibold tabular-nums">
+                      {ViewHelpers.human_number_space(@package_count)}
+                    </strong>
+                    {if @package_count == 1, do: "package", else: "packages"} found <% total_pages =
+                      max(1, ceil(@package_count / @per_page)) %>
+                    <span
+                      :if={total_pages > 1}
+                      class="inline-block w-[3px] h-[3px] rounded-full bg-grey-300 dark:bg-grey-500 align-middle mx-2"
+                    >
+                    </span>
+                    <span :if={total_pages > 1}>
+                      Page {@page} of {total_pages}
+                    </span>
                   </div>
                 </div>
-
-                <.sort_selector sort={@sort} />
+                <div class="text-right shrink-0">
+                  <label
+                    for="sort-select"
+                    class="block text-tiny font-semibold uppercase tracking-[0.08em] text-grey-400 dark:text-grey-300 mb-1.5"
+                  >
+                    Sort by
+                  </label>
+                  <form phx-change="sort_change">
+                    <div class="relative min-w-[200px]">
+                      <select
+                        id="sort-select"
+                        name="sort"
+                        class="w-full h-9 pl-3 pr-8 text-small bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-600 rounded-lg text-grey-700 dark:text-grey-100 cursor-pointer appearance-none focus:outline-none focus:border-primary-600 focus:ring-[3px] focus:ring-primary-100 dark:focus:ring-primary-900/40 transition-[border-color,box-shadow] duration-150"
+                      >
+                        <option
+                          :for={{label, value} <- @sort_options}
+                          value={value}
+                          selected={to_string(@sort) == value}
+                        >
+                          {label}
+                        </option>
+                      </select>
+                      <div class="absolute right-2.5 top-1/2 -translate-y-1/2 pointer-events-none text-grey-400 dark:text-grey-300">
+                        {icon(:heroicon, "chevron-down", width: 14, height: 14)}
+                      </div>
+                    </div>
+                  </form>
+                </div>
               </div>
 
-              <%!-- Package List --%>
-              <div class="bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-xl overflow-hidden">
-                <ul class="divide-y divide-grey-200 dark:divide-grey-700">
+              <%!-- Mobile results header --%>
+              <div class="md:hidden flex items-baseline justify-between mb-2 px-1">
+                <h2 class="text-[17px] font-bold text-grey-900 dark:text-grey-100 m-0">
+                  {if @exact_match, do: "Search Results", else: "All Packages"}
+                </h2>
+                <span class="text-caption text-grey-400 dark:text-grey-300 tabular-nums">
+                  <strong class="text-grey-700 dark:text-grey-100 font-semibold">
+                    {ViewHelpers.human_number_space(@package_count)}
+                  </strong>
+                  found
+                </span>
+              </div>
+
+              <%!-- Package list --%>
+              <div class="bg-white dark:bg-grey-800 md:border md:border-grey-100 dark:md:border-grey-700 md:rounded-xl overflow-hidden">
+                <ul class="divide-y divide-grey-100 dark:divide-grey-700">
                   <%= for package <- @packages do %>
                     {HexpmWeb.PackageView.render("_package.html",
                       exact_match?: false,
@@ -222,10 +301,13 @@ defmodule HexpmWeb.PackageLive.Index do
                   path_fn: &~p"/packages?#{ViewHelpers.params(&1, search: @search, sort: @sort)}"
                 )}
               </div>
-            <% end %>
+            </div>
           </div>
         </div>
-      </div>
+      </main>
+
+      <%!-- Mobile filter bottom sheet --%>
+      <.mobile_sheet query={@search_query} />
     </div>
     """
   end
@@ -233,7 +315,6 @@ defmodule HexpmWeb.PackageLive.Index do
   @impl true
   def handle_event("filter_change", params, socket) do
     build_tool = nil_if_empty(params["build_tool"])
-
     depends = nil_if_empty(params["depends"])
 
     updated_after =
@@ -250,13 +331,25 @@ defmodule HexpmWeb.PackageLive.Index do
         updated_after: updated_after
     }
 
-    new_search = nil_if_empty(SearchQuery.serialize(new_query))
+    {:noreply, push_query(socket, new_query)}
+  end
 
-    url_params =
-      %{sort: socket.assigns.sort, search: new_search}
-      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  @impl true
+  def handle_event("remove_filter", %{"key" => key}, socket) do
+    field =
+      case key do
+        "build_tool" -> :build_tool
+        "depends" -> :depends
+        "updated_after" -> :updated_after
+        _ -> nil
+      end
 
-    {:noreply, push_patch(socket, to: ~p"/packages?#{url_params}")}
+    new_query =
+      if field,
+        do: Map.put(socket.assigns.search_query, field, nil),
+        else: socket.assigns.search_query
+
+    {:noreply, push_query(socket, new_query)}
   end
 
   @impl true
@@ -293,6 +386,16 @@ defmodule HexpmWeb.PackageLive.Index do
   @impl true
   def handle_event("clear_filters", _params, socket) do
     {:noreply, push_patch(socket, to: ~p"/packages?#{[sort: socket.assigns.sort]}")}
+  end
+
+  defp push_query(socket, %SearchQuery{} = query) do
+    new_search = nil_if_empty(SearchQuery.serialize(query))
+
+    url_params =
+      %{sort: socket.assigns.sort, search: new_search}
+      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+
+    push_patch(socket, to: ~p"/packages?#{url_params}")
   end
 
   defp nil_if_empty(nil), do: nil

--- a/lib/hexpm_web/templates/package/_package.html.heex
+++ b/lib/hexpm_web/templates/package/_package.html.heex
@@ -1,19 +1,21 @@
 <% exact_match? = assigns[:exact_match?] || false %>
 <li class={[
-  "group p-6 transition-colors",
+  "group px-4 md:px-6 py-5 transition-colors",
   exact_match? && "hover:bg-green-100 dark:hover:bg-green-900/20",
   not exact_match? && "hover:bg-grey-50 dark:hover:bg-grey-700/60"
 ]}>
-  <div class="flex items-start justify-between gap-6">
+  <div class="grid grid-cols-[1fr_auto] gap-4 md:gap-6 items-center">
     <%!-- Package Info --%>
-    <div class="flex-1 min-w-0">
-      <div class="flex items-center gap-3 mb-2">
+    <div class="min-w-0">
+      <div class="flex items-baseline gap-2.5 mb-1">
         <a
           href={ViewHelpers.path_for_package(@package)}
           class={[
-            "text-grey-900 dark:text-grey-100 font-semibold text-xl transition-colors",
-            exact_match? && "hover:text-green-600 dark:hover:text-green-300",
-            not exact_match? && "hover:text-primary-600 dark:hover:text-primary-300"
+            "text-xl font-semibold transition-colors",
+            exact_match? &&
+              "text-grey-900 dark:text-grey-100 hover:text-green-600 dark:hover:text-green-300",
+            not exact_match? &&
+              "text-grey-700 dark:text-grey-100 hover:text-primary-600 dark:hover:text-primary-300"
           ]}
         >
           {ViewHelpers.package_name(@package)}
@@ -22,11 +24,11 @@
           <a
             href={ViewHelpers.path_for_package(@package)}
             class={[
-              "inline-flex items-center px-2.5 py-0.5 rounded-md text-xs font-medium transition-colors",
+              "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium transition-colors",
               exact_match? &&
                 "bg-green-100 dark:bg-green-900/20 group-hover:bg-green-200 dark:group-hover:bg-green-900/30 text-green-700 dark:text-green-300 hover:text-green-800 dark:hover:text-green-200",
               not exact_match? &&
-                "bg-grey-100 dark:bg-grey-700 text-grey-700 dark:text-grey-200 hover:bg-primary-100 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-200"
+                "bg-grey-50 dark:bg-grey-700 border border-grey-100 dark:border-grey-600 text-grey-500 dark:text-grey-200 hover:bg-primary-100 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-200"
             ]}
           >
             v{@package.latest_release.version}
@@ -35,28 +37,28 @@
       </div>
 
       <%= if @package.meta.description do %>
-        <p class="text-grey-600 dark:text-grey-300 text-sm leading-6 line-clamp-2">
+        <p class="text-grey-500 dark:text-grey-300 text-small leading-snug line-clamp-2 mb-1.5">
           {ViewHelpers.text_length(@package.meta.description, 200)}
         </p>
       <% end %>
 
       <%= if @package.updated_at do %>
-        <p class="text-grey-500 dark:text-grey-300 text-xs mt-2">
+        <p class="text-grey-400 dark:text-grey-400 text-caption mt-1.5">
           Updated {ViewHelpers.human_relative_time_from_now(@package.updated_at)}
         </p>
       <% end %>
     </div>
 
     <%!-- Download Stats --%>
-    <div class="flex flex-col items-end gap-1 shrink-0 min-w-[120px]">
-      <div class="text-grey-900 dark:text-grey-100 text-2xl font-bold text-right">
+    <div class="text-right shrink-0 min-w-[120px] md:min-w-[180px]">
+      <div class="text-[22px] font-bold tracking-[-0.01em] text-grey-900 dark:text-grey-100 tabular-nums leading-none">
         {ViewHelpers.human_number_space(display_downloads(@package_downloads, @view) || 0)}
       </div>
-      <div class="text-grey-500 dark:text-grey-300 text-xs text-right">
+      <div class="text-grey-400 dark:text-grey-300 text-caption mt-1.5">
         {display_downloads_view_title(@view)}
       </div>
       <div
-        class="text-grey-400 dark:text-grey-300 text-xs text-right cursor-help"
+        class="text-grey-400 dark:text-grey-300 text-caption mt-0.5 tabular-nums cursor-help hidden md:block"
         title={display_downloads_for_opposite_views(@package_downloads, @view)}
       >
         {display_downloads_for_opposite_views(@package_downloads, @view)}

--- a/test/hexpm_web/live/package_live/index_test.exs
+++ b/test/hexpm_web/live/package_live/index_test.exs
@@ -149,7 +149,7 @@ defmodule HexpmWeb.PackageLive.IndexTest do
     test "clear all button resets the URL", %{conn: conn} do
       {:ok, view, _} = live(conn, ~p"/packages?search=build_tool%3Amix")
 
-      view |> element("button", "Clear all") |> render_click()
+      view |> element("#clear-filters") |> render_click()
       assert_patch(view, ~p"/packages?sort=recent_downloads")
     end
   end


### PR DESCRIPTION
Restyles the `/packages` index to match the design-system `Packages.html` and `Packages.mobile.html` mocks.

## What changed

**Filter sidebar (desktop)**
- `FILTERS` eyebrow with an `N active` count badge
- Selects/inputs share a single 36px geometry, focus rings use primary-100
- `Depends on` gets a leading search icon, `Updated after` gets a `last release` hint
- Sidebar is sticky at `top-6` and aligns to start

**Mobile**
- Sticky toolbar with an outline `Filters` button (active-count pill) + `Sort: …` dropdown
- `ACTIVE` chip strip below the toolbar; each chip has a per-filter `×` remove button (new `remove_filter` event)
- Bottom sheet modal: grabber, header with eyebrow/active count + close, scrollable body, sticky footer with outline `Clear all` + filled blue `Show results`

**Results column**
- `28px` `All Packages` heading with `N packages found · Page X of Y` meta line
- `Sort by` selector right-aligned with its own tracked eyebrow label
- Package rows tightened: `20px` name with bordered version chip, `text-grey-500` description, `13px` updated time, `22px` tabular download number; total-downloads hidden on mobile

**Misc**
- `clear-filters` ID added to the desktop Clear all button so the existing test selector still uniquely matches; mobile sheet has its own un-IDed copy

## Screenshots

### Desktop · light

Before · After
<img width="1600" height="1132" alt="before-desktop-list-light" src="https://github.com/user-attachments/assets/1454bd92-ace8-4a84-9ac7-3a8d2cc6d7dd" />

<img width="1600" height="1132" alt="after-desktop-list-light" src="https://github.com/user-attachments/assets/35a59a59-80b8-4c7d-ad9b-92c30c06b3b5" />

With filters applied (Before · After)
<img width="1600" height="1132" alt="before-desktop-filtered-light" src="https://github.com/user-attachments/assets/11f659f6-48de-410e-9e17-78dd5c677f98" />

<img width="1600" height="1132" alt="after-desktop-filtered-light" src="https://github.com/user-attachments/assets/866d1f6b-1cf9-47aa-ac4d-f27376037b58" />

### Desktop · dark

Before · After
<img width="1600" height="1132" alt="before-desktop-list-dark" src="https://github.com/user-attachments/assets/70c063f8-6841-4b1d-b9d1-32108f21cff7" />

<img width="1600" height="1132" alt="after-desktop-list-dark" src="https://github.com/user-attachments/assets/1b842be1-4303-41ff-ad31-c2ad58d64504" />

### Mobile · light

Before · After
<img width="900" height="1600" alt="before-mobile-list-light" src="https://github.com/user-attachments/assets/21e362ae-0f5d-4e4e-af94-6ca3821567e2" />

<img width="900" height="1600" alt="after-mobile-list-light" src="https://github.com/user-attachments/assets/9715748d-eb87-4677-bbde-7ae9dd93c671" />

With filters applied — note the new active-filter chip strip (Before · After)
<img width="900" height="1600" alt="before-mobile-filtered-light" src="https://github.com/user-attachments/assets/350b8f78-be42-45a4-8aa6-9c87e2bd7afd" />

<img width="900" height="1600" alt="after-mobile-chips-light" src="https://github.com/user-attachments/assets/59919122-3457-48c1-81b3-eb65e5bb671c" />

Filter bottom sheet (new on this branch)
<img width="900" height="1600" alt="after-mobile-sheet-light" src="https://github.com/user-attachments/assets/1686bd0a-caf7-41e5-924c-6dba136248d5" />

### Mobile · dark

Before · After
<img width="900" height="1600" alt="before-mobile-list-dark" src="https://github.com/user-attachments/assets/16d5cf6c-7da1-421c-babe-709a2679c599" />

<img width="900" height="1600" alt="after-mobile-list-dark" src="https://github.com/user-attachments/assets/ae2f9636-d6f6-4560-90db-406e0cf443e2" />

Filter bottom sheet
<img width="900" height="1600" alt="after-mobile-sheet-dark" src="https://github.com/user-attachments/assets/11959dd9-d253-4a43-b530-485c829cc9f7" />