### PR TITLE
Purge expired records in batches

### DIFF
--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -6,102 +6,139 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
   @retention_days 90
   # Plug session cookies have a 30-day max_age; rows older than that are unreachable.
   @plug_session_retention_days 30
+  # Deletes run in batches so each statement stays well below the query timeout
+  # regardless of how many rows have accumulated.
+  @batch_size 10_000
 
-  def run() do
+  def run(opts \\ []) do
+    batch_size = Keyword.get(opts, :batch_size, @batch_size)
+
     Enum.each(@repos, fn repo ->
       app = Keyword.get(repo.config(), :otp_app)
       Logger.info("[task] Purging expired records for #{app}")
 
-      purge_authorization_codes(repo)
-      purge_device_codes(repo)
-      purge_oauth_tokens(repo)
-      purge_user_sessions(repo)
-      purge_plug_sessions(repo)
-      purge_password_resets(repo)
-      purge_keys(repo)
+      purge_authorization_codes(repo, batch_size)
+      purge_device_codes(repo, batch_size)
+      purge_oauth_tokens(repo, batch_size)
+      purge_user_sessions(repo, batch_size)
+      purge_plug_sessions(repo, batch_size)
+      purge_password_resets(repo, batch_size)
+      purge_keys(repo, batch_size)
     end)
   end
 
-  defp purge_authorization_codes(repo) do
-    {count, _} =
-      repo.delete_all(
+  defp purge_authorization_codes(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.OAuth.AuthorizationCode,
         from(ac in Hexpm.OAuth.AuthorizationCode,
           where: ac.expires_at < fragment("NOW()")
-        )
+        ),
+        batch_size
       )
 
     Logger.info("[task] Purged #{count} expired authorization codes")
   end
 
-  defp purge_device_codes(repo) do
-    {count, _} =
-      repo.delete_all(
+  defp purge_device_codes(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.OAuth.DeviceCode,
         from(dc in Hexpm.OAuth.DeviceCode,
           where: dc.expires_at < fragment("NOW()")
-        )
+        ),
+        batch_size
       )
 
     Logger.info("[task] Purged #{count} expired device codes")
   end
 
-  defp purge_oauth_tokens(repo) do
-    {count, _} =
-      repo.delete_all(
+  defp purge_oauth_tokens(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.OAuth.Token,
         from(t in Hexpm.OAuth.Token,
           where: t.expires_at < fragment("NOW()") or not is_nil(t.revoked_at)
-        )
+        ),
+        batch_size
       )
 
     Logger.info("[task] Purged #{count} expired/revoked OAuth tokens")
   end
 
-  defp purge_user_sessions(repo) do
-    {count, _} =
-      repo.delete_all(
+  defp purge_user_sessions(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.UserSession,
         from(us in Hexpm.UserSession,
           where:
             (not is_nil(us.expires_at) and us.expires_at < fragment("NOW()")) or
               not is_nil(us.revoked_at)
-        )
+        ),
+        batch_size
       )
 
     Logger.info("[task] Purged #{count} expired/revoked user sessions")
   end
 
-  defp purge_plug_sessions(repo) do
-    {count, _} =
-      repo.delete_all(
+  defp purge_plug_sessions(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.PlugSession,
         from(s in Hexpm.PlugSession,
           where:
             s.updated_at <
               fragment("NOW() - make_interval(days => ?)", @plug_session_retention_days)
-        )
+        ),
+        batch_size
       )
 
     Logger.info("[task] Purged #{count} stale plug sessions")
   end
 
-  defp purge_password_resets(repo) do
-    {count, _} =
-      repo.delete_all(
+  defp purge_password_resets(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.Accounts.PasswordReset,
         from(pr in Hexpm.Accounts.PasswordReset,
           where: pr.inserted_at < fragment("NOW() - make_interval(days => ?)", @retention_days)
-        )
+        ),
+        batch_size
       )
 
     Logger.info("[task] Purged #{count} expired password resets")
   end
 
-  defp purge_keys(repo) do
-    {count, _} =
-      repo.delete_all(
+  defp purge_keys(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.Accounts.Key,
         from(k in Hexpm.Accounts.Key,
           where:
             not is_nil(k.revoke_at) and
               k.revoke_at < fragment("NOW() - make_interval(days => ?)", @retention_days)
-        )
+        ),
+        batch_size
       )
 
     Logger.info("[task] Purged #{count} revoked keys")
+  end
+
+  defp delete_in_batches(repo, schema, query, batch_size, total \\ 0) do
+    ids = from(r in query, select: r.id, limit: ^batch_size)
+    {count, _} = repo.delete_all(from(r in schema, where: r.id in subquery(ids)))
+
+    if count < batch_size do
+      total + count
+    else
+      delete_in_batches(repo, schema, query, batch_size, total + count)
+    end
   end
 end

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -145,6 +145,43 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
 
       refute Repo.get(Hexpm.OAuth.Token, revoked.id)
     end
+
+    test "deletes records exceeding the batch size and keeps active ones" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      expired =
+        for i <- 1..5 do
+          Repo.insert!(%Hexpm.OAuth.Token{
+            jti: "expired-jti-#{i}",
+            token_type: "bearer",
+            scopes: ["api"],
+            expires_at: truncated_seconds_ago(60),
+            grant_type: "authorization_code",
+            user_id: user.id,
+            client_id: client.client_id
+          })
+        end
+
+      active =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "active-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at: truncated_seconds_from_now(86400),
+          grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run(batch_size: 2)
+
+      for token <- expired do
+        refute Repo.get(Hexpm.OAuth.Token, token.id)
+      end
+
+      assert Repo.get(Hexpm.OAuth.Token, active.id)
+    end
   end
 
   describe "purge user sessions" do


### PR DESCRIPTION
The nightly purge deleted all matching rows in a single statement. The oauth_tokens purge had accumulated ~886k purgeable rows in prod, so the delete exceeded the 15s query timeout and the task failed every night, growing the backlog further and aborting the remaining purges.

Delete in batches of 10k rows so each statement stays well below the query timeout regardless of backlog size.