### PR TITLE
Replace invalid UTF-8 bytes when rendering readmes

### DIFF
--- a/lib/hexpm_web/readme/renderer.ex
+++ b/lib/hexpm_web/readme/renderer.ex
@@ -24,6 +24,7 @@ defmodule HexpmWeb.Readme.Renderer do
   """
   def render(filename, content, package_name, version) do
     ext = Path.extname(filename) |> String.downcase()
+    content = scrub_invalid_utf8(content)
 
     html =
       case ext do
@@ -51,6 +52,25 @@ defmodule HexpmWeb.Readme.Renderer do
     |> Sanitizer.sanitize()
     |> URLRewriter.rewrite(package_name, version)
     |> Floki.raw_html()
+  end
+
+  # README files are extracted from package tarballs as raw bytes and may use
+  # legacy encodings. MDEx's native parser raises on invalid UTF-8.
+  defp scrub_invalid_utf8(content) do
+    if String.valid?(content) do
+      content
+    else
+      content
+      |> String.chunk(:valid)
+      |> Enum.map(fn chunk ->
+        if String.valid?(chunk) do
+          chunk
+        else
+          String.duplicate("�", byte_size(chunk))
+        end
+      end)
+      |> IO.iodata_to_binary()
+    end
   end
 
   defp protect_pre_whitespace(html) do

--- a/test/hexpm_web/readme/renderer_test.exs
+++ b/test/hexpm_web/readme/renderer_test.exs
@@ -45,4 +45,20 @@ defmodule HexpmWeb.Readme.RendererTest do
     assert result =~ ~s[href="#fn-note"]
     assert result =~ ~s[<li id="fn-note">]
   end
+
+  test "invalid UTF-8 bytes are replaced with the replacement character" do
+    content = "the \x91simple form\x92 that is used by Xmerl"
+
+    result = render(content)
+
+    assert result =~ "the �simple form� that is used by Xmerl"
+  end
+
+  test "invalid UTF-8 bytes in plain text readmes are replaced" do
+    content = "caf\xE9 au lait"
+
+    result = Renderer.render("README", content, "my_package", "1.0.0")
+
+    assert result =~ "<pre>caf� au lait</pre>"
+  end
 end


### PR DESCRIPTION
README files are extracted from package tarballs as raw bytes and may use legacy encodings. MDEx's native parser raises ArgumentError on invalid UTF-8, crashing readme.hex.pm for packages like erlsom 1.4.1 whose README is Windows-1252 encoded. Scrub the content before rendering, replacing invalid bytes with the Unicode replacement character.