### PR TITLE
Fix docs width overflowing

### DIFF
--- a/lib/hexpm_web/templates/docs/layout.html.heex
+++ b/lib/hexpm_web/templates/docs/layout.html.heex
@@ -254,7 +254,7 @@
     </aside>
 
     <%!-- Content --%>
-    <main class="flex-1">
+    <main class="lg:w-64 flex-1">
       <article class="bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-6 lg:p-10 shadow-xs docs-content">
         <style nonce={@style_src_nonce}>
           .docs-content h2 {


### PR DESCRIPTION
In the "Publishing a package" and "Self-hosting" docs pages, the width of the content overflows

### Before: 
<img width="890" height="867" alt="file-a9ea21038892e0c243e09d3479a6237d" src="https://github.com/user-attachments/assets/f39a6f1a-9570-4f0a-97c5-6e325c376669" />

### After: 
<img width="856" height="868" alt="image" src="https://github.com/user-attachments/assets/362d8b74-d785-42df-8f54-55ccdcaa8655" />


### Links with the overflow: 
- https://hex.pm/docs/publish
- https://hex.pm/docs/rebar3-publish
- https://hex.pm/docs/self-hosting