### PR TITLE
Add API endpoint to retire all active package releases

### DIFF
--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -138,11 +138,19 @@ defmodule Hexpm.Repository.Releases do
       Enum.reduce(releases, Multi.new(), fn release, multi ->
         key = {:release, release.id}
 
-        multi
-        |> Multi.update(key, Release.retire(release, params))
-        |> audit(audit_data, "release.retire", fn changes ->
-          {package, Map.fetch!(changes, key)}
-        end)
+        Multi.update(multi, key, Release.retire(release, params))
+      end)
+      |> Multi.merge(fn changes ->
+        retirements =
+          Enum.map(releases, fn release ->
+            {package, Map.fetch!(changes, {:release, release.id})}
+          end)
+
+        if retirements == [] do
+          Multi.new()
+        else
+          audit_many(Multi.new(), audit_data, "release.retire", retirements)
+        end
       end)
     end)
     |> Repo.transaction(timeout: @publish_timeout)

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -119,7 +119,9 @@ defmodule Hexpm.Repository.Releases do
     |> retire_result()
   end
 
-  def retire(package, params, audit: audit_data) do
+  def retire(package, params, opts) do
+    audit_data = Keyword.fetch!(opts, :audit)
+    replace? = Keyword.get(opts, :replace, false)
     params = %{"retirement" => params}
 
     Multi.new()
@@ -127,14 +129,10 @@ defmodule Hexpm.Repository.Releases do
     |> Multi.update(:package, Ecto.Changeset.change(package, []), force: true)
     |> Multi.run(:retirement, fn _, _ -> validate_retirement(params) end)
     |> Multi.run(:releases, fn repo, _ ->
-      releases =
-        from(r in assoc(package, :releases),
-          where: is_nil(r.retirement),
-          lock: "FOR UPDATE"
-        )
-        |> repo.all()
+      query = from(r in assoc(package, :releases), lock: "FOR UPDATE")
+      query = if replace?, do: query, else: from(r in query, where: is_nil(r.retirement))
 
-      {:ok, releases}
+      {:ok, repo.all(query)}
     end)
     |> Multi.merge(fn %{releases: releases} ->
       Enum.reduce(releases, Multi.new(), fn release, multi ->

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -119,6 +119,38 @@ defmodule Hexpm.Repository.Releases do
     |> retire_result()
   end
 
+  def retire(package, params, audit: audit_data) do
+    params = %{"retirement" => params}
+
+    Multi.new()
+    |> Multi.run(:repository, fn _, _ -> {:ok, package.repository} end)
+    |> Multi.update(:package, Ecto.Changeset.change(package, []), force: true)
+    |> Multi.run(:retirement, fn _, _ -> validate_retirement(params) end)
+    |> Multi.run(:releases, fn repo, _ ->
+      releases =
+        from(r in assoc(package, :releases),
+          where: is_nil(r.retirement),
+          lock: "FOR UPDATE"
+        )
+        |> repo.all()
+
+      {:ok, releases}
+    end)
+    |> Multi.merge(fn %{releases: releases} ->
+      Enum.reduce(releases, Multi.new(), fn release, multi ->
+        key = {:release, release.id}
+
+        multi
+        |> Multi.update(key, Release.retire(release, params))
+        |> audit(audit_data, "release.retire", fn changes ->
+          {package, Map.fetch!(changes, key)}
+        end)
+      end)
+    end)
+    |> Repo.transaction(timeout: @publish_timeout)
+    |> retire_result()
+  end
+
   def unretire(package, release, audit: audit_data) do
     Multi.new()
     |> Multi.run(:repository, fn _, _ -> {:ok, package.repository} end)
@@ -147,6 +179,16 @@ defmodule Hexpm.Repository.Releases do
   end
 
   defp retire_result(result), do: result
+
+  defp validate_retirement(params) do
+    changeset = Release.retire(%Release{}, params)
+
+    if changeset.valid? do
+      {:ok, params}
+    else
+      {:error, changeset}
+    end
+  end
 
   defp revert_result({:ok, %{package: package, release: release, release_count: 0}}) do
     remove_package_from_registry(package)

--- a/lib/hexpm_web/controllers/api/retirement_controller.ex
+++ b/lib/hexpm_web/controllers/api/retirement_controller.ex
@@ -8,7 +8,12 @@ defmodule HexpmWeb.API.RetirementController do
 
   def create_package(conn, params) do
     if package = conn.assigns.package do
-      case Releases.retire(package, params, audit: audit_data(conn)) do
+      {replace?, params} = Map.pop(params, "replace", false)
+
+      case Releases.retire(package, params,
+             audit: audit_data(conn),
+             replace: replace? in [true, "true"]
+           ) do
         :ok ->
           conn
           |> api_cache(:private)

--- a/lib/hexpm_web/controllers/api/retirement_controller.ex
+++ b/lib/hexpm_web/controllers/api/retirement_controller.ex
@@ -1,12 +1,12 @@
 defmodule HexpmWeb.API.RetirementController do
   use HexpmWeb, :controller
 
-  plug :maybe_fetch_package when action in [:create_package]
+  plug :maybe_fetch_package when action in [:create_all]
   plug :maybe_fetch_release when action in [:create, :delete]
 
   plug :authorize, domains: [{"api", "write"}, "package"], fun: {AuthHelpers, :package_owner}
 
-  def create_package(conn, params) do
+  def create_all(conn, params) do
     if package = conn.assigns.package do
       {replace?, params} = Map.pop(params, "replace", false)
 

--- a/lib/hexpm_web/controllers/api/retirement_controller.ex
+++ b/lib/hexpm_web/controllers/api/retirement_controller.ex
@@ -1,9 +1,26 @@
 defmodule HexpmWeb.API.RetirementController do
   use HexpmWeb, :controller
 
+  plug :maybe_fetch_package when action in [:create_package]
   plug :maybe_fetch_release when action in [:create, :delete]
 
   plug :authorize, domains: [{"api", "write"}, "package"], fun: {AuthHelpers, :package_owner}
+
+  def create_package(conn, params) do
+    if package = conn.assigns.package do
+      case Releases.retire(package, params, audit: audit_data(conn)) do
+        :ok ->
+          conn
+          |> api_cache(:private)
+          |> send_resp(204, "")
+
+        {:error, _, changeset, _} ->
+          validation_failed(conn, changeset)
+      end
+    else
+      not_found(conn)
+    end
+  end
 
   def create(conn, params) do
     package = conn.assigns.package

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -389,6 +389,7 @@ defmodule HexpmWeb.Router do
         get "/packages/:name/releases/:version", ReleaseController, :show
         delete "/packages/:name/releases/:version", ReleaseController, :delete
 
+        post "/packages/:name/retire", RetirementController, :create_package
         post "/packages/:name/releases/:version/retire", RetirementController, :create
         delete "/packages/:name/releases/:version/retire", RetirementController, :delete
 

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -389,7 +389,7 @@ defmodule HexpmWeb.Router do
         get "/packages/:name/releases/:version", ReleaseController, :show
         delete "/packages/:name/releases/:version", ReleaseController, :delete
 
-        post "/packages/:name/retire", RetirementController, :create_package
+        post "/packages/:name/retire", RetirementController, :create_all
         post "/packages/:name/releases/:version/retire", RetirementController, :create
         delete "/packages/:name/releases/:version/retire", RetirementController, :delete
 

--- a/lib/hexpm_web/views/api/index_view.ex
+++ b/lib/hexpm_web/views/api/index_view.ex
@@ -5,6 +5,7 @@ defmodule HexpmWeb.API.IndexView do
     %{
       packages_url: url(~p"/api/packages"),
       package_url: fix_placeholder(url(~p"/api/packages/{name}")),
+      package_retirement_url: fix_placeholder(url(~p"/api/packages/{name}/retire")),
       package_release_url: fix_placeholder(url(~p"/api/packages/{name}/releases/{version}")),
       package_owners_url: fix_placeholder(url(~p"/api/packages/{name}/owners")),
       keys_url: url(~p"/api/keys"),

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -246,6 +246,61 @@ defmodule Hexpm.Repository.ReleasesTest do
     end
   end
 
+  describe "retire/3" do
+    test "retires every active release and updates the registry", %{
+      package: package,
+      release: release,
+      user: user
+    } do
+      insert(:release,
+        package: package,
+        version: "0.2.0",
+        retirement: %Hexpm.Repository.ReleaseRetirement{
+          reason: "security",
+          message: "Existing retirement"
+        }
+      )
+
+      insert(:release, package: package, version: "0.3.0")
+
+      assert :ok =
+               Releases.retire(
+                 package,
+                 %{"reason" => "deprecated", "message" => "No longer maintained"},
+                 audit: audit_data(user)
+               )
+
+      assert Releases.get(package, release.version).retirement.reason == "deprecated"
+
+      previously_retired = Releases.get(package, "0.2.0")
+      assert previously_retired.retirement.reason == "security"
+      assert previously_retired.retirement.message == "Existing retirement"
+
+      assert registry = Hexpm.Store.get(:repo_bucket, "packages/#{package.name}", [])
+
+      retirements =
+        registry
+        |> decode_registry_package()
+        |> Map.fetch!(:releases)
+        |> Map.new(&{&1.version, &1.retired})
+
+      assert retirements["0.1.0"] == %{
+               reason: :RETIRED_DEPRECATED,
+               message: "No longer maintained"
+             }
+
+      assert retirements["0.2.0"] == %{
+               reason: :RETIRED_SECURITY,
+               message: "Existing retirement"
+             }
+
+      assert retirements["0.3.0"] == %{
+               reason: :RETIRED_DEPRECATED,
+               message: "No longer maintained"
+             }
+    end
+  end
+
   defp decode_registry_package(registry) do
     assert {:ok, releases} =
              registry

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -299,6 +299,46 @@ defmodule Hexpm.Repository.ReleasesTest do
                message: "No longer maintained"
              }
     end
+
+    test "replaces existing retirements when requested", %{
+      package: package,
+      user: user
+    } do
+      insert(:release,
+        package: package,
+        version: "0.2.0",
+        retirement: %Hexpm.Repository.ReleaseRetirement{
+          reason: "security",
+          message: "Existing retirement"
+        }
+      )
+
+      assert :ok =
+               Releases.retire(
+                 package,
+                 %{"reason" => "deprecated", "message" => "No longer maintained"},
+                 audit: audit_data(user),
+                 replace: true
+               )
+
+      assert registry = Hexpm.Store.get(:repo_bucket, "packages/#{package.name}", [])
+
+      retirements =
+        registry
+        |> decode_registry_package()
+        |> Map.fetch!(:releases)
+        |> Map.new(&{&1.version, &1.retired})
+
+      assert retirements["0.1.0"] == %{
+               reason: :RETIRED_DEPRECATED,
+               message: "No longer maintained"
+             }
+
+      assert retirements["0.2.0"] == %{
+               reason: :RETIRED_DEPRECATED,
+               message: "No longer maintained"
+             }
+    end
   end
 
   defp decode_registry_package(registry) do

--- a/test/hexpm_web/controllers/api/index_controller_test.exs
+++ b/test/hexpm_web/controllers/api/index_controller_test.exs
@@ -5,5 +5,6 @@ defmodule HexpmWeb.API.IndexControllerTest do
     conn = get(build_conn(), "/api")
 
     assert json_response(conn, 200)["package_url"] =~ "/api/packages/{name}"
+    assert json_response(conn, 200)["package_retirement_url"] =~ "/api/packages/{name}/retire"
   end
 end

--- a/test/hexpm_web/controllers/api/retirement_controller_test.exs
+++ b/test/hexpm_web/controllers/api/retirement_controller_test.exs
@@ -55,6 +55,80 @@ defmodule HexpmWeb.API.RetirementControllerTest do
     end
   end
 
+  describe "POST /api/packages/:name/retire" do
+    test "retires all active releases and preserves existing retirements", %{
+      user: user,
+      package: package
+    } do
+      insert(:release, package: package, version: "3.0.0")
+      params = %{"reason" => "deprecated", "message" => "No longer maintained"}
+
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/packages/#{package.name}/retire", params)
+      |> response(204)
+
+      release = Hexpm.Repository.Releases.get(package, "1.0.0")
+      assert release.retirement.reason == "deprecated"
+      assert release.retirement.message == "No longer maintained"
+
+      previously_retired = Hexpm.Repository.Releases.get(package, "2.0.0")
+      assert previously_retired.retirement.reason == "security"
+      assert previously_retired.retirement.message == nil
+
+      latest_release = Hexpm.Repository.Releases.get(package, "3.0.0")
+      assert latest_release.retirement.reason == "deprecated"
+      assert latest_release.retirement.message == "No longer maintained"
+
+      logs =
+        package
+        |> Hexpm.Accounts.AuditLogs.all_by()
+        |> Enum.filter(&(&1.action == "release.retire"))
+
+      assert Enum.sort(Enum.map(logs, & &1.params["release"]["version"])) == ["1.0.0", "3.0.0"]
+    end
+
+    test "validates the retirement", %{user: user, package: package} do
+      params = %{"reason" => "unknown"}
+
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/packages/#{package.name}/retire", params)
+      |> response(422)
+
+      release = Hexpm.Repository.Releases.get(package, "1.0.0")
+      refute release.retirement
+    end
+
+    test "validates the retirement when all releases are already retired", %{
+      user: user,
+      package: package
+    } do
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/packages/#{package.name}/retire", %{
+        "reason" => "deprecated",
+        "message" => "No longer maintained"
+      })
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/packages/#{package.name}/retire", %{"reason" => "unknown"})
+      |> response(422)
+    end
+
+    test "returns 404 for an unknown package", %{user: user} do
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/packages/UNKNOWN_PACKAGE/retire", %{
+        "reason" => "deprecated",
+        "message" => "No longer maintained"
+      })
+      |> response(404)
+    end
+  end
+
   describe "POST /api/repos/:repository/packages/:name/releases/:version/retire" do
     test "returns 404 if you are not authorized", %{
       user: user,
@@ -195,6 +269,30 @@ defmodule HexpmWeb.API.RetirementControllerTest do
       assert release.retirement
       assert release.retirement.reason == "security"
       assert release.retirement.message == "See CVE-NNNN"
+    end
+  end
+
+  describe "POST /api/repos/:repository/packages/:name/retire" do
+    test "retires all active releases using repository write permission", %{
+      repository: repository,
+      repository_package: package
+    } do
+      user = insert(:user)
+      insert(:organization_user, organization: repository.organization, user: user, role: "write")
+
+      params = %{"reason" => "deprecated", "message" => "No longer maintained"}
+
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/repos/#{repository.name}/packages/#{package.name}/retire", params)
+      |> response(204)
+
+      release = Hexpm.Repository.Releases.get(package, "1.0.0")
+      assert release.retirement.reason == "deprecated"
+      assert release.retirement.message == "No longer maintained"
+
+      previously_retired = Hexpm.Repository.Releases.get(package, "2.0.0")
+      assert previously_retired.retirement.reason == "security"
     end
   end
 

--- a/test/hexpm_web/controllers/api/retirement_controller_test.exs
+++ b/test/hexpm_web/controllers/api/retirement_controller_test.exs
@@ -88,6 +88,47 @@ defmodule HexpmWeb.API.RetirementControllerTest do
       assert Enum.sort(Enum.map(logs, & &1.params["release"]["version"])) == ["1.0.0", "3.0.0"]
     end
 
+    test "replaces existing retirements when requested", %{user: user, package: package} do
+      params = %{
+        "reason" => "deprecated",
+        "message" => "No longer maintained",
+        "replace" => true
+      }
+
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/packages/#{package.name}/retire", params)
+      |> response(204)
+
+      for version <- ["1.0.0", "2.0.0"] do
+        retirement = Hexpm.Repository.Releases.get(package, version).retirement
+        assert retirement.reason == "deprecated"
+        assert retirement.message == "No longer maintained"
+      end
+
+      logs =
+        package
+        |> Hexpm.Accounts.AuditLogs.all_by()
+        |> Enum.filter(&(&1.action == "release.retire"))
+
+      assert Enum.sort(Enum.map(logs, & &1.params["release"]["version"])) == ["1.0.0", "2.0.0"]
+    end
+
+    test "accepts replace as a query-style string", %{user: user, package: package} do
+      build_conn()
+      |> put_req_header("authorization", key_for(user))
+      |> post("/api/packages/#{package.name}/retire", %{
+        "reason" => "deprecated",
+        "message" => "No longer maintained",
+        "replace" => "true"
+      })
+      |> response(204)
+
+      retirement = Hexpm.Repository.Releases.get(package, "2.0.0").retirement
+      assert retirement.reason == "deprecated"
+      assert retirement.message == "No longer maintained"
+    end
+
     test "validates the retirement", %{user: user, package: package} do
       params = %{"reason" => "unknown"}
 


### PR DESCRIPTION
Implements the server-side API portion of #1650 by adding support for retiring all active releases of a package in a single request.


Resolved: #1650 