### PR TITLE
Reserve hexdocs subdomain names in package validation

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -43,6 +43,7 @@ defmodule Hexpm.Repository.Package do
     lpt3 lpt4 lpt5 lpt6 lpt7 lpt8 lpt9
   )
   @generic_names ~w(package organization www myapp lock locked all assets)
+  @subdomain_names ~w(api docs preview search staging stats static)
 
   @reserved_names Enum.concat([
                     @elixir_names,
@@ -51,7 +52,8 @@ defmodule Hexpm.Repository.Package do
                     @tool_names,
                     @app_names,
                     @windows_names,
-                    @generic_names
+                    @generic_names,
+                    @subdomain_names
                   ])
 
   def build(repository, user, params) do

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -217,6 +217,18 @@ defmodule Hexpm.Repository.PackageTest do
              |> Hexpm.Repo.insert()
   end
 
+  test "reserved subdomain names", %{user: user, repository: repository} do
+    for name <- ~w(api docs preview search staging stats static) do
+      assert {:error, %{errors: [name: {"is reserved", _}]}} =
+               Package.build(
+                 repository,
+                 user,
+                 pkg_meta(%{name: name, description: "Awesomeness."})
+               )
+               |> Hexpm.Repo.insert()
+    end
+  end
+
   test "search repository", %{repository: repository} do
     other_repository = insert(:repository)
     package1 = insert(:package, repository_id: repository.id)


### PR DESCRIPTION
Adds `api`, `docs`, `preview`, `search`, `staging`, `stats`, `static` to the reserved package-name list so they cannot be claimed as new packages.

Prep work for the upcoming `PACKAGE.hexdocs.pm` migration — these subdomains are reserved for infra (Typesense, Plausible, future apps) and must not collide with package subdomains. Validation runs on `Package.build/3` only; existing `search` and `stats` packages keep working.