### PR TITLE
Fix crash when filtering release "all" downloads by date range

### DIFF
--- a/lib/hexpm/repository/downloads.ex
+++ b/lib/hexpm/repository/downloads.ex
@@ -39,15 +39,20 @@ defmodule Hexpm.Repository.Downloads do
   end
 
   def for_period(package_or_release, group_by, opts \\ []) do
+    date_filters = Keyword.take(opts, [:downloads_after, :downloads_before])
+    date_filtered? = Enum.any?(date_filters, fn {_key, value} -> match?(%Date{}, value) end)
+
     base =
       case package_or_release do
-        %Package{id: package_id} -> Download.by_period(package_id, group_by || :all)
-        %Release{id: release_id} -> ReleaseDownload.by_period(release_id, group_by || :all)
+        %Package{id: package_id} ->
+          Download.by_period(package_id, group_by || :all)
+
+        %Release{id: release_id} ->
+          ReleaseDownload.by_period(release_id, group_by || :all, date_filtered?)
       end
 
     query =
-      opts
-      |> Keyword.take([:downloads_after, :downloads_before])
+      date_filters
       |> Enum.reduce(base, fn
         {:downloads_after, %Date{} = date}, query -> Download.since_date(query, date)
         {:downloads_after, nil}, query -> query

--- a/lib/hexpm/repository/release_download.ex
+++ b/lib/hexpm/repository/release_download.ex
@@ -14,7 +14,7 @@ defmodule Hexpm.Repository.ReleaseDownload do
     from(rd in ReleaseDownload, where: rd.release_id == ^release.id)
   end
 
-  def by_period(release_id, :all) do
+  def by_period(release_id, :all, false) do
     from(d in ReleaseDownload,
       where: d.release_id == ^release_id,
       select: %Download{
@@ -25,7 +25,19 @@ defmodule Hexpm.Repository.ReleaseDownload do
     )
   end
 
-  def by_period(release_id, filter) do
+  def by_period(release_id, :all, true) do
+    from(d in Download,
+      where: d.release_id == ^release_id,
+      group_by: [d.package_id, d.release_id],
+      select: %Download{
+        package_id: d.package_id,
+        release_id: d.release_id,
+        downloads: sum(d.downloads)
+      }
+    )
+  end
+
+  def by_period(release_id, filter, _date_filtered?) do
     from(d in Download, where: d.release_id == ^release_id)
     |> Download.query_filter(filter)
   end

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -1600,6 +1600,29 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
                ["2000-02-07", 2]
              ]
     end
+
+    test "get release downloads (all) limited to range", %{package: package, release: release} do
+      result =
+        build_conn()
+        |> get(
+          "/api/packages/#{package.name}/releases/#{release.version}?downloads_after=2000-02-01"
+        )
+        |> json_response(200)
+
+      assert result["version"] == "#{release.version}"
+      assert result["downloads"] == 9
+
+      result =
+        build_conn()
+        |> get(
+          "/api/packages/#{package.name}/releases/#{release.version}?" <>
+            "downloads=all&downloads_after=2000-02-01&downloads_before=2000-02-07"
+        )
+        |> json_response(200)
+
+      assert result["version"] == "#{release.version}"
+      assert result["downloads"] == 5
+    end
   end
 
   describe "TOTP validation for write operations with OAuth tokens" do


### PR DESCRIPTION
The release downloads API accepts `downloads_after`/`downloads_before` date filters. For the `all` period (the default), the base query was built from the `release_downloads` materialized view, which only stores lifetime totals and has no `day` column. Applying the date filters then referenced `day`, raising `Ecto.QueryError`.

When a date filter is present, build the `all` aggregate from the `downloads` table (which has `day`) and sum over the filtered range instead of reading the pre-aggregated view.

Fixes HEXPM-AV