### PR TITLE
disable autorecover on the filter and sort forms

### DIFF
--- a/lib/hexpm_web/live/package_live/filter_sidebar.ex
+++ b/lib/hexpm_web/live/package_live/filter_sidebar.ex
@@ -132,7 +132,8 @@ defmodule HexpmWeb.PackageLive.FilterSidebar do
 
   defp filter_form(assigns) do
     ~H"""
-    <form phx-change="filter_change" id={@id}>
+    <%!-- phx-auto-recover stops reconnects from re-firing filter_change and resetting the page --%>
+    <form phx-change="filter_change" id={@id} phx-auto-recover="ignore">
       <div class="mb-[18px]">
         <label
           class="flex items-center justify-between gap-2 text-small font-semibold text-grey-600 dark:text-grey-200 mb-1.5"

--- a/lib/hexpm_web/live/package_live/index.ex
+++ b/lib/hexpm_web/live/package_live/index.ex
@@ -118,7 +118,8 @@ defmodule HexpmWeb.PackageLive.Index do
             </span>
           </button>
           <div class="flex-1"></div>
-          <form phx-change="sort_change" class="inline-flex">
+          <%!-- phx-auto-recover stops reconnects from re-firing sort_change and resetting the page --%>
+          <form phx-change="sort_change" phx-auto-recover="ignore" class="inline-flex">
             <label for="sort-select-mobile" class="sr-only">Sort</label>
             <div class="relative">
               <select
@@ -237,7 +238,8 @@ defmodule HexpmWeb.PackageLive.Index do
                   >
                     Sort by
                   </label>
-                  <form phx-change="sort_change">
+                  <%!-- phx-auto-recover stops reconnects from re-firing sort_change and resetting the page --%>
+                  <form phx-change="sort_change" phx-auto-recover="ignore">
                     <div class="relative min-w-[200px]">
                       <select
                         id="sort-select"


### PR DESCRIPTION
Fixes #1676 

When the connection is reset and because the filter has both `phx-change` and an `id` it auto recovers the form (docs: https://phoenix-live-view.hexdocs.pm/form-bindings.html#recovery-following-crashes-or-disconnects) which then results in a change event that resets the page because of the handler. I also added the same for sort even though the bug is not currently present I thought that would be the defensive choice.


To test in the chrome browser before and after the change you can write this in the console from a page that is not the first: `liveSocket.disconnect(); liveSocket.connect()` 