### PR TITLE
Configure Swoosh Finch API client to use Hexpm.Finch

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -43,10 +43,9 @@ config :hexpm, Hexpm.RepoBase,
   migration_timestamps: [type: :utc_datetime_usec]
 
 config :swoosh, :api_client, Swoosh.ApiClient.Finch
+config :swoosh, :finch_name, Hexpm.Finch
 
-config :hexpm, Hexpm.Emails.Mailer,
-  adapter: Swoosh.Adapters.Sendgrid,
-  finch_name: Hexpm.Finch
+config :hexpm, Hexpm.Emails.Mailer, adapter: Swoosh.Adapters.Sendgrid
 
 config :phoenix, :template_engines, md: HexpmWeb.MarkdownEngine
 


### PR DESCRIPTION
The Swoosh Finch API client (`Swoosh.ApiClient.Finch`) resolves its Finch instance name from the `:swoosh` application env key `:finch_name`, falling back to `Swoosh.Finch`:

```elixir
defp finch_name do
  Application.get_env(:swoosh, :finch_name, Swoosh.Finch)
end
```

In #1612 the name was set under the `Hexpm.Emails.Mailer` adapter config (`finch_name: Hexpm.Finch`), where the API client never reads it. As a result every outbound email looked up the `Swoosh.Finch` pool, which is not started in the supervision tree (only `Hexpm.Finch` is), raising `ArgumentError: unknown registry: Swoosh.Finch` for any email send (key creation, password reset, email verification, org invites, etc.).

Move `finch_name` to the `:swoosh` app env so the existing `Hexpm.Finch` pool is reused.

Fixes HEXPM-AS