### PR TITLE
Route HTTP timeout opts to Finch.request/3 after Finch 0.22 bump

### DIFF
--- a/lib/hexpm/http.ex
+++ b/lib/hexpm/http.ex
@@ -24,49 +24,35 @@ defmodule Hexpm.HTTP do
   @behaviour Hexpm.HTTP.Interface
   @max_retry_times 3
   @base_sleep_time 100
+  @request_opts [:pool_timeout, :receive_timeout, :request_timeout]
 
   def impl() do
     Application.get_env(:hexpm, :http_impl, __MODULE__)
   end
 
   @impl Hexpm.HTTP.Interface
-  def get(url, headers, opts \\ []) do
-    build_request(:get, url, headers, nil, opts)
-    |> Finch.request(Hexpm.Finch)
-    |> read_response()
-  end
+  def get(url, headers, opts \\ []), do: do_request(:get, url, headers, nil, opts)
 
   @impl Hexpm.HTTP.Interface
-  def post(url, headers, body, opts \\ []) do
-    build_request(:post, url, headers, body, opts)
-    |> Finch.request(Hexpm.Finch)
-    |> read_response()
-  end
+  def post(url, headers, body, opts \\ []), do: do_request(:post, url, headers, body, opts)
 
   @impl Hexpm.HTTP.Interface
-  def put(url, headers, body, opts \\ []) do
-    build_request(:put, url, headers, body, opts)
-    |> Finch.request(Hexpm.Finch)
-    |> read_response()
-  end
+  def put(url, headers, body, opts \\ []), do: do_request(:put, url, headers, body, opts)
 
   @impl Hexpm.HTTP.Interface
-  def patch(url, headers, body, opts \\ []) do
-    build_request(:patch, url, headers, body, opts)
-    |> Finch.request(Hexpm.Finch)
-    |> read_response()
-  end
+  def patch(url, headers, body, opts \\ []), do: do_request(:patch, url, headers, body, opts)
 
   @impl Hexpm.HTTP.Interface
-  def delete(url, headers, opts \\ []) do
-    build_request(:delete, url, headers, nil, opts)
-    |> Finch.request(Hexpm.Finch)
-    |> read_response()
-  end
+  def delete(url, headers, opts \\ []), do: do_request(:delete, url, headers, nil, opts)
 
-  defp build_request(method, url, headers, body, opts) do
+  defp do_request(method, url, headers, body, opts) do
+    {request_opts, build_opts} = Keyword.split(opts, @request_opts)
     params = encode_params(body, headers)
-    Finch.build(method, url, headers, params, opts)
+
+    method
+    |> Finch.build(url, headers, params, build_opts)
+    |> Finch.request(Hexpm.Finch, request_opts)
+    |> read_response()
   end
 
   defp encode_params(body, _headers) when is_binary(body) or is_nil(body) do

--- a/test/hexpm/http_test.exs
+++ b/test/hexpm/http_test.exs
@@ -95,6 +95,21 @@ defmodule Hexpm.HTTPTest do
     assert {:ok, 200, _headers, %{"key" => "value"}} = HTTP.get(lasso_url(lasso, "/get"), [])
   end
 
+  test "passes receive_timeout, pool_timeout, and request_timeout to Finch.request/3", %{
+    lasso: lasso
+  } do
+    Lasso.expect_once(lasso, "GET", "/get", fn conn ->
+      Conn.resp(conn, 200, "ok")
+    end)
+
+    assert {:ok, 200, _headers, "ok"} =
+             HTTP.get(lasso_url(lasso, "/get"), [],
+               receive_timeout: 5_000,
+               pool_timeout: 5_000,
+               request_timeout: 5_000
+             )
+  end
+
   defp lasso_url(lasso, path) do
     "http://localhost:#{lasso.port}#{path}"
   end


### PR DESCRIPTION
Finch 0.22 dropped `:receive_timeout`, `:pool_timeout`, and `:request_timeout` from `Finch.Request.build/5`; they belong on `Finch.request/3` now. `Hexpm.HTTP` forwards opts straight into `build`, so every billing call (and the security updater, billing proxy, and pwned path) was crashing with `ArgumentError: unknown keys [:receive_timeout]` after the bump.

Split the opts so the timeouts go to `Finch.request/3` and the rest stay on `Finch.build/5`. While in there, collapse the five near-identical get/post/put/patch/delete bodies into one helper.

Showing up in Sentry on staging as HEXPM-AK.