### PR TITLE
Disable Earmark HTML escaping in favor of downstream sanitization

### DIFF
--- a/lib/hexpm_web/controllers/readme_controller.ex
+++ b/lib/hexpm_web/controllers/readme_controller.ex
@@ -109,7 +109,7 @@ defmodule HexpmWeb.ReadmeController do
       case ext do
         ext when ext in [".md", ".markdown"] ->
           {_status, ast, _messages} = Earmark.Parser.as_ast(content, gfm: true)
-          ast |> TaskList.convert() |> Earmark.transform()
+          ast |> TaskList.convert() |> Earmark.transform(escape: false)
 
         _ ->
           "<pre>#{Plug.HTML.html_escape(content)}</pre>"

--- a/priv/preview/files/decimal/0.1.0/README.md
+++ b/priv/preview/files/decimal/0.1.0/README.md
@@ -52,6 +52,11 @@ end)
 #=> Decimal.new("0.33333")
 ```
 
+## Inline HTML
+
+Most values have <ins>multiple</ins> representations, for example, `Decimal.new("0.30")` and
+`Decimal.new("0.3")` are <ins>equal</ins> under comparison but distinct structs.
+
 ## Rounding Modes
 
 | Mode | Description |

--- a/test/hexpm_web/controllers/readme_controller_test.exs
+++ b/test/hexpm_web/controllers/readme_controller_test.exs
@@ -305,6 +305,23 @@ defmodule HexpmWeb.ReadmeControllerTest do
       assert conn.resp_body =~ "normal"
     end
 
+    test "renders inline HTML tags like <ins> in markdown paragraphs", %{package: package} do
+      mock_file_list_and_readme(
+        package.name,
+        "1.0.0",
+        "README.md",
+        "Most colors have <ins>multiple</ins> names."
+      )
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "<ins>multiple</ins>"
+    end
+
     test "renders markdown with parse warnings", %{package: package} do
       mock_file_list_and_readme(
         package.name,


### PR DESCRIPTION
Earmark's transform/2 escapes inline HTML tags like `<ins>` within paragraphs by default, causing them to render as literal text rather than HTML. Since the sanitizer already strips disallowed tags downstream, Earmark's escaping is redundant and can be safely disabled with `escape: false`.

Resolves https://github.com/hexpm/hexpm/issues/1602#issuecomment-4559211439