### PR TITLE
Restrict organization names to underscores and hyphenate docs subdomains

### DIFF
--- a/lib/hexpm/accounts/organization.ex
+++ b/lib/hexpm/accounts/organization.ex
@@ -21,7 +21,7 @@ defmodule Hexpm.Accounts.Organization do
     has_many :audit_logs, AuditLog, foreign_key: :organization_id
   end
 
-  @name_regex ~r"^[a-z0-9_\-\.]+$"
+  @name_regex ~r"^[a-z0-9_]+$"
   @roles ~w(admin write read)
 
   @reserved_names Enum.uniq(Hexpm.Repository.Package.reserved_names() ++ ~w(phoenix acme))

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -160,14 +160,14 @@ defmodule Hexpm.Utils do
   @spec docs_html_url(Repository.t(), Package.t(), Release.t() | nil) :: String.t()
   def docs_html_url(%Repository{id: 1}, package, release) do
     docs_url = URI.parse(Application.get_env(:hexpm, :docs_url))
-    docs_url = %{docs_url | host: "#{package_to_subdomain(package.name)}.#{docs_url.host}"}
+    docs_url = %{docs_url | host: "#{name_to_subdomain(package.name)}.#{docs_url.host}"}
     version = release && "#{release.version}/"
     "#{docs_url}/#{version}"
   end
 
   def docs_html_url(%Repository{} = repository, package, release) do
     docs_url = URI.parse(Application.get_env(:hexpm, :private_docs_url))
-    docs_url = %{docs_url | host: "#{repository.name}.#{docs_url.host}"}
+    docs_url = %{docs_url | host: "#{name_to_subdomain(repository.name)}.#{docs_url.host}"}
     package = package.name
     version = release && "#{release.version}/"
     "#{docs_url}/#{package}/#{version}"
@@ -188,12 +188,14 @@ defmodule Hexpm.Utils do
     Application.get_env(:hexpm, :docs_url) <> "/" <> package_name <> "/"
   end
 
-  # Hex package names allow underscores (`^[a-z][a-z0-9_]*$`), but RFC 1123
-  # hostname labels and RFC 6125 wildcard SAN matching don't, and Fastly
-  # enforces strict SAN matching at the HTTP edge. Map `_` -> `-` for the
-  # public hexdocs.pm subdomain. The Fastly Compute subdomain handler
-  # reverses the mapping before building the GCS bucket key.
-  defp package_to_subdomain(name), do: String.replace(name, "_", "-")
+  # Hex package and organization names allow underscores (packages
+  # `^[a-z][a-z0-9_]*$`, orgs `^[a-z0-9_]+$`), but RFC 1123 hostname labels
+  # and RFC 6125 wildcard SAN matching don't, and Fastly enforces strict SAN
+  # matching at the HTTP edge. Map `_` -> `-` for the subdomain. For public
+  # hexdocs.pm packages the Fastly Compute subdomain handler reverses the
+  # mapping before building the GCS bucket key; for hexorgs.pm orgs the
+  # hexdocs app reverses it.
+  defp name_to_subdomain(name), do: String.replace(name, "_", "-")
 
   @doc """
   Sidebar docs URL for a package given the currently-displayed release and the

--- a/test/hexpm/accounts/organization_test.exs
+++ b/test/hexpm/accounts/organization_test.exs
@@ -1,0 +1,23 @@
+defmodule Hexpm.Accounts.OrganizationTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.Accounts.Organization
+
+  describe "changeset/2 name validation" do
+    test "accepts underscores" do
+      assert Organization.changeset(%Organization{}, %{name: "foo_bar"}).valid?
+    end
+
+    test "accepts plain alphanumeric names" do
+      assert Organization.changeset(%Organization{}, %{name: "globex"}).valid?
+    end
+
+    test "rejects hyphens" do
+      refute Organization.changeset(%Organization{}, %{name: "foo-bar"}).valid?
+    end
+
+    test "rejects dots" do
+      refute Organization.changeset(%Organization{}, %{name: "foo.bar"}).valid?
+    end
+  end
+end

--- a/test/hexpm/utils_test.exs
+++ b/test/hexpm/utils_test.exs
@@ -122,5 +122,16 @@ defmodule Hexpm.UtilsTest do
       assert url =~ "//phoenix-live-view."
       refute url =~ "phoenix_live_view"
     end
+
+    test "maps underscores in the org repository name to hyphens in the subdomain" do
+      repository = %Hexpm.Repository.Repository{id: 2, name: "my_org"}
+      package = %Hexpm.Repository.Package{name: "secret", repository: repository}
+      release = %Hexpm.Repository.Release{version: Version.parse!("1.0.0")}
+
+      url = Utils.docs_html_url(repository, package, release)
+
+      assert url =~ "//my-org."
+      refute url =~ "my_org"
+    end
   end
 end

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -278,7 +278,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
                "http://localhost:5000/packages/#{repository.name}/#{package3.name}"
 
       assert result["docs_html_url"] ==
-               "http://#{repository.name}.localhost:5002/#{package3.name}/"
+               "http://#{String.replace(repository.name, "_", "-")}.localhost:5002/#{package3.name}/"
     end
 
     test "get package with retired versions", %{package4: package4} do

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -1500,7 +1500,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
                "http://localhost:5000/packages/#{repository.name}/#{package.name}/0.0.1"
 
       assert result["docs_html_url"] ==
-               "http://#{repository.name}.localhost:5002/#{package.name}/0.0.1/"
+               "http://#{String.replace(repository.name, "_", "-")}.localhost:5002/#{package.name}/0.0.1/"
 
       assert result["version"] == "0.0.1"
     end

--- a/test/hexpm_web/controllers/dashboard/profile_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/profile_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule HexpmWeb.Dashboard.ProfileControllerTest do
   use HexpmWeb.ConnCase, async: true
-  import Swoosh.TestAssertions
 
   alias Hexpm.Accounts.{User, Users}
 

--- a/test/hexpm_web/controllers/dashboard_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard_controller_test.exs
@@ -1,6 +1,5 @@
 defmodule HexpmWeb.DashboardControllerTest do
   use HexpmWeb.ConnCase, async: true
-  import Swoosh.TestAssertions
 
   setup do
     %{

--- a/test/hexpm_web/controllers/test_controller_test.exs
+++ b/test/hexpm_web/controllers/test_controller_test.exs
@@ -44,7 +44,7 @@ defmodule HexpmWeb.TestControllerTest do
 
   test "POST /api/repo creates organization and returns 204" do
     user = insert(:user)
-    org_name = "org-" <> Fake.sequence(:username)
+    org_name = "org_" <> Fake.sequence(:package)
 
     conn =
       build_conn()


### PR DESCRIPTION
Organization docs move to per-org subdomains under hexorgs.pm, where the subdomain label maps `_` -> `-` (RFC 1123 / strict SAN matching). Tighten the org name charset from `^[a-z0-9_\-\.]+$` to `^[a-z0-9_]+$` so the `_` <-> `-` mapping is an exact bijection, mirroring package names.

docs_html_url/3 now hyphenates the org repository name when building the subdomain (reusing the renamed name_to_subdomain/1 helper), so the generated documentation links point at the canonical host.

See https://github.com/hexpm/hexdocs/pull/121.