### PR TITLE
Emit per-package subdomain URLs for hexpm-repo docs links

### DIFF
--- a/lib/hexpm/short_urls/short_url.ex
+++ b/lib/hexpm/short_urls/short_url.ex
@@ -60,11 +60,14 @@ defmodule Hexpm.ShortURLs.ShortURL do
       url.host == "hex.pm" or String.ends_with?(url.host, [".hex.pm"]) ->
         []
 
+      String.ends_with?(url.host || "", [".hexdocs.pm"]) ->
+        []
+
       url.host in ["hexdocs.pm", "staging.hex.pm"] and url.path in [nil, "/"] ->
         []
 
       true ->
-        [url: "domain must match hex.pm, *.hex.pm, or hexdocs.pm"]
+        [url: "domain must match hex.pm, *.hex.pm, hexdocs.pm, or *.hexdocs.pm"]
     end
   end
 end

--- a/lib/hexpm/short_urls/short_url.ex
+++ b/lib/hexpm/short_urls/short_url.ex
@@ -60,14 +60,14 @@ defmodule Hexpm.ShortURLs.ShortURL do
       url.host == "hex.pm" or String.ends_with?(url.host, [".hex.pm"]) ->
         []
 
-      String.ends_with?(url.host || "", [".hexdocs.pm"]) ->
+      String.ends_with?(url.host || "", [".hexdocs.pm", ".hexorgs.pm"]) ->
         []
 
       url.host in ["hexdocs.pm", "staging.hex.pm"] and url.path in [nil, "/"] ->
         []
 
       true ->
-        [url: "domain must match hex.pm, *.hex.pm, hexdocs.pm, or *.hexdocs.pm"]
+        [url: "domain must match hex.pm, *.hex.pm, hexdocs.pm, *.hexdocs.pm, or *.hexorgs.pm"]
     end
   end
 end

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -172,13 +172,6 @@ defmodule Hexpm.Utils do
     "#{docs_url}/#{version}"
   end
 
-  # Hex package names allow underscores (`^[a-z][a-z0-9_]*$`), but RFC 1123
-  # hostname labels and RFC 6125 wildcard SAN matching don't, and Fastly
-  # enforces strict SAN matching at the HTTP edge. Map `_` -> `-` for the
-  # public hexdocs.pm subdomain. The Fastly Compute subdomain handler
-  # reverses the mapping before building the GCS bucket key.
-  defp package_to_subdomain(name), do: String.replace(name, "_", "-")
-
   def docs_html_url(%Repository{} = repository, package, release) do
     docs_url = URI.parse(Application.get_env(:hexpm, :private_docs_url))
     docs_url = %{docs_url | host: "#{repository.name}.#{docs_url.host}"}
@@ -186,6 +179,28 @@ defmodule Hexpm.Utils do
     version = release && "#{release.version}/"
     "#{docs_url}/#{package}/#{version}"
   end
+
+  @doc """
+  Apex-form docs URL for a hexpm-repo package: `<docs_url>/<package>/`.
+
+  Used by `docs_sitemap.xml`, which lists per-package sitemap index
+  entries. Sitemap consumers (Googlebot) require all listed URLs to
+  share a common host with the sitemap file, so even after package
+  docs move to `<package>.hexdocs.pm`, the index keeps emitting
+  `hexdocs.pm/<package>/...` and lets the apex 301 deliver the
+  canonical URL to the crawler.
+  """
+  @spec docs_html_apex_url(String.t()) :: String.t()
+  def docs_html_apex_url(package_name) do
+    Application.get_env(:hexpm, :docs_url) <> "/" <> package_name <> "/"
+  end
+
+  # Hex package names allow underscores (`^[a-z][a-z0-9_]*$`), but RFC 1123
+  # hostname labels and RFC 6125 wildcard SAN matching don't, and Fastly
+  # enforces strict SAN matching at the HTTP edge. Map `_` -> `-` for the
+  # public hexdocs.pm subdomain. The Fastly Compute subdomain handler
+  # reverses the mapping before building the GCS bucket key.
+  defp package_to_subdomain(name), do: String.replace(name, "_", "-")
 
   @doc """
   Sidebar docs URL for a package given the currently-displayed release and the

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -167,10 +167,17 @@ defmodule Hexpm.Utils do
   @spec docs_html_url(Repository.t(), Package.t(), Release.t() | nil) :: String.t()
   def docs_html_url(%Repository{id: 1}, package, release) do
     docs_url = URI.parse(Application.get_env(:hexpm, :docs_url))
-    docs_url = %{docs_url | host: "#{package.name}.#{docs_url.host}"}
+    docs_url = %{docs_url | host: "#{package_to_subdomain(package.name)}.#{docs_url.host}"}
     version = release && "#{release.version}/"
     "#{docs_url}/#{version}"
   end
+
+  # Hex package names allow underscores (`^[a-z][a-z0-9_]*$`), but RFC 1123
+  # hostname labels and RFC 6125 wildcard SAN matching don't, and Fastly
+  # enforces strict SAN matching at the HTTP edge. Map `_` -> `-` for the
+  # public hexdocs.pm subdomain. The Fastly Compute subdomain handler
+  # reverses the mapping before building the GCS bucket key.
+  defp package_to_subdomain(name), do: String.replace(name, "_", "-")
 
   def docs_html_url(%Repository{} = repository, package, release) do
     docs_url = URI.parse(Application.get_env(:hexpm, :private_docs_url))

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -166,10 +166,10 @@ defmodule Hexpm.Utils do
   """
   @spec docs_html_url(Repository.t(), Package.t(), Release.t() | nil) :: String.t()
   def docs_html_url(%Repository{id: 1}, package, release) do
-    docs_url = Application.get_env(:hexpm, :docs_url)
-    package = package.name
+    docs_url = URI.parse(Application.get_env(:hexpm, :docs_url))
+    docs_url = %{docs_url | host: "#{package.name}.#{docs_url.host}"}
     version = release && "#{release.version}/"
-    "#{docs_url}/#{package}/#{version}"
+    "#{docs_url}/#{version}"
   end
 
   def docs_html_url(%Repository{} = repository, package, release) do

--- a/lib/hexpm_web/controllers/docs_controller.ex
+++ b/lib/hexpm_web/controllers/docs_controller.ex
@@ -28,7 +28,7 @@ defmodule HexpmWeb.DocsController do
   end
 
   def tasks(conn, _params) do
-    redirect(conn, external: "https://hexdocs.pm/hex")
+    redirect(conn, external: "https://hex.hexdocs.pm")
   end
 
   def gleam_usage(conn, _params) do

--- a/lib/hexpm_web/templates/sitemap/docs_sitemap.xml.eex
+++ b/lib/hexpm_web/templates/sitemap/docs_sitemap.xml.eex
@@ -2,7 +2,7 @@
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 <%= for {name, docs_updated_at} <- @packages do %>
   <sitemap>
-    <loc><%= Hexpm.Utils.docs_html_url(Repository.hexpm(), %Package{name: name}, nil) <> "sitemap.xml" %></loc><%= if docs_updated_at do %>
+    <loc><%= Hexpm.Utils.docs_html_apex_url(name) <> "sitemap.xml" %></loc><%= if docs_updated_at do %>
     <lastmod><%= Hexpm.Utils.binarify(docs_updated_at) %></lastmod><% end %>
   </sitemap>
 <% end %>

--- a/test/hexpm/short_urls/short_url_test.exs
+++ b/test/hexpm/short_urls/short_url_test.exs
@@ -39,6 +39,17 @@ defmodule Hexpm.ShortURLs.ShortURLTest do
                ShortURL.changeset(%{"url" => "https://acme.staging.hexdocs.pm/some/page"})
     end
 
+    test "validate redirecting to a *.hexorgs.pm subdomain" do
+      assert %{valid?: true} = ShortURL.changeset(%{"url" => "https://acme.hexorgs.pm"})
+      assert %{valid?: true} = ShortURL.changeset(%{"url" => "https://acme.hexorgs.pm/"})
+
+      assert %{valid?: true} =
+               ShortURL.changeset(%{"url" => "https://acme.hexorgs.pm/some_package/readme.html"})
+
+      assert %{valid?: true} =
+               ShortURL.changeset(%{"url" => "https://acme.staging.hexorgs.pm/pkg/page"})
+    end
+
     test "with incorrect params" do
       assert %{valid?: false, errors: errors} = ShortURL.changeset(%{foo: 420})
       assert errors == [{:url, {"can't be blank", [validation: :required]}}]
@@ -61,7 +72,11 @@ defmodule Hexpm.ShortURLs.ShortURLTest do
                ShortURL.changeset(%{url: "https://supersimple.org?spoof=hex.pm"})
 
       assert errors ==
-               [url: {"domain must match hex.pm, *.hex.pm, hexdocs.pm, or *.hexdocs.pm", []}]
+               [
+                 url:
+                   {"domain must match hex.pm, *.hex.pm, hexdocs.pm, *.hexdocs.pm, or *.hexorgs.pm",
+                    []}
+               ]
     end
   end
 end

--- a/test/hexpm/short_urls/short_url_test.exs
+++ b/test/hexpm/short_urls/short_url_test.exs
@@ -28,6 +28,17 @@ defmodule Hexpm.ShortURLs.ShortURLTest do
       assert %{valid?: false} = ShortURL.changeset(%{"url" => "https://hexdocs.pm/foo"})
     end
 
+    test "validate redirecting to a *.hexdocs.pm subdomain" do
+      assert %{valid?: true} = ShortURL.changeset(%{"url" => "https://phoenix.hexdocs.pm"})
+      assert %{valid?: true} = ShortURL.changeset(%{"url" => "https://phoenix.hexdocs.pm/"})
+
+      assert %{valid?: true} =
+               ShortURL.changeset(%{"url" => "https://phoenix.hexdocs.pm/1.7.0/Phoenix.html"})
+
+      assert %{valid?: true} =
+               ShortURL.changeset(%{"url" => "https://acme.staging.hexdocs.pm/some/page"})
+    end
+
     test "with incorrect params" do
       assert %{valid?: false, errors: errors} = ShortURL.changeset(%{foo: 420})
       assert errors == [{:url, {"can't be blank", [validation: :required]}}]
@@ -49,7 +60,8 @@ defmodule Hexpm.ShortURLs.ShortURLTest do
       assert %{valid?: false, errors: errors} =
                ShortURL.changeset(%{url: "https://supersimple.org?spoof=hex.pm"})
 
-      assert errors == [url: {"domain must match hex.pm, *.hex.pm, or hexdocs.pm", []}]
+      assert errors ==
+               [url: {"domain must match hex.pm, *.hex.pm, hexdocs.pm, or *.hexdocs.pm", []}]
     end
   end
 end

--- a/test/hexpm/utils_test.exs
+++ b/test/hexpm/utils_test.exs
@@ -88,7 +88,7 @@ defmodule Hexpm.UtilsTest do
       current: current
     } do
       url = Utils.current_docs_html_url(package, current, current)
-      assert url =~ "/decimal/"
+      assert url =~ "//decimal."
       assert url =~ "1.2.3"
     end
 
@@ -98,7 +98,7 @@ defmodule Hexpm.UtilsTest do
       older: older
     } do
       url = Utils.current_docs_html_url(package, current, older)
-      assert url =~ "/decimal/"
+      assert url =~ "//decimal."
       refute url =~ "1.2.3"
       refute url =~ "1.0.0"
     end
@@ -108,7 +108,7 @@ defmodule Hexpm.UtilsTest do
       older: older
     } do
       url = Utils.current_docs_html_url(package, nil, older)
-      assert url =~ "/decimal/"
+      assert url =~ "//decimal."
       refute url =~ "1.0.0"
     end
   end

--- a/test/hexpm/utils_test.exs
+++ b/test/hexpm/utils_test.exs
@@ -111,5 +111,16 @@ defmodule Hexpm.UtilsTest do
       assert url =~ "//decimal."
       refute url =~ "1.0.0"
     end
+
+    test "maps underscores in the package name to hyphens in the subdomain" do
+      hexpm = %Hexpm.Repository.Repository{id: 1, name: "hexpm"}
+      package = %Hexpm.Repository.Package{name: "phoenix_live_view", repository: hexpm}
+      release = %Hexpm.Repository.Release{version: Version.parse!("1.0.0")}
+
+      url = Utils.docs_html_url(hexpm, package, release)
+
+      assert url =~ "//phoenix-live-view."
+      refute url =~ "phoenix_live_view"
+    end
   end
 end

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -201,7 +201,9 @@ defmodule HexpmWeb.API.PackageControllerTest do
       assert String.slice(result["updated_at"], -1, 1) == "Z"
       assert result["url"] == "http://localhost:5000/api/packages/#{package1.name}"
       assert result["html_url"] == "http://localhost:5000/packages/#{package1.name}"
-      assert result["docs_html_url"] == "http://#{package1.name}.localhost:5002/"
+
+      assert result["docs_html_url"] ==
+               "http://#{String.replace(package1.name, "_", "-")}.localhost:5002/"
 
       assert result["latest_version"] == "0.0.1"
       assert result["latest_stable_version"] == "0.0.1"

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -201,7 +201,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
       assert String.slice(result["updated_at"], -1, 1) == "Z"
       assert result["url"] == "http://localhost:5000/api/packages/#{package1.name}"
       assert result["html_url"] == "http://localhost:5000/packages/#{package1.name}"
-      assert result["docs_html_url"] == "http://localhost:5002/#{package1.name}/"
+      assert result["docs_html_url"] == "http://#{package1.name}.localhost:5002/"
 
       assert result["latest_version"] == "0.0.1"
       assert result["latest_stable_version"] == "0.0.1"

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -1384,7 +1384,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
                "http://localhost:5000/packages/#{package.name}/#{release.version}"
 
       assert result["docs_html_url"] ==
-               "http://localhost:5002/#{package.name}/#{release.version}/"
+               "http://#{package.name}.localhost:5002/#{release.version}/"
 
       assert result["version"] == "#{release.version}"
 

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -1384,7 +1384,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
                "http://localhost:5000/packages/#{package.name}/#{release.version}"
 
       assert result["docs_html_url"] ==
-               "http://#{package.name}.localhost:5002/#{release.version}/"
+               "http://#{String.replace(package.name, "_", "-")}.localhost:5002/#{release.version}/"
 
       assert result["version"] == "#{release.version}"
 


### PR DESCRIPTION
Phase 2 of the [HexDocs subdomain migration](https://github.com/hexpm/hexpm-ops/blob/main/docs/hexdocs-subdomain-migration.md). Once \`*.hexdocs.pm\` DNS is flipped to Fastly Compute (hexpm-ops#129), the canonical docs URL for a hexpm package is \`https://<package>.hexdocs.pm/<version>/\` — this PR makes hexpm itself emit that form everywhere.

**Changes:**

- \`Hexpm.Utils.docs_html_url/3\` for the hexpm-repo branch (\`%Repository{id: 1}\`) now splices the package name as a subdomain, mirroring the org-repo branch just below it. Every consumer that reads from this helper picks up the new format automatically: API responses (\`package_view\`, \`release_view\`), the docs sitemap, the package layout component, the package controller's sidebar URL.
- \`HexpmWeb.DocsController.tasks/2\` redirects to \`https://hex.hexdocs.pm\` (Mix tasks doc for the Hex package).
- \`Hexpm.ShortURLs.ShortURL\` validator accepts \`*.hexdocs.pm\` subdomains (any path) so short URLs can point at deep package-docs pages. The apex \`hexdocs.pm\` keeps its root-only restriction (existing behaviour).

OAuth client callback validators already accept the \`*.hexdocs.pm\` wildcard, no change needed.

**Tests:** \`mix test test/hexpm/utils_test.exs test/hexpm/short_urls/short_url_test.exs test/hexpm_web/controllers/api/package_controller_test.exs test/hexpm_web/controllers/api/release_controller_test.exs\` — 124 passing.

**Merge timing:** must land **after** hexpm-ops#129 (the prod \`*.hexdocs.pm\` A→CNAME flip). Before that, the new URLs hit subdomains that don't resolve.