### PR TITLE
Fix absolute image paths in READMEs not resolving to preview URL

### DIFF
--- a/lib/hexpm_web/readme/url_rewriter.ex
+++ b/lib/hexpm_web/readme/url_rewriter.ex
@@ -86,7 +86,10 @@ defmodule HexpmWeb.Readme.URLRewriter do
         url
 
       true ->
-        path = String.trim_leading(url, "./")
+        path =
+          url
+          |> String.trim_leading("/")
+          |> String.trim_leading("./")
 
         case Path.safe_relative(path) do
           {:ok, safe_path} -> "#{base_url}/#{safe_path}"

--- a/test/hexpm_web/readme/url_rewriter_test.exs
+++ b/test/hexpm_web/readme/url_rewriter_test.exs
@@ -122,6 +122,15 @@ defmodule HexpmWeb.Readme.URLRewriterTest do
       refute result =~ "preview"
       assert result =~ ~s[href="../../etc/passwd"]
     end
+
+    test "resolves absolute image paths to preview URL and proxies them" do
+      html = ~s[<img src="/images/examples.png">]
+      result = URLRewriter.rewrite(html, "my_package", "1.0.0")
+
+      expected = "http://localhost:5000/preview/my_package/1.0.0/images/examples.png"
+      encoded = Base.encode16(expected, case: :lower)
+      assert result =~ encoded
+    end
   end
 
   describe "proxy_image_url/1" do


### PR DESCRIPTION
Paths like `/images/foo.png` were returned unchanged because `Path.safe_relative/1` rejects leading slashes. Strip the leading `/` alongside `./` so they resolve against the package preview base URL.

This resolves the first part of #1602 