### PR TITLE
Fix crash on search suggestions ending with backslash

### DIFF
--- a/lib/hexpm/repository/packages.ex
+++ b/lib/hexpm/repository/packages.ex
@@ -343,7 +343,7 @@ defmodule Hexpm.Repository.Packages do
 
   defp add_suggest_order_by(query, pkg_part, prefix, substr) do
     # Name-match tiers are exclusive so each package falls into exactly one band:
-    #   exact       → 3.0  (name LIKE term)
+    #   exact       → 3.0  (name = term)
     #   prefix      → 2.0  (name LIKE term%)
     #   substr      → 1.0  (name LIKE %term%)
     #   desc-only   → 0.5  (matched via full-text search, not name)
@@ -356,7 +356,7 @@ defmodule Hexpm.Repository.Packages do
         fragment(
           """
           (CASE
-            WHEN ? LIKE ?           THEN 3.0
+            WHEN ? = ?              THEN 3.0
             WHEN ? LIKE ?           THEN 2.0
             WHEN ? LIKE ?           THEN 1.0
             ELSE 0.5

--- a/test/hexpm/repository/packages_suggest_test.exs
+++ b/test/hexpm/repository/packages_suggest_test.exs
@@ -136,6 +136,20 @@ defmodule Hexpm.Repository.PackagesSuggestTest do
       assert is_list(Packages.suggest(repository, "my%package"))
     end
 
+    test "handles trailing backslash in search term", %{repository: repository} do
+      package =
+        insert(:package,
+          name: "abc_package",
+          repository_id: repository.id,
+          meta: build(:package_metadata, description: "abc utilities")
+        )
+
+      insert(:release, package: package)
+
+      assert "abc_package" in names(Packages.suggest(repository, "abc\\"))
+      assert "abc_package" in names(Packages.suggest(repository, "abc\\\\\\"))
+    end
+
     test "includes package metadata in results", %{repository: repository} do
       package =
         insert(:package,


### PR DESCRIPTION
Search suggestion queries ending in a backslash crashed with `Postgrex.Error: ERROR 22025 (invalid_escape_sequence) LIKE pattern must not end with escape character` ([Sentry issue](https://hexpm.sentry.io/issues/7497151017/)).

The exact-match tier in the suggest ORDER BY passed the raw search term as a LIKE pattern, so a trailing backslash produced a pattern ending with the escape character. The prefix and substring tiers already use the escaped term. Compare the exact tier with `=` instead, which is also the correct semantics since LIKE wildcards should not apply to an exact match.

The error only triggers when the WHERE clause matches at least one row, since Postgres does not evaluate the ORDER BY expression otherwise. The regression test inserts a package whose description matches the term to exercise that path.