### PR TITLE
Constrain OAuth authorize page width

### DIFF
--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -108,20 +108,13 @@ defmodule Hexpm.Utils do
   def parse_search(search) when is_binary(search), do: String.trim(search)
   def parse_search(_), do: nil
 
-  defp diff(a, b) do
-    {days, time} = :calendar.time_difference(a, b)
-    days * 24 * 60 * 60 + :calendar.time_to_seconds(time)
-  end
-
   @doc """
   Determine if a given timestamp is less than a day (86400 seconds) old
   """
   def within_last_day?(nil), do: false
 
   def within_last_day?(a) do
-    diff = diff(NaiveDateTime.to_erl(a), :calendar.universal_time())
-
-    diff < 24 * 60 * 60
+    NaiveDateTime.diff(NaiveDateTime.utc_now(), a, :second) < 24 * 60 * 60
   end
 
   def binarify(term, opts \\ [])

--- a/lib/hexpm_web/templates/o_auth/authorize.html.eex
+++ b/lib/hexpm_web/templates/o_auth/authorize.html.eex
@@ -1,2 +1,6 @@
-<%= render HexpmWeb.SharedView, "_authorization.html", Map.merge(assigns, authorization_assigns(@conn, @client, @redirect_uri, @scopes, assigns[:state], assigns[:code_challenge], assigns[:code_challenge_method])) %>
+<div class="flex items-center justify-center my-auto py-16">
+  <div class="w-full max-w-lg">
+    <%= render HexpmWeb.SharedView, "_authorization.html", Map.merge(assigns, authorization_assigns(@conn, @client, @redirect_uri, @scopes, assigns[:state], assigns[:code_challenge], assigns[:code_challenge_method])) %>
+  </div>
+</div>
 

--- a/test/hexpm_web/plugs/attack_test.exs
+++ b/test/hexpm_web/plugs/attack_test.exs
@@ -39,6 +39,7 @@ defmodule HexpmWeb.Plugs.AttackTest do
     end
 
     test "broadcasts user rate limits", %{user: user} do
+      align_to_throttle_bucket()
       time = System.system_time(:millisecond)
       Phoenix.PubSub.broadcast!(Hexpm.PubSub, "ratelimit", {:throttle, {:user, user.id}, time})
       Phoenix.PubSub.broadcast!(Hexpm.PubSub, "ratelimit", {:throttle, {:user, -1}, time})
@@ -52,6 +53,7 @@ defmodule HexpmWeb.Plugs.AttackTest do
     end
 
     test "broadcasts ip rate limits" do
+      align_to_throttle_bucket()
       time = System.system_time(:millisecond)
       Phoenix.PubSub.broadcast!(Hexpm.PubSub, "ratelimit", {:throttle, {:ip, {3, 3, 3, 3}}, time})
       Phoenix.PubSub.broadcast!(Hexpm.PubSub, "ratelimit", {:throttle, {:ip, {4, 4, 4, 4}}, time})
@@ -65,6 +67,8 @@ defmodule HexpmWeb.Plugs.AttackTest do
     end
 
     test "halts requests when ip limit is exceeded" do
+      align_to_throttle_bucket()
+
       Enum.each(99..0//-1, fn i ->
         conn = request_ip({1, 1, 1, 1})
         assert conn.status == 200
@@ -79,6 +83,8 @@ defmodule HexpmWeb.Plugs.AttackTest do
     end
 
     test "halts requests when user limit is exceeded", %{user: user} do
+      align_to_throttle_bucket()
+
       Enum.each(499..0//-1, fn i ->
         conn = request_user(user)
         assert conn.status == 200
@@ -259,6 +265,14 @@ defmodule HexpmWeb.Plugs.AttackTest do
       result2 = HexpmWeb.Plugs.Attack.tfa_session_throttle(tfa_user_id_2)
       assert {:allow, _data} = result2
     end
+  end
+
+  # The throttle counter is keyed by `div(time_ms, period_ms)`. If a test's
+  # setup and assertion fall in different buckets, the counter resets between
+  # them. Wait past the next boundary if we're too close to it.
+  defp align_to_throttle_bucket(period_ms \\ 60_000, headroom_ms \\ 5_000) do
+    remaining = period_ms - rem(System.system_time(:millisecond), period_ms)
+    if remaining < headroom_ms, do: Process.sleep(remaining + 50)
   end
 
   defp request_ip(remote_ip) do


### PR DESCRIPTION
The OAuth authorize template rendered the shared authorization partial without a width-constraining wrapper, so the card stretched to the full width of the main content area — making the Authorize button (which has `flex-1`) gobble up all the space next to the natural-width Deny button.

Wrap it in the same centered `max-w-lg` container the device authorization flow uses.