### PR TITLE
Fix anchor link scrolling in README iframe

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -121,6 +121,7 @@ window.liveSocket = liveSocket;
 
 // README iframe: show spinner until loaded, fall back to description if no readme
 var readmeFrame = document.getElementById("readme-frame");
+var pendingInitialHash = window.location.hash ? window.location.hash.slice(1) : null;
 
 window.addEventListener("message", function (event) {
   if (!event.data || !readmeFrame) return;
@@ -136,6 +137,14 @@ window.addEventListener("message", function (event) {
     syncReadmeFrameTheme(resolveTheme());
     var loading = document.getElementById("readme-loading");
     if (loading) loading.remove();
+
+    if (pendingInitialHash !== null && readmeFrame.contentWindow) {
+      readmeFrame.contentWindow.postMessage(
+        { type: "scroll-to-anchor", id: pendingInitialHash },
+        "*",
+      );
+      pendingInitialHash = null;
+    }
   }
 
   if (event.data.type === "readme-not-found") {
@@ -144,5 +153,19 @@ window.addEventListener("message", function (event) {
     readmeFrame.remove();
     var fallback = document.getElementById("readme-fallback");
     if (fallback) fallback.classList.remove("hidden");
+  }
+
+  if (
+    event.data.type === "readme-anchor" &&
+    typeof event.data.id === "string" &&
+    typeof event.data.top === "number"
+  ) {
+    var frameTop = readmeFrame.getBoundingClientRect().top + window.scrollY;
+    window.scrollTo({ top: frameTop + event.data.top, behavior: "smooth" });
+    if (event.data.id) {
+      history.replaceState(null, "", "#" + event.data.id);
+    } else {
+      history.replaceState(null, "", window.location.pathname + window.location.search);
+    }
   }
 });

--- a/lib/hexpm_web/markdown_engine.ex
+++ b/lib/hexpm_web/markdown_engine.ex
@@ -1,6 +1,7 @@
 defmodule HexpmWeb.MarkdownEngine do
   @behaviour Phoenix.Template.Engine
 
+  alias HexpmWeb.MDExPlugins.HeadingAnchors
   alias HexpmWeb.MDExPlugins.InlineAttributeLists
 
   # Placeholder that will be replaced with the actual nonce at runtime
@@ -16,6 +17,7 @@ defmodule HexpmWeb.MarkdownEngine do
       |> MDExGFM.attach()
       |> MDEx.Document.run()
       |> MDEx.traverse_and_update(&InlineAttributeLists.transform/1)
+      |> MDEx.traverse_and_update(HeadingAnchors.transform(levels: @header_tags))
       |> MDEx.traverse_and_update(&transform_node/1)
       |> MDEx.to_html!()
 
@@ -29,33 +31,6 @@ defmodule HexpmWeb.MarkdownEngine do
     end
   end
 
-  defp transform_node(%MDEx.Heading{level: level, nodes: children} = node)
-       when level in @header_tags do
-    anchor =
-      children
-      |> extract_text()
-      |> String.downcase()
-      |> String.replace(" ", "-")
-      |> String.replace(~r/[^a-zA-Z0-9\-]/, "")
-
-    icon_html =
-      HexpmWeb.ViewIcons.icon(:heroicon, :link, class: "icon-link")
-      |> Phoenix.HTML.safe_to_string()
-
-    inner_html =
-      %{node | nodes: children}
-      |> MDEx.to_html!()
-      |> String.trim()
-      |> String.replace(~r/\A<h#{level}>(.*)<\/h#{level}>\z/s, "\\1")
-
-    link_html = ~s|<a href="##{anchor}" class="hover-link">#{icon_html}</a> |
-
-    %MDEx.HtmlBlock{
-      literal:
-        ~s|<h#{level} id="#{anchor}" class="section-heading">#{link_html}#{inner_html}</h#{level}>\n|
-    }
-  end
-
   defp transform_node(%MDEx.HtmlBlock{literal: literal} = node) do
     if String.contains?(literal, "<script") and
          not String.contains?(literal, ~s|nonce="#{@nonce_placeholder}"|) do
@@ -67,10 +42,4 @@ defmodule HexpmWeb.MarkdownEngine do
   end
 
   defp transform_node(node), do: node
-
-  defp extract_text(nodes) when is_list(nodes), do: Enum.map_join(nodes, &extract_text/1)
-  defp extract_text(%{nodes: children}), do: extract_text(children)
-  defp extract_text(%MDEx.Text{literal: text}), do: text
-  defp extract_text(%MDEx.Code{literal: text}), do: text
-  defp extract_text(_), do: ""
 end

--- a/lib/hexpm_web/mdex_plugins/heading_anchors.ex
+++ b/lib/hexpm_web/mdex_plugins/heading_anchors.ex
@@ -1,0 +1,75 @@
+defmodule HexpmWeb.MDExPlugins.HeadingAnchors do
+  @moduledoc ~S"""
+  MDEx AST plugin that rewrites headings into anchored sections.
+
+  For each `<h{level}>` whose level is in `:levels`, the heading is replaced
+  with an HTML block of the form:
+
+      <h{level} id="{slug}" class="section-heading">
+        <a href="#{slug}" class="hover-link">{icon}</a> {inner}
+      </h{level}>
+
+  The slug is derived from the heading's text content.
+  """
+
+  @doc """
+  Returns a `MDEx.traverse_and_update/2` callback that anchors headings whose
+  level is in `opts[:levels]`.
+
+  Options:
+
+    * `:levels` (required) - list of heading levels to anchor (e.g. `[3, 4]`).
+    * `:hover_link` - when `true` (default), prepend an `<a class="hover-link">`
+      with the `:link` heroicon to each anchored heading. When `false`, only
+      the heading's `id` and `class` are emitted.
+  """
+  def transform(opts) when is_list(opts) do
+    levels = Keyword.fetch!(opts, :levels)
+    hover_link? = Keyword.get(opts, :hover_link, true)
+    fn node -> do_transform(node, levels, hover_link?) end
+  end
+
+  defp hover_link_html(anchor) do
+    icon_html =
+      HexpmWeb.ViewIcons.icon(:heroicon, :link, class: "icon-link")
+      |> Phoenix.HTML.safe_to_string()
+
+    ~s|<a href="##{anchor}" class="hover-link">#{icon_html}</a> |
+  end
+
+  defp do_transform(%MDEx.Heading{level: level, nodes: children} = node, levels, hover_link?) do
+    if level in levels do
+      anchor = slugify(extract_text(children))
+
+      inner_html =
+        %{node | nodes: children}
+        |> MDEx.to_html!()
+        |> String.trim()
+        |> String.replace(~r/\A<h#{level}>(.*)<\/h#{level}>\z/s, "\\1")
+
+      link_html = if hover_link?, do: hover_link_html(anchor), else: ""
+
+      %MDEx.HtmlBlock{
+        literal:
+          ~s|<h#{level} id="#{anchor}" class="section-heading">#{link_html}#{inner_html}</h#{level}>\n|
+      }
+    else
+      node
+    end
+  end
+
+  defp do_transform(node, _levels, _hover_link?), do: node
+
+  defp slugify(text) do
+    text
+    |> String.downcase()
+    |> String.replace(" ", "-")
+    |> String.replace(~r/[^a-zA-Z0-9\-]/, "")
+  end
+
+  defp extract_text(nodes) when is_list(nodes), do: Enum.map_join(nodes, &extract_text/1)
+  defp extract_text(%{nodes: children}), do: extract_text(children)
+  defp extract_text(%MDEx.Text{literal: text}), do: text
+  defp extract_text(%MDEx.Code{literal: text}), do: text
+  defp extract_text(_), do: ""
+end

--- a/lib/hexpm_web/readme/renderer.ex
+++ b/lib/hexpm_web/readme/renderer.ex
@@ -8,8 +8,11 @@ defmodule HexpmWeb.Readme.Renderer do
   inside <pre> blocks.
   """
 
+  alias HexpmWeb.MDExPlugins.HeadingAnchors
   alias HexpmWeb.MDExPlugins.InlineAttributeLists
   alias HexpmWeb.Readme.{Sanitizer, URLRewriter}
+
+  @header_tags [1, 2, 3, 4, 5, 6]
 
   # Matches whitespace-only text between tags inside <pre> blocks.
   # Replaced with HTML entities before Floki parsing to work around
@@ -33,6 +36,9 @@ defmodule HexpmWeb.Readme.Renderer do
           |> MDExGFM.attach()
           |> MDEx.Document.run()
           |> MDEx.traverse_and_update(&InlineAttributeLists.transform/1)
+          |> MDEx.traverse_and_update(
+            HeadingAnchors.transform(levels: @header_tags, hover_link: false)
+          )
           |> MDEx.to_html!()
 
         _ ->

--- a/lib/hexpm_web/readme/url_rewriter.ex
+++ b/lib/hexpm_web/readme/url_rewriter.ex
@@ -81,7 +81,7 @@ defmodule HexpmWeb.Readme.URLRewriter do
       url == "#" ->
         url
 
-      Regex.match?(~r/^#fn(ref)?-\d+$/, url) ->
+      Regex.match?(~r/^#fn(ref)?-.+$/, url) ->
         url
 
       String.starts_with?(url, "#") ->

--- a/lib/hexpm_web/readme/url_rewriter.ex
+++ b/lib/hexpm_web/readme/url_rewriter.ex
@@ -78,8 +78,14 @@ defmodule HexpmWeb.Readme.URLRewriter do
       String.starts_with?(url, "//") ->
         "https:" <> url
 
-      String.starts_with?(url, "#") ->
+      url == "#" ->
         url
+
+      Regex.match?(~r/^#fn(ref)?-\d+$/, url) ->
+        url
+
+      String.starts_with?(url, "#") ->
+        "#user-content-" <> String.trim_leading(url, "#")
 
       true ->
         path =

--- a/lib/hexpm_web/templates/readme/show.html.heex
+++ b/lib/hexpm_web/templates/readme/show.html.heex
@@ -37,11 +37,44 @@
           });
         }
 
+        function findAnchorTarget(id) {
+          return document.getElementById(id) || document.getElementsByName(id)[0] || null;
+        }
+
+        function resolveAnchorTop(id) {
+          if (id === "") return 0;
+          var target = findAnchorTarget(id);
+          if (!target) return null;
+          return target.getBoundingClientRect().top + window.scrollY;
+        }
+
+        function postAnchor(id) {
+          var top = resolveAnchorTop(id);
+          if (top === null) return;
+          origins.forEach(function(o) {
+            window.parent.postMessage({type: 'readme-anchor', id: id, top: top}, o);
+          });
+        }
+
         window.addEventListener("message", function(event) {
           if (!event.data || !isAllowedOrigin(event.origin)) return;
           if (event.data.type === "theme-change") {
             applyTheme(event.data.theme);
           }
+          if (event.data.type === "scroll-to-anchor" && typeof event.data.id === "string") {
+            postAnchor(event.data.id);
+          }
+        });
+
+        document.addEventListener("click", function(event) {
+          var link = event.target.closest && event.target.closest('a[href]');
+          if (!link) return;
+          var href = link.getAttribute("href");
+          if (!href || href.charAt(0) !== "#") return;
+          var id = decodeURIComponent(href.slice(1));
+          if (id !== "" && !findAnchorTarget(id)) return;
+          event.preventDefault();
+          postAnchor(id);
         });
 
         sendHeight();

--- a/priv/preview/files/decimal/0.1.0/README.md
+++ b/priv/preview/files/decimal/0.1.0/README.md
@@ -2,6 +2,8 @@
 
 Arbitrary precision decimal arithmetic for Elixir. Use `<-- comment -->` more text.
 
+Jump to: [Rounding Modes](#rounding-modes) · [Configuration](#configuration) · [License](#license) · [Top](#)
+
 ## Features
 
 - **Exact arithmetic** with no floating point rounding errors

--- a/test/hexpm_web/readme/renderer_test.exs
+++ b/test/hexpm_web/readme/renderer_test.exs
@@ -1,0 +1,48 @@
+defmodule HexpmWeb.Readme.RendererTest do
+  use ExUnit.Case, async: true
+
+  alias HexpmWeb.Readme.Renderer
+
+  defp render(content) do
+    Renderer.render("README.md", content, "my_package", "1.0.0")
+  end
+
+  test "author fragment links resolve to the anchored heading id" do
+    content = """
+    [Go to install](#installation)
+
+    ## Installation
+    """
+
+    result = render(content)
+
+    assert result =~ ~s[<h2 id="user-content-installation">]
+    assert result =~ ~s[href="#user-content-installation"]
+  end
+
+  test "numeric footnote links resolve to their target id" do
+    content = """
+    Reference.[^1]
+
+    [^1]: numeric.
+    """
+
+    result = render(content)
+
+    assert result =~ ~s[href="#fn-1"]
+    assert result =~ ~s[<li id="fn-1">]
+  end
+
+  test "named footnote links resolve to their target id" do
+    content = """
+    Reference.[^note]
+
+    [^note]: named.
+    """
+
+    result = render(content)
+
+    assert result =~ ~s[href="#fn-note"]
+    assert result =~ ~s[<li id="fn-note">]
+  end
+end

--- a/test/hexpm_web/readme/url_rewriter_test.exs
+++ b/test/hexpm_web/readme/url_rewriter_test.exs
@@ -50,6 +50,14 @@ defmodule HexpmWeb.Readme.URLRewriterTest do
       assert result =~ ~s[href="#fnref-1"]
     end
 
+    test "preserves named footnote fragment links unchanged" do
+      html = ~s[<a href="#fn-note">1</a><a href="#fnref-note">back</a>]
+      result = rewrite(html, "my_package", "1.0.0")
+
+      assert result =~ ~s[href="#fn-note"]
+      assert result =~ ~s[href="#fnref-note"]
+    end
+
     test "preserves absolute link URLs" do
       html = ~s[<a href="https://hexdocs.pm/phoenix">Phoenix</a>]
       result = rewrite(html, "my_package", "1.0.0")

--- a/test/hexpm_web/readme/url_rewriter_test.exs
+++ b/test/hexpm_web/readme/url_rewriter_test.exs
@@ -35,11 +35,19 @@ defmodule HexpmWeb.Readme.URLRewriterTest do
       assert result =~ "http://localhost:5000/preview/my_package/1.0.0/CHANGELOG.md"
     end
 
-    test "preserves fragment-only links" do
+    test "prefixes fragment-only links with user-content-" do
       html = ~s[<a href="#installation">Install</a>]
       result = rewrite(html, "my_package", "1.0.0")
 
-      assert result =~ ~s[href="#installation"]
+      assert result =~ ~s[href="#user-content-installation"]
+    end
+
+    test "preserves footnote fragment links unchanged" do
+      html = ~s[<a href="#fn-1">1</a><a href="#fnref-1">back</a>]
+      result = rewrite(html, "my_package", "1.0.0")
+
+      assert result =~ ~s[href="#fn-1"]
+      assert result =~ ~s[href="#fnref-1"]
     end
 
     test "preserves absolute link URLs" do


### PR DESCRIPTION
The README is rendered in a sandboxed iframe sized to its content, so in-page anchor clicks scrolled the (non-scrolling) iframe instead of the parent, and URL fragments on reload were never honored.

* Bridge anchor clicks from the iframe to the parent via postMessage, translating the target's offset into a parent-page scroll and updating the URL fragment.
* On load, the parent forwards location.hash to the iframe once the README has been laid out, reusing the same scroll path.
* Extract heading anchor generation into a shared HeadingAnchors MDEx plugin parameterized by levels and hover_link. Blog posts use levels 3-4 with the hover link; READMEs use levels 1-6 without it, since the hover link's negative-margin gutter would be clipped by the content-sized iframe.
* In URLRewriter, prefix author-written fragment hrefs with "user-content-" so they match the sanitizer-prefixed heading ids; pass through bare "#" and footnote refs (#fn-N / #fnref-N).

Closes #1615