### PR TITLE
Verify the database CA without TLS hostname matching

### DIFF
--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -79,7 +79,6 @@ defmodule Hexpm.RepoBase do
       ca_cert = System.get_env("HEXPM_DATABASE_CA_CERT")
       client_key = System.get_env("HEXPM_DATABASE_CLIENT_KEY")
       client_cert = System.get_env("HEXPM_DATABASE_CLIENT_CERT")
-      common_name = System.get_env("HEXPM_DATABASE_COMMON_NAME")
 
       ssl_opts =
         if ca_cert do
@@ -88,7 +87,15 @@ defmodule Hexpm.RepoBase do
             cacerts: [decode_cert(ca_cert)],
             key: decode_key(client_key),
             cert: decode_cert(client_cert),
-            server_name_indication: String.to_charlist(common_name)
+            # Cloud SQL's server certificate (GOOGLE_MANAGED_INTERNAL_CA) has a Common
+            # Name but no Subject Alternative Name. OTP's TLS hostname verification
+            # requires a SAN and rejects such certificates with
+            # {:bad_cert, {:hostname_check_failed, :missing_subject_altnames}}, so we use
+            # verify-CA semantics: the certificate chain is still validated against the
+            # pinned instance CA above and the mTLS client certificate is still presented,
+            # but the hostname is not matched. (customize_hostname_check does not help —
+            # the missing-SAN check short-circuits before the match_fun runs.)
+            server_name_indication: :disable
           ]
         end
 


### PR DESCRIPTION
The Cloud SQL server certificate (GOOGLE_MANAGED_INTERNAL_CA) has a Common Name but no Subject Alternative Name. OTP builds that include the CVE-2026-42790 certificate-validation fix (public_key 1.17.1.3 / 1.20.3.1, i.e. OTP 27.3.4.12 / 28.5.0.1 and later) reject such certificates during hostname verification with `{:bad_cert, {:hostname_check_failed, :missing_subject_altnames}}`, which prevents the app from connecting to the database.

Switch the connection to verify-CA semantics: `verify: :verify_peer` with the pinned instance CA and the mTLS client certificate are kept (a certificate from a different CA is still rejected), and only the hostname match is disabled via `server_name_indication: :disable`.

Validated against OTP 27.3.4.12 with a CN-only, no-SAN certificate: the current config and `customize_hostname_check` both fail with `missing_subject_altnames`; `server_name_indication: :disable` connects while a wrong-CA certificate is still rejected with `unknown_ca`.