### PR TITLE
feat: add GitHub issue templates for common contribution workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,83 @@
+name: Bug Report
+description: Report a bug, regression, or unexpected behavior.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve Hex.pm. Please include enough detail for maintainers to reproduce the issue.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the bug clearly and briefly.
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: What happened?
+      description: Tell us what you observed.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: What did you expect?
+      description: Describe the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: List the exact steps needed to reproduce the issue.
+      placeholder: |
+        1.
+        2.
+        3.
+    validations:
+      required: true
+  - type: dropdown
+    id: trigger-type
+    attributes:
+      label: Area
+      description: Where did the issue occur?
+      options:
+        - Website
+        - API
+        - Authentication
+        - Package publishing
+        - Organizations
+        - Billing
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Please redact private data before posting. Do not include API keys, session tokens, email addresses, billing details, or other sensitive account information.
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment / context
+      description: Share the relevant package, organization, account, browser, OS, API client, or permissions context.
+      placeholder: |
+        Package:
+        Organization:
+        API endpoint or client:
+        Browser:
+        OS:
+        Recent permission or account changes:
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / screenshots
+      description: Paste logs, error messages, screenshots, or relevant run output here.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add anything else that may help reproduce the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,9 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Report a security vulnerability
+    url: mailto:security@hex.pm
+    about: Privately report auth, billing, API, package publishing, or other security vulnerabilities.
+  - name: Hex.pm Documentation
+    url: https://hex.pm/docs
+    about: Read the docs before opening an issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,37 @@
+name: Documentation
+description: Report unclear, missing, or outdated documentation.
+title: "[Docs]: "
+labels: ["documentation"]
+body:
+  - type: textarea
+    id: page-section
+    attributes:
+      label: Page / section
+      description: Which docs page or section is affected?
+      placeholder: https://hex.pm/docs/...
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is unclear or missing?
+      description: Describe the issue with the documentation.
+    validations:
+      required: true
+  - type: textarea
+    id: suggested-improvement
+    attributes:
+      label: Suggested improvement
+      description: What would make this easier to understand?
+    validations:
+      required: true
+  - type: textarea
+    id: expected-outcome
+    attributes:
+      label: Expected outcome
+      description: What should a new contributor or user be able to do after reading this?
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add links, screenshots, or examples if helpful.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature Request
+description: Suggest a new capability or improvement.
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement. Please focus on the workflow or user problem first.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem statement
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you would like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: usefulness
+    attributes:
+      label: Why is this useful?
+      description: Explain the benefit to Hex.pm users or maintainers.
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: How would this be used in a real package, organization, or account workflow?
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: List any other approaches you considered.
+  - type: textarea
+    id: implementation-ideas
+    attributes:
+      label: Implementation ideas
+      description: Optional notes about how this could be implemented.
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Any examples, references, or screenshots that help explain the idea.

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,43 @@
+name: Question
+description: Ask a question about using Hex.pm.
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For usage help, please check the Hex.pm documentation first: https://hex.pm/docs
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What would you like to know?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: What are you trying to do on Hex.pm or with a package?
+    validations:
+      required: true
+  - type: textarea
+    id: attempted
+    attributes:
+      label: What have you tried?
+      description: Share any steps you already attempted.
+  - type: textarea
+    id: relevant-details
+    attributes:
+      label: Relevant details
+      description: Share relevant package, organization, API client, logs, or screenshots. This question is public, so redact secrets, tokens, account identifiers, and other sensitive data before posting.
+      placeholder: |
+        Package:
+        Organization:
+        API endpoint or client:
+        Relevant logs or screenshots:
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Anything else that would help answer the question.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Summary
+
+<!-- Briefly describe the change and the problem it solves. -->
+
+## Testing
+
+<!-- List the checks you ran, or explain why testing was not needed. -->
+
+## Screenshots
+
+For web UI changes, provide before and after screenshots.
+Include dark mode and mobile screenshots when relevant.
+
+<!-- Add screenshots here, or write N/A if this PR does not change the web UI. -->


### PR DESCRIPTION
Summary
This PR adds GitHub issue templates to make issue reporting more structured and consistent.

Changes

Added:

- Bug Report template
- Feature Request template
- Documentation template
- Question template
- Config.yml for issue template configuration
- pull_request_template.md

fixes: #1665 