### PR TITLE
Require authentication when creating API keys

### DIFF
--- a/lib/hexpm_web/controllers/api/key_controller.ex
+++ b/lib/hexpm_web/controllers/api/key_controller.ex
@@ -7,7 +7,8 @@ defmodule HexpmWeb.API.KeyController do
        [
          domains: [{"api", "write"}],
          allow_unconfirmed: true,
-         fun: {AuthHelpers, :organization_access, [organization_role: "write"]}
+         fun: {AuthHelpers, :organization_access, [organization_role: "write"]},
+         authentication: :required
        ]
        when action == :create
 

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -142,6 +142,18 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert %{"name" => "macbook"} = log.params
     end
 
+    test "create key without authentication returns 401" do
+      body = %{name: "macbook"}
+
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> post("/api/keys", body)
+
+      body = json_response(conn, 401)
+      assert body["message"] == "missing authentication information"
+    end
+
     test "create repository key", c do
       body = %{
         name: "macbook",


### PR DESCRIPTION
Unauthenticated POST /api/keys crashed with a 500 (FunctionClauseError in Ecto.build_assoc/3) because the create action's authorize plug was missing `authentication: :required`, so requests without credentials reached `Keys.create/3` with a nil user. The other key endpoints already require authentication; create now returns 401 like them.

Caught by Sentry: https://hexpm.sentry.io/issues/7600990752/