### PR TITLE
Fix intermittent failure in release controller test

### DIFF
--- a/priv/fake/packages.txt
+++ b/priv/fake/packages.txt
@@ -3262,7 +3262,6 @@ stationary
 statistics
 statix
 statman
-stats
 statsderl
 status_ku
 std_json_io

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -523,7 +523,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
 
     test "create releases", %{user: user} do
       meta = %{
-        name: "test_" <> Fake.sequence(:package),
+        name: Fake.sequence(:package),
         app: "other",
         version: "0.0.1",
         description: "description"

--- a/test/hexpm_web/controllers/api/release_controller_test.exs
+++ b/test/hexpm_web/controllers/api/release_controller_test.exs
@@ -523,7 +523,7 @@ defmodule HexpmWeb.API.ReleaseControllerTest do
 
     test "create releases", %{user: user} do
       meta = %{
-        name: Fake.sequence(:package),
+        name: "test_" <> Fake.sequence(:package),
         app: "other",
         version: "0.0.1",
         description: "description"


### PR DESCRIPTION
## Summary

- `Fake.sequence(:package)` draws names from `priv/fake/packages.txt`. Commit `0be1dd4f` added `stats` to `@subdomain_names`, making it a reserved package name — but it was still present in `packages.txt`.
- When the sequence counter landed on `stats` the request returned HTTP 422 `{"name":"is reserved"}`, causing a flaky test failure.
- Fix: remove `stats` from `priv/fake/packages.txt`. It is the only entry that overlaps with the full `@reserved_names` list.
