### PR TITLE
Fix package-scoped key generation for organizations

### DIFF
--- a/lib/hexpm/accounts/organization.ex
+++ b/lib/hexpm/accounts/organization.ex
@@ -93,13 +93,15 @@ defmodule Hexpm.Accounts.Organization do
   end
 
   def verify_permissions(%Organization{} = organization, "package", name) do
-    [organization_name, package] = String.split(name, "/", parts: 2)
-    package = Packages.get(organization_name, package)
+    case String.split(name, "/", parts: 2) do
+      [organization_name, package_name] when organization_name == organization.name ->
+        case Packages.get(organization_name, package_name) do
+          nil -> :error
+          package -> {:ok, package}
+        end
 
-    if package && Packages.owner_with_access?(package, organization.user) do
-      {:ok, package}
-    else
-      :error
+      _ ->
+        :error
     end
   end
 

--- a/lib/hexpm_web/templates/dashboard/key/components/generate_key_modal.ex
+++ b/lib/hexpm_web/templates/dashboard/key/components/generate_key_modal.ex
@@ -181,7 +181,7 @@ defmodule HexpmWeb.Dashboard.Key.Components.GenerateKeyModal do
                   <label class="flex items-center">
                     <input
                       type="checkbox"
-                      name={"key[permissions][package][#{package.name}]"}
+                      name={"key[permissions][package][#{package_resource(@organization, package)}]"}
                       value="on"
                       class="rounded border-grey-300 text-purple-600 focus:ring-purple-500"
                     />
@@ -209,4 +209,7 @@ defmodule HexpmWeb.Dashboard.Key.Components.GenerateKeyModal do
     </.modal>
     """
   end
+
+  defp package_resource(nil, package), do: package.name
+  defp package_resource(organization, package), do: "#{organization.name}/#{package.name}"
 end

--- a/test/hexpm/accounts/keys_test.exs
+++ b/test/hexpm/accounts/keys_test.exs
@@ -109,20 +109,50 @@ defmodule Hexpm.Accounts.KeysTest do
                "you do not have access to this package"
     end
 
-    test "organization package permissions", %{organization: organization, package: package} do
+    test "organization package permissions" do
+      repository = insert(:repository)
+      organization = repository.organization
+      package = insert(:package, repository_id: repository.id)
+
+      # The organization owns every package in its own repository, even when the
+      # organization's backing user is not an explicit package owner.
+      refute Hexpm.Repository.Packages.owner_with_access?(
+               %{package | repository: repository},
+               organization.user
+             )
+
       params = %{
         "name" => "keyname",
-        "permissions" => [%{"domain" => "package", "resource" => package.name}]
+        "permissions" => [
+          %{"domain" => "package", "resource" => "#{organization.name}/#{package.name}"}
+        ]
       }
 
       assert {:ok, %{key: %Key{}}} =
                Keys.create(organization, params, audit: audit_data(organization))
 
-      unowned_package = insert(:package)
+      # A package in another repository is not accessible to this organization.
+      other_package = insert(:package)
 
       params = %{
         "name" => "keyname",
-        "permissions" => [%{"domain" => "package", "resource" => unowned_package.name}]
+        "permissions" => [
+          %{"domain" => "package", "resource" => "#{organization.name}/#{other_package.name}"}
+        ]
+      }
+
+      assert {:error, :key, changeset, _} =
+               Keys.create(organization, params, audit: audit_data(organization))
+
+      assert errors_on(changeset)[:permissions][:resource] ==
+               "you do not have access to this package"
+
+      # A package qualified with another organization's name is not accessible.
+      params = %{
+        "name" => "keyname",
+        "permissions" => [
+          %{"domain" => "package", "resource" => "other-org/#{package.name}"}
+        ]
       }
 
       assert {:error, :key, changeset, _} =
@@ -133,7 +163,9 @@ defmodule Hexpm.Accounts.KeysTest do
 
       params = %{
         "name" => "keyname",
-        "permissions" => [%{"domain" => "package", "resource" => "NON_EXISTANT_PACKAGE"}]
+        "permissions" => [
+          %{"domain" => "package", "resource" => "#{organization.name}/NON_EXISTANT_PACKAGE"}
+        ]
       }
 
       assert {:error, :key, changeset, _} =


### PR DESCRIPTION
Generating an organization key scoped to one of the organization's own packages silently failed: the form submitted the bare package name, which KeyPermission.normalize_resource/1 prefixes with "hexpm/", so the access check looked for the package in the hexpm repository instead of the organization's repository.

The dashboard modal now emits the repository-qualified resource (organization_name/package_name) for organization keys, while user keys keep the bare name so the hexpm default still applies.

Organization.verify_permissions/3 for packages now authorizes by repository membership rather than running owner_with_access?/2 against the organization's backing user. That backing user is never a member of its own organization, so the check always failed, and it additionally raised because Packages.get/2 does not preload repository.organization. An organization owns every package in its own repository, and the acting user's organization-level write permission is already enforced in create_key via access_organization/4.