### PR TITLE
Fix 2FA redirect crash when continuing OAuth flow

### DIFF
--- a/lib/hexpm_web/controllers/auth_controller.ex
+++ b/lib/hexpm_web/controllers/auth_controller.ex
@@ -71,15 +71,17 @@ defmodule HexpmWeb.AuthController do
   end
 
   defp handle_existing_user_login(conn, user) do
+    return = safe_return_path(conn.params["return"])
+
     if User.tfa_enabled?(user) do
       conn
-      |> start_tfa_session(user, conn.params["return"])
+      |> start_tfa_session(user, return)
       |> redirect(to: ~p"/tfa")
     else
       conn
       |> start_session_internal(user)
       |> HexpmWeb.Plugs.Sudo.set_sudo_authenticated()
-      |> redirect(to: conn.params["return"] || ~p"/users/#{user}")
+      |> redirect(to: return || ~p"/users/#{user}")
     end
   end
 

--- a/lib/hexpm_web/controllers/controller_helpers.ex
+++ b/lib/hexpm_web/controllers/controller_helpers.ex
@@ -523,6 +523,16 @@ defmodule HexpmWeb.ControllerHelpers do
   def safe_string(_), do: nil
 
   @doc """
+  Returns the value if it is a local path (starts with `/` but not `//`),
+  otherwise returns nil. Use to validate user-supplied redirect targets before
+  passing to `redirect(to: ...)`.
+  """
+  def safe_return_path("/"), do: "/"
+  def safe_return_path("//" <> _), do: nil
+  def safe_return_path("/" <> _ = path), do: path
+  def safe_return_path(_), do: nil
+
+  @doc """
   Safely parses a string to integer. Returns nil for non-string or invalid input.
   """
   def safe_to_integer(value) when is_binary(value) do

--- a/lib/hexpm_web/controllers/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/oauth_controller.ex
@@ -40,8 +40,7 @@ defmodule HexpmWeb.OAuthController do
           code_challenge_method: params["code_challenge_method"]
         })
       else
-        return_path = request_url(conn) |> URI.encode_www_form()
-        redirect(conn, to: ~p"/login?return=#{return_path}")
+        redirect(conn, to: ~p"/login?return=#{current_path(conn)}")
       end
     else
       {:error, error} ->

--- a/lib/hexpm_web/controllers/tfa_auth_controller.ex
+++ b/lib/hexpm_web/controllers/tfa_auth_controller.ex
@@ -26,7 +26,7 @@ defmodule HexpmWeb.TFAAuthController do
       conn
       |> delete_session("tfa_user_id")
       |> HexpmWeb.Plugs.Sudo.set_sudo_authenticated()
-      |> redirect(to: session_data["return"] || ~p"/users/#{user}")
+      |> redirect(to: safe_return_path(session_data["return"]) || ~p"/users/#{user}")
     else
       Logger.warning("Failed 2FA attempt",
         user_id: uid,

--- a/test/hexpm_web/controllers/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/oauth_controller_test.exs
@@ -71,6 +71,23 @@ defmodule HexpmWeb.OAuthControllerTest do
       assert redirected_to(conn) =~ "/login"
     end
 
+    test "return param to login is a local path, not the full URL", %{client: client} do
+      conn =
+        get(build_conn(), ~p"/oauth/authorize", %{
+          "client_id" => client.client_id,
+          "redirect_uri" => "https://example.com/callback",
+          "scope" => "api:read",
+          "state" => "test_state",
+          "code_challenge" => "challenge123",
+          "code_challenge_method" => "S256"
+        })
+
+      %URI{path: "/login", query: query} = URI.parse(redirected_to(conn))
+      return = URI.decode_query(query)["return"]
+      assert String.starts_with?(return, "/oauth/authorize?")
+      assert return =~ "client_id=#{client.client_id}"
+    end
+
     test "shows authorization page when authenticated", %{client: client} do
       user = insert(:user)
       conn = login_user(build_conn(), user)

--- a/test/hexpm_web/controllers/tfa_auth_controller_test.exs
+++ b/test/hexpm_web/controllers/tfa_auth_controller_test.exs
@@ -51,6 +51,33 @@ defmodule HexpmWeb.TFAAuthControllerTest do
       assert redirected_to(conn) == "/"
     end
 
+    test "with valid token and non-path return falls back to user profile", c do
+      token = Hexpm.Accounts.TFA.time_based_token(c.user.tfa.secret)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "https%3A%2F%2Fhex.pm%2Foauth%2Fauthorize%3Fclient_id%3Dabc"
+        })
+        |> post("/tfa", %{"code" => token})
+
+      assert redirected_to(conn) == "/users/#{c.user.username}"
+    end
+
+    test "with valid token and protocol-relative return falls back to user profile", c do
+      token = Hexpm.Accounts.TFA.time_based_token(c.user.tfa.secret)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "//evil.com"})
+        |> post("/tfa", %{"code" => token})
+
+      assert redirected_to(conn) == "/users/#{c.user.username}"
+    end
+
     test "redirects to login after too many failed attempts", c do
       PlugAttack.Storage.Ets.clean(HexpmWeb.Plugs.Attack.Storage)
 


### PR DESCRIPTION
The OAuth authorize endpoint bounced logged-out users to /login with the full request URL (URL-encoded) stashed in the return param. After 2FA, the TFA controller passed that value to redirect(to: ...), which raises ArgumentError because Phoenix requires a local path.

Store only the request path + query string from the OAuth controller, and validate the stored return value is a local path (rejecting full URLs and protocol-relative URLs) in the controllers that consume it.