### PR TITLE
Reserve package names for organizations

### DIFF
--- a/lib/hexpm/accounts/organization.ex
+++ b/lib/hexpm/accounts/organization.ex
@@ -24,7 +24,7 @@ defmodule Hexpm.Accounts.Organization do
   @name_regex ~r"^[a-z0-9_\-\.]+$"
   @roles ~w(admin write read)
 
-  @reserved_names ~w(www staging elixir erlang otp rebar rebar3 phoenix acme search)
+  @reserved_names Enum.uniq(Hexpm.Repository.Package.reserved_names() ++ ~w(phoenix acme))
 
   def changeset(struct, params) do
     cast(struct, params, ~w(name)a)

--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -56,6 +56,8 @@ defmodule Hexpm.Repository.Package do
                     @subdomain_names
                   ])
 
+  def reserved_names(), do: @reserved_names
+
   def build(repository, user, params) do
     package =
       build_assoc(repository, :packages)

--- a/test/hexpm/accounts/organizations_test.exs
+++ b/test/hexpm/accounts/organizations_test.exs
@@ -20,6 +20,15 @@ defmodule Hexpm.Accounts.OrganizationsTest do
       refute csv =~ "hexpm\n"
       refute String.starts_with?(csv, "hexpm")
     end
+
+    test "rejects reserved package names" do
+      user = insert(:user)
+
+      for name <- ~w(elixir mix kernel api docs phoenix acme) do
+        assert {:error, %{errors: [name: {"is reserved", _}]}} =
+                 Organizations.create(user, %{"name" => name}, audit: audit_data(user))
+      end
+    end
   end
 
   describe "remove_member/3" do


### PR DESCRIPTION
Organization name validation now rejects every name in the package reserved-names list (Elixir/OTP/Erlang tools, Windows device names, hexpm subdomains, etc.), in addition to the existing org-only `phoenix` and `acme`. Previously only a small subset overlapped, so names like `mix` or `kernel` could be claimed as organizations while being blocked for packages.