### PR TITLE
Regenerate structure.sql

### DIFF
--- a/priv/repo/structure.sql
+++ b/priv/repo/structure.sql
@@ -2,8 +2,9 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 15.1 (Debian 15.1-1.pgdg110+1)
--- Dumped by pg_dump version 15.0 (Homebrew)
+
+-- Dumped from database version 14.23 (Debian 14.23-1.pgdg13+1)
+-- Dumped by pg_dump version 14.23 (Homebrew)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -146,6 +147,38 @@ SET default_tablespace = '';
 SET default_table_access_method = heap;
 
 --
+-- Name: account_deletion_requests; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.account_deletion_requests (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    key character varying(255) NOT NULL,
+    primary_email character varying(255) NOT NULL,
+    inserted_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: account_deletion_requests_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.account_deletion_requests_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: account_deletion_requests_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.account_deletion_requests_id_seq OWNED BY public.account_deletion_requests.id;
+
+
+--
 -- Name: audit_logs; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -157,7 +190,11 @@ CREATE TABLE public.audit_logs (
     inserted_at timestamp without time zone NOT NULL,
     user_agent character varying(255),
     organization_id bigint,
-    remote_ip character varying(255)
+    remote_ip character varying(255),
+    key_id bigint,
+    oauth_token_id bigint,
+    user_data jsonb,
+    key_data jsonb
 );
 
 
@@ -178,6 +215,45 @@ CREATE SEQUENCE public.audit_logs_id_seq
 --
 
 ALTER SEQUENCE public.audit_logs_id_seq OWNED BY public.audit_logs.id;
+
+
+--
+-- Name: authorization_codes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.authorization_codes (
+    id bigint NOT NULL,
+    code character varying(255) NOT NULL,
+    redirect_uri character varying(255) NOT NULL,
+    scopes character varying(255)[] DEFAULT ARRAY[]::character varying[] NOT NULL,
+    expires_at timestamp(0) without time zone NOT NULL,
+    used_at timestamp(0) without time zone,
+    code_challenge character varying(255),
+    code_challenge_method character varying(255),
+    user_id bigint NOT NULL,
+    client_id uuid NOT NULL,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: authorization_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.authorization_codes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: authorization_codes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.authorization_codes_id_seq OWNED BY public.authorization_codes.id;
 
 
 --
@@ -209,6 +285,47 @@ CREATE SEQUENCE public.blocked_addresses_id_seq
 --
 
 ALTER SEQUENCE public.blocked_addresses_id_seq OWNED BY public.blocked_addresses.id;
+
+
+--
+-- Name: device_codes; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.device_codes (
+    id bigint NOT NULL,
+    device_code character varying(255) NOT NULL,
+    user_code character varying(255) NOT NULL,
+    verification_uri character varying(255) NOT NULL,
+    verification_uri_complete character varying(255),
+    name character varying(255),
+    client_id uuid NOT NULL,
+    expires_at timestamp without time zone NOT NULL,
+    "interval" integer NOT NULL,
+    status character varying(255) NOT NULL,
+    scopes character varying(255)[] DEFAULT ARRAY[]::character varying[] NOT NULL,
+    user_id bigint,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: device_codes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.device_codes_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: device_codes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.device_codes_id_seq OWNED BY public.device_codes.id;
 
 
 --
@@ -326,7 +443,6 @@ CREATE TABLE public.keys (
     updated_at timestamp without time zone NOT NULL,
     secret_first text NOT NULL,
     secret_second text NOT NULL,
-    revoked_at timestamp without time zone,
     permissions jsonb[] NOT NULL,
     last_use jsonb,
     organization_id bigint,
@@ -356,6 +472,69 @@ ALTER SEQUENCE public.keys_id_seq OWNED BY public.keys.id;
 
 
 --
+-- Name: oauth_clients; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_clients (
+    client_id uuid NOT NULL,
+    client_secret character varying(255),
+    name character varying(255) NOT NULL,
+    client_type character varying(255) NOT NULL,
+    allowed_grant_types character varying(255)[] NOT NULL,
+    redirect_uris character varying(255)[],
+    allowed_scopes character varying(255)[] NOT NULL,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: oauth_tokens; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.oauth_tokens (
+    id bigint NOT NULL,
+    jti text NOT NULL,
+    refresh_jti text,
+    token_type character varying(255) DEFAULT 'bearer'::character varying NOT NULL,
+    refresh_token_expires_at timestamp(0) without time zone,
+    scopes character varying(255)[] DEFAULT ARRAY[]::character varying[] NOT NULL,
+    expires_at timestamp(0) without time zone NOT NULL,
+    revoked_at timestamp(0) without time zone,
+    user_id bigint,
+    client_id uuid NOT NULL,
+    grant_type character varying(255) NOT NULL,
+    grant_reference text,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    user_session_id bigint,
+    refresh_token_hash text,
+    organization_id bigint,
+    granted_scopes character varying(255)[] DEFAULT ARRAY[]::character varying[] NOT NULL,
+    CONSTRAINT user_or_organization_required CHECK (((user_id IS NOT NULL) OR (organization_id IS NOT NULL)))
+);
+
+
+--
+-- Name: oauth_tokens_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.oauth_tokens_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: oauth_tokens_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.oauth_tokens_id_seq OWNED BY public.oauth_tokens.id;
+
+
+--
 -- Name: organization_users; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -376,27 +555,44 @@ CREATE TABLE public.organization_users (
 CREATE TABLE public.organizations (
     id bigint NOT NULL,
     name character varying(255) NOT NULL,
-    public boolean DEFAULT false NOT NULL,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
     billing_active boolean DEFAULT false NOT NULL,
-    trial_end timestamp without time zone NOT NULL
+    trial_end timestamp without time zone NOT NULL,
+    billing_override boolean,
+    billing_seats integer
 );
 
 
 --
--- Name: packages; Type: TABLE; Schema: public; Owner: -
+-- Name: package_dependants; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.packages (
-    id integer NOT NULL,
-    name character varying(255) NOT NULL,
-    meta jsonb NOT NULL,
-    inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL,
-    docs_updated_at timestamp without time zone,
-    repository_id integer NOT NULL
+CREATE TABLE public.package_dependants (
+    id bigint NOT NULL,
+    dependency_id bigint NOT NULL,
+    package_id bigint NOT NULL,
+    dependant_repository_id bigint NOT NULL
 );
+
+
+--
+-- Name: package_dependants_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.package_dependants_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: package_dependants_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.package_dependants_id_seq OWNED BY public.package_dependants.id;
 
 
 --
@@ -416,49 +612,6 @@ CREATE TABLE public.releases (
     inner_checksum bytea NOT NULL,
     outer_checksum bytea
 );
-
-
---
--- Name: repositories; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.repositories (
-    id bigint NOT NULL,
-    name character varying(255) NOT NULL,
-    organization_id bigint,
-    inserted_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
-);
-
-
---
--- Name: requirements; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.requirements (
-    id integer NOT NULL,
-    release_id integer NOT NULL,
-    dependency_id integer NOT NULL,
-    requirement text NOT NULL,
-    optional boolean DEFAULT false NOT NULL,
-    app text NOT NULL
-);
-
-
---
--- Name: package_dependants; Type: MATERIALIZED VIEW; Schema: public; Owner: -
---
-
-CREATE MATERIALIZED VIEW public.package_dependants AS
- SELECT DISTINCT p3.name,
-    r4.name AS repo,
-    p0.id AS dependant_id
-   FROM ((((public.packages p0
-     JOIN public.releases r1 ON ((r1.package_id = p0.id)))
-     JOIN public.requirements r2 ON ((r2.release_id = r1.id)))
-     JOIN public.packages p3 ON ((p3.id = r2.dependency_id)))
-     JOIN public.repositories r4 ON ((r4.id = p3.repository_id)))
-  WITH NO DATA;
 
 
 --
@@ -548,7 +701,7 @@ ALTER SEQUENCE public.package_owners_id_seq OWNED BY public.package_owners.id;
 CREATE TABLE public.package_report_comments (
     id bigint NOT NULL,
     text text NOT NULL,
-    author_id bigint NOT NULL,
+    author_id bigint,
     package_report_id bigint NOT NULL,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
@@ -615,7 +768,7 @@ CREATE TABLE public.package_reports (
     description text NOT NULL,
     state character varying(255) NOT NULL,
     package_id bigint NOT NULL,
-    author_id bigint NOT NULL,
+    author_id bigint,
     inserted_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -638,6 +791,21 @@ CREATE SEQUENCE public.package_reports_id_seq
 --
 
 ALTER SEQUENCE public.package_reports_id_seq OWNED BY public.package_reports.id;
+
+
+--
+-- Name: packages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.packages (
+    id integer NOT NULL,
+    name character varying(255) NOT NULL,
+    meta jsonb NOT NULL,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    docs_updated_at timestamp without time zone,
+    repository_id integer NOT NULL
+);
 
 
 --
@@ -726,6 +894,19 @@ ALTER SEQUENCE public.releases_id_seq OWNED BY public.releases.id;
 
 
 --
+-- Name: repositories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.repositories (
+    id bigint NOT NULL,
+    name character varying(255) NOT NULL,
+    organization_id bigint,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
 -- Name: repositories_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -783,6 +964,20 @@ ALTER SEQUENCE public.repository_users_id_seq OWNED BY public.organization_users
 
 
 --
+-- Name: requirements; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.requirements (
+    id integer NOT NULL,
+    release_id integer NOT NULL,
+    dependency_id integer NOT NULL,
+    requirement text NOT NULL,
+    optional boolean DEFAULT false NOT NULL,
+    app text NOT NULL
+);
+
+
+--
 -- Name: requirements_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
@@ -835,6 +1030,36 @@ ALTER SEQUENCE public.reserved_packages_id_seq OWNED BY public.reserved_packages
 
 
 --
+-- Name: reserved_usernames; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.reserved_usernames (
+    id bigint NOT NULL,
+    name character varying(255) NOT NULL,
+    inserted_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: reserved_usernames_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.reserved_usernames_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: reserved_usernames_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.reserved_usernames_id_seq OWNED BY public.reserved_usernames.id;
+
+
+--
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -842,6 +1067,105 @@ CREATE TABLE public.schema_migrations (
     version bigint NOT NULL,
     inserted_at timestamp(0) without time zone
 );
+
+
+--
+-- Name: security_advisories; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.security_advisories (
+    id character varying(255) NOT NULL,
+    summary character varying(255) NOT NULL,
+    aliases character varying(255)[] DEFAULT ARRAY[]::character varying[] NOT NULL,
+    published_at timestamp(0) without time zone NOT NULL,
+    modified_at timestamp(0) without time zone NOT NULL,
+    withdrawn_at timestamp(0) without time zone,
+    cvss_vector character varying(255),
+    cvss_score double precision,
+    cvss_rating character varying(255)
+);
+
+
+--
+-- Name: security_advisory_affected_packages; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.security_advisory_affected_packages (
+    advisory_id character varying(255) NOT NULL,
+    package_id bigint NOT NULL
+);
+
+
+--
+-- Name: security_advisory_affected_releases; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.security_advisory_affected_releases (
+    advisory_id character varying(255) NOT NULL,
+    release_id bigint NOT NULL
+);
+
+
+--
+-- Name: security_advisory_affected_versions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.security_advisory_affected_versions (
+    id bigint NOT NULL,
+    advisory_id character varying(255) NOT NULL,
+    package_id bigint NOT NULL,
+    requirement character varying(255) NOT NULL
+);
+
+
+--
+-- Name: security_advisory_affected_versions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.security_advisory_affected_versions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: security_advisory_affected_versions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.security_advisory_affected_versions_id_seq OWNED BY public.security_advisory_affected_versions.id;
+
+
+--
+-- Name: security_advisory_references; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.security_advisory_references (
+    id bigint NOT NULL,
+    advisory_id character varying(255) NOT NULL,
+    type character varying(255) NOT NULL,
+    url character varying(255) NOT NULL
+);
+
+
+--
+-- Name: security_advisory_references_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.security_advisory_references_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: security_advisory_references_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.security_advisory_references_id_seq OWNED BY public.security_advisory_references.id;
 
 
 --
@@ -908,6 +1232,81 @@ ALTER SEQUENCE public.short_urls_id_seq OWNED BY public.short_urls.id;
 
 
 --
+-- Name: user_providers; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_providers (
+    id bigint NOT NULL,
+    user_id bigint NOT NULL,
+    provider character varying(255) NOT NULL,
+    provider_uid character varying(255) NOT NULL,
+    provider_email character varying(255),
+    provider_data jsonb DEFAULT '{}'::jsonb,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL
+);
+
+
+--
+-- Name: user_providers_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_providers_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_providers_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_providers_id_seq OWNED BY public.user_providers.id;
+
+
+--
+-- Name: user_sessions; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.user_sessions (
+    id bigint NOT NULL,
+    user_id bigint,
+    type character varying(255) NOT NULL,
+    name character varying(255),
+    revoked_at timestamp without time zone,
+    last_use jsonb,
+    session_token bytea,
+    client_id uuid,
+    inserted_at timestamp without time zone NOT NULL,
+    updated_at timestamp without time zone NOT NULL,
+    expires_at timestamp without time zone,
+    organization_id bigint,
+    CONSTRAINT user_or_organization_required CHECK (((user_id IS NOT NULL) OR (organization_id IS NOT NULL)))
+);
+
+
+--
+-- Name: user_sessions_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.user_sessions_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: user_sessions_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.user_sessions_id_seq OWNED BY public.user_sessions.id;
+
+
+--
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -923,7 +1322,8 @@ CREATE TABLE public.users (
     organization_id bigint,
     deactivated_at timestamp(0) without time zone,
     tfa jsonb,
-    role character varying(255) DEFAULT 'basic'::character varying
+    role character varying(255) DEFAULT 'basic'::character varying,
+    optional_emails jsonb
 );
 
 
@@ -948,6 +1348,13 @@ ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
 
 
 --
+-- Name: account_deletion_requests id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.account_deletion_requests ALTER COLUMN id SET DEFAULT nextval('public.account_deletion_requests_id_seq'::regclass);
+
+
+--
 -- Name: audit_logs id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -955,10 +1362,24 @@ ALTER TABLE ONLY public.audit_logs ALTER COLUMN id SET DEFAULT nextval('public.a
 
 
 --
+-- Name: authorization_codes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.authorization_codes ALTER COLUMN id SET DEFAULT nextval('public.authorization_codes_id_seq'::regclass);
+
+
+--
 -- Name: blocked_addresses id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.blocked_addresses ALTER COLUMN id SET DEFAULT nextval('public.blocked_addresses_id_seq'::regclass);
+
+
+--
+-- Name: device_codes id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.device_codes ALTER COLUMN id SET DEFAULT nextval('public.device_codes_id_seq'::regclass);
 
 
 --
@@ -990,6 +1411,13 @@ ALTER TABLE ONLY public.keys ALTER COLUMN id SET DEFAULT nextval('public.keys_id
 
 
 --
+-- Name: oauth_tokens id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_tokens ALTER COLUMN id SET DEFAULT nextval('public.oauth_tokens_id_seq'::regclass);
+
+
+--
 -- Name: organization_users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1001,6 +1429,13 @@ ALTER TABLE ONLY public.organization_users ALTER COLUMN id SET DEFAULT nextval('
 --
 
 ALTER TABLE ONLY public.organizations ALTER COLUMN id SET DEFAULT nextval('public.repositories_id_seq'::regclass);
+
+
+--
+-- Name: package_dependants id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_dependants ALTER COLUMN id SET DEFAULT nextval('public.package_dependants_id_seq'::regclass);
 
 
 --
@@ -1074,6 +1509,27 @@ ALTER TABLE ONLY public.reserved_packages ALTER COLUMN id SET DEFAULT nextval('p
 
 
 --
+-- Name: reserved_usernames id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reserved_usernames ALTER COLUMN id SET DEFAULT nextval('public.reserved_usernames_id_seq'::regclass);
+
+
+--
+-- Name: security_advisory_affected_versions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_versions ALTER COLUMN id SET DEFAULT nextval('public.security_advisory_affected_versions_id_seq'::regclass);
+
+
+--
+-- Name: security_advisory_references id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_references ALTER COLUMN id SET DEFAULT nextval('public.security_advisory_references_id_seq'::regclass);
+
+
+--
 -- Name: sessions id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -1088,10 +1544,32 @@ ALTER TABLE ONLY public.short_urls ALTER COLUMN id SET DEFAULT nextval('public.s
 
 
 --
+-- Name: user_providers id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_providers ALTER COLUMN id SET DEFAULT nextval('public.user_providers_id_seq'::regclass);
+
+
+--
+-- Name: user_sessions id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_sessions ALTER COLUMN id SET DEFAULT nextval('public.user_sessions_id_seq'::regclass);
+
+
+--
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+
+
+--
+-- Name: account_deletion_requests account_deletion_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.account_deletion_requests
+    ADD CONSTRAINT account_deletion_requests_pkey PRIMARY KEY (id);
 
 
 --
@@ -1103,11 +1581,27 @@ ALTER TABLE ONLY public.audit_logs
 
 
 --
+-- Name: authorization_codes authorization_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.authorization_codes
+    ADD CONSTRAINT authorization_codes_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: blocked_addresses blocked_addresses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.blocked_addresses
     ADD CONSTRAINT blocked_addresses_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: device_codes device_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.device_codes
+    ADD CONSTRAINT device_codes_pkey PRIMARY KEY (id);
 
 
 --
@@ -1151,6 +1645,22 @@ ALTER TABLE ONLY public.keys
 
 
 --
+-- Name: oauth_clients oauth_clients_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_clients
+    ADD CONSTRAINT oauth_clients_pkey PRIMARY KEY (client_id);
+
+
+--
+-- Name: oauth_tokens oauth_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_tokens
+    ADD CONSTRAINT oauth_tokens_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: organization_users organization_users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1164,6 +1674,14 @@ ALTER TABLE ONLY public.organization_users
 
 ALTER TABLE ONLY public.organizations
     ADD CONSTRAINT organizations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: package_dependants package_dependants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_dependants
+    ADD CONSTRAINT package_dependants_pkey PRIMARY KEY (id);
 
 
 --
@@ -1263,11 +1781,59 @@ ALTER TABLE ONLY public.reserved_packages
 
 
 --
+-- Name: reserved_usernames reserved_usernames_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.reserved_usernames
+    ADD CONSTRAINT reserved_usernames_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (version);
+
+
+--
+-- Name: security_advisories security_advisories_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisories
+    ADD CONSTRAINT security_advisories_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: security_advisory_affected_packages security_advisory_affected_packages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_packages
+    ADD CONSTRAINT security_advisory_affected_packages_pkey PRIMARY KEY (advisory_id, package_id);
+
+
+--
+-- Name: security_advisory_affected_releases security_advisory_affected_releases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_releases
+    ADD CONSTRAINT security_advisory_affected_releases_pkey PRIMARY KEY (advisory_id, release_id);
+
+
+--
+-- Name: security_advisory_affected_versions security_advisory_affected_versions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_versions
+    ADD CONSTRAINT security_advisory_affected_versions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: security_advisory_references security_advisory_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_references
+    ADD CONSTRAINT security_advisory_references_pkey PRIMARY KEY (id);
 
 
 --
@@ -1287,6 +1853,22 @@ ALTER TABLE ONLY public.short_urls
 
 
 --
+-- Name: user_providers user_providers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_providers
+    ADD CONSTRAINT user_providers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: user_sessions user_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_sessions
+    ADD CONSTRAINT user_sessions_pkey PRIMARY KEY (id);
+
+
+--
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1295,38 +1877,94 @@ ALTER TABLE ONLY public.users
 
 
 --
--- Name: audit_logs_actor_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: account_deletion_requests_user_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX audit_logs_actor_id_index ON public.audit_logs USING btree (user_id);
-
-
---
--- Name: audit_logs_inserted_at_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX audit_logs_inserted_at_index ON public.audit_logs USING btree (inserted_at);
+CREATE UNIQUE INDEX account_deletion_requests_user_id_index ON public.account_deletion_requests USING btree (user_id);
 
 
 --
--- Name: audit_logs_organization_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: audit_logs_key_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX audit_logs_organization_id_index ON public.audit_logs USING btree (organization_id);
-
-
---
--- Name: audit_logs_params_package_id_index; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX audit_logs_params_package_id_index ON public.audit_logs USING btree (((((params -> 'package'::text) ->> 'id'::text))::integer));
+CREATE INDEX audit_logs_key_id_index ON public.audit_logs USING btree (key_id);
 
 
 --
--- Name: blocked_addresses_ip_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: audit_logs_oauth_token_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX blocked_addresses_ip_idx ON public.blocked_addresses USING btree (ip);
+CREATE INDEX audit_logs_oauth_token_id_index ON public.audit_logs USING btree (oauth_token_id);
+
+
+--
+-- Name: audit_logs_organization_id_inserted_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_logs_organization_id_inserted_at_index ON public.audit_logs USING btree (organization_id, inserted_at DESC);
+
+
+--
+-- Name: audit_logs_params_package_id_inserted_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_logs_params_package_id_inserted_at_index ON public.audit_logs USING btree (((((params -> 'package'::text) ->> 'id'::text))::integer), inserted_at DESC);
+
+
+--
+-- Name: audit_logs_user_id_inserted_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX audit_logs_user_id_inserted_at_index ON public.audit_logs USING btree (user_id, inserted_at DESC);
+
+
+--
+-- Name: authorization_codes_client_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authorization_codes_client_id_index ON public.authorization_codes USING btree (client_id);
+
+
+--
+-- Name: authorization_codes_code_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX authorization_codes_code_index ON public.authorization_codes USING btree (code);
+
+
+--
+-- Name: authorization_codes_expires_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX authorization_codes_expires_at_index ON public.authorization_codes USING btree (expires_at);
+
+
+--
+-- Name: device_codes_device_code_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX device_codes_device_code_index ON public.device_codes USING btree (device_code);
+
+
+--
+-- Name: device_codes_expires_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX device_codes_expires_at_index ON public.device_codes USING btree (expires_at);
+
+
+--
+-- Name: device_codes_status_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX device_codes_status_index ON public.device_codes USING btree (status);
+
+
+--
+-- Name: device_codes_user_code_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX device_codes_user_code_index ON public.device_codes USING btree (user_code);
 
 
 --
@@ -1337,17 +1975,17 @@ CREATE INDEX downloads_day_idx ON public.downloads USING btree (day);
 
 
 --
--- Name: downloads_package_id_index; Type: INDEX; Schema: public; Owner: -
+-- Name: downloads_package_id_day_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX downloads_package_id_index ON public.downloads USING btree (package_id);
+CREATE INDEX downloads_package_id_day_idx ON public.downloads USING btree (package_id, day);
 
 
 --
--- Name: downloads_release_id_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: downloads_release_id_day_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX downloads_release_id_idx ON public.downloads USING btree (release_id);
+CREATE INDEX downloads_release_id_day_idx ON public.downloads USING btree (release_id, day);
 
 
 --
@@ -1394,17 +2032,17 @@ CREATE UNIQUE INDEX installs_hex_index ON public.installs USING btree (hex);
 
 
 --
--- Name: keys_name_index; Type: INDEX; Schema: public; Owner: -
+-- Name: keys_organization_id_name_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX keys_name_index ON public.keys USING btree (name);
+CREATE INDEX keys_organization_id_name_index ON public.keys USING btree (organization_id, name);
 
 
 --
--- Name: keys_organization_id_name_revoked_at_key; Type: INDEX; Schema: public; Owner: -
+-- Name: keys_public_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX keys_organization_id_name_revoked_at_key ON public.keys USING btree (organization_id, name) WHERE (revoked_at IS NULL);
+CREATE INDEX keys_public_index ON public.keys USING btree (public);
 
 
 --
@@ -1415,17 +2053,59 @@ CREATE INDEX keys_revoke_at_index ON public.keys USING btree (revoke_at);
 
 
 --
--- Name: keys_revoked_at_index; Type: INDEX; Schema: public; Owner: -
+-- Name: keys_user_id_name_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX keys_revoked_at_index ON public.keys USING btree (revoked_at);
+CREATE INDEX keys_user_id_name_index ON public.keys USING btree (user_id, name);
 
 
 --
--- Name: keys_user_id_name_revoked_at_key; Type: INDEX; Schema: public; Owner: -
+-- Name: oauth_tokens_device_code_grant_reference_client_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX keys_user_id_name_revoked_at_key ON public.keys USING btree (user_id, name) WHERE (revoked_at IS NULL);
+CREATE UNIQUE INDEX oauth_tokens_device_code_grant_reference_client_id_index ON public.oauth_tokens USING btree (grant_reference, client_id) WHERE (((grant_type)::text = 'urn:ietf:params:oauth:grant-type:device_code'::text) AND (revoked_at IS NULL));
+
+
+--
+-- Name: oauth_tokens_expires_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oauth_tokens_expires_at_index ON public.oauth_tokens USING btree (expires_at);
+
+
+--
+-- Name: oauth_tokens_jti_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX oauth_tokens_jti_index ON public.oauth_tokens USING btree (jti);
+
+
+--
+-- Name: oauth_tokens_refresh_jti_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX oauth_tokens_refresh_jti_index ON public.oauth_tokens USING btree (refresh_jti);
+
+
+--
+-- Name: oauth_tokens_refresh_token_hash_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX oauth_tokens_refresh_token_hash_index ON public.oauth_tokens USING btree (refresh_token_hash) WHERE (refresh_token_hash IS NOT NULL);
+
+
+--
+-- Name: oauth_tokens_user_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oauth_tokens_user_id_index ON public.oauth_tokens USING btree (user_id);
+
+
+--
+-- Name: oauth_tokens_user_session_id_full_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX oauth_tokens_user_session_id_full_index ON public.oauth_tokens USING btree (user_session_id);
 
 
 --
@@ -1450,17 +2130,17 @@ CREATE UNIQUE INDEX organizations_name_index ON public.organizations USING btree
 
 
 --
--- Name: organizations_public_index; Type: INDEX; Schema: public; Owner: -
+-- Name: package_dependants_dependency_id_dependant_repository_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX organizations_public_index ON public.organizations USING btree (public);
+CREATE INDEX package_dependants_dependency_id_dependant_repository_id_index ON public.package_dependants USING btree (dependency_id, dependant_repository_id) INCLUDE (package_id);
 
 
 --
--- Name: package_dependants_name_repo_dependant_id_idx; Type: INDEX; Schema: public; Owner: -
+-- Name: package_dependants_dependency_id_package_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX package_dependants_name_repo_dependant_id_idx ON public.package_dependants USING btree (name, repo, dependant_id);
+CREATE UNIQUE INDEX package_dependants_dependency_id_package_id_index ON public.package_dependants USING btree (dependency_id, package_id);
 
 
 --
@@ -1478,10 +2158,10 @@ CREATE UNIQUE INDEX package_downloads_package_id_view_idx ON public.package_down
 
 
 --
--- Name: package_downloads_view_index; Type: INDEX; Schema: public; Owner: -
+-- Name: package_downloads_view_downloads_package_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX package_downloads_view_index ON public.package_downloads USING btree (view);
+CREATE INDEX package_downloads_view_downloads_package_id_idx ON public.package_downloads USING btree (view, downloads DESC NULLS LAST, package_id);
 
 
 --
@@ -1590,6 +2270,13 @@ CREATE INDEX releases_inserted_at_idx ON public.releases USING btree (inserted_a
 
 
 --
+-- Name: releases_meta_build_tools_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX releases_meta_build_tools_idx ON public.releases USING gin (((meta -> 'build_tools'::text)));
+
+
+--
 -- Name: releases_package_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1611,6 +2298,13 @@ CREATE UNIQUE INDEX repositories_organization_id_index ON public.repositories US
 
 
 --
+-- Name: requirements_dependency_id_release_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX requirements_dependency_id_release_id_index ON public.requirements USING btree (dependency_id, release_id);
+
+
+--
 -- Name: requirements_release_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1625,10 +2319,108 @@ CREATE UNIQUE INDEX reserved_packages_repository_id_name_version_index ON public
 
 
 --
+-- Name: reserved_usernames_name_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX reserved_usernames_name_idx ON public.reserved_usernames USING btree (lower((name)::text));
+
+
+--
+-- Name: security_advisory_affected_packages_package_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX security_advisory_affected_packages_package_id_index ON public.security_advisory_affected_packages USING btree (package_id);
+
+
+--
+-- Name: security_advisory_affected_releases_release_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX security_advisory_affected_releases_release_id_index ON public.security_advisory_affected_releases USING btree (release_id);
+
+
+--
+-- Name: security_advisory_affected_versions_advisory_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX security_advisory_affected_versions_advisory_id_index ON public.security_advisory_affected_versions USING btree (advisory_id);
+
+
+--
+-- Name: security_advisory_affected_versions_package_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX security_advisory_affected_versions_package_id_index ON public.security_advisory_affected_versions USING btree (package_id);
+
+
+--
+-- Name: security_advisory_references_advisory_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX security_advisory_references_advisory_id_index ON public.security_advisory_references USING btree (advisory_id);
+
+
+--
+-- Name: sessions_updated_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX sessions_updated_at_index ON public.sessions USING btree (updated_at);
+
+
+--
 -- Name: short_urls_short_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX short_urls_short_code_index ON public.short_urls USING btree (short_code);
+
+
+--
+-- Name: user_providers_provider_provider_uid_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX user_providers_provider_provider_uid_index ON public.user_providers USING btree (provider, provider_uid);
+
+
+--
+-- Name: user_providers_user_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_providers_user_id_index ON public.user_providers USING btree (user_id);
+
+
+--
+-- Name: user_sessions_expires_at_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_sessions_expires_at_index ON public.user_sessions USING btree (expires_at);
+
+
+--
+-- Name: user_sessions_organization_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_sessions_organization_id_index ON public.user_sessions USING btree (organization_id);
+
+
+--
+-- Name: user_sessions_session_token_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_sessions_session_token_index ON public.user_sessions USING btree (session_token);
+
+
+--
+-- Name: user_sessions_type_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_sessions_type_index ON public.user_sessions USING btree (type);
+
+
+--
+-- Name: user_sessions_user_id_index; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX user_sessions_user_id_index ON public.user_sessions USING btree (user_id);
 
 
 --
@@ -1646,11 +2438,35 @@ CREATE UNIQUE INDEX users_username_idx ON public.users USING btree (username);
 
 
 --
+-- Name: account_deletion_requests account_deletion_requests_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.account_deletion_requests
+    ADD CONSTRAINT account_deletion_requests_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
 -- Name: audit_logs audit_logs_actor_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
 ALTER TABLE ONLY public.audit_logs
-    ADD CONSTRAINT audit_logs_actor_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+    ADD CONSTRAINT audit_logs_actor_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE SET NULL;
+
+
+--
+-- Name: audit_logs audit_logs_key_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_key_id_fkey FOREIGN KEY (key_id) REFERENCES public.keys(id) ON DELETE SET NULL;
+
+
+--
+-- Name: audit_logs audit_logs_oauth_token_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.audit_logs
+    ADD CONSTRAINT audit_logs_oauth_token_id_fkey FOREIGN KEY (oauth_token_id) REFERENCES public.oauth_tokens(id) ON DELETE SET NULL;
 
 
 --
@@ -1659,6 +2475,38 @@ ALTER TABLE ONLY public.audit_logs
 
 ALTER TABLE ONLY public.audit_logs
     ADD CONSTRAINT audit_logs_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id);
+
+
+--
+-- Name: authorization_codes authorization_codes_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.authorization_codes
+    ADD CONSTRAINT authorization_codes_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(client_id) ON DELETE CASCADE;
+
+
+--
+-- Name: authorization_codes authorization_codes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.authorization_codes
+    ADD CONSTRAINT authorization_codes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: device_codes device_codes_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.device_codes
+    ADD CONSTRAINT device_codes_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(client_id) ON DELETE CASCADE;
+
+
+--
+-- Name: device_codes device_codes_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.device_codes
+    ADD CONSTRAINT device_codes_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 
 --
@@ -1702,6 +2550,38 @@ ALTER TABLE ONLY public.keys
 
 
 --
+-- Name: oauth_tokens oauth_tokens_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_tokens
+    ADD CONSTRAINT oauth_tokens_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(client_id) ON DELETE CASCADE;
+
+
+--
+-- Name: oauth_tokens oauth_tokens_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_tokens
+    ADD CONSTRAINT oauth_tokens_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: oauth_tokens oauth_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_tokens
+    ADD CONSTRAINT oauth_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: oauth_tokens oauth_tokens_user_session_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.oauth_tokens
+    ADD CONSTRAINT oauth_tokens_user_session_id_fkey FOREIGN KEY (user_session_id) REFERENCES public.user_sessions(id) ON DELETE SET NULL;
+
+
+--
 -- Name: organization_users organization_users_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1714,7 +2594,31 @@ ALTER TABLE ONLY public.organization_users
 --
 
 ALTER TABLE ONLY public.organization_users
-    ADD CONSTRAINT organization_users_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+    ADD CONSTRAINT organization_users_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_dependants package_dependants_dependant_repository_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_dependants
+    ADD CONSTRAINT package_dependants_dependant_repository_id_fkey FOREIGN KEY (dependant_repository_id) REFERENCES public.repositories(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_dependants package_dependants_dependency_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_dependants
+    ADD CONSTRAINT package_dependants_dependency_id_fkey FOREIGN KEY (dependency_id) REFERENCES public.packages(id) ON DELETE CASCADE;
+
+
+--
+-- Name: package_dependants package_dependants_package_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.package_dependants
+    ADD CONSTRAINT package_dependants_package_id_fkey FOREIGN KEY (package_id) REFERENCES public.packages(id) ON DELETE CASCADE;
 
 
 --
@@ -1738,7 +2642,7 @@ ALTER TABLE ONLY public.package_owners
 --
 
 ALTER TABLE ONLY public.package_report_comments
-    ADD CONSTRAINT package_report_comments_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id);
+    ADD CONSTRAINT package_report_comments_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id) ON DELETE SET NULL;
 
 
 --
@@ -1770,7 +2674,7 @@ ALTER TABLE ONLY public.package_report_releases
 --
 
 ALTER TABLE ONLY public.package_reports
-    ADD CONSTRAINT package_reports_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id);
+    ADD CONSTRAINT package_reports_author_id_fkey FOREIGN KEY (author_id) REFERENCES public.users(id) ON DELETE SET NULL;
 
 
 --
@@ -1794,7 +2698,7 @@ ALTER TABLE ONLY public.packages
 --
 
 ALTER TABLE ONLY public.password_resets
-    ADD CONSTRAINT password_resets_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id);
+    ADD CONSTRAINT password_resets_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
 
 --
@@ -1810,7 +2714,7 @@ ALTER TABLE ONLY public.releases
 --
 
 ALTER TABLE ONLY public.releases
-    ADD CONSTRAINT releases_publisher_id_fkey FOREIGN KEY (publisher_id) REFERENCES public.users(id);
+    ADD CONSTRAINT releases_publisher_id_fkey FOREIGN KEY (publisher_id) REFERENCES public.users(id) ON DELETE SET NULL;
 
 
 --
@@ -1846,6 +2750,94 @@ ALTER TABLE ONLY public.reserved_packages
 
 
 --
+-- Name: security_advisory_affected_packages security_advisory_affected_packages_advisory_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_packages
+    ADD CONSTRAINT security_advisory_affected_packages_advisory_id_fkey FOREIGN KEY (advisory_id) REFERENCES public.security_advisories(id) ON DELETE CASCADE;
+
+
+--
+-- Name: security_advisory_affected_packages security_advisory_affected_packages_package_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_packages
+    ADD CONSTRAINT security_advisory_affected_packages_package_id_fkey FOREIGN KEY (package_id) REFERENCES public.packages(id) ON DELETE CASCADE;
+
+
+--
+-- Name: security_advisory_affected_releases security_advisory_affected_releases_advisory_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_releases
+    ADD CONSTRAINT security_advisory_affected_releases_advisory_id_fkey FOREIGN KEY (advisory_id) REFERENCES public.security_advisories(id) ON DELETE CASCADE;
+
+
+--
+-- Name: security_advisory_affected_releases security_advisory_affected_releases_release_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_releases
+    ADD CONSTRAINT security_advisory_affected_releases_release_id_fkey FOREIGN KEY (release_id) REFERENCES public.releases(id) ON DELETE CASCADE;
+
+
+--
+-- Name: security_advisory_affected_versions security_advisory_affected_versions_advisory_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_versions
+    ADD CONSTRAINT security_advisory_affected_versions_advisory_id_fkey FOREIGN KEY (advisory_id) REFERENCES public.security_advisories(id) ON DELETE CASCADE;
+
+
+--
+-- Name: security_advisory_affected_versions security_advisory_affected_versions_package_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_affected_versions
+    ADD CONSTRAINT security_advisory_affected_versions_package_id_fkey FOREIGN KEY (package_id) REFERENCES public.packages(id) ON DELETE CASCADE;
+
+
+--
+-- Name: security_advisory_references security_advisory_references_advisory_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.security_advisory_references
+    ADD CONSTRAINT security_advisory_references_advisory_id_fkey FOREIGN KEY (advisory_id) REFERENCES public.security_advisories(id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_providers user_providers_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_providers
+    ADD CONSTRAINT user_providers_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_sessions user_sessions_client_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_sessions
+    ADD CONSTRAINT user_sessions_client_id_fkey FOREIGN KEY (client_id) REFERENCES public.oauth_clients(client_id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_sessions user_sessions_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_sessions
+    ADD CONSTRAINT user_sessions_organization_id_fkey FOREIGN KEY (organization_id) REFERENCES public.organizations(id) ON DELETE CASCADE;
+
+
+--
+-- Name: user_sessions user_sessions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.user_sessions
+    ADD CONSTRAINT user_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
 -- Name: users users_organization_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -1856,6 +2848,7 @@ ALTER TABLE ONLY public.users
 --
 -- PostgreSQL database dump complete
 --
+
 
 INSERT INTO public."schema_migrations" (version) VALUES (20140128201839);
 INSERT INTO public."schema_migrations" (version) VALUES (20140128205233);
@@ -1965,3 +2958,46 @@ INSERT INTO public."schema_migrations" (version) VALUES (20220219013427);
 INSERT INTO public."schema_migrations" (version) VALUES (20220323140836);
 INSERT INTO public."schema_migrations" (version) VALUES (20221103004202);
 INSERT INTO public."schema_migrations" (version) VALUES (20221106173432);
+INSERT INTO public."schema_migrations" (version) VALUES (20230124011453);
+INSERT INTO public."schema_migrations" (version) VALUES (20230504180925);
+INSERT INTO public."schema_migrations" (version) VALUES (20230510205035);
+INSERT INTO public."schema_migrations" (version) VALUES (20240604161405);
+INSERT INTO public."schema_migrations" (version) VALUES (20250919152128);
+INSERT INTO public."schema_migrations" (version) VALUES (20250923100001);
+INSERT INTO public."schema_migrations" (version) VALUES (20250923100002);
+INSERT INTO public."schema_migrations" (version) VALUES (20250923100003);
+INSERT INTO public."schema_migrations" (version) VALUES (20250923100004);
+INSERT INTO public."schema_migrations" (version) VALUES (20250923100005);
+INSERT INTO public."schema_migrations" (version) VALUES (20251004230016);
+INSERT INTO public."schema_migrations" (version) VALUES (20251004230017);
+INSERT INTO public."schema_migrations" (version) VALUES (20251005174900);
+INSERT INTO public."schema_migrations" (version) VALUES (20251007175802);
+INSERT INTO public."schema_migrations" (version) VALUES (20251010135827);
+INSERT INTO public."schema_migrations" (version) VALUES (20251010172623);
+INSERT INTO public."schema_migrations" (version) VALUES (20251020202843);
+INSERT INTO public."schema_migrations" (version) VALUES (20251023120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20251029131044);
+INSERT INTO public."schema_migrations" (version) VALUES (20251211004001);
+INSERT INTO public."schema_migrations" (version) VALUES (20260202233553);
+INSERT INTO public."schema_migrations" (version) VALUES (20260203000536);
+INSERT INTO public."schema_migrations" (version) VALUES (20260206120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260206130000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260227120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260305120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260315120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260325120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260416120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260417120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260417130000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260417140000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260417153000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260419014711);
+INSERT INTO public."schema_migrations" (version) VALUES (20260419051646);
+INSERT INTO public."schema_migrations" (version) VALUES (20260419071136);
+INSERT INTO public."schema_migrations" (version) VALUES (20260419152629);
+INSERT INTO public."schema_migrations" (version) VALUES (20260420120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260421120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260511000000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260604120000);
+INSERT INTO public."schema_migrations" (version) VALUES (20260611000001);
+INSERT INTO public."schema_migrations" (version) VALUES (20260612000000);


### PR DESCRIPTION
The dumped schema was stale, capturing only migrations through late 2022 (108 of the 150 migrations on disk). Regenerate it from a fully migrated database so it reflects the current schema.

Notable columns and constraints that were missing, including `audit_logs.key_id` (with its `ON DELETE SET NULL` foreign key), `audit_logs.user_data`/`key_data`/`oauth_token_id`, and the OAuth tables, are now present.

Verified by loading the regenerated file into a fresh database and confirming `ecto.migrate` reports no pending migrations.