### PR TITLE
Show version requirement on dependants page

### DIFF
--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -68,6 +68,23 @@ defmodule Hexpm.Repository.Packages do
     update_in(package.releases, &Release.sort/1)
   end
 
+  def dependant_requirements(dependants, dependency) do
+    package_ids = Enum.map(dependants, & &1.id)
+
+    from(
+      req in Requirement,
+      join: rel in assoc(req, :release),
+      where: req.dependency_id == ^dependency.id,
+      where: rel.package_id in ^package_ids,
+      where: is_nil(rel.retirement),
+      order_by: [asc: rel.package_id, desc: rel.version],
+      distinct: rel.package_id,
+      select: {rel.package_id, req.requirement}
+    )
+    |> Repo.all()
+    |> Map.new()
+  end
+
   def attach_latest_releases(packages) do
     package_ids = Enum.map(packages, & &1.id)
 

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -84,6 +84,7 @@ defmodule HexpmWeb.PackageController do
         |> Packages.attach_latest_releases()
 
       dependants_downloads = Downloads.packages_all_views(dependants)
+      dependants_requirements = Packages.dependant_requirements(dependants, package)
 
       render(
         conn,
@@ -94,6 +95,7 @@ defmodule HexpmWeb.PackageController do
           releases: releases,
           dependants: dependants,
           dependants_downloads: dependants_downloads,
+          dependants_requirements: dependants_requirements,
           page: page,
           per_page: per_page
         ] ++

--- a/lib/hexpm_web/templates/package/_package.html.heex
+++ b/lib/hexpm_web/templates/package/_package.html.heex
@@ -34,6 +34,12 @@
             v{@package.latest_release.version}
           </a>
         <% end %>
+        <%= if assigns[:dependency_requirement] do %>
+          <span class="text-grey-400 dark:text-grey-500 text-xs">requires</span>
+          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium font-mono bg-grey-50 dark:bg-grey-700 border border-grey-100 dark:border-grey-600 text-grey-500 dark:text-grey-200">
+            {@dependency_requirement}
+          </span>
+        <% end %>
       </div>
 
       <%= if @package.meta.description do %>

--- a/lib/hexpm_web/templates/package/dependents.html.heex
+++ b/lib/hexpm_web/templates/package/dependents.html.heex
@@ -27,7 +27,8 @@
             {render("_package.html",
               package: package,
               package_downloads: downloads_for_package(package, @dependants_downloads),
-              view: :recent_downloads
+              view: :recent_downloads,
+              dependency_requirement: @dependants_requirements[package.id]
             )}
           <% end %>
         </ul>

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -887,5 +887,7 @@ Hexpm.Repo.transaction(fn ->
   Hexpm.Repo.refresh_view(ReleaseDownload, concurrently: false)
 end)
 
+Hexpm.Repository.PackageDependants.backfill()
+
 Hexpm.Repository.RegistryBuilder.full(Hexpm.Repository.Repositories.get("hexpm"))
 Hexpm.Repository.RegistryBuilder.full(Hexpm.Repository.Repositories.get("myrepo"))

--- a/test/hexpm/repository/package_dependants_test.exs
+++ b/test/hexpm/repository/package_dependants_test.exs
@@ -1,7 +1,7 @@
 defmodule Hexpm.Repository.PackageDependantsTest do
   use Hexpm.DataCase, async: true
 
-  alias Hexpm.Repository.{Package, PackageDependant, PackageDependants}
+  alias Hexpm.Repository.{Package, PackageDependant, PackageDependants, Packages}
 
   setup do
     repository = insert(:repository)
@@ -152,6 +152,46 @@ defmodule Hexpm.Repository.PackageDependantsTest do
 
     assert latest == nil
     assert row_count(dependant.id) == 0
+  end
+
+  describe "dependant_requirements/2" do
+    test "returns the requirement from the latest non-retired release", %{repository: repository} do
+      dep = insert(:package, name: "dep", repository_id: repository.id)
+      dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+      old_rel = insert(:release, package: dependant, version: "1.0.0")
+      insert(:requirement, release: old_rel, dependency: dep, requirement: "~> 1.0")
+
+      new_rel = insert(:release, package: dependant, version: "2.0.0")
+      insert(:requirement, release: new_rel, dependency: dep, requirement: "~> 2.0")
+
+      {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+
+      requirements = Packages.dependant_requirements([dependant], dep)
+      assert requirements[dependant.id] == "~> 2.0"
+    end
+
+    test "skips retired releases", %{repository: repository} do
+      dep = insert(:package, name: "dep", repository_id: repository.id)
+      dependant = insert(:package, name: "dependant", repository_id: repository.id)
+
+      old_rel = insert(:release, package: dependant, version: "1.0.0")
+      insert(:requirement, release: old_rel, dependency: dep, requirement: "~> 1.0")
+
+      retired_rel =
+        insert(:release,
+          package: dependant,
+          version: "2.0.0",
+          retirement: %{reason: "deprecated", message: "use something else"}
+        )
+
+      insert(:requirement, release: retired_rel, dependency: dep, requirement: "~> 2.0")
+
+      {:ok, _} = PackageDependants.recompute_for_package(Repo, dependant)
+
+      requirements = Packages.dependant_requirements([dependant], dep)
+      assert requirements[dependant.id] == "~> 1.0"
+    end
   end
 
   test "retired releases still count as latest", %{repository: repository} do

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -708,6 +708,15 @@ defmodule HexpmWeb.PackageControllerTest do
       assert response(conn, 404)
     end
 
+    test "shows requirement for each dependant", %{package1: package1} do
+      add_dependant(package1, "requiring_package")
+
+      html = get(build_conn(), "/packages/#{package1.name}/dependents") |> response(200)
+
+      assert html =~ "requiring_package"
+      assert html =~ "~&gt; 0.0.1"
+    end
+
     test "computes daily_graph for sidebar", %{package1: package1} do
       release = Hexpm.Repository.Releases.all(package1) |> List.first()
 


### PR DESCRIPTION
Maintainers can now see which version requirement each dependent package uses, making it easy to assess ecosystem adoption of latest releases and to coordinate CVEs across affected dependants.

<img width="880" height="284" alt="Screenshot 2026-05-26 at 18 52 47" src="https://github.com/user-attachments/assets/78134697-9e47-4744-a169-177f16914481" />
<img width="888" height="299" alt="Screenshot 2026-05-26 at 18 52 58" src="https://github.com/user-attachments/assets/e1254bf9-e364-4478-a462-90a093eb46dc" />

(The seed postgrex entry actually requires `0.1.0`, this change also shows more realistic requirements like `~> X.Y`)
