### PR TITLE
Filter bandit websocket protocol errors from Sentry

### DIFF
--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -46,11 +46,20 @@ defmodule Hexpm.Application do
 
   def sentry_before_send(%Sentry.Event{original_exception: exception} = event) do
     cond do
+      websocket_protocol_error?(event) -> nil
       Plug.Exception.status(exception) < 500 -> nil
       Sentry.DefaultEventFilter.exclude_exception?(exception, event.source) -> nil
       true -> event
     end
   end
+
+  # Bandit stops the websocket connection process with a non-shutdown reason when a
+  # client sends invalid frames, which gets logged as a crash even though the client
+  # was correctly rejected
+  defp websocket_protocol_error?(%Sentry.Event{extra: %{crash_reason: "{:deserializing," <> _}}),
+    do: true
+
+  defp websocket_protocol_error?(%Sentry.Event{}), do: false
 
   # Make sure we exit after hex client tests are finished running
   if Mix.env() == :hex do

--- a/test/hexpm/application_test.exs
+++ b/test/hexpm/application_test.exs
@@ -1,0 +1,40 @@
+defmodule Hexpm.ApplicationTest do
+  use ExUnit.Case, async: true
+
+  describe "sentry_before_send/1" do
+    test "drops websocket frame deserialization crash reports" do
+      event =
+        Sentry.Event.create_event(
+          message: "GenServer #PID<0.123.0> terminating",
+          extra: %{crash_reason: ~s({:deserializing, "Received unsupported RSV flags 2"})}
+        )
+
+      assert Hexpm.Application.sentry_before_send(event) == nil
+    end
+
+    test "keeps other crash reports" do
+      event =
+        Sentry.Event.create_event(
+          message: "GenServer #PID<0.123.0> terminating",
+          extra: %{crash_reason: "{:badmatch, :error}"}
+        )
+
+      assert Hexpm.Application.sentry_before_send(event) == event
+    end
+
+    test "keeps events without a crash reason" do
+      event = Sentry.Event.create_event(exception: %RuntimeError{message: "oops"})
+
+      assert Hexpm.Application.sentry_before_send(event) == event
+    end
+
+    test "drops exceptions with a status below 500" do
+      event =
+        Sentry.Event.create_event(
+          exception: %Phoenix.Router.NoRouteError{message: "no route", plug_status: 404}
+        )
+
+      assert Hexpm.Application.sentry_before_send(event) == nil
+    end
+  end
+end


### PR DESCRIPTION
Sentry issue [7496905034](https://hexpm.sentry.io/issues/7496905034/) collects "GenServer terminating" crash reports with the stop reason `{:deserializing, "Received unsupported RSV flags 2"}` from the LiveView websocket. These come from scanners sending garbage bytes after the websocket upgrade. Bandit rejects the frames and closes the connection with a 1002 protocol error close code, but the connection process stops with a non-shutdown reason, so OTP logs it as a crash and `Sentry.LoggerHandler` ships it to Sentry.

The events are not actionable, so drop logger crash reports whose crash reason is a Bandit websocket frame deserialization error in `sentry_before_send`. This covers all frame parse errors (invalid RSV flags, unknown opcodes, oversized frames) while leaving real crashes untouched.

This is a workaround; the cleaner fix is for Bandit to stop with a `{:shutdown, ...}` reason on client protocol violations, like its HTTP handlers do.