### PR TITLE
Allow users to delete their account

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -12,7 +12,8 @@ config :hexpm,
   cdn_impl: Hexpm.CDN.Local,
   billing_impl: Hexpm.Billing.Local,
   pwned_impl: Hexpm.Pwned.Local,
-  sudo_timeout: Duration.new!(hour: 1)
+  sudo_timeout: Duration.new!(hour: 1),
+  sudo_force_timeout: Duration.new!(minute: 5)
 
 config :hexpm, :features, package_reports: true
 

--- a/config/config.exs
+++ b/config/config.exs
@@ -13,7 +13,7 @@ config :hexpm,
   billing_impl: Hexpm.Billing.Local,
   pwned_impl: Hexpm.Pwned.Local,
   sudo_timeout: Duration.new!(hour: 1),
-  sudo_force_timeout: Duration.new!(minute: 5)
+  sudo_force_timeout: Duration.new!(second: 30)
 
 config :hexpm, :features, package_reports: true
 

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,6 +3,7 @@ import Config
 config :hexpm,
   billing_report: false,
   sudo_timeout: Duration.new!(minute: 60),
+  sudo_force_timeout: Duration.new!(minute: 5),
   secret: "796f75666f756e64746865686578",
   jwt_signing_key: """
   -----BEGIN EC PRIVATE KEY-----

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -3,7 +3,7 @@ import Config
 config :hexpm,
   billing_report: false,
   sudo_timeout: Duration.new!(minute: 60),
-  sudo_force_timeout: Duration.new!(minute: 5),
+  sudo_force_timeout: Duration.new!(second: 30),
   secret: "796f75666f756e64746865686578",
   jwt_signing_key: """
   -----BEGIN EC PRIVATE KEY-----

--- a/lib/hexpm/accounts/account_deletion_request.ex
+++ b/lib/hexpm/accounts/account_deletion_request.ex
@@ -1,0 +1,28 @@
+defmodule Hexpm.Accounts.AccountDeletionRequest do
+  use Hexpm.Schema
+
+  schema "account_deletion_requests" do
+    field :key, :string
+    field :primary_email, :string
+    belongs_to :user, User
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(request, user) do
+    change(request, %{
+      key: Auth.gen_key(),
+      primary_email: User.email(user, :primary)
+    })
+    |> unique_constraint(:user_id)
+  end
+
+  def can_confirm?(request, user, key) do
+    valid_user? = request.user_id == user.id
+    valid_email? = User.email(user, :primary) == request.primary_email
+    valid_key? = !!(request.key && Hexpm.Utils.secure_check(request.key, key))
+    within_time? = Hexpm.Utils.within_last_day?(request.inserted_at)
+
+    valid_user? and valid_email? and valid_key? and within_time?
+  end
+end

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -18,7 +18,7 @@ defmodule Hexpm.Accounts.AuditLog do
   end
 
   def build(%{user: nil} = audit_data, action, params)
-      when action in ~w(password.reset.init password.reset.finish user_provider.create) do
+      when action in ~w(password.reset.init password.reset.finish user_provider.create user.delete) do
     params = extract_params(action, params)
 
     {key, oauth_token} = extract_auth_credential(audit_data.auth_credential)
@@ -226,6 +226,8 @@ defmodule Hexpm.Accounts.AuditLog do
     do: %{old_email: serialize(old_email), new_email: serialize(new_email)}
 
   defp extract_params("user.create", user), do: serialize(user)
+  defp extract_params("user.delete", user), do: serialize(user)
+  defp extract_params("user.delete.request", user), do: serialize(user)
   defp extract_params("user.update", user), do: serialize(user)
   defp extract_params("security.update", user), do: serialize(user)
   defp extract_params("security.rotate_recovery_codes", user), do: serialize(user)

--- a/lib/hexpm/accounts/reserved_username.ex
+++ b/lib/hexpm/accounts/reserved_username.ex
@@ -1,0 +1,13 @@
+defmodule Hexpm.Accounts.ReservedUsername do
+  use Hexpm.Schema
+
+  schema "reserved_usernames" do
+    field :name, :string
+
+    timestamps(updated_at: false)
+  end
+
+  def by_name(name) do
+    from(r in __MODULE__, where: fragment("lower(?)", r.name) == ^String.downcase(name))
+  end
+end

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -27,6 +27,7 @@ defmodule Hexpm.Accounts.User do
     has_many :organizations, through: [:organization_users, :organization]
     has_many :keys, Key
     has_many :audit_logs, AuditLog
+    has_many :account_deletion_requests, AccountDeletionRequest
     has_many :password_resets, PasswordReset
     has_many :package_reports, Hexpm.Repository.PackageReport, foreign_key: :author_id
     has_many :user_providers, UserProvider

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -48,8 +48,21 @@ defmodule Hexpm.Accounts.User do
     |> validate_format(:username, @username_reject_regex)
     |> validate_exclusion(:username, @reserved_names)
     |> unique_constraint(:username, name: "users_username_idx")
+    |> validate_username_not_reserved()
     |> ensure_optional_email_preferences()
     |> validate_password()
+  end
+
+  defp validate_username_not_reserved(changeset) do
+    prepare_changes(changeset, fn changeset ->
+      username = get_field(changeset, :username)
+
+      if username && changeset.repo.exists?(ReservedUsername.by_name(username)) do
+        add_error(changeset, :username, "has already been taken")
+      else
+        changeset
+      end
+    end)
   end
 
   defp validate_password(changeset) do
@@ -87,6 +100,7 @@ defmodule Hexpm.Accounts.User do
     |> validate_format(:username, @username_regex)
     |> validate_exclusion(:username, @reserved_names)
     |> unique_constraint(:username, name: "users_username_idx")
+    |> validate_username_not_reserved()
   end
 
   def to_organization(user, organization) do

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -169,33 +169,37 @@ defmodule Hexpm.Accounts.Users do
     with {:ok, _warnings} <- delete_eligibility(user) do
       user = Repo.preload(user, :emails)
 
-      changeset =
-        AccountDeletionRequest.changeset(
-          build_assoc(user, :account_deletion_requests),
-          user
-        )
+      if User.email(user, :primary) do
+        changeset =
+          AccountDeletionRequest.changeset(
+            build_assoc(user, :account_deletion_requests),
+            user
+          )
 
-      result =
-        Multi.new()
-        |> Multi.delete_all(:existing_requests, assoc(user, :account_deletion_requests))
-        |> Multi.insert(:request, changeset)
-        |> audit(audit_data, "user.delete.request", user)
-        |> Repo.transaction()
+        result =
+          Multi.new()
+          |> Multi.delete_all(:existing_requests, assoc(user, :account_deletion_requests))
+          |> Multi.insert(:request, changeset)
+          |> audit(audit_data, "user.delete.request", user)
+          |> Repo.transaction()
 
-      case result do
-        {:ok, %{request: request}} ->
-          Emails.account_deletion_request(user, request)
-          |> Mailer.deliver!()
-
-          :ok
-
-        {:error, :request, _changeset, _} ->
-          if request = Repo.get_by(AccountDeletionRequest, user_id: user.id) do
+        case result do
+          {:ok, %{request: request}} ->
             Emails.account_deletion_request(user, request)
             |> Mailer.deliver!()
-          end
 
-          :ok
+            :ok
+
+          {:error, :request, _changeset, _} ->
+            if request = Repo.get_by(AccountDeletionRequest, user_id: user.id) do
+              Emails.account_deletion_request(user, request)
+              |> Mailer.deliver!()
+            end
+
+            :ok
+        end
+      else
+        {:error, :no_primary_email}
       end
     end
   end

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -138,7 +138,9 @@ defmodule Hexpm.Accounts.Users do
     |> Repo.all()
   end
 
-  def delete(user, audit: audit_data) do
+  def delete(user, opts) do
+    audit_data = Keyword.fetch!(opts, :audit)
+    notify? = Keyword.get(opts, :notify, true)
     user = Repo.preload(user, :emails)
 
     multi =
@@ -151,7 +153,7 @@ defmodule Hexpm.Accounts.Users do
 
     case Repo.transaction(multi) do
       {:ok, _} ->
-        if User.email(user, :primary) do
+        if notify? && User.email(user, :primary) do
           Emails.account_deleted(user)
           |> Mailer.deliver!()
         end

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -188,6 +188,11 @@ defmodule Hexpm.Accounts.Users do
           :ok
 
         {:error, :request, _changeset, _} ->
+          if request = Repo.get_by(AccountDeletionRequest, user_id: user.id) do
+            Emails.account_deletion_request(user, request)
+            |> Mailer.deliver!()
+          end
+
           :ok
       end
     end

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -163,6 +163,57 @@ defmodule Hexpm.Accounts.Users do
     end
   end
 
+  def delete_request(user, audit: audit_data) do
+    with {:ok, _warnings} <- delete_eligibility(user) do
+      user = Repo.preload(user, :emails)
+
+      changeset =
+        AccountDeletionRequest.changeset(
+          build_assoc(user, :account_deletion_requests),
+          user
+        )
+
+      result =
+        Multi.new()
+        |> Multi.delete_all(:existing_requests, assoc(user, :account_deletion_requests))
+        |> Multi.insert(:request, changeset)
+        |> audit(audit_data, "user.delete.request", user)
+        |> Repo.transaction()
+
+      case result do
+        {:ok, %{request: request}} ->
+          Emails.account_deletion_request(user, request)
+          |> Mailer.deliver!()
+
+          :ok
+
+        {:error, :request, _changeset, _} ->
+          :ok
+      end
+    end
+  end
+
+  def get_delete_request(user, key) when is_binary(key) do
+    user = Repo.preload(user, :emails)
+    request = Repo.get_by(AccountDeletionRequest, user_id: user.id)
+
+    if request && AccountDeletionRequest.can_confirm?(request, user, key) do
+      request
+    end
+  end
+
+  def get_delete_request(_user, _key), do: nil
+
+  def delete_confirm(user, key, audit: audit_data) do
+    if get_delete_request(user, key) do
+      with {:ok, _warnings} <- delete_eligibility(user) do
+        delete(user, audit: audit_data)
+      end
+    else
+      {:error, :invalid_request}
+    end
+  end
+
   def email_verification(%User{organization_id: id}, email) when not is_nil(id) do
     email
   end
@@ -276,6 +327,7 @@ defmodule Hexpm.Accounts.Users do
     multi =
       Multi.new()
       |> Multi.update(:user, User.update_password(user, params))
+      |> Multi.delete_all(:account_deletion_requests, assoc(user, :account_deletion_requests))
       |> audit(audit_data, "password.update", nil)
 
     case Repo.transaction(multi) do
@@ -418,6 +470,7 @@ defmodule Hexpm.Accounts.Users do
       Multi.new()
       |> Multi.update(:password, User.update_password_no_check(user, params))
       |> Multi.delete_all(:reset, assoc(user, :password_resets))
+      |> Multi.delete_all(:account_deletion_requests, assoc(user, :account_deletion_requests))
       |> Multi.update_all(:revoke_sessions, sessions_query, [])
       |> Multi.update_all(:revoke_tokens, tokens_query, [])
 

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -96,6 +96,31 @@ defmodule Hexpm.Accounts.Users do
     end
   end
 
+  def delete(user, audit: audit_data) do
+    user = Repo.preload(user, :emails)
+
+    multi =
+      Multi.new()
+      |> audit(audit_data, "user.delete", user)
+      |> Multi.insert(:reserved_username, %ReservedUsername{name: user.username},
+        on_conflict: :nothing
+      )
+      |> Multi.delete(:user, user, stale_error_field: :id)
+
+    case Repo.transaction(multi) do
+      {:ok, _} ->
+        if User.email(user, :primary) do
+          Emails.account_deleted(user)
+          |> Mailer.deliver!()
+        end
+
+        :ok
+
+      {:error, _operation, changeset, _changes} ->
+        {:error, changeset}
+    end
+  end
+
   def email_verification(%User{organization_id: id}, email) when not is_nil(id) do
     email
   end

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -96,6 +96,48 @@ defmodule Hexpm.Accounts.Users do
     end
   end
 
+  def delete_eligibility(user) do
+    cond do
+      User.organization?(user) ->
+        {:error, :organization_account}
+
+      (organizations = organizations_blocking_delete(user)) != [] ->
+        {:error, {:organizations, organizations}}
+
+      true ->
+        {:ok, %{sole_owned_packages: sole_owned_packages(user)}}
+    end
+  end
+
+  defp organizations_blocking_delete(user) do
+    user = Repo.preload(user, organizations: :organization_users)
+
+    user.organizations
+    |> Enum.filter(fn organization ->
+      members = organization.organization_users
+      admins = Enum.filter(members, &(&1.role == "admin"))
+
+      length(members) == 1 or
+        (length(admins) == 1 and hd(admins).user_id == user.id)
+    end)
+    |> Enum.sort_by(& &1.name)
+  end
+
+  defp sole_owned_packages(user) do
+    owned = from(po in PackageOwner, where: po.user_id == ^user.id, select: po.package_id)
+
+    from(
+      p in Package,
+      join: po in PackageOwner,
+      on: po.package_id == p.id,
+      where: p.repository_id == 1 and p.id in subquery(owned),
+      group_by: p.id,
+      having: count(po.id) == 1,
+      order_by: p.name
+    )
+    |> Repo.all()
+  end
+
   def delete(user, audit: audit_data) do
     user = Repo.preload(user, :emails)
 

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -551,6 +551,7 @@ defmodule Hexpm.Accounts.Users do
       Multi.new()
       |> email_flag_multi(user, params, :primary, opts)
       |> Multi.delete_all(:reset, assoc(user, :password_resets))
+      |> Multi.delete_all(:account_deletion_requests, assoc(user, :account_deletion_requests))
 
     case Repo.transaction(multi) do
       {:ok, _} ->

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -149,6 +149,15 @@ defmodule Hexpm.Accounts.Users do
       |> Multi.insert(:reserved_username, %ReservedUsername{name: user.username},
         on_conflict: :nothing
       )
+      # Keys and OAuth tokens cascade when the user is deleted, but audit logs
+      # reference both them and the user with ON DELETE SET NULL. Deleting them
+      # in their own statements first keeps the cascade from hitting a foreign
+      # key trigger ordering issue that can otherwise fail the deletion.
+      |> Multi.delete_all(:keys, assoc(user, :keys))
+      |> Multi.delete_all(
+        :oauth_tokens,
+        from(t in Hexpm.OAuth.Token, where: t.user_id == ^user.id)
+      )
       |> Multi.delete(:user, user, stale_error_field: :id)
 
     case Repo.transaction(multi) do

--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -175,23 +175,29 @@ defmodule Hexpm.AdminTasks do
       iex> AdminTasks.remove_user("spammer", delete_packages: true)
       :ok
   """
-  @spec remove_user(String.t(), keyword()) :: :ok | {:error, atom()}
+  @spec remove_user(String.t(), keyword()) :: :ok | {:error, atom() | Ecto.Changeset.t()}
   def remove_user(username, opts \\ []) do
     with {:ok, user} <- find_user(username) do
       if Keyword.get(opts, :delete_packages, false) do
-        {:ok, deleted} =
-          Repo.transaction(fn ->
-            deleted = delete_sole_owned_packages(user)
-            Repo.delete!(user)
-            deleted
-          end)
+        Repo.transaction(fn ->
+          deleted = delete_sole_owned_packages(user)
 
-        Enum.each(deleted, &run_package_removal_side_effects/1)
+          case Users.delete(user, audit: AuditLogs.admin()) do
+            :ok -> deleted
+            {:error, reason} -> Repo.rollback(reason)
+          end
+        end)
+        |> case do
+          {:ok, deleted} ->
+            Enum.each(deleted, &run_package_removal_side_effects/1)
+            :ok
+
+          {:error, reason} ->
+            {:error, reason}
+        end
       else
-        Repo.delete!(user)
+        Users.delete(user, audit: AuditLogs.admin())
       end
-
-      :ok
     end
   end
 

--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -182,7 +182,7 @@ defmodule Hexpm.AdminTasks do
         Repo.transaction(fn ->
           deleted = delete_sole_owned_packages(user)
 
-          case Users.delete(user, audit: AuditLogs.admin()) do
+          case Users.delete(user, audit: AuditLogs.admin(), notify: false) do
             :ok -> deleted
             {:error, reason} -> Repo.rollback(reason)
           end
@@ -196,7 +196,7 @@ defmodule Hexpm.AdminTasks do
             {:error, reason}
         end
       else
-        Users.delete(user, audit: AuditLogs.admin())
+        Users.delete(user, audit: AuditLogs.admin(), notify: false)
       end
     end
   end

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -48,6 +48,15 @@ defmodule Hexpm.Emails do
     |> render_body(:security_password_reset)
   end
 
+  def account_deletion_request(user, request) do
+    base_email()
+    |> email_to(user)
+    |> subject("Hex.pm - Account deletion request")
+    |> assign(:username, user.username)
+    |> assign(:key, request.key)
+    |> render_body(:account_deletion_request)
+  end
+
   def account_deleted(user) do
     base_email()
     |> email_to(user)

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -48,6 +48,14 @@ defmodule Hexpm.Emails do
     |> render_body(:security_password_reset)
   end
 
+  def account_deleted(user) do
+    base_email()
+    |> email_to(user)
+    |> subject("Hex.pm - Your account has been deleted")
+    |> assign(:username, user.username)
+    |> render_body(:account_deleted)
+  end
+
   def password_changed(user) do
     base_email()
     |> email_to(user)

--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -122,7 +122,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
         repo,
         Hexpm.Accounts.AccountDeletionRequest,
         from(r in Hexpm.Accounts.AccountDeletionRequest,
-          where: r.inserted_at < fragment("NOW() - make_interval(days => ?)", @retention_days)
+          where: r.inserted_at < ago(@retention_days, "day")
         ),
         batch_size
       )

--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -23,6 +23,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
       purge_user_sessions(repo, batch_size)
       purge_plug_sessions(repo, batch_size)
       purge_password_resets(repo, batch_size)
+      purge_account_deletion_requests(repo, batch_size)
       purge_keys(repo, batch_size)
     end)
   end
@@ -113,6 +114,20 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
       )
 
     Logger.info("[task] Purged #{count} expired password resets")
+  end
+
+  defp purge_account_deletion_requests(repo, batch_size) do
+    count =
+      delete_in_batches(
+        repo,
+        Hexpm.Accounts.AccountDeletionRequest,
+        from(r in Hexpm.Accounts.AccountDeletionRequest,
+          where: r.inserted_at < fragment("NOW() - make_interval(days => ?)", @retention_days)
+        ),
+        batch_size
+      )
+
+    Logger.info("[task] Purged #{count} expired account deletion requests")
   end
 
   defp purge_keys(repo, batch_size) do

--- a/lib/hexpm/shared.ex
+++ b/lib/hexpm/shared.ex
@@ -13,6 +13,7 @@ defmodule Hexpm.Shared do
         Accounts.Organizations,
         Accounts.OrganizationUser,
         Accounts.PasswordReset,
+        Accounts.ReservedUsername,
         Accounts.Session,
         Accounts.User,
         Accounts.UserHandles,

--- a/lib/hexpm/shared.ex
+++ b/lib/hexpm/shared.ex
@@ -2,6 +2,7 @@ defmodule Hexpm.Shared do
   defmacro __using__(_opts) do
     quote do
       alias Hexpm.{
+        Accounts.AccountDeletionRequest,
         Accounts.AuditLog,
         Accounts.AuditLogs,
         Accounts.Auth,

--- a/lib/hexpm_web/captcha.ex
+++ b/lib/hexpm_web/captcha.ex
@@ -8,25 +8,29 @@ defmodule HexpmWeb.Captcha do
     sitekey() != nil
   end
 
-  def verify(token) when is_binary(token) do
+  def verify(token) do
     if enabled?() do
-      headers = [{"content-type", "application/x-www-form-urlencoded"}]
-      params = %{response: token, secret: secret()}
-
-      case HTTP.impl().post(@verify_endpoint, headers, params) do
-        {:ok, 200, _headers, %{"success" => success}} ->
-          success
-
-        {:error, reason} ->
-          Logger.error("hcaptcha request failed: #{inspect(reason)}")
-          false
-      end
+      verify_token(token)
     else
       true
     end
   end
 
-  def verify(_token), do: false
+  defp verify_token(token) when is_binary(token) do
+    headers = [{"content-type", "application/x-www-form-urlencoded"}]
+    params = %{response: token, secret: secret()}
+
+    case HTTP.impl().post(@verify_endpoint, headers, params) do
+      {:ok, 200, _headers, %{"success" => success}} ->
+        success
+
+      {:error, reason} ->
+        Logger.error("hcaptcha request failed: #{inspect(reason)}")
+        false
+    end
+  end
+
+  defp verify_token(_token), do: false
 
   def sitekey() do
     Application.get_env(:hexpm, :hcaptcha, [])[:sitekey]

--- a/lib/hexpm_web/controllers/auth_controller.ex
+++ b/lib/hexpm_web/controllers/auth_controller.ex
@@ -274,6 +274,7 @@ defmodule HexpmWeb.AuthController do
       conn
       |> HexpmWeb.Plugs.Sudo.set_sudo_authenticated()
       |> delete_session("sudo_return_to")
+      |> delete_session("sudo_force")
       |> redirect(to: return_to)
     else
       conn

--- a/lib/hexpm_web/controllers/dashboard/delete_account_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/delete_account_controller.ex
@@ -1,0 +1,100 @@
+defmodule HexpmWeb.Dashboard.DeleteAccountController do
+  use HexpmWeb, :controller
+
+  alias HexpmWeb.Plugs.Attack
+
+  plug :requires_login
+  plug HexpmWeb.Plugs.Sudo, force: true
+
+  def show(conn, _params) do
+    render_show(conn)
+  end
+
+  def create(conn, params) do
+    user = conn.assigns.current_user
+
+    cond do
+      params["username"] != user.username ->
+        conn
+        |> put_flash(:error, "Entered username does not match your username.")
+        |> redirect(to: ~p"/dashboard/delete-account")
+
+      match?({:block, _}, Attack.account_delete_request_throttle(user.id)) ->
+        conn
+        |> put_flash(:error, "Too many deletion requests. Please try again later.")
+        |> redirect(to: ~p"/dashboard/delete-account")
+
+      true ->
+        case Users.delete_request(user, audit: audit_data(conn)) do
+          :ok ->
+            conn
+            |> put_flash(
+              :info,
+              "A confirmation link has been sent to #{User.email(user, :primary)}. " <>
+                "It is valid for 24 hours."
+            )
+            |> redirect(to: ~p"/dashboard/delete-account")
+
+          {:error, _reason} ->
+            conn
+            |> put_flash(:error, "Your account cannot be deleted right now.")
+            |> redirect(to: ~p"/dashboard/delete-account")
+        end
+    end
+  end
+
+  def confirm(conn, params) do
+    user = conn.assigns.current_user
+
+    with request when not is_nil(request) <- Users.get_delete_request(user, params["key"]),
+         {:ok, warnings} <- Users.delete_eligibility(user) do
+      render(conn, "confirm.html",
+        title: "Confirm account deletion",
+        container: "container page dashboard",
+        key: request.key,
+        warnings: warnings
+      )
+    else
+      nil ->
+        conn
+        |> put_flash(:error, "This account deletion link is invalid or has expired.")
+        |> redirect(to: ~p"/dashboard/delete-account")
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "Your account cannot be deleted right now.")
+        |> redirect(to: ~p"/dashboard/delete-account")
+    end
+  end
+
+  def confirm_delete(conn, params) do
+    user = conn.assigns.current_user
+
+    case Users.delete_confirm(user, params["key"] || "", audit: audit_data(conn)) do
+      :ok ->
+        conn
+        |> clear_session()
+        |> configure_session(renew: true)
+        |> put_flash(:info, "Your account has been permanently deleted.")
+        |> redirect(to: ~p"/")
+
+      {:error, :invalid_request} ->
+        conn
+        |> put_flash(:error, "This account deletion link is invalid or has expired.")
+        |> redirect(to: ~p"/dashboard/delete-account")
+
+      {:error, _reason} ->
+        conn
+        |> put_flash(:error, "Your account cannot be deleted right now.")
+        |> redirect(to: ~p"/dashboard/delete-account")
+    end
+  end
+
+  defp render_show(conn) do
+    render(conn, "show.html",
+      title: "Delete account",
+      container: "container page dashboard",
+      eligibility: Users.delete_eligibility(conn.assigns.current_user)
+    )
+  end
+end

--- a/lib/hexpm_web/controllers/dashboard/delete_account_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/delete_account_controller.ex
@@ -70,6 +70,16 @@ defmodule HexpmWeb.Dashboard.DeleteAccountController do
   def confirm_delete(conn, params) do
     user = conn.assigns.current_user
 
+    if params["username"] != user.username do
+      conn
+      |> put_flash(:error, "Entered username does not match your username.")
+      |> redirect(to: ~p"/dashboard/delete-account/confirm?key=#{params["key"] || ""}")
+    else
+      do_confirm_delete(conn, user, params)
+    end
+  end
+
+  defp do_confirm_delete(conn, user, params) do
     case Users.delete_confirm(user, params["key"] || "", audit: audit_data(conn)) do
       :ok ->
         conn

--- a/lib/hexpm_web/controllers/signup_controller.ex
+++ b/lib/hexpm_web/controllers/signup_controller.ex
@@ -6,20 +6,21 @@ defmodule HexpmWeb.SignupController do
       path = ~p"/users/#{conn.assigns.current_user}"
       redirect(conn, to: path)
     else
-      # Initialize with one empty email record so inputs_for can render the fields
-      changeset = User.build(%{"emails" => [%{"email" => "", "email_confirmation" => ""}]})
+      changeset = User.build(signup_params(%{}))
       render_show(conn, changeset)
     end
   end
 
   def create(conn, params) do
+    user_params = signup_params(params["user"])
+
     cond do
       logged_in?(conn) ->
         path = ~p"/users/#{conn.assigns.current_user}"
         redirect(conn, to: path)
 
       HexpmWeb.Captcha.verify(params["h-captcha-response"]) ->
-        case Users.add(params["user"], audit: audit_data(conn)) do
+        case Users.add(user_params, audit: audit_data(conn)) do
           {:ok, _user} ->
             flash =
               "A confirmation email has been sent, " <>
@@ -37,7 +38,7 @@ defmodule HexpmWeb.SignupController do
         end
 
       true ->
-        changeset = %{User.build(sanitize_params(params["user"])) | action: :insert}
+        changeset = %{User.build(sanitize_params(user_params)) | action: :insert}
 
         conn
         |> put_status(400)
@@ -55,4 +56,25 @@ defmodule HexpmWeb.SignupController do
       captcha_error: captcha_error
     )
   end
+
+  defp signup_params(params) when is_map(params) do
+    Map.put(params, "emails", normalize_email_params(params["emails"]))
+  end
+
+  defp signup_params(_params), do: %{"emails" => empty_email_params()}
+
+  defp normalize_email_params(%{} = emails) do
+    emails
+    |> Enum.sort_by(fn {index, _email_params} -> index end)
+    |> Enum.map(fn {_index, email_params} -> email_params end)
+    |> ensure_email_params()
+  end
+
+  defp normalize_email_params(emails) when is_list(emails), do: ensure_email_params(emails)
+  defp normalize_email_params(_emails), do: empty_email_params()
+
+  defp ensure_email_params([]), do: empty_email_params()
+  defp ensure_email_params(emails), do: emails
+
+  defp empty_email_params, do: [%{"email" => "", "email_confirmation" => ""}]
 end

--- a/lib/hexpm_web/controllers/signup_controller.ex
+++ b/lib/hexpm_web/controllers/signup_controller.ex
@@ -65,7 +65,7 @@ defmodule HexpmWeb.SignupController do
 
   defp normalize_email_params(%{} = emails) do
     emails
-    |> Enum.sort_by(fn {index, _email_params} -> index end)
+    |> Enum.sort_by(fn {index, _email_params} -> String.to_integer(index) end)
     |> Enum.map(fn {_index, email_params} -> email_params end)
     |> ensure_email_params()
   end

--- a/lib/hexpm_web/controllers/sudo_controller.ex
+++ b/lib/hexpm_web/controllers/sudo_controller.ex
@@ -9,7 +9,7 @@ defmodule HexpmWeb.SudoController do
 
   @spec show(Plug.Conn.t(), map()) :: Plug.Conn.t()
   def show(conn, _params) do
-    if Sudo.sudo_active?(conn) do
+    if Sudo.sudo_active?(conn) and !get_session(conn, "sudo_force") do
       return_to = get_session(conn, "sudo_return_to") || ~p"/dashboard/security"
 
       conn
@@ -190,6 +190,7 @@ defmodule HexpmWeb.SudoController do
     conn
     |> Sudo.set_sudo_authenticated()
     |> delete_session("sudo_return_to")
+    |> delete_session("sudo_force")
     |> redirect(to: return_to)
   end
 

--- a/lib/hexpm_web/plugs/attack.ex
+++ b/lib/hexpm_web/plugs/attack.ex
@@ -223,6 +223,20 @@ defmodule HexpmWeb.Plugs.Attack do
     )
   end
 
+  @spec account_delete_request_throttle(integer(), keyword()) ::
+          {:allow | :block, {:throttle, keyword()}}
+  def account_delete_request_throttle(user_id, opts \\ []) do
+    time = opts[:time] || System.system_time(:millisecond)
+
+    timed_throttle(
+      {:account_delete_request, user_id},
+      time: time,
+      storage: @storage,
+      limit: 3,
+      period: 60 * 60_000
+    )
+  end
+
   @spec sudo_password_throttle(integer(), keyword()) :: {:allow | :block, {:throttle, keyword()}}
   def sudo_password_throttle(user_id, opts \\ []) do
     time = opts[:time] || System.system_time(:millisecond)

--- a/lib/hexpm_web/plugs/sudo.ex
+++ b/lib/hexpm_web/plugs/sudo.ex
@@ -12,8 +12,13 @@ defmodule HexpmWeb.Plugs.Sudo do
   sudo or a valid form token, so form submissions work even if sudo expires
   between page load and form submit.
 
+  Pass `force: true` to require a fresh authentication (`:hexpm, :sudo_force_timeout`)
+  regardless of the rolling sudo window — used for destructive pages like account
+  deletion. The signed form token still covers non-GET submissions.
+
   Usage in controllers:
       plug HexpmWeb.Plugs.Sudo
+      plug HexpmWeb.Plugs.Sudo, force: true
   """
 
   use HexpmWeb, :verified_routes
@@ -29,9 +34,11 @@ defmodule HexpmWeb.Plugs.Sudo do
   def init(opts), do: opts
 
   @impl Plug
-  def call(conn, _opts) do
+  def call(conn, opts) do
+    force? = Keyword.get(opts, :force, false)
+
     cond do
-      sudo_active?(conn) ->
+      sudo_satisfied?(conn, force?) ->
         conn
 
       conn.method != "GET" and valid_form_token?(conn) ->
@@ -44,10 +51,19 @@ defmodule HexpmWeb.Plugs.Sudo do
           end
 
         conn
+        |> put_force_flag(force?)
         |> redirect_to_sudo(return_to)
         |> halt()
     end
   end
+
+  @spec sudo_satisfied?(Plug.Conn.t(), boolean()) :: boolean()
+  defp sudo_satisfied?(conn, false), do: sudo_active?(conn)
+  defp sudo_satisfied?(conn, true), do: sudo_fresh?(conn)
+
+  @spec put_force_flag(Plug.Conn.t(), boolean()) :: Plug.Conn.t()
+  defp put_force_flag(conn, true), do: put_session(conn, "sudo_force", true)
+  defp put_force_flag(conn, false), do: conn
 
   @doc """
   Redirects to the sudo verification page with a return URL.
@@ -80,6 +96,16 @@ defmodule HexpmWeb.Plugs.Sudo do
 
   @spec sudo_active?(Plug.Conn.t()) :: boolean()
   def sudo_active?(conn) do
+    authenticated_within?(conn, sudo_timeout())
+  end
+
+  @spec sudo_fresh?(Plug.Conn.t()) :: boolean()
+  def sudo_fresh?(conn) do
+    authenticated_within?(conn, sudo_force_timeout())
+  end
+
+  @spec authenticated_within?(Plug.Conn.t(), Duration.t()) :: boolean()
+  defp authenticated_within?(conn, duration) do
     case get_session(conn, "sudo_authenticated_at") do
       nil ->
         false
@@ -87,7 +113,7 @@ defmodule HexpmWeb.Plugs.Sudo do
       timestamp_string ->
         case NaiveDateTime.from_iso8601(timestamp_string) do
           {:ok, authenticated_at} ->
-            expires_at = NaiveDateTime.shift(authenticated_at, sudo_timeout())
+            expires_at = NaiveDateTime.shift(authenticated_at, duration)
             NaiveDateTime.compare(NaiveDateTime.utc_now(), expires_at) == :lt
 
           _ ->
@@ -99,6 +125,11 @@ defmodule HexpmWeb.Plugs.Sudo do
   @spec sudo_timeout() :: Duration.t()
   defp sudo_timeout do
     Application.fetch_env!(:hexpm, :sudo_timeout)
+  end
+
+  @spec sudo_force_timeout() :: Duration.t()
+  defp sudo_force_timeout do
+    Application.fetch_env!(:hexpm, :sudo_force_timeout)
   end
 
   @spec set_sudo_authenticated(Plug.Conn.t()) :: Plug.Conn.t()

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -302,6 +302,11 @@ defmodule HexpmWeb.Router do
     delete "/sessions", SessionController, :delete
 
     get "/audit-logs", AuditLogController, :index
+
+    get "/delete-account", DeleteAccountController, :show
+    post "/delete-account", DeleteAccountController, :create
+    get "/delete-account/confirm", DeleteAccountController, :confirm
+    post "/delete-account/confirm", DeleteAccountController, :confirm_delete
   end
 
   scope "/dashboard", HexpmWeb.Dashboard do

--- a/lib/hexpm_web/templates/dashboard/audit_log/components/audit_log_card.ex
+++ b/lib/hexpm_web/templates/dashboard/audit_log/components/audit_log_card.ex
@@ -465,6 +465,14 @@ defmodule HexpmWeb.Dashboard.AuditLog.Components.AuditLogCard do
     "Disconnected #{provider} account"
   end
 
+  defp humanize_action(%AuditLog{action: "user.delete.request"}) do
+    "Requested account deletion"
+  end
+
+  defp humanize_action(%AuditLog{action: "user.delete"}) do
+    "Deleted user account"
+  end
+
   defp humanize_action(%AuditLog{action: action}) do
     action
     |> String.replace(".", " ")

--- a/lib/hexpm_web/templates/dashboard/delete_account/confirm.html.heex
+++ b/lib/hexpm_web/templates/dashboard/delete_account/confirm.html.heex
@@ -35,9 +35,25 @@
             id="confirm-delete-account-form"
           >
             <input type="hidden" name="key" value={@key} />
-            <.button type="submit" variant="danger">
-              Delete my account
-            </.button>
+            <label
+              for="confirm-delete-account-username"
+              class="block text-grey-700 dark:text-grey-200 mb-2"
+            >
+              Type your username <strong>{@current_user.username}</strong> to confirm:
+            </label>
+            <.text_input
+              id="confirm-delete-account-username"
+              name="username"
+              autocomplete="off"
+              required
+              pattern={username_pattern(@current_user.username)}
+              title={"Please type '#{@current_user.username}' to confirm"}
+            />
+            <div class="mt-6">
+              <.button type="submit" variant="danger">
+                Delete my account
+              </.button>
+            </div>
           </.sudo_form>
         </div>
       </div>

--- a/lib/hexpm_web/templates/dashboard/delete_account/confirm.html.heex
+++ b/lib/hexpm_web/templates/dashboard/delete_account/confirm.html.heex
@@ -1,0 +1,46 @@
+<div class="bg-grey-50 dark:bg-grey-950 min-h-screen py-4 sm:py-8">
+  <div class="max-w-7xl mx-auto px-4">
+    <div class="flex flex-col gap-4 sm:gap-8 lg:flex-row">
+      <%!-- Left Sidebar --%>
+      <div class="w-full lg:w-64 flex-shrink-0">
+        {render(HexpmWeb.DashboardView, "_sidebar.html", assigns)}
+      </div>
+
+      <%!-- Right Content - Single White Card --%>
+      <div class="flex-1 min-w-0">
+        <div class="bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-4 sm:p-8">
+          <h2 class="text-grey-900 dark:text-white text-xl font-semibold mb-8">
+            Confirm account deletion
+          </h2>
+
+          <p class="text-grey-700 dark:text-grey-200 mb-4">
+            This is the final step. Deleting the account <strong>{@current_user.username}</strong>
+            is permanent and cannot be undone.
+          </p>
+
+          <%= if @warnings.sole_owned_packages != [] do %>
+            <p class="text-grey-700 dark:text-grey-200 mb-2 font-semibold">
+              These packages will be left without an owner:
+            </p>
+            <ul class="list-disc pl-6 mb-4 text-grey-700 dark:text-grey-200">
+              <%= for package <- @warnings.sole_owned_packages do %>
+                <li>{package.name}</li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <.sudo_form
+            current_user={@current_user}
+            action={~p"/dashboard/delete-account/confirm"}
+            id="confirm-delete-account-form"
+          >
+            <input type="hidden" name="key" value={@key} />
+            <.button type="submit" variant="danger">
+              Delete my account
+            </.button>
+          </.sudo_form>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/hexpm_web/templates/dashboard/delete_account/show.html.heex
+++ b/lib/hexpm_web/templates/dashboard/delete_account/show.html.heex
@@ -1,0 +1,81 @@
+<div class="bg-grey-50 dark:bg-grey-950 min-h-screen py-4 sm:py-8">
+  <div class="max-w-7xl mx-auto px-4">
+    <div class="flex flex-col gap-4 sm:gap-8 lg:flex-row">
+      <%!-- Left Sidebar --%>
+      <div class="w-full lg:w-64 flex-shrink-0">
+        {render(HexpmWeb.DashboardView, "_sidebar.html", assigns)}
+      </div>
+
+      <%!-- Right Content - Single White Card --%>
+      <div class="flex-1 min-w-0">
+        <div class="bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-4 sm:p-8">
+          <h2 class="text-grey-900 dark:text-white text-xl font-semibold mb-8">
+            Delete account
+          </h2>
+
+          <%= case @eligibility do %>
+            <% {:error, :organization_account} -> %>
+              <p class="text-grey-700 dark:text-grey-200 mb-4">
+                Organization accounts cannot be deleted from the dashboard.
+              </p>
+            <% {:error, {:organizations, organizations}} -> %>
+              <p class="text-grey-700 dark:text-grey-200 mb-4">
+                Your account cannot be deleted because you are the last admin or only
+                member of the following organizations. Promote another admin, leave the
+                organization, or contact support to dissolve it first.
+              </p>
+              <ul class="list-disc pl-6 mb-4 text-grey-700 dark:text-grey-200">
+                <%= for organization <- organizations do %>
+                  <li>{organization.name}</li>
+                <% end %>
+              </ul>
+            <% {:ok, warnings} -> %>
+              <p class="text-grey-700 dark:text-grey-200 mb-4">
+                Deleting your account is permanent. Your username will be retired and can
+                never be registered again. Packages and versions you published stay
+                available, and your activity log is preserved without your account
+                attached to it.
+              </p>
+
+              <%= if warnings.sole_owned_packages != [] do %>
+                <p class="text-grey-700 dark:text-grey-200 mb-2 font-semibold">
+                  You are the only owner of the following packages. After deletion they
+                  will have no owner; new owners can only be assigned by the Hex team.
+                  Consider transferring ownership first.
+                </p>
+                <ul class="list-disc pl-6 mb-4 text-grey-700 dark:text-grey-200">
+                  <%= for package <- warnings.sole_owned_packages do %>
+                    <li>{package.name}</li>
+                  <% end %>
+                </ul>
+              <% end %>
+
+              <.sudo_form
+                current_user={@current_user}
+                action={~p"/dashboard/delete-account"}
+                id="delete-account-form"
+              >
+                <label
+                  for="delete-account-username"
+                  class="block text-grey-700 dark:text-grey-200 mb-2"
+                >
+                  Type your username <strong>{@current_user.username}</strong> to confirm:
+                </label>
+                <.text_input
+                  id="delete-account-username"
+                  name="username"
+                  autocomplete="off"
+                  required
+                  pattern={@current_user.username}
+                  title={"Please type '#{@current_user.username}' to confirm"}
+                />
+                <.button type="submit" variant="danger">
+                  Request account deletion
+                </.button>
+              </.sudo_form>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/lib/hexpm_web/templates/dashboard/delete_account/show.html.heex
+++ b/lib/hexpm_web/templates/dashboard/delete_account/show.html.heex
@@ -31,10 +31,12 @@
               </ul>
             <% {:ok, warnings} -> %>
               <p class="text-grey-700 dark:text-grey-200 mb-4">
-                Deleting your account is permanent. Your username will be retired and can
-                never be registered again. Packages and versions you published stay
-                available, and your activity log is preserved without your account
-                attached to it.
+                Deleting your account is permanent. You will lose access to all resources
+                associated with your account, and you will no longer be able to publish
+                packages. Packages and versions you published stay available, and packages
+                left without an owner may be claimed by someone else in the future. Your
+                username will be retired and can never be registered again, and your
+                activity log is preserved without your account attached to it.
               </p>
 
               <%= if warnings.sole_owned_packages != [] do %>
@@ -69,9 +71,11 @@
                   pattern={@current_user.username}
                   title={"Please type '#{@current_user.username}' to confirm"}
                 />
-                <.button type="submit" variant="danger">
-                  Request account deletion
-                </.button>
+                <div class="mt-6">
+                  <.button type="submit" variant="danger">
+                    Request account deletion
+                  </.button>
+                </div>
               </.sudo_form>
           <% end %>
         </div>

--- a/lib/hexpm_web/templates/dashboard/delete_account/show.html.heex
+++ b/lib/hexpm_web/templates/dashboard/delete_account/show.html.heex
@@ -68,7 +68,7 @@
                   name="username"
                   autocomplete="off"
                   required
-                  pattern={@current_user.username}
+                  pattern={username_pattern(@current_user.username)}
                   title={"Please type '#{@current_user.username}' to confirm"}
                 />
                 <div class="mt-6">

--- a/lib/hexpm_web/templates/email/account_deleted.html.eex
+++ b/lib/hexpm_web/templates/email/account_deleted.html.eex
@@ -1,0 +1,7 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  <%= AccountDeleted.title() %>
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= AccountDeleted.message(@username) %>
+</p>

--- a/lib/hexpm_web/templates/email/account_deleted.text.eex
+++ b/lib/hexpm_web/templates/email/account_deleted.text.eex
@@ -1,0 +1,3 @@
+<%= AccountDeleted.title() %>
+
+<%= AccountDeleted.message(@username) %>

--- a/lib/hexpm_web/templates/email/account_deletion_request.html.eex
+++ b/lib/hexpm_web/templates/email/account_deletion_request.html.eex
@@ -1,0 +1,19 @@
+<%
+confirm_url = url(~p"/dashboard/delete-account/confirm?key=#{@key}")
+%>
+
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  <%= AccountDeletionRequest.title() %>
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= AccountDeletionRequest.message(@username) %>
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <a href="<%= confirm_url %>" style="color: #0f59d8; text-decoration: none; word-break: break-all;"><%= confirm_url %></a>
+</p>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= AccountDeletionRequest.warning() %>
+</p>

--- a/lib/hexpm_web/templates/email/account_deletion_request.text.eex
+++ b/lib/hexpm_web/templates/email/account_deletion_request.text.eex
@@ -1,0 +1,10 @@
+<%
+confirm_url = url(~p"/dashboard/delete-account/confirm?key=#{@key}")
+%>
+<%= AccountDeletionRequest.title() %>
+
+<%= AccountDeletionRequest.message(@username) %>
+
+<%= confirm_url %>
+
+<%= AccountDeletionRequest.warning() %>

--- a/lib/hexpm_web/views/dashboard/delete_account_view.ex
+++ b/lib/hexpm_web/views/dashboard/delete_account_view.ex
@@ -4,4 +4,8 @@ defmodule HexpmWeb.Dashboard.DeleteAccountView do
   import HexpmWeb.Components.Buttons, only: [button: 1]
   import HexpmWeb.Components.Form, only: [sudo_form: 1]
   import HexpmWeb.Components.Input, only: [text_input: 1]
+
+  def username_pattern(username) do
+    String.replace(username, ".", "\\.")
+  end
 end

--- a/lib/hexpm_web/views/dashboard/delete_account_view.ex
+++ b/lib/hexpm_web/views/dashboard/delete_account_view.ex
@@ -1,0 +1,7 @@
+defmodule HexpmWeb.Dashboard.DeleteAccountView do
+  use HexpmWeb, :view
+
+  import HexpmWeb.Components.Buttons, only: [button: 1]
+  import HexpmWeb.Components.Form, only: [sudo_form: 1]
+  import HexpmWeb.Components.Input, only: [text_input: 1]
+end

--- a/lib/hexpm_web/views/dashboard_view.ex
+++ b/lib/hexpm_web/views/dashboard_view.ex
@@ -24,7 +24,8 @@ defmodule HexpmWeb.DashboardView do
       email: {"Emails", ~p"/dashboard/email"},
       keys: {"Keys", ~p"/dashboard/keys"},
       sessions: {"Sessions", ~p"/dashboard/sessions"},
-      audit_logs: {"Recent Activities", ~p"/dashboard/audit-logs"}
+      audit_logs: {"Recent Activities", ~p"/dashboard/audit-logs"},
+      delete_account: {"Delete account", ~p"/dashboard/delete-account"}
     ]
   end
 
@@ -56,6 +57,11 @@ defmodule HexpmWeb.DashboardView do
   defp icon_for_setting(:audit_logs, selected?) do
     color = if selected?, do: "text-purple-600", else: "text-grey-600"
     icon(:heroicon, "clock", class: "w-5 h-5 #{color}")
+  end
+
+  defp icon_for_setting(:delete_account, selected?) do
+    color = if selected?, do: "text-purple-600", else: "text-grey-600"
+    icon(:heroicon, "trash", class: "w-5 h-5 #{color}")
   end
 
   defp selected_setting(conn, id) do

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -45,6 +45,18 @@ defmodule HexpmWeb.EmailView do
     end
   end
 
+  defmodule AccountDeleted do
+    def title() do
+      "Your account has been deleted"
+    end
+
+    def message(username) do
+      "The Hex.pm account \"#{username}\" has been permanently deleted. " <>
+        "The username has been retired and cannot be registered again. " <>
+        "Packages and versions you published remain available to the community."
+    end
+  end
+
   defmodule BuildTools do
     def mix_hex_user_auth(), do: "mix hex.user auth"
     def rebar3_hex_user_auth(), do: "rebar3 hex user auth"

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -45,6 +45,23 @@ defmodule HexpmWeb.EmailView do
     end
   end
 
+  defmodule AccountDeletionRequest do
+    def title() do
+      "Confirm account deletion"
+    end
+
+    def message(username) do
+      "We received a request to permanently delete the Hex.pm account \"#{username}\". " <>
+        "To proceed, open the link below while logged in and confirm the deletion. " <>
+        "The link is valid for 24 hours and can only be used once."
+    end
+
+    def warning() do
+      "If you did not request this, change your password immediately. " <>
+        "Changing your password cancels this deletion request."
+    end
+  end
+
   defmodule AccountDeleted do
     def title() do
       "Your account has been deleted"

--- a/priv/repo/migrations/20260611000001_add_account_deletion.exs
+++ b/priv/repo/migrations/20260611000001_add_account_deletion.exs
@@ -1,0 +1,23 @@
+defmodule Hexpm.Repo.Migrations.AddAccountDeletion do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists table(:reserved_usernames) do
+      add :name, :string, null: false
+      timestamps(updated_at: false)
+    end
+
+    create_if_not_exists(
+      unique_index(:reserved_usernames, ["(lower(name))"], name: "reserved_usernames_name_idx")
+    )
+
+    create_if_not_exists table(:account_deletion_requests) do
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :key, :string, null: false
+      add :primary_email, :string, null: false
+      timestamps(updated_at: false)
+    end
+
+    create_if_not_exists(unique_index(:account_deletion_requests, [:user_id]))
+  end
+end

--- a/test/hexpm/accounts/organizations_test.exs
+++ b/test/hexpm/accounts/organizations_test.exs
@@ -31,6 +31,18 @@ defmodule Hexpm.Accounts.OrganizationsTest do
     end
   end
 
+  describe "create/3 with reserved username" do
+    test "rejects an organization name in reserved_usernames" do
+      Repo.insert!(%Hexpm.Accounts.ReservedUsername{name: "graveyard"})
+      user = insert(:user)
+
+      assert {:error, changeset} =
+               Organizations.create(user, %{"name" => "graveyard"}, audit: audit_data(user))
+
+      assert %{username: "has already been taken"} = errors_on(changeset)
+    end
+  end
+
   describe "remove_member/3" do
     test "cannot remove last member" do
       user = insert(:user)

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -301,6 +301,78 @@ defmodule Hexpm.Accounts.UsersTest do
     end
   end
 
+  describe "delete_eligibility/1" do
+    test "ok with no warnings for a plain user" do
+      user = insert(:user)
+      assert {:ok, %{sole_owned_packages: []}} = Users.delete_eligibility(user)
+    end
+
+    test "warns about packages where the user is the sole owner" do
+      user = insert(:user)
+      other = insert(:user)
+
+      sole = insert(:package, package_owners: [build(:package_owner, user: user)])
+
+      _co =
+        insert(:package,
+          package_owners: [
+            build(:package_owner, user: user),
+            build(:package_owner, user: other)
+          ]
+        )
+
+      assert {:ok, %{sole_owned_packages: [package]}} = Users.delete_eligibility(user)
+      assert package.id == sole.id
+    end
+
+    test "blocks the last member of an organization" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_user, user: user, organization: organization, role: "admin")
+
+      assert {:error, {:organizations, [blocked]}} = Users.delete_eligibility(user)
+      assert blocked.id == organization.id
+    end
+
+    test "blocks the last admin even when other members exist" do
+      user = insert(:user)
+      other = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_user, user: user, organization: organization, role: "admin")
+      insert(:organization_user, user: other, organization: organization, role: "write")
+
+      assert {:error, {:organizations, [blocked]}} = Users.delete_eligibility(user)
+      assert blocked.id == organization.id
+    end
+
+    test "allows a non-last admin" do
+      user = insert(:user)
+      other = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_user, user: user, organization: organization, role: "admin")
+      insert(:organization_user, user: other, organization: organization, role: "admin")
+
+      assert {:ok, _} = Users.delete_eligibility(user)
+    end
+
+    test "blocks organization service accounts" do
+      organization = insert(:organization)
+      assert {:error, :organization_account} = Users.delete_eligibility(organization.user)
+    end
+
+    test "does not warn about private repository packages" do
+      user = insert(:user)
+      repository = insert(:repository)
+
+      insert(:package,
+        repository_id: repository.id,
+        package_owners: [build(:package_owner, user: user)]
+      )
+
+      assert {:ok, %{sole_owned_packages: []}} = Users.delete_eligibility(user)
+    end
+  end
+
   describe "update_profile/3 when user is an organization" do
     test "updates full_name" do
       organization = insert(:organization, user: build(:user, full_name: "Old Full Name"))

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -285,6 +285,31 @@ defmodule Hexpm.Accounts.UsersTest do
       refute_email_sent()
     end
 
+    test "an audit log referencing the user's key does not block deletion" do
+      user = insert(:user)
+      key = insert(:key, user: user)
+
+      key_log =
+        insert(:audit_log,
+          user: user,
+          key: key,
+          action: "key.generate",
+          user_data: %{"id" => user.id, "username" => user.username},
+          key_data: %{"id" => key.id, "name" => key.name}
+        )
+
+      assert :ok = Users.delete(user, audit: audit_data(user))
+
+      refute Repo.get(User, user.id)
+      refute Repo.get(Hexpm.Accounts.Key, key.id)
+
+      # the key_id FK is ON DELETE SET NULL, so cascading the key deletion
+      # nulls the reference instead of restricting the user deletion
+      key_log_reloaded = Repo.get(AuditLog, key_log.id)
+      assert key_log_reloaded.key_id == nil
+      assert key_log_reloaded.key_data["name"] == key.name
+    end
+
     test "re-registering a deleted username fails" do
       user = insert(:user)
       username = user.username

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -1,7 +1,9 @@
 defmodule Hexpm.Accounts.UsersTest do
   use Hexpm.DataCase, async: true
 
-  alias Hexpm.Accounts.{OptionalEmails, User, Users, UserProviders}
+  import Swoosh.TestAssertions
+
+  alias Hexpm.Accounts.{AuditLog, OptionalEmails, User, Users, UserProviders}
 
   describe "add_from_oauth_with_provider/6" do
     test "creates user and provider atomically" do
@@ -198,6 +200,89 @@ defmodule Hexpm.Accounts.UsersTest do
 
       audit = %{user: nil, user_agent: "TEST", remote_ip: "127.0.0.1", auth_credential: nil}
 
+      assert {:error, changeset} = Users.add(params, audit: audit)
+      assert %{username: "has already been taken"} = errors_on(changeset)
+    end
+  end
+
+  describe "delete/2" do
+    test "deletes the user, preserves packages/releases/audit logs, reserves the username" do
+      user = insert(:user)
+      other_owner = insert(:user)
+
+      sole_package = insert(:package, package_owners: [build(:package_owner, user: user)])
+
+      co_package =
+        insert(:package,
+          package_owners: [
+            build(:package_owner, user: user),
+            build(:package_owner, user: other_owner)
+          ]
+        )
+
+      release = insert(:release, package: sole_package, publisher: user)
+      key = insert(:key, user: user)
+      session = insert(:session, user_id: user.id)
+
+      organization = insert(:organization)
+      org_user = insert(:organization_user, user: user, organization: organization)
+
+      old_log =
+        insert(:audit_log, user: user, action: "user.update", user_data: %{"id" => user.id})
+
+      email_ids = Enum.map(user.emails, & &1.id)
+      username = user.username
+
+      assert :ok = Users.delete(user, audit: audit_data(user))
+
+      # user row gone
+      refute Repo.get(User, user.id)
+
+      # packages and releases preserved, publisher nulled
+      assert Repo.get(Hexpm.Repository.Package, sole_package.id)
+      assert Repo.get(Hexpm.Repository.Package, co_package.id)
+      assert Repo.get(Hexpm.Repository.Release, release.id).publisher_id == nil
+
+      # ownership rows gone; the co-owned package keeps its other owner
+      sole_reloaded = Repo.get(Hexpm.Repository.Package, sole_package.id)
+      co_reloaded = Repo.get(Hexpm.Repository.Package, co_package.id)
+      assert Repo.all(Ecto.assoc(sole_reloaded, :package_owners)) == []
+      assert [%{user_id: other_id}] = Repo.all(Ecto.assoc(co_reloaded, :package_owners))
+      assert other_id == other_owner.id
+
+      # credentials and memberships gone
+      refute Repo.get(Hexpm.Accounts.Key, key.id)
+      refute Repo.get(Hexpm.UserSession, session.id)
+      refute Repo.get(Hexpm.Accounts.OrganizationUser, org_user.id)
+      for email_id <- email_ids, do: refute(Repo.get(Hexpm.Accounts.Email, email_id))
+
+      # audit logs preserved with snapshot; a user.delete log was written
+      assert Repo.get(AuditLog, old_log.id).user_id == nil
+
+      delete_log = Repo.get_by(AuditLog, action: "user.delete")
+      assert delete_log
+      assert delete_log.user_id == nil
+      assert delete_log.user_data["username"] == username
+      assert delete_log.params["username"] == username
+
+      # username reserved
+      assert Repo.exists?(Hexpm.Accounts.ReservedUsername.by_name(username))
+
+      # notice sent to the former primary email
+      assert_email_sent(subject: "Hex.pm - Your account has been deleted")
+    end
+
+    test "re-registering a deleted username fails" do
+      user = insert(:user)
+      username = user.username
+      assert :ok = Users.delete(user, audit: audit_data(user))
+
+      params = %{
+        "username" => username,
+        "emails" => [%{"email" => Hexpm.Fake.sequence(:email)}]
+      }
+
+      audit = %{user: nil, user_agent: "TEST", remote_ip: "127.0.0.1", auth_credential: nil}
       assert {:error, changeset} = Users.add(params, audit: audit)
       assert %{username: "has already been taken"} = errors_on(changeset)
     end

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -232,6 +232,7 @@ defmodule Hexpm.Accounts.UsersTest do
 
       email_ids = Enum.map(user.emails, & &1.id)
       username = user.username
+      primary_email = User.email(user, :primary)
 
       assert :ok = Users.delete(user, audit: audit_data(user))
 
@@ -269,7 +270,19 @@ defmodule Hexpm.Accounts.UsersTest do
       assert Repo.exists?(Hexpm.Accounts.ReservedUsername.by_name(username))
 
       # notice sent to the former primary email
-      assert_email_sent(subject: "Hex.pm - Your account has been deleted")
+      assert_email_sent(fn email ->
+        email.subject == "Hex.pm - Your account has been deleted" and
+          Enum.any?(email.to, fn {_name, address} -> address == primary_email end)
+      end)
+    end
+
+    test "deletes a user without a primary email and sends no email" do
+      user = insert(:user, emails: [])
+
+      assert :ok = Users.delete(user, audit: audit_data(user))
+
+      refute Repo.get(User, user.id)
+      refute_email_sent()
     end
 
     test "re-registering a deleted username fails" do

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -173,6 +173,36 @@ defmodule Hexpm.Accounts.UsersTest do
     assert %{optional_emails: _} = errors_on(changeset)
   end
 
+  describe "add/2 with reserved username" do
+    test "rejects a username in reserved_usernames" do
+      Repo.insert!(%Hexpm.Accounts.ReservedUsername{name: "graveyard"})
+
+      params = %{
+        "username" => "graveyard",
+        "emails" => [%{"email" => Hexpm.Fake.sequence(:email)}]
+      }
+
+      audit = %{user: nil, user_agent: "TEST", remote_ip: "127.0.0.1", auth_credential: nil}
+
+      assert {:error, changeset} = Users.add(params, audit: audit)
+      assert %{username: "has already been taken"} = errors_on(changeset)
+    end
+
+    test "comparison is case-insensitive" do
+      Repo.insert!(%Hexpm.Accounts.ReservedUsername{name: "GraveYard"})
+
+      params = %{
+        "username" => "graveyard",
+        "emails" => [%{"email" => Hexpm.Fake.sequence(:email)}]
+      }
+
+      audit = %{user: nil, user_agent: "TEST", remote_ip: "127.0.0.1", auth_credential: nil}
+
+      assert {:error, changeset} = Users.add(params, audit: audit)
+      assert %{username: "has already been taken"} = errors_on(changeset)
+    end
+  end
+
   describe "update_profile/3 when user is an organization" do
     test "updates full_name" do
       organization = insert(:organization, user: build(:user, full_name: "Old Full Name"))

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -285,9 +285,11 @@ defmodule Hexpm.Accounts.UsersTest do
       refute_email_sent()
     end
 
-    test "an audit log referencing the user's key does not block deletion" do
+    test "audit logs referencing the user's key and token do not block deletion" do
       user = insert(:user)
       key = insert(:key, user: user)
+      client = insert(:oauth_client)
+      token = insert(:oauth_token, user: user, client_id: client.client_id)
 
       key_log =
         insert(:audit_log,
@@ -298,16 +300,28 @@ defmodule Hexpm.Accounts.UsersTest do
           key_data: %{"id" => key.id, "name" => key.name}
         )
 
+      token_log =
+        insert(:audit_log,
+          user: user,
+          oauth_token: token,
+          action: "key.generate",
+          user_data: %{"id" => user.id, "username" => user.username}
+        )
+
       assert :ok = Users.delete(user, audit: audit_data(user))
 
       refute Repo.get(User, user.id)
       refute Repo.get(Hexpm.Accounts.Key, key.id)
+      refute Repo.get(Hexpm.OAuth.Token, token.id)
 
-      # the key_id FK is ON DELETE SET NULL, so cascading the key deletion
-      # nulls the reference instead of restricting the user deletion
+      # the references are ON DELETE SET NULL, so the audit logs survive with
+      # their snapshots and the foreign keys nulled
       key_log_reloaded = Repo.get(AuditLog, key_log.id)
       assert key_log_reloaded.key_id == nil
       assert key_log_reloaded.key_data["name"] == key.name
+
+      token_log_reloaded = Repo.get(AuditLog, token_log.id)
+      assert token_log_reloaded.oauth_token_id == nil
     end
 
     test "re-registering a deleted username fails" do

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -373,6 +373,162 @@ defmodule Hexpm.Accounts.UsersTest do
     end
   end
 
+  describe "delete_request/2 and delete_confirm/3" do
+    test "creates a request, emails the confirmation link, and confirm deletes the account" do
+      user = insert(:user)
+      username = user.username
+
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+
+      request = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+      user = Repo.preload(user, :emails)
+      assert_email_sent(Hexpm.Emails.account_deletion_request(user, request))
+
+      request_log = Repo.get_by(Hexpm.Accounts.AuditLog, action: "user.delete.request")
+      assert request_log.user_id == user.id
+
+      assert :ok = Users.delete_confirm(user, request.key, audit: audit_data(user))
+      refute Repo.get(User, user.id)
+      assert Repo.exists?(Hexpm.Accounts.ReservedUsername.by_name(username))
+      refute Repo.get(Hexpm.Accounts.AccountDeletionRequest, request.id)
+    end
+
+    test "a new request replaces the previous one" do
+      user = insert(:user)
+
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+      first = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+      second = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+
+      assert first.id != second.id
+
+      assert {:error, :invalid_request} =
+               Users.delete_confirm(user, first.key, audit: audit_data(user))
+
+      assert Repo.get(User, user.id)
+    end
+
+    test "confirm rejects a wrong, expired, or foreign key" do
+      user = insert(:user)
+      attacker = insert(:user)
+
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+      request = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+
+      # wrong key
+      assert {:error, :invalid_request} =
+               Users.delete_confirm(user, "deadbeef", audit: audit_data(user))
+
+      # foreign key: attacker's own request used against user's account
+      assert :ok = Users.delete_request(attacker, audit: audit_data(attacker))
+      attacker_request = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: attacker.id)
+
+      assert {:error, :invalid_request} =
+               Users.delete_confirm(user, attacker_request.key, audit: audit_data(user))
+
+      # expired key
+      Repo.update_all(Hexpm.Accounts.AccountDeletionRequest,
+        set: [inserted_at: DateTime.add(DateTime.utc_now(), -2, :day)]
+      )
+
+      assert {:error, :invalid_request} =
+               Users.delete_confirm(user, request.key, audit: audit_data(user))
+
+      assert Repo.get(User, user.id)
+    end
+
+    test "request is blocked for users failing eligibility" do
+      user = insert(:user)
+      organization = insert(:organization)
+      insert(:organization_user, user: user, organization: organization, role: "admin")
+
+      assert {:error, {:organizations, _}} = Users.delete_request(user, audit: audit_data(user))
+    end
+
+    test "changing the password deletes pending requests" do
+      user = insert(:user)
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+
+      {:ok, _} =
+        Users.update_password(
+          user,
+          %{
+            "password_current" => "password",
+            "password" => "new_password_123",
+            "password_confirmation" => "new_password_123"
+          },
+          audit: audit_data(user)
+        )
+
+      refute Repo.get_by(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+    end
+
+    test "changing the primary email invalidates the pending request" do
+      user = insert(:user)
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+      request = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+
+      {:ok, user} = Users.add_email(user, %{email: "new@example.com"}, audit: audit_data(user))
+      new_email = Enum.find(user.emails, &(&1.email == "new@example.com"))
+      Repo.update!(Ecto.Changeset.change(new_email, verified: true))
+      user = Users.get_by_id(user.id, [:emails])
+      :ok = Users.primary_email(user, %{"email" => "new@example.com"}, audit: audit_data(user))
+
+      user = Users.get_by_id(user.id, [:emails])
+
+      assert {:error, :invalid_request} =
+               Users.delete_confirm(user, request.key, audit: audit_data(user))
+    end
+
+    test "password reset deletes pending requests" do
+      user = insert(:user)
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+
+      :ok = Users.password_reset_init(user.username, audit: audit_data(user))
+      user = Users.get_by_id(user.id, [:emails, :password_resets])
+      [reset] = user.password_resets
+
+      :ok =
+        Users.password_reset_finish(
+          user.username,
+          reset.key,
+          %{
+            "username" => user.username,
+            "password" => "new_password_123",
+            "password_confirmation" => "new_password_123"
+          },
+          false,
+          audit: audit_data(user)
+        )
+
+      refute Repo.get_by(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+    end
+
+    test "confirm is blocked when eligibility changed after the request" do
+      user = insert(:user)
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+      request = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+
+      organization = insert(:organization)
+      insert(:organization_user, user: user, organization: organization, role: "admin")
+
+      assert {:error, {:organizations, _}} =
+               Users.delete_confirm(user, request.key, audit: audit_data(user))
+
+      assert Repo.get(User, user.id)
+    end
+
+    test "confirm rejects a nil key" do
+      user = insert(:user)
+      assert :ok = Users.delete_request(user, audit: audit_data(user))
+
+      assert {:error, :invalid_request} = Users.delete_confirm(user, nil, audit: audit_data(user))
+      assert Repo.get(User, user.id)
+    end
+  end
+
   describe "update_profile/3 when user is an organization" do
     test "updates full_name" do
       organization = insert(:organization, user: build(:user, full_name: "Old Full Name"))

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -447,6 +447,13 @@ defmodule Hexpm.Accounts.UsersTest do
       assert {:error, {:organizations, _}} = Users.delete_request(user, audit: audit_data(user))
     end
 
+    test "request is rejected for users without a primary email" do
+      user = insert(:user, emails: [])
+
+      assert {:error, :no_primary_email} = Users.delete_request(user, audit: audit_data(user))
+      refute Repo.get_by(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
+    end
+
     test "changing the password deletes pending requests" do
       user = insert(:user)
       assert :ok = Users.delete_request(user, audit: audit_data(user))

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -465,7 +465,7 @@ defmodule Hexpm.Accounts.UsersTest do
       refute Repo.get_by(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
     end
 
-    test "changing the primary email invalidates the pending request" do
+    test "changing the primary email deletes the pending request" do
       user = insert(:user)
       assert :ok = Users.delete_request(user, audit: audit_data(user))
       request = Repo.get_by!(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
@@ -475,6 +475,8 @@ defmodule Hexpm.Accounts.UsersTest do
       Repo.update!(Ecto.Changeset.change(new_email, verified: true))
       user = Users.get_by_id(user.id, [:emails])
       :ok = Users.primary_email(user, %{"email" => "new@example.com"}, audit: audit_data(user))
+
+      refute Repo.get_by(Hexpm.Accounts.AccountDeletionRequest, user_id: user.id)
 
       user = Users.get_by_id(user.id, [:emails])
 

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -82,6 +82,20 @@ defmodule Hexpm.AdminTasksTest do
       assert {:error, :user_not_found} = AdminTasks.remove_user("nonexistent")
     end
 
+    test "reserves the username and writes an audit log" do
+      user = insert(:user)
+      username = user.username
+
+      assert :ok = AdminTasks.remove_user(user.username)
+
+      assert Repo.exists?(Hexpm.Accounts.ReservedUsername.by_name(username))
+
+      delete_log = Repo.get_by(Hexpm.Accounts.AuditLog, action: "user.delete")
+      assert delete_log
+      assert delete_log.params["username"] == username
+      assert delete_log.user_agent == "ADMIN"
+    end
+
     test "removes user with associated records" do
       user = insert(:user)
       user_id = user.id

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -1,5 +1,6 @@
 defmodule Hexpm.AdminTasksTest do
   use Hexpm.DataCase, async: true
+  import Swoosh.TestAssertions
 
   alias Hexpm.AdminTasks
   alias Hexpm.Accounts.{Organization, User}
@@ -94,6 +95,14 @@ defmodule Hexpm.AdminTasksTest do
       assert delete_log
       assert delete_log.params["username"] == username
       assert delete_log.user_agent == "ADMIN"
+    end
+
+    test "does not send a notification email when removing a user" do
+      user = insert(:user)
+
+      assert :ok = AdminTasks.remove_user(user.username)
+
+      refute_email_sent()
     end
 
     test "removes user with associated records" do

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -295,6 +295,33 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
     end
   end
 
+  describe "purge account deletion requests" do
+    test "deletes requests older than 90 days" do
+      user1 = insert(:user)
+      user2 = insert(:user)
+
+      old =
+        Repo.insert!(%Hexpm.Accounts.AccountDeletionRequest{
+          key: "old-key",
+          primary_email: "old@example.com",
+          user_id: user1.id,
+          inserted_at: days_ago(91)
+        })
+
+      recent =
+        Repo.insert!(%Hexpm.Accounts.AccountDeletionRequest{
+          key: "new-key",
+          primary_email: "new@example.com",
+          user_id: user2.id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.Accounts.AccountDeletionRequest, old.id)
+      assert Repo.get(Hexpm.Accounts.AccountDeletionRequest, recent.id)
+    end
+  end
+
   describe "purge keys" do
     test "deletes keys revoked more than 90 days ago" do
       user = insert(:user)

--- a/test/hexpm_web/captcha_test.exs
+++ b/test/hexpm_web/captcha_test.exs
@@ -1,5 +1,7 @@
 defmodule HexpmWeb.CaptchaTest do
   use HexpmWeb.ConnCase
+
+  alias Hexpm.Accounts.Users
   alias HexpmWeb.Captcha
 
   setup :verify_on_exit!
@@ -43,5 +45,31 @@ defmodule HexpmWeb.CaptchaTest do
   test "returns true with missing token when disabled" do
     app_env(:hexpm, :hcaptcha, nil)
     assert Captcha.verify(nil)
+  end
+
+  test "POST /signup creates user when captcha is disabled" do
+    app_env(:hexpm, :hcaptcha, nil)
+
+    username = Fake.sequence(:username)
+    email = Fake.sequence(:email)
+
+    conn =
+      post(build_conn(), "/signup", %{
+        "user" => %{
+          "username" => username,
+          "emails" => %{
+            "0" => %{
+              "email" => email,
+              "email_confirmation" => email
+            }
+          },
+          "password" => "hunter42",
+          "password_confirmation" => "hunter42",
+          "full_name" => "José"
+        }
+      })
+
+    assert redirected_to(conn) == "/"
+    assert Users.get(username).username == username
   end
 end

--- a/test/hexpm_web/captcha_test.exs
+++ b/test/hexpm_web/captcha_test.exs
@@ -39,4 +39,9 @@ defmodule HexpmWeb.CaptchaTest do
     app_env(:hexpm, :hcaptcha, sitekey: nil)
     assert Captcha.verify("disabled")
   end
+
+  test "returns true with missing token when disabled" do
+    app_env(:hexpm, :hcaptcha, nil)
+    assert Captcha.verify(nil)
+  end
 end

--- a/test/hexpm_web/controllers/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/auth_controller_test.exs
@@ -181,12 +181,14 @@ defmodule HexpmWeb.AuthControllerTest do
         |> Plug.Conn.assign(:current_user, user)
         |> put_session("sudo_verification", true)
         |> put_session("sudo_return_to", "/dashboard/keys")
+        |> put_session("sudo_force", true)
         |> HexpmWeb.AuthController.callback(%{})
 
       assert redirected_to(conn) == "/dashboard/keys"
       assert HexpmWeb.Plugs.Sudo.sudo_active?(conn)
       refute get_session(conn, "sudo_verification")
       refute get_session(conn, "sudo_return_to")
+      refute get_session(conn, "sudo_force")
     end
 
     test "OAuth callback with mismatched provider_uid shows error" do

--- a/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
@@ -304,6 +304,10 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
       # public pages: profile 404s, package page renders with nil publisher
       assert build_conn() |> get("/users/#{username}") |> response(404)
       assert build_conn() |> get("/packages/#{sole_package.name}") |> response(200)
+
+      assert build_conn()
+             |> get("/packages/#{sole_package.name}/#{release.version}")
+             |> response(200)
     end
   end
 

--- a/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
@@ -30,6 +30,17 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
       assert html =~ package.name
     end
 
+    test "escapes regex characters in the username confirmation pattern" do
+      user = insert(:user, username: "some.user")
+
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> get("/dashboard/delete-account")
+
+      assert response(conn, 200) =~ ~s(pattern="some\\.user")
+    end
+
     test "renders blockers for last org admin", c do
       organization = insert(:organization)
       insert(:organization_user, user: c.user, organization: organization, role: "admin")

--- a/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
@@ -22,8 +22,12 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
         |> test_login(c.user)
         |> get("/dashboard/delete-account")
 
-      assert response(conn, 200) =~ "Delete account"
-      assert response(conn, 200) =~ package.name
+      html = conn |> response(200) |> String.replace(~r/\s+/, " ")
+      assert html =~ "Delete account"
+      assert html =~ "lose access to all resources associated with your account"
+      assert html =~ "you will no longer be able to publish packages"
+      assert html =~ "may be claimed by someone else in the future"
+      assert html =~ package.name
     end
 
     test "renders blockers for last org admin", c do

--- a/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
@@ -189,6 +189,124 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
     end
   end
 
+  describe "full lifecycle" do
+    test "maximal user deletes their account through the entire web flow" do
+      # user_with_tfa: TFA-enabled factory user; extra unverified secondary email
+      user =
+        insert(:user_with_tfa,
+          emails: [build(:email), build(:email, primary: false, public: false, verified: false)]
+        )
+
+      other_owner = insert(:user)
+      org_admin = insert(:user)
+
+      sole_package = insert(:package, package_owners: [build(:package_owner, user: user)])
+
+      co_package =
+        insert(:package,
+          package_owners: [
+            build(:package_owner, user: user),
+            build(:package_owner, user: other_owner, level: "full")
+          ]
+        )
+
+      release = insert(:release, package: sole_package, publisher: user)
+      co_release = insert(:release, package: co_package, publisher: user)
+
+      key = insert(:key, user: user)
+
+      organization = insert(:organization)
+      insert(:organization_user, user: org_admin, organization: organization, role: "admin")
+
+      org_membership =
+        insert(:organization_user, user: user, organization: organization, role: "write")
+
+      old_log =
+        insert(:audit_log,
+          user: user,
+          action: "user.update",
+          user_data: %{"id" => user.id, "username" => user.username}
+        )
+
+      username = user.username
+      email_ids = Enum.map(user.emails, & &1.id)
+
+      # 1. the warnings page lists the sole-owned package
+      conn = build_conn() |> test_login(user) |> get("/dashboard/delete-account")
+      assert response(conn, 200) =~ sole_package.name
+      refute response(conn, 200) =~ co_package.name
+
+      # 2. request deletion
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("/dashboard/delete-account", %{"username" => username})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      request = Repo.get_by!(AccountDeletionRequest, user_id: user.id)
+      assert_email_sent(subject: "Hex.pm - Account deletion request")
+
+      # 3. follow the emailed link
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> get("/dashboard/delete-account/confirm", %{"key" => request.key})
+
+      assert response(conn, 200) =~ "Delete my account"
+
+      # 4. final confirmation
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+
+      assert redirected_to(conn) == "/"
+      assert_email_sent(subject: "Hex.pm - Your account has been deleted")
+
+      # user and credentials gone
+      refute Repo.get(User, user.id)
+      refute Repo.get(Hexpm.Accounts.Key, key.id)
+      refute Repo.get(Hexpm.Accounts.OrganizationUser, org_membership.id)
+      for email_id <- email_ids, do: refute(Repo.get(Hexpm.Accounts.Email, email_id))
+
+      # packages and releases preserved with nulled publisher
+      assert Repo.get(Hexpm.Repository.Package, sole_package.id)
+      assert Repo.get(Hexpm.Repository.Package, co_package.id)
+      assert Repo.get(Hexpm.Repository.Release, release.id).publisher_id == nil
+      assert Repo.get(Hexpm.Repository.Release, co_release.id).publisher_id == nil
+
+      # co-owned package keeps its other owner; sole-owned is orphaned
+      sole_reloaded = Repo.get(Hexpm.Repository.Package, sole_package.id)
+      co_reloaded = Repo.get(Hexpm.Repository.Package, co_package.id)
+      assert [%{user_id: other_id}] = Repo.all(Ecto.assoc(co_reloaded, :package_owners))
+      assert other_id == other_owner.id
+      assert Repo.all(Ecto.assoc(sole_reloaded, :package_owners)) == []
+
+      # organization survives with its admin
+      assert Repo.get(Hexpm.Accounts.Organization, organization.id)
+
+      # audit logs preserved; request + delete logs exist with snapshots
+      assert Repo.get(Hexpm.Accounts.AuditLog, old_log.id).user_id == nil
+      assert Repo.get(Hexpm.Accounts.AuditLog, old_log.id).user_data["username"] == username
+      assert Repo.get_by(Hexpm.Accounts.AuditLog, action: "user.delete.request")
+      assert Repo.get_by(Hexpm.Accounts.AuditLog, action: "user.delete")
+
+      # username reserved against user signup and org creation
+      params = %{"username" => username, "emails" => [%{"email" => Hexpm.Fake.sequence(:email)}]}
+      audit = %{user: nil, user_agent: "TEST", remote_ip: "127.0.0.1", auth_credential: nil}
+      assert {:error, _} = Users.add(params, audit: audit)
+
+      assert {:error, _} =
+               Hexpm.Accounts.Organizations.create(org_admin, %{"name" => username},
+                 audit: audit_data(org_admin)
+               )
+
+      # public pages: profile 404s, package page renders with nil publisher
+      assert build_conn() |> get("/users/#{username}") |> response(404)
+      assert build_conn() |> get("/packages/#{sole_package.name}") |> response(200)
+    end
+  end
+
   describe "POST /dashboard/delete-account/confirm" do
     test "deletes the account, logs out, redirects home", c do
       request = request_deletion(c.user)

--- a/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
@@ -1,0 +1,241 @@
+defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
+  use HexpmWeb.ConnCase, async: true
+  import Swoosh.TestAssertions
+
+  alias Hexpm.Accounts.{AccountDeletionRequest, User, Users}
+
+  setup do
+    %{user: insert(:user)}
+  end
+
+  defp request_deletion(user) do
+    :ok = Users.delete_request(user, audit: audit_data(user))
+    Repo.get_by!(AccountDeletionRequest, user_id: user.id)
+  end
+
+  describe "GET /dashboard/delete-account" do
+    test "renders warnings for sole-owned packages", c do
+      package = insert(:package, package_owners: [build(:package_owner, user: c.user)])
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/delete-account")
+
+      assert response(conn, 200) =~ "Delete account"
+      assert response(conn, 200) =~ package.name
+    end
+
+    test "renders blockers for last org admin", c do
+      organization = insert(:organization)
+      insert(:organization_user, user: c.user, organization: organization, role: "admin")
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/delete-account")
+
+      assert response(conn, 200) =~ organization.name
+      refute response(conn, 200) =~ "Request account deletion"
+    end
+
+    test "requires login" do
+      conn = get(build_conn(), "/dashboard/delete-account")
+      assert redirected_to(conn) == "/login?return=%2Fdashboard%2Fdelete-account"
+    end
+
+    test "redirects to /sudo without sudo", c do
+      conn =
+        build_conn()
+        |> test_login(c.user, sudo: false)
+        |> get("/dashboard/delete-account")
+
+      assert redirected_to(conn) =~ "/sudo"
+    end
+
+    test "redirects to /sudo when sudo is active but stale (forced freshness)", c do
+      conn =
+        build_conn()
+        |> test_login(c.user, sudo_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -10, :minute))
+        |> get("/dashboard/delete-account")
+
+      assert redirected_to(conn) =~ "/sudo"
+    end
+
+    test "confirm page also redirects to /sudo without fresh sudo", c do
+      conn =
+        build_conn()
+        |> test_login(c.user, sudo: false)
+        |> get("/dashboard/delete-account/confirm", %{"key" => "anything"})
+
+      assert redirected_to(conn) =~ "/sudo"
+    end
+  end
+
+  describe "POST /dashboard/delete-account" do
+    test "creates a request and sends the email", c do
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/delete-account", %{"username" => c.user.username})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "confirmation link"
+      assert Repo.get_by(AccountDeletionRequest, user_id: c.user.id)
+      assert_email_sent(subject: "Hex.pm - Account deletion request")
+    end
+
+    test "rejects a wrong typed username", c do
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/delete-account", %{"username" => "someone-else"})
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "does not match"
+      refute Repo.get_by(AccountDeletionRequest, user_id: c.user.id)
+    end
+
+    test "is throttled per user", c do
+      conn = build_conn() |> test_login(c.user)
+
+      for _ <- 1..3 do
+        post(conn, "/dashboard/delete-account", %{"username" => c.user.username})
+      end
+
+      conn = post(conn, "/dashboard/delete-account", %{"username" => c.user.username})
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "Too many"
+    end
+
+    test "blocked for last org admin", c do
+      organization = insert(:organization)
+      insert(:organization_user, user: c.user, organization: organization, role: "admin")
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/delete-account", %{"username" => c.user.username})
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error)
+      refute Repo.get_by(AccountDeletionRequest, user_id: c.user.id)
+    end
+
+    test "a signed _sudo_token keeps the form working after the freshness window", c do
+      token =
+        HexpmWeb.Plugs.Sudo.generate_form_token(c.user.id, "POST", "/dashboard/delete-account")
+
+      conn =
+        build_conn()
+        |> test_login(c.user, sudo_at: NaiveDateTime.add(NaiveDateTime.utc_now(), -10, :minute))
+        |> post("/dashboard/delete-account", %{
+          "username" => c.user.username,
+          "_sudo_token" => token
+        })
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      assert Repo.get_by(AccountDeletionRequest, user_id: c.user.id)
+    end
+  end
+
+  describe "GET /dashboard/delete-account/confirm" do
+    test "renders the final confirmation page with a valid key", c do
+      request = request_deletion(c.user)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/delete-account/confirm", %{"key" => request.key})
+
+      assert response(conn, 200) =~ "Delete my account"
+    end
+
+    test "rejects an invalid key with a generic error", c do
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/delete-account/confirm", %{"key" => "deadbeef"})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "invalid or has expired"
+    end
+
+    test "rejects another user's key with the same generic error", c do
+      attacker = insert(:user)
+      attacker_request = request_deletion(attacker)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/delete-account/confirm", %{"key" => attacker_request.key})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "invalid or has expired"
+      assert Repo.get(User, c.user.id)
+      assert Repo.get(User, attacker.id)
+    end
+
+    test "redirects when eligibility changed after the request", c do
+      request = request_deletion(c.user)
+
+      organization = insert(:organization)
+      insert(:organization_user, user: c.user, organization: organization, role: "admin")
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/delete-account/confirm", %{"key" => request.key})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "cannot be deleted right now"
+    end
+  end
+
+  describe "POST /dashboard/delete-account/confirm" do
+    test "deletes the account, logs out, redirects home", c do
+      request = request_deletion(c.user)
+      assert_email_sent(subject: "Hex.pm - Account deletion request")
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+
+      assert redirected_to(conn) == "/"
+      assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "permanently deleted"
+      refute Repo.get(User, c.user.id)
+      refute Plug.Conn.get_session(conn, "session_token")
+      assert_email_sent(subject: "Hex.pm - Your account has been deleted")
+    end
+
+    test "a key cannot be reused", c do
+      request = request_deletion(c.user)
+      other = insert(:user)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+
+      assert redirected_to(conn) == "/"
+
+      conn =
+        build_conn()
+        |> test_login(other)
+        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      assert Repo.get(User, other.id)
+    end
+
+    test "rejects with invalid key and deletes nothing", c do
+      _request = request_deletion(c.user)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/delete-account/confirm", %{"key" => "deadbeef"})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      assert Repo.get(User, c.user.id)
+    end
+  end
+end

--- a/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/delete_account_controller_test.exs
@@ -273,7 +273,10 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
       conn =
         build_conn()
         |> test_login(user)
-        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+        |> post("/dashboard/delete-account/confirm", %{
+          "key" => request.key,
+          "username" => username
+        })
 
       assert redirected_to(conn) == "/"
       assert_email_sent(subject: "Hex.pm - Your account has been deleted")
@@ -334,13 +337,32 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+        |> post("/dashboard/delete-account/confirm", %{
+          "key" => request.key,
+          "username" => c.user.username
+        })
 
       assert redirected_to(conn) == "/"
       assert Phoenix.Flash.get(conn.assigns.flash, :info) =~ "permanently deleted"
       refute Repo.get(User, c.user.id)
       refute Plug.Conn.get_session(conn, "session_token")
       assert_email_sent(subject: "Hex.pm - Your account has been deleted")
+    end
+
+    test "rejects with mismatched username and deletes nothing", c do
+      request = request_deletion(c.user)
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/delete-account/confirm", %{
+          "key" => request.key,
+          "username" => "someone-else"
+        })
+
+      assert redirected_to(conn) == "/dashboard/delete-account/confirm?key=#{request.key}"
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "does not match"
+      assert Repo.get(User, c.user.id)
     end
 
     test "a key cannot be reused", c do
@@ -350,14 +372,20 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+        |> post("/dashboard/delete-account/confirm", %{
+          "key" => request.key,
+          "username" => c.user.username
+        })
 
       assert redirected_to(conn) == "/"
 
       conn =
         build_conn()
         |> test_login(other)
-        |> post("/dashboard/delete-account/confirm", %{"key" => request.key})
+        |> post("/dashboard/delete-account/confirm", %{
+          "key" => request.key,
+          "username" => other.username
+        })
 
       assert redirected_to(conn) == "/dashboard/delete-account"
       assert Repo.get(User, other.id)
@@ -369,7 +397,10 @@ defmodule HexpmWeb.Dashboard.DeleteAccountControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> post("/dashboard/delete-account/confirm", %{"key" => "deadbeef"})
+        |> post("/dashboard/delete-account/confirm", %{
+          "key" => "deadbeef",
+          "username" => c.user.username
+        })
 
       assert redirected_to(conn) == "/dashboard/delete-account"
       assert Repo.get(User, c.user.id)

--- a/test/hexpm_web/controllers/signup_controller_test.exs
+++ b/test/hexpm_web/controllers/signup_controller_test.exs
@@ -75,6 +75,51 @@ defmodule HexpmWeb.SignupControllerTest do
       assert response(conn, 400) =~ "Sign up"
       assert conn.resp_body =~ "Oops, something went wrong!"
     end
+
+    test "keeps email fields after validation errors" do
+      conn =
+        post(build_conn(), "/signup", %{
+          "user" => %{
+            "username" => "",
+            "emails" => %{"0" => %{"email" => "", "email_confirmation" => ""}},
+            "password" => "",
+            "password_confirmation" => "",
+            "full_name" => ""
+          },
+          "h-captcha-response" => "captcha"
+        })
+
+      html = response(conn, 400)
+      assert html =~ ~s(name="user[emails][0][email]")
+      assert html =~ ~s(name="user[emails][0][email_confirmation]")
+      assert html =~ "can&#39;t be blank"
+    end
+  end
+
+  test "POST /signup creates user when captcha is disabled" do
+    app_env(:hexpm, :hcaptcha, nil)
+
+    username = Fake.sequence(:username)
+    email = Fake.sequence(:email)
+
+    conn =
+      post(build_conn(), "/signup", %{
+        "user" => %{
+          "username" => username,
+          "emails" => %{
+            "0" => %{
+              "email" => email,
+              "email_confirmation" => email
+            }
+          },
+          "password" => "hunter42",
+          "password_confirmation" => "hunter42",
+          "full_name" => "José"
+        }
+      })
+
+    assert redirected_to(conn) == "/"
+    assert Users.get(username).username == username
   end
 
   test "POST /signup captha failed" do

--- a/test/hexpm_web/controllers/signup_controller_test.exs
+++ b/test/hexpm_web/controllers/signup_controller_test.exs
@@ -96,32 +96,6 @@ defmodule HexpmWeb.SignupControllerTest do
     end
   end
 
-  test "POST /signup creates user when captcha is disabled" do
-    app_env(:hexpm, :hcaptcha, nil)
-
-    username = Fake.sequence(:username)
-    email = Fake.sequence(:email)
-
-    conn =
-      post(build_conn(), "/signup", %{
-        "user" => %{
-          "username" => username,
-          "emails" => %{
-            "0" => %{
-              "email" => email,
-              "email_confirmation" => email
-            }
-          },
-          "password" => "hunter42",
-          "password_confirmation" => "hunter42",
-          "full_name" => "José"
-        }
-      })
-
-    assert redirected_to(conn) == "/"
-    assert Users.get(username).username == username
-  end
-
   test "POST /signup captha failed" do
     mock_captcha_failure()
 

--- a/test/hexpm_web/controllers/sudo_controller_test.exs
+++ b/test/hexpm_web/controllers/sudo_controller_test.exs
@@ -333,6 +333,41 @@ defmodule HexpmWeb.SudoControllerTest do
     end
   end
 
+  describe "forced sudo re-prompt" do
+    defp put_session_values(conn, values) do
+      session = conn |> Plug.Conn.get_session() |> Map.merge(values)
+      Plug.Test.init_test_session(conn, session)
+    end
+
+    test "GET /sudo renders the form when sudo_force is set, even with active sudo" do
+      user = insert(:user)
+
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> put_session_values(%{"sudo_force" => true})
+        |> get("/sudo")
+
+      assert html_response(conn, 200) =~ "Verify your identity"
+    end
+
+    test "successful re-auth clears sudo_force and redirects to return path" do
+      user = insert(:user)
+
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> put_session_values(%{
+          "sudo_force" => true,
+          "sudo_return_to" => "/dashboard/delete-account"
+        })
+        |> post("/sudo", %{"type" => "password", "password" => "password"})
+
+      assert redirected_to(conn) == "/dashboard/delete-account"
+      refute Plug.Conn.get_session(conn, "sudo_force")
+    end
+  end
+
   describe "redirects to sudo_return_to on success" do
     test "redirects to stored path after password verification" do
       user = insert(:user)

--- a/test/hexpm_web/plugs/sudo_test.exs
+++ b/test/hexpm_web/plugs/sudo_test.exs
@@ -95,6 +95,69 @@ defmodule HexpmWeb.Plugs.SudoTest do
       assert redirected_to(conn) == "/sudo"
       refute get_session(conn, "sudo_return_to")
     end
+
+    test "stale-but-active sudo + force: halts and redirects, sets flag; same sudo passes default mode" do
+      user = insert(:user)
+      stale_sudo_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -10, :minute)
+
+      conn =
+        build_conn()
+        |> test_login(user, sudo_at: stale_sudo_at)
+        |> fetch_flash()
+        |> Sudo.call(force: true)
+
+      assert conn.halted
+      assert redirected_to(conn) == "/sudo"
+      assert get_session(conn, "sudo_force") == true
+
+      conn2 =
+        build_conn()
+        |> test_login(user, sudo_at: stale_sudo_at)
+        |> Sudo.call([])
+
+      refute conn2.halted
+    end
+
+    test "fresh sudo + force: not halted" do
+      user = insert(:user)
+
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> Sudo.call(force: true)
+
+      refute conn.halted
+    end
+
+    test "non-GET with valid form token, stale sudo, force: not halted" do
+      user = insert(:user)
+      path = "/dashboard/delete-account"
+      token = Sudo.generate_form_token(user.id, "POST", path)
+      stale_sudo_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -10, :minute)
+
+      conn =
+        build_conn(:post, path, %{"_sudo_token" => token})
+        |> test_login(user, sudo_at: stale_sudo_at)
+        |> Plug.Conn.assign(:current_user, user)
+        |> Sudo.call(force: true)
+
+      refute conn.halted
+    end
+
+    test "default mode redirect does not set sudo_force flag" do
+      user = insert(:user)
+      expired_sudo_at = NaiveDateTime.add(NaiveDateTime.utc_now(), -3601, :second)
+
+      conn =
+        build_conn()
+        |> test_login(user, sudo_at: expired_sudo_at)
+        |> fetch_flash()
+        |> Sudo.call([])
+
+      assert conn.halted
+      assert redirected_to(conn) == "/sudo"
+      assert get_session(conn, "sudo_force") == nil
+    end
   end
 
   describe "form token" do

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -47,6 +47,7 @@ defmodule HexpmWeb.ConnCase do
     alias Hexpm.UserSessions
 
     sudo = Keyword.get(opts, :sudo, true)
+    sudo_at = Keyword.get(opts, :sudo_at)
     audit_data = test_audit_data(user)
 
     {:ok, _session, session_token} =
@@ -55,14 +56,19 @@ defmodule HexpmWeb.ConnCase do
     session_data = %{"session_token" => Base.encode64(session_token)}
 
     session_data =
-      if sudo do
-        Map.put(
-          session_data,
-          "sudo_authenticated_at",
-          NaiveDateTime.utc_now() |> NaiveDateTime.to_iso8601()
-        )
-      else
-        session_data
+      cond do
+        sudo_at ->
+          Map.put(session_data, "sudo_authenticated_at", NaiveDateTime.to_iso8601(sudo_at))
+
+        sudo ->
+          Map.put(
+            session_data,
+            "sudo_authenticated_at",
+            NaiveDateTime.utc_now() |> NaiveDateTime.to_iso8601()
+          )
+
+        true ->
+          session_data
       end
 
     Plug.Test.init_test_session(conn, session_data)


### PR DESCRIPTION
Adds self-service account deletion under /dashboard/delete-account.

Deleting an account is a hard delete of the users row. Audit logs and packages are preserved through the existing FK rules: releases keep existing with a NULL publisher, audit logs keep their user_data snapshot. Keys, emails, sessions and org memberships are cascade deleted. The username goes into a new reserved_usernames table and can never be registered again, by a user or an organization, so nobody can impersonate the old account or appear to inherit its packages.

Users who are the last admin or only member of an organization cannot delete their account until they hand the organization over. Being the sole owner of packages only warns: those packages become ownerless but stay installable, and new owners can only be assigned by us.

The flow requires a fresh sudo re-authentication (a new force option on the sudo plug that ignores the rolling window granted at login), typing your username, and then clicking a single-use link emailed to the primary address, valid for 24 hours. The link only works from a logged in session of the same user, so a leaked or stolen key does nothing on its own. Changing your password or primary email cancels a pending request, and request creation is throttled and audit logged.

AdminTasks.remove_user now goes through the same code path, so admin removals also reserve the username and write an audit log. The request table is cleaned up by the daily purge task.