### PR TITLE
Enable auto-recovery and pagination protection for package search

### DIFF
--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -223,10 +223,14 @@ defmodule HexpmWeb.Components.Navbar do
     <div id="mobile-search-bar" class="hidden lg:hidden! bg-grey-800 pb-4">
       <div class="flex items-center gap-2">
         <form
+          id="mobile-search-bar-form"
           role="search"
           action={~p"/packages"}
           class="flex-1"
+          phx-change={if @live_search, do: "search_change"}
           phx-submit={@live_search && "search_submit"}
+          phx-hook={@live_search && "FormSync"}
+          data-sync-to={@live_search && "mobile-menu-search-form"}
         >
           <div class="relative">
             <div class="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
@@ -237,7 +241,6 @@ defmodule HexpmWeb.Components.Navbar do
               name="search"
               type="text"
               value={@search}
-              phx-change={if @live_search, do: "search_change"}
               phx-debounce={if @live_search, do: "300"}
               placeholder="Find packages..."
               class="w-full bg-grey-800 border border-grey-600 rounded-lg px-3 pl-10 py-[11px] text-white text-base font-medium leading-4 placeholder:text-grey-300 focus:outline-none focus:border-grey-500 focus:shadow-[inset_0px_0px_6px_0px_rgba(255,255,255,0.3)]"
@@ -269,10 +272,15 @@ defmodule HexpmWeb.Components.Navbar do
       <div class="flex flex-col">
         <div :if={@show_search} class="flex items-center gap-2 pb-4">
           <form
+            id="mobile-menu-search-form"
             role="search"
             action={~p"/packages"}
             class="flex-1"
+            phx-change={if @live_search, do: "search_change"}
             phx-submit={@live_search && "search_submit"}
+            phx-hook={@live_search && "FormSync"}
+            data-sync-to={@live_search && "mobile-search-bar-form"}
+            phx-auto-recover={if @live_search, do: "ignore"}
           >
             <div class="relative">
               <div class="absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none">
@@ -282,7 +290,6 @@ defmodule HexpmWeb.Components.Navbar do
                 name="search"
                 type="text"
                 value={@search}
-                phx-change={if @live_search, do: "search_change"}
                 phx-debounce={if @live_search, do: "300"}
                 placeholder="Find packages..."
                 class="w-full bg-grey-800 border border-grey-600 rounded-lg px-3 pl-10 py-[11px] text-white text-base font-medium leading-4 placeholder:text-grey-300 focus:outline-none focus:border-grey-500 focus:shadow-[inset_0px_0px_6px_0px_rgba(255,255,255,0.3)]"

--- a/lib/hexpm_web/live/package_live/index.ex
+++ b/lib/hexpm_web/live/package_live/index.ex
@@ -384,11 +384,15 @@ defmodule HexpmWeb.PackageLive.Index do
   def handle_event("search_change", %{"search" => search}, socket) do
     search = nil_if_empty(search)
 
-    url_params =
-      %{sort: socket.assigns.sort, search: search}
-      |> Enum.reject(fn {_k, v} -> is_nil(v) end)
+    if search == socket.assigns.search do
+      {:noreply, socket}
+    else
+      url_params =
+        %{sort: socket.assigns.sort, search: search}
+        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
 
-    {:noreply, push_patch(socket, to: ~p"/packages?#{url_params}")}
+      {:noreply, push_patch(socket, to: ~p"/packages?#{url_params}")}
+    end
   end
 
   @impl true

--- a/test/hexpm_web/live/package_live/index_test.exs
+++ b/test/hexpm_web/live/package_live/index_test.exs
@@ -234,5 +234,17 @@ defmodule HexpmWeb.PackageLive.IndexTest do
 
       refute_patched(view)
     end
+
+    test "does not reset page when search change event is triggered with the same search term", %{
+      conn: conn
+    } do
+      {:ok, view, _html} = live(conn, ~p"/packages?page=2&search=phoenix_test_pkg")
+
+      view
+      |> form("#mobile-search-bar-form", %{"search" => "phoenix_test_pkg"})
+      |> render_change()
+
+      refute_patched(view)
+    end
   end
 end


### PR DESCRIPTION
Adds unique HTML IDs to mobile search forms so Phoenix LiveView can track and recover form state upon reconnection.

Additionally, compares the search parameter with the assigned search query in the `search_change` handler. This avoids redundant URL patches, preventing the user's pagination state from resetting to page 1 during auto-recovery or identical change events.

Similar to #1695, but because it is orthogonal to the original problem I'm sending as a separate PR. I can rebase later to merge the test cases into a single `describe` block.