### PR TITLE
Build Docker image for arm64 only

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -183,18 +183,11 @@ jobs:
         run: cd hex && mix test --include integration && cd ..
 
   docker:
-    name: Docker (${{ matrix.platform }})
-    runs-on: ${{ matrix.runner }}
+    name: Docker
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: "read"
       id-token: "write"
-    strategy:
-      matrix:
-        include:
-          - platform: linux/amd64
-            runner: ubuntu-24.04
-          - platform: linux/arm64
-            runner: ubuntu-24.04-arm
     env:
       IMAGE_NAME: "hexpm"
       PROJECT_ID: "hexpm-prod"
@@ -204,6 +197,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: Set short git commit SHA
+        run: echo "COMMIT_SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - name: Google auth
@@ -223,71 +218,12 @@ jobs:
           registry: gcr.io
           username: "oauth2accesstoken"
           password: "${{ steps.auth.outputs.access_token }}"
-      - name: Build and push by digest
+      - name: Build and push
         id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
-          platforms: ${{ matrix.platform }}
-          outputs: type=image,name=gcr.io/${{ env.PROJECT_ID }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' }}
-          cache-from: type=gha,scope=${{ matrix.runner }}
-          cache-to: type=gha,scope=${{ matrix.runner }},mode=max
-      - name: Export digest
-        if: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' }}
-        env:
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: |
-          mkdir -p /tmp/digests
-          touch "/tmp/digests/${DIGEST#sha256:}"
-      - name: Upload digest
-        if: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: digests-${{ matrix.runner }}
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
-
-  docker-merge:
-    name: Docker Merge
-    runs-on: ubuntu-24.04
-    if: ${{ github.event_name != 'pull_request' && github.repository == 'hexpm/hexpm' }}
-    needs: docker
-    permissions:
-      contents: "read"
-      id-token: "write"
-    env:
-      IMAGE_NAME: "hexpm"
-      PROJECT_ID: "hexpm-prod"
-      SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
-      WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCLOUD_WORKFLOW_IDENTITY_POOL_PROVIDER }}
-    steps:
-      - name: Set short git commit SHA
-        run: echo "COMMIT_SHORT_SHA=${GITHUB_SHA::7}" >> $GITHUB_ENV
-      - name: Download digests
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          path: /tmp/digests
-          pattern: digests-*
-          merge-multiple: true
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-      - name: Google auth
-        id: auth
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 #v3.0.0
-        with:
-          token_format: "access_token"
-          project_id: ${{ env.PROJECT_ID }}
-          service_account: ${{ env.SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
-      - name: Docker Auth
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: gcr.io
-          username: "oauth2accesstoken"
-          password: "${{ steps.auth.outputs.access_token }}"
-      - name: Create manifest list and push
-        working-directory: /tmp/digests
-        run: |
-          docker buildx imagetools create \
-            -t gcr.io/${{ env.PROJECT_ID }}/${{ env.IMAGE_NAME }}:${COMMIT_SHORT_SHA} \
-            $(printf 'gcr.io/${{ env.PROJECT_ID }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          platforms: linux/arm64
+          tags: gcr.io/${{ env.PROJECT_ID }}/${{ env.IMAGE_NAME }}:${{ env.COMMIT_SHORT_SHA }}
+          push: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Drop the linux/amd64 Docker build and the manifest-merge job; build and push a single arm64 image tagged with the commit SHA directly. Deployments run on arm64 nodes, so the amd64 image and the multi-arch manifest are no longer needed.