### PR TITLE
Fix long package name overflow on mobile

### DIFF
--- a/lib/hexpm_web/components/home.ex
+++ b/lib/hexpm_web/components/home.ex
@@ -211,16 +211,17 @@ defmodule HexpmWeb.Components.Home do
     <li class="py-4 border-b border-grey-100 dark:border-grey-800 last:border-b-0">
       <div class="flex items-start justify-between gap-4">
         <div class="flex flex-col gap-1 min-w-0">
-          <div class="flex items-end gap-2">
+          <div class="flex items-end gap-2 min-w-0">
             <a
               href={~p"/packages/#{@package}"}
-              class="text-grey-900 dark:text-grey-100 font-medium text-lg hover:text-primary-600 dark:hover:text-primary-300 transition-colors"
+              title={@package}
+              class="min-w-0 truncate text-grey-900 dark:text-grey-100 font-medium text-lg hover:text-primary-600 dark:hover:text-primary-300 transition-colors"
             >
               {@package}
             </a>
             <span
               :if={@version}
-              class="text-grey-500 dark:text-grey-300 text-xs bg-grey-50 dark:bg-grey-800 p-1 rounded-md"
+              class="text-grey-500 dark:text-grey-300 text-xs bg-grey-50 dark:bg-grey-800 p-1 rounded-md shrink-0"
             >
               {@version}
             </span>

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -110,8 +110,8 @@ defmodule HexpmWeb.Components.PackageLayout do
             >
               {HexpmWeb.ViewIcons.icon(:heroicon, "arrow-left", class: "size-3")} Packages
             </a>
-            <div class="flex items-end gap-4">
-              <h1 class="text-grey-900 dark:text-grey-100 text-2xl font-semibold">
+            <div class="flex min-w-0 flex-wrap items-end gap-4">
+              <h1 class="min-w-0 break-words text-grey-900 dark:text-grey-100 text-2xl font-semibold">
                 <a
                   href={ViewHelpers.path_for_package(@package)}
                   class="text-grey-900 dark:text-grey-100 hover:text-purple-600 dark:hover:text-primary-300 transition-colors"

--- a/lib/hexpm_web/templates/package/_package.html.heex
+++ b/lib/hexpm_web/templates/package/_package.html.heex
@@ -4,44 +4,44 @@
   exact_match? && "hover:bg-green-100 dark:hover:bg-green-900/20",
   not exact_match? && "hover:bg-grey-50 dark:hover:bg-grey-700/60"
 ]}>
-  <div class="grid grid-cols-[1fr_auto] gap-4 md:gap-6 items-center">
+  <div class="flex flex-wrap items-baseline gap-2.5 min-w-0 mb-1">
+    <a
+      href={ViewHelpers.path_for_package(@package)}
+      class={[
+        "min-w-0 break-words text-xl font-semibold transition-colors",
+        exact_match? &&
+          "text-grey-900 dark:text-grey-100 hover:text-green-600 dark:hover:text-green-300",
+        not exact_match? &&
+          "text-grey-700 dark:text-grey-100 hover:text-primary-600 dark:hover:text-primary-300"
+      ]}
+    >
+      {ViewHelpers.package_name(@package)}
+    </a>
+    <%= if @package.latest_release do %>
+      <a
+        href={ViewHelpers.path_for_package(@package)}
+        class={[
+          "inline-flex shrink-0 items-center px-2 py-0.5 rounded text-xs font-medium transition-colors",
+          exact_match? &&
+            "bg-green-100 dark:bg-green-900/20 group-hover:bg-green-200 dark:group-hover:bg-green-900/30 text-green-700 dark:text-green-300 hover:text-green-800 dark:hover:text-green-200",
+          not exact_match? &&
+            "bg-grey-50 dark:bg-grey-700 border border-grey-100 dark:border-grey-600 text-grey-500 dark:text-grey-200 hover:bg-primary-100 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-200"
+        ]}
+      >
+        v{@package.latest_release.version}
+      </a>
+    <% end %>
+    <%= if assigns[:dependency_requirement] do %>
+      <span class="text-grey-400 dark:text-grey-500 text-xs">requires</span>
+      <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium font-mono bg-grey-50 dark:bg-grey-700 border border-grey-100 dark:border-grey-600 text-grey-500 dark:text-grey-200">
+        {@dependency_requirement}
+      </span>
+    <% end %>
+  </div>
+
+  <div class="grid grid-cols-[minmax(0,1fr)_auto] gap-4 md:gap-6 items-start">
     <%!-- Package Info --%>
     <div class="min-w-0">
-      <div class="flex items-baseline gap-2.5 mb-1">
-        <a
-          href={ViewHelpers.path_for_package(@package)}
-          class={[
-            "text-xl font-semibold transition-colors",
-            exact_match? &&
-              "text-grey-900 dark:text-grey-100 hover:text-green-600 dark:hover:text-green-300",
-            not exact_match? &&
-              "text-grey-700 dark:text-grey-100 hover:text-primary-600 dark:hover:text-primary-300"
-          ]}
-        >
-          {ViewHelpers.package_name(@package)}
-        </a>
-        <%= if @package.latest_release do %>
-          <a
-            href={ViewHelpers.path_for_package(@package)}
-            class={[
-              "inline-flex items-center px-2 py-0.5 rounded text-xs font-medium transition-colors",
-              exact_match? &&
-                "bg-green-100 dark:bg-green-900/20 group-hover:bg-green-200 dark:group-hover:bg-green-900/30 text-green-700 dark:text-green-300 hover:text-green-800 dark:hover:text-green-200",
-              not exact_match? &&
-                "bg-grey-50 dark:bg-grey-700 border border-grey-100 dark:border-grey-600 text-grey-500 dark:text-grey-200 hover:bg-primary-100 dark:hover:bg-primary-900/30 hover:text-primary-700 dark:hover:text-primary-200"
-            ]}
-          >
-            v{@package.latest_release.version}
-          </a>
-        <% end %>
-        <%= if assigns[:dependency_requirement] do %>
-          <span class="text-grey-400 dark:text-grey-500 text-xs">requires</span>
-          <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium font-mono bg-grey-50 dark:bg-grey-700 border border-grey-100 dark:border-grey-600 text-grey-500 dark:text-grey-200">
-            {@dependency_requirement}
-          </span>
-        <% end %>
-      </div>
-
       <%= if @package.meta.description do %>
         <p class="text-grey-500 dark:text-grey-300 text-small leading-snug line-clamp-2 mb-1.5">
           {ViewHelpers.text_length(@package.meta.description, 200)}
@@ -56,7 +56,7 @@
     </div>
 
     <%!-- Download Stats --%>
-    <div class="text-right shrink-0 min-w-[120px] md:min-w-[180px]">
+    <div class="text-right shrink-0 w-fit">
       <div class="text-[22px] font-bold tracking-[-0.01em] text-grey-900 dark:text-grey-100 tabular-nums leading-none">
         {ViewHelpers.human_number_space(display_downloads(@package_downloads, @view) || 0)}
       </div>

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -248,6 +248,32 @@ defmodule HexpmWeb.PackageControllerTest do
       assert [_ | _] = Floki.find(document, "details summary.package-tabs-mobile-trigger")
     end
 
+    test "show package with long name" do
+      long_name = "opentelemetry_semantic_conventions"
+
+      package =
+        insert(:package,
+          name: long_name,
+          meta: build(:package_metadata, description: "Test package for long name overflow")
+        )
+
+      insert(
+        :release,
+        package: package,
+        version: "0.1.0",
+        meta: build(:release_metadata, app: long_name)
+      )
+
+      conn = get(build_conn(), "/packages/#{long_name}")
+      html = response(conn, 200)
+
+      assert html =~ long_name
+      assert html =~ "min-w-0 break-words"
+
+      assert {:ok, document} = Floki.parse_document(html)
+      assert [_ | _] = Floki.find(document, "details summary.package-tabs-mobile-trigger")
+    end
+
     test "show package uses singular dependant label for one dependant", %{package1: package1} do
       add_dependant(package1, "single_dependant")
 

--- a/test/hexpm_web/controllers/page_controller_test.exs
+++ b/test/hexpm_web/controllers/page_controller_test.exs
@@ -75,4 +75,23 @@ defmodule HexpmWeb.PageControllerTest do
 
     assert html =~ ~r/(week|weeks|day|days|hour|hours|minute|minutes) ago/
   end
+
+  test "index renders long package names without overlapping version and time" do
+    long_name = "opentelemetry_semantic_conventions"
+
+    package =
+      insert(:package,
+        name: long_name,
+        inserted_at: NaiveDateTime.utc_now(),
+        updated_at: NaiveDateTime.utc_now(),
+        meta: build(:package_metadata, description: "Distributed shared dictionary")
+      )
+
+    insert(:release, package: package, version: "0.1.0", inserted_at: NaiveDateTime.utc_now())
+
+    html = build_conn() |> get("/") |> response(200)
+
+    assert html =~ long_name
+    assert html =~ "truncate"
+  end
 end

--- a/test/hexpm_web/views/package_view_test.exs
+++ b/test/hexpm_web/views/package_view_test.exs
@@ -155,6 +155,38 @@ defmodule HexpmWeb.PackageViewTest do
       assert result =~ package.name
       assert result =~ "v1.0.0"
     end
+
+    test "renders long package name with break-words and without truncate" do
+      long_name = "opentelemetry_semantic_conventions"
+
+      package =
+        build(:package,
+          name: long_name,
+          repository_id: 1,
+          repository: build(:repository, id: 1, name: "hexpm"),
+          inserted_at: ~U[2025-01-01 00:00:00Z]
+        )
+
+      package = %{
+        package
+        | latest_release: %Hexpm.Repository.Release{
+            version: Version.parse!("1.27.0"),
+            inserted_at: ~N[2025-01-01 00:00:00]
+          }
+      }
+
+      result =
+        render_to_string(PackageView, "_package.html",
+          package: package,
+          package_downloads: %{"all" => 1000, "recent" => 100},
+          view: :recent_downloads
+        )
+
+      assert result =~ long_name
+      assert result =~ "v1.27.0"
+      assert result =~ "break-words"
+      refute result =~ "truncate"
+    end
   end
 
   describe "retirement_message/1" do


### PR DESCRIPTION
## Summary

- Fix horizontal overflow for long package names on narrow viewports (fixes #1656)
- **Homepage lists** : `truncate` + `title` on the name link, `shrink-0` on version badge
- **Search / exact-match cards** : title + version on a full-width row with `break-words`; description and downloads on a second row
- **Package show page** : `min-w-0 flex-wrap` on the header row and `break-words` on the `<h1>`

## Changes

I considered that on the search result and the package page, the user expect the full name to be visible.
However on the homepage lists, truncate acceptable and is favored in order to keep the layout identical between the items

- Homepage uses ellipsis (existing hexpm list pattern: `truncate` + `min-w-0`)
- Search results keep the full name visible with word wrapping, not truncation
- Show page keeps the full name visible and wraps inside the header

### Before screenshots:
<img width="365" height="136" alt="before_result" src="https://github.com/user-attachments/assets/161d5791-6ac3-4768-8fd1-26b3c9b87cfb" />
<img width="365" height="268" alt="before_match" src="https://github.com/user-attachments/assets/32d175ca-a9f0-4b8a-9f73-408cd48205fb" />
<img width="318" height="92" alt="before_home_updated" src="https://github.com/user-attachments/assets/eb58a916-6b6f-44ea-8cce-0f417be30175" />
<img width="312" height="220" alt="before_home_most" src="https://github.com/user-attachments/assets/5e9a3eae-013c-430e-abb5-06515025c595" />
<img width="378" height="672" alt="before_pkg_page" src="https://github.com/user-attachments/assets/7f1a3947-2c0e-429c-a117-0daa350be26c" />



### After screenshots:
<img width="365" height="184" alt="after_result" src="https://github.com/user-attachments/assets/fe857d3a-aeb6-4e9e-8248-bc44d1507b70" />
<img width="365" height="328" alt="after_match" src="https://github.com/user-attachments/assets/ade2cc39-f92b-4aac-affb-17f403aa71d4" />
<img width="365" height="210" alt="after_home_updated" src="https://github.com/user-attachments/assets/eac1c3e2-d938-4660-bc19-f080d6fa071e" />
<img width="373" height="217" alt="after_home_most" src="https://github.com/user-attachments/assets/d6540b5e-740b-4058-ae25-b466bbb41696" />
<img width="750" height="1334" alt="after_pkg_page" src="https://github.com/user-attachments/assets/5de7b633-9871-4a23-83f0-b31445cd54ae" />
