### PR TITLE
Add security notification emails for email and API key events

### DIFF
--- a/lib/hexpm/accounts/keys.ex
+++ b/lib/hexpm/accounts/keys.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Accounts.Keys do
   use Hexpm.Context
 
+  alias Hexpm.Accounts.Organization
+
   def all(user_or_organization) do
     Key.all(user_or_organization)
     |> Repo.all()
@@ -22,6 +24,16 @@ defmodule Hexpm.Accounts.Keys do
     |> Multi.insert(:key, Key.build(user_or_organization, params))
     |> audit(audit_data, "key.generate", fn %{key: key} -> key end)
     |> Repo.transaction()
+    |> tap(fn
+      {:ok, %{key: key}} ->
+        user_or_organization
+        |> preload_for_email()
+        |> Emails.api_key_created(key)
+        |> Mailer.deliver_later!()
+
+      _ ->
+        :ok
+    end)
     |> maybe_retry_for_unique_name(fn ->
       create(user_or_organization, params, audit: audit_data)
     end)
@@ -36,7 +48,16 @@ defmodule Hexpm.Accounts.Keys do
 
   def revoke(user_or_organization, name, audit: audit_data) do
     if key = get(user_or_organization, name) do
-      revoke(key, audit: audit_data)
+      result = revoke(key, audit: audit_data)
+
+      if match?({:ok, _}, result) do
+        user_or_organization
+        |> preload_for_email()
+        |> Emails.api_key_revoked(key)
+        |> Mailer.deliver_later!()
+      end
+
+      result
     else
       {:error, :not_found}
     end
@@ -47,6 +68,16 @@ defmodule Hexpm.Accounts.Keys do
     |> Multi.update_all(:keys, Key.revoke_all(user_or_organization), [])
     |> audit_many(audit_data, "key.remove", all(user_or_organization))
     |> Repo.transaction()
+    |> tap(fn
+      {:ok, %{keys: {count, _}}} when count > 0 ->
+        user_or_organization
+        |> preload_for_email()
+        |> Emails.api_keys_all_revoked()
+        |> Mailer.deliver_later!()
+
+      _ ->
+        :ok
+    end)
   end
 
   # Throttle last_use updates to at most once per 5 minutes per key,
@@ -64,6 +95,11 @@ defmodule Hexpm.Accounts.Keys do
   def update_last_use(%Key{public: false} = key, _usage_info) do
     key
   end
+
+  defp preload_for_email(%Organization{} = org),
+    do: Repo.preload(org, organization_users: [user: :emails])
+
+  defp preload_for_email(user), do: user
 
   defp should_update_last_use?(%Key{last_use: %{used_at: used_at}})
        when not is_nil(used_at) do

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -378,6 +378,9 @@ defmodule Hexpm.Accounts.Users do
         Emails.verification(user, email)
         |> Mailer.deliver_later!()
 
+        Emails.email_added(user, email)
+        |> Mailer.deliver_later!()
+
         {:ok, user}
 
       {:error, :email, changeset, _} ->
@@ -414,15 +417,27 @@ defmodule Hexpm.Accounts.Users do
     organization_error(user, "cannot set email of organizations")
   end
 
-  def primary_email(user, params, opts) do
+  def primary_email(user, params, [audit: _audit_data] = opts) do
+    old_primary = User.email(user, :primary)
+
     multi =
       Multi.new()
       |> email_flag_multi(user, params, :primary, opts)
       |> Multi.delete_all(:reset, assoc(user, :password_resets))
 
     case Repo.transaction(multi) do
-      {:ok, _} -> :ok
-      {:error, :primary_email, reason, _} -> {:error, reason}
+      {:ok, _} ->
+        new_primary = params["email"]
+
+        if is_binary(new_primary) and old_primary != new_primary do
+          Emails.primary_email_changed(user, old_primary, new_primary)
+          |> Mailer.deliver_later!()
+        end
+
+        :ok
+
+      {:error, :primary_email, reason, _} ->
+        {:error, reason}
     end
   end
 

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -2,7 +2,7 @@ defmodule Hexpm.Emails do
   use Bamboo.Phoenix, view: HexpmWeb.EmailView
   import Bamboo.Email
   import Bamboo.SendGridHelper, only: [with_click_tracking: 2]
-  alias Hexpm.Accounts.{Email, User}
+  alias Hexpm.Accounts.{Email, Organization, User}
 
   def owner_added(package, owners, owner) do
     email()
@@ -82,6 +82,51 @@ defmodule Hexpm.Emails do
     |> render(:tfa_recovery_rotated)
   end
 
+  def email_added(user, new_email) do
+    email()
+    |> email_to(user)
+    |> subject("Hex.pm - A new email address was added to your account")
+    |> assign(:username, user.username)
+    |> assign(:new_email, new_email.email)
+    |> render(:email_added)
+  end
+
+  def primary_email_changed(user, old_addr, new_addr) do
+    email()
+    |> email_to(old_addr)
+    |> subject("Hex.pm - Your primary email address has changed")
+    |> assign(:username, user.username)
+    |> assign(:old_addr, old_addr)
+    |> assign(:new_addr, new_addr)
+    |> render(:primary_email_changed)
+  end
+
+  def api_key_created(user_or_org, key) do
+    email()
+    |> email_to(user_or_org)
+    |> subject("Hex.pm - A new API key was created on your account")
+    |> assign(:username, display_name(user_or_org))
+    |> assign(:key_name, key.name)
+    |> render(:api_key_created)
+  end
+
+  def api_key_revoked(user_or_org, key) do
+    email()
+    |> email_to(user_or_org)
+    |> subject("Hex.pm - An API key was revoked on your account")
+    |> assign(:username, display_name(user_or_org))
+    |> assign(:key_name, key.name)
+    |> render(:api_key_revoked)
+  end
+
+  def api_keys_all_revoked(user_or_org) do
+    email()
+    |> email_to(user_or_org)
+    |> subject("Hex.pm - All API keys have been revoked on your account")
+    |> assign(:username, display_name(user_or_org))
+    |> render(:api_keys_all_revoked)
+  end
+
   def typosquat_candidates(candidates, threshold) do
     email()
     |> email_to(Application.get_env(:hexpm, :support_email))
@@ -146,12 +191,14 @@ defmodule Hexpm.Emails do
       to
       |> List.wrap()
       |> Enum.flat_map(&expand_organization/1)
+      |> Enum.reject(&is_nil(recipient_email(&1)))
       |> Enum.sort_by(&recipient_email/1)
       |> Enum.uniq_by(&recipient_email/1)
 
     to(email, to)
   end
 
+  defp recipient_email(nil), do: nil
   defp recipient_email(email) when is_binary(email), do: email
   defp recipient_email(%Email{email: email}), do: email
   defp recipient_email(%User{} = user), do: User.email(user, :primary)
@@ -161,11 +208,33 @@ defmodule Hexpm.Emails do
   defp expand_organization(%User{organization: nil} = user), do: [user]
   defp expand_organization(%User{organization: %Ecto.Association.NotLoaded{}} = user), do: [user]
 
+  defp expand_organization(
+         %User{organization: %{organization_users: %Ecto.Association.NotLoaded{}}} = user
+       ) do
+    [user]
+  end
+
   defp expand_organization(%User{organization: organization}) do
     organization.organization_users
     |> Enum.filter(&(&1.role == "admin"))
     |> Enum.map(&User.email(&1.user, :primary))
   end
+
+  defp expand_organization(%Organization{organization_users: org_users}) do
+    admins =
+      org_users
+      |> Enum.filter(&(&1.role == "admin"))
+      |> Enum.map(&User.email(&1.user, :primary))
+
+    if admins == [] do
+      Enum.map(org_users, &User.email(&1.user, :primary))
+    else
+      admins
+    end
+  end
+
+  defp display_name(%User{username: username}), do: username
+  defp display_name(%Organization{name: name}), do: name
 
   defp email() do
     new_email()

--- a/lib/hexpm_web/templates/email/api_key_created.html.eex
+++ b/lib/hexpm_web/templates/email/api_key_created.html.eex
@@ -1,0 +1,15 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  New API Key Created
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= Common.greeting(@username) %>,
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  A new API key named <strong><%= @key_name %></strong> has been created on the <%= @username %> Hex.pm account.
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(Common.unauthorized_change_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/api_key_created.text.eex
+++ b/lib/hexpm_web/templates/email/api_key_created.text.eex
@@ -1,0 +1,7 @@
+New API Key Created
+
+<%= Common.greeting(@username) %>
+
+A new API key named "<%= @key_name %>" has been created on the <%= @username %> Hex.pm account.
+
+<%= Common.unauthorized_change_notice(:text) %>

--- a/lib/hexpm_web/templates/email/api_key_revoked.html.eex
+++ b/lib/hexpm_web/templates/email/api_key_revoked.html.eex
@@ -1,0 +1,15 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  API Key Revoked
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= Common.greeting(@username) %>,
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  The API key named <strong><%= @key_name %></strong> has been revoked on the <%= @username %> Hex.pm account.
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(Common.unauthorized_change_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/api_key_revoked.text.eex
+++ b/lib/hexpm_web/templates/email/api_key_revoked.text.eex
@@ -1,0 +1,7 @@
+API Key Revoked
+
+<%= Common.greeting(@username) %>
+
+The API key named "<%= @key_name %>" has been revoked on the <%= @username %> Hex.pm account.
+
+<%= Common.unauthorized_change_notice(:text) %>

--- a/lib/hexpm_web/templates/email/api_keys_all_revoked.html.eex
+++ b/lib/hexpm_web/templates/email/api_keys_all_revoked.html.eex
@@ -1,0 +1,15 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  All API Keys Revoked
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= Common.greeting(@username) %>,
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  All API keys on the <%= @username %> Hex.pm account have been revoked.
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(Common.unauthorized_change_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/api_keys_all_revoked.text.eex
+++ b/lib/hexpm_web/templates/email/api_keys_all_revoked.text.eex
@@ -1,0 +1,7 @@
+All API Keys Revoked
+
+<%= Common.greeting(@username) %>
+
+All API keys on the <%= @username %> Hex.pm account have been revoked.
+
+<%= Common.unauthorized_change_notice(:text) %>

--- a/lib/hexpm_web/templates/email/email_added.html.eex
+++ b/lib/hexpm_web/templates/email/email_added.html.eex
@@ -1,0 +1,15 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  New Email Address Added
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= Common.greeting(@username) %>,
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  The email address <strong><%= @new_email %></strong> has been added to your Hex.pm account.
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(Common.unauthorized_change_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/email_added.text.eex
+++ b/lib/hexpm_web/templates/email/email_added.text.eex
@@ -1,0 +1,7 @@
+New Email Address Added
+
+<%= Common.greeting(@username) %>
+
+The email address <%= @new_email %> has been added to your Hex.pm account.
+
+<%= Common.unauthorized_change_notice(:text) %>

--- a/lib/hexpm_web/templates/email/primary_email_changed.html.eex
+++ b/lib/hexpm_web/templates/email/primary_email_changed.html.eex
@@ -1,0 +1,16 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  Primary Email Address Changed
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= Common.greeting(@username) %>,
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  The primary email address on your Hex.pm account has changed from
+  <strong><%= @old_addr %></strong> to <strong><%= @new_addr %></strong>.
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(Common.unauthorized_change_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/primary_email_changed.text.eex
+++ b/lib/hexpm_web/templates/email/primary_email_changed.text.eex
@@ -1,0 +1,7 @@
+Primary Email Address Changed
+
+<%= Common.greeting(@username) %>
+
+The primary email address on your Hex.pm account has changed from <%= @old_addr %> to <%= @new_addr %>.
+
+<%= Common.unauthorized_change_notice(:text) %>

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule HexpmWeb.API.KeyControllerTest do
   use HexpmWeb.ConnCase, async: true
+  use Bamboo.Test
 
   alias Hexpm.Repo
   alias Hexpm.Accounts.{AuditLog, Key, KeyPermission}
@@ -135,7 +136,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
       key = Repo.one!(Key.get(c.eric, "macbook"))
       assert [%KeyPermission{domain: "api"}] = key.permissions
 
-      log = Repo.one!(AuditLog)
+      log = Repo.one!(from(a in AuditLog, where: a.action == "key.generate"))
       assert log.user_id == c.eric.id
       assert log.action == "key.generate"
       assert %{"name" => "macbook"} = log.params
@@ -287,7 +288,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert Repo.one(Key.get_revoked(c.eric, "key_b"))
 
       assert [log_a, log_b] =
-               AuditLog
+               from(a in AuditLog, where: a.action == "key.remove")
                |> Repo.all()
                |> Enum.sort_by(fn %{params: %{"name" => name}} -> name end)
 
@@ -308,6 +309,18 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert conn.status == 401
       body = Jason.decode!(conn.resp_body)
       assert %{"message" => "API key revoked", "status" => 401} == body
+    end
+
+    test "revoking all keys sends a single consolidated notification", c do
+      key_a = Key.build(c.eric, %{name: "notif-key-a"}) |> Repo.insert!()
+      _key_b = Key.build(c.eric, %{name: "notif-key-b"}) |> Repo.insert!()
+
+      build_conn()
+      |> put_req_header("authorization", key_a.user_secret)
+      |> delete("/api/keys")
+
+      user = Hexpm.Repo.preload(c.eric, :emails)
+      assert_delivered_email(Hexpm.Emails.api_keys_all_revoked(user))
     end
   end
 
@@ -361,7 +374,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
 
       assert Repo.one(Key.get_revoked(c.eric, "computer"))
 
-      log = Repo.one!(AuditLog)
+      log = Repo.one!(from(a in AuditLog, where: a.action == "key.remove"))
       assert log.user_id == c.eric.id
       assert log.action == "key.remove"
       assert %{"name" => "computer"} = log.params
@@ -387,7 +400,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
 
       assert Repo.one(Key.get_revoked(c.eric, "current"))
 
-      log = Repo.one!(AuditLog)
+      log = Repo.one!(from(a in AuditLog, where: a.action == "key.remove"))
       assert log.user_id == c.eric.id
       assert log.action == "key.remove"
       assert %{"name" => "current"} = log.params

--- a/test/hexpm_web/controllers/dashboard/email_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/email_controller_test.exs
@@ -76,6 +76,40 @@ defmodule HexpmWeb.Dashboard.EmailControllerTest do
     refute email.public
   end
 
+  test "add email sends security notification to existing primary", c do
+    new_email_addr = Fake.sequence(:email)
+
+    build_conn()
+    |> test_login(c.user)
+    |> post("/dashboard/email", %{email: %{email: new_email_addr}})
+
+    user = Hexpm.Repo.preload(c.user, :emails, force: true)
+    new_email = Enum.find(user.emails, &(&1.email == new_email_addr))
+    assert new_email, "expected new email #{new_email_addr} to exist after POST"
+
+    assert_delivered_email(Hexpm.Emails.email_added(user, new_email))
+  end
+
+  test "change primary email sends security notification to old address", c do
+    new_email_addr = Fake.sequence(:email)
+    user = add_email(c.user, new_email_addr)
+
+    # Verify the new email so it can become primary
+    email_record =
+      Enum.find(Hexpm.Repo.preload(user, :emails).emails, &(&1.email == new_email_addr))
+
+    Hexpm.Accounts.Email.verify(email_record) |> Hexpm.Repo.update!()
+
+    user = Hexpm.Repo.preload(user, :emails, force: true)
+    old_primary = Hexpm.Accounts.User.email(user, :primary)
+
+    build_conn()
+    |> test_login(user)
+    |> post("/dashboard/email/primary", %{email: new_email_addr})
+
+    assert_delivered_email(Hexpm.Emails.primary_email_changed(user, old_primary, new_email_addr))
+  end
+
   test "cannot add existing email", c do
     email = hd(c.user.emails).email
 

--- a/test/hexpm_web/controllers/dashboard/key_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/key_controller_test.exs
@@ -1,5 +1,6 @@
 defmodule HexpmWeb.Dashboard.KeyControllerTest do
   use HexpmWeb.ConnCase, async: true
+  use Bamboo.Test
 
   setup do
     %{
@@ -43,6 +44,17 @@ defmodule HexpmWeb.Dashboard.KeyControllerTest do
 
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~
                "The key computer was successfully generated"
+    end
+
+    test "generating a key sends security notification", c do
+      build_conn()
+      |> test_login(c.user)
+      |> post("/dashboard/keys", %{key: %{name: "notify-test", expires_in: "30"}})
+
+      user = Hexpm.Repo.preload(c.user, :emails)
+      key = Hexpm.Accounts.Keys.get(user, "notify-test")
+
+      assert_delivered_email(Hexpm.Emails.api_key_created(user, key))
     end
 
     test "shows validation errors when name is missing", c do
@@ -189,6 +201,20 @@ defmodule HexpmWeb.Dashboard.KeyControllerTest do
         |> delete("/dashboard/keys", %{name: "computer"})
 
       assert response(conn, 400) =~ "The key computer was not found"
+    end
+
+    test "revoking a key sends security notification", c do
+      {:ok, %{key: key}} =
+        Hexpm.Accounts.Keys.create(c.user, %{"name" => "to-revoke", "permissions" => []},
+          audit: audit_data(c.user)
+        )
+
+      build_conn()
+      |> test_login(c.user)
+      |> delete("/dashboard/keys", %{"name" => key.name})
+
+      user = Hexpm.Repo.preload(c.user, :emails)
+      assert_delivered_email(Hexpm.Emails.api_key_revoked(user, key))
     end
   end
 end


### PR DESCRIPTION
Closes #1290 (remaining items from [this comment](https://github.com/hexpm/hexpm/issues/1290#issuecomment-4481245409)) and #1327.

## Summary

- Notifies the existing primary address when a new email is added to an account
- Notifies both old and new primary addresses when the primary email changes
- Notifies the user (or all org admins) when an API key is created
- Notifies the user (or all org admins) when a single API key is revoked
- Notifies the user (or all org admins) with a single consolidated email when all API keys are revoked at once

All notifications also write a standalone audit log entry (`security_notification.*`) with the same request context as the originating action.

## Architecture

A new `Hexpm.Accounts.SecurityNotifications` module is the single dispatch point for all these emails + audit entries. Context functions (`users.ex`, `keys.ex`) call into it after a successful transaction rather than directly into `Hexpm.Emails`.
