### PR TITLE
Restore form recovery on package index

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -24,6 +24,7 @@ import { PrivateRepoTabs } from "./hooks/private_repo_tabs";
 import { PolicyDirtyState } from "./hooks/policy_dirty_state";
 import LineHighlight from "./hooks/line_highlight";
 import { InfiniteScroll } from "./hooks/diff";
+import { FormSync } from "./hooks/form_sync";
 
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
@@ -51,6 +52,7 @@ let Hooks = {
   PolicyDirtyState,
   LineHighlight,
   InfiniteScroll,
+  FormSync,
 };
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },

--- a/assets/js/hooks/form_sync.js
+++ b/assets/js/hooks/form_sync.js
@@ -1,0 +1,41 @@
+/**
+ * FormSync Hook
+ *
+ * Keeps inputs in two parallel forms in sync client-side in real-time.
+ * Used for package filtering where we render two distinct forms (desktop sidebar
+ * vs mobile bottom sheet) to match viewport mockups.
+ *
+ * By syncing inputs dynamically in the DOM, we can safely disable auto-recovery
+ * on the mobile form (phx-auto-recover="ignore") and only recover the desktop form,
+ * without losing the mobile user's unsaved typing progress.
+ *
+ * This also provides a seamless UX during viewport transitions (e.g. rotating
+ * a device or resizing the browser window) because the newly visible form's
+ * input elements immediately reflect the exact values the user was just interacting
+ * with in the previously visible form.
+ */
+export const FormSync = {
+  mounted() {
+    const sync = (e) => {
+      const targetFormId = this.el.dataset.syncTo;
+      const targetForm = document.getElementById(targetFormId);
+      if (targetForm) {
+        const input = e.target;
+        const name = input.name;
+        if (name) {
+          const targetInput = targetForm.querySelector(`[name="${name}"]`);
+          if (targetInput && document.activeElement !== targetInput) {
+            if (input.type === "checkbox" || input.type === "radio") {
+              targetInput.checked = input.checked;
+            } else {
+              targetInput.value = input.value;
+            }
+          }
+        }
+      }
+    };
+
+    this.el.addEventListener("input", sync);
+    this.el.addEventListener("change", sync);
+  }
+};

--- a/lib/hexpm_web/live/package_live/filter_sidebar.ex
+++ b/lib/hexpm_web/live/package_live/filter_sidebar.ex
@@ -28,6 +28,7 @@ defmodule HexpmWeb.PackageLive.FilterSidebar do
           id="filter-form"
           query={@query}
           build_tools={@build_tools}
+          sync_to="filter-form-mobile"
         />
         <.filter_actions />
       </div>
@@ -74,6 +75,8 @@ defmodule HexpmWeb.PackageLive.FilterSidebar do
             id="filter-form-mobile"
             query={@query}
             build_tools={@build_tools}
+            auto_recover="ignore"
+            sync_to="filter-form"
           />
         </div>
 
@@ -129,11 +132,21 @@ defmodule HexpmWeb.PackageLive.FilterSidebar do
   attr :id, :string, required: true
   attr :query, SearchQuery, required: true
   attr :build_tools, :list, required: true
+  attr :auto_recover, :string, default: nil
+
+  attr :sync_to, :string,
+    default: nil,
+    doc: "The ID of the parallel form that this form should sync its input values to client-side."
 
   defp filter_form(assigns) do
     ~H"""
-    <%!-- phx-auto-recover stops reconnects from re-firing filter_change and resetting the page --%>
-    <form phx-change="filter_change" id={@id} phx-auto-recover="ignore">
+    <form
+      id={@id}
+      phx-change="filter_change"
+      phx-auto-recover={@auto_recover}
+      phx-hook={@sync_to && "FormSync"}
+      data-sync-to={@sync_to}
+    >
       <div class="mb-[18px]">
         <label
           class="flex items-center justify-between gap-2 text-small font-semibold text-grey-600 dark:text-grey-200 mb-1.5"

--- a/lib/hexpm_web/live/package_live/index.ex
+++ b/lib/hexpm_web/live/package_live/index.ex
@@ -118,8 +118,14 @@ defmodule HexpmWeb.PackageLive.Index do
             </span>
           </button>
           <div class="flex-1"></div>
-          <%!-- phx-auto-recover stops reconnects from re-firing sort_change and resetting the page --%>
-          <form phx-change="sort_change" phx-auto-recover="ignore" class="inline-flex">
+          <form
+            id="sort-form-mobile"
+            phx-change="sort_change"
+            phx-auto-recover="ignore"
+            phx-hook="FormSync"
+            data-sync-to="sort-form"
+            class="inline-flex"
+          >
             <label for="sort-select-mobile" class="sr-only">Sort</label>
             <div class="relative">
               <select
@@ -238,8 +244,12 @@ defmodule HexpmWeb.PackageLive.Index do
                   >
                     Sort by
                   </label>
-                  <%!-- phx-auto-recover stops reconnects from re-firing sort_change and resetting the page --%>
-                  <form phx-change="sort_change" phx-auto-recover="ignore">
+                  <form
+                    id="sort-form"
+                    phx-change="sort_change"
+                    phx-hook="FormSync"
+                    data-sync-to="sort-form-mobile"
+                  >
                     <div class="relative min-w-[200px]">
                       <select
                         id="sort-select"
@@ -332,7 +342,11 @@ defmodule HexpmWeb.PackageLive.Index do
         updated_after: updated_after
     }
 
-    {:noreply, push_query(socket, new_query)}
+    if new_query == socket.assigns.search_query do
+      {:noreply, socket}
+    else
+      {:noreply, push_query(socket, new_query)}
+    end
   end
 
   @impl true
@@ -354,12 +368,16 @@ defmodule HexpmWeb.PackageLive.Index do
   end
 
   @impl true
-  def handle_event("sort_change", %{"sort" => sort}, socket) do
-    url_params =
-      %{sort: sort, search: socket.assigns.search}
-      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+  def handle_event("sort_change", %{"sort" => sort_param}, socket) do
+    if sort(sort_param) == socket.assigns.sort do
+      {:noreply, socket}
+    else
+      url_params =
+        %{sort: sort_param, search: socket.assigns.search}
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
-    {:noreply, push_patch(socket, to: ~p"/packages?#{url_params}")}
+      {:noreply, push_patch(socket, to: ~p"/packages?#{url_params}")}
+    end
   end
 
   @impl true

--- a/test/hexpm_web/live/package_live/index_test.exs
+++ b/test/hexpm_web/live/package_live/index_test.exs
@@ -211,4 +211,28 @@ defmodule HexpmWeb.PackageLive.IndexTest do
       assert html =~ ~s(name="updated_after" value="2024-01-01")
     end
   end
+
+  describe "form recovery" do
+    test "does not reset page when sort form change event is triggered with the same sort option",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/packages?page=2&sort=recent_downloads")
+
+      view
+      |> form("#sort-form", %{"sort" => "recent_downloads"})
+      |> render_change()
+
+      refute_patched(view)
+    end
+
+    test "does not reset page when filter form change event is triggered with the same filter options",
+         %{conn: conn} do
+      {:ok, view, _html} = live(conn, ~p"/packages?page=2&search=build_tool%3Amix")
+
+      view
+      |> form("#filter-form", %{"build_tool" => "mix", "depends" => "", "updated_after" => ""})
+      |> render_change()
+
+      refute_patched(view)
+    end
+  end
 end


### PR DESCRIPTION
And prevent page reset on reconnect.

This is another take on #1676, as I casually noticed that by disabling form recovery we ended up breaking other common use cases, such as if a user types or updates filters while (potentially briefly) offline the browser-local inputs are discarded.

Instead of ignoring form recovery, we check if the incoming event payload represents an actual change relative to the current assigns. If they are identical, we return `{:noreply, socket}` without patching the URL. This preserves the page state on reconnect when no local form changes happened, while still allowing explicit user changes to correctly reset the page.

It also reduces the amount of patches in the normal connected case, since we don't patch when nothing is supposed to change (if load is actually a problem we can also add `phx-debounce` to reduce the frequency of events as users type).

Additionally, LiveView form recovery requires forms with `phx-change` to have an `id`, so that was added where missing.

