### PR TITLE
Validate TFA recovery return paths

### DIFF
--- a/lib/hexpm_web/controllers/tfa_recovery_controller.ex
+++ b/lib/hexpm_web/controllers/tfa_recovery_controller.ex
@@ -15,7 +15,7 @@ defmodule HexpmWeb.TFARecoveryController do
       |> delete_session("tfa_user_id")
       |> start_session_internal(updated_user)
       |> HexpmWeb.Plugs.Sudo.set_sudo_authenticated()
-      |> redirect(to: session["return"] || ~p"/users/#{updated_user}")
+      |> redirect(to: safe_return_path(session["return"]) || ~p"/users/#{updated_user}")
     else
       _ ->
         render_show_error(conn)

--- a/test/hexpm_web/controllers/tfa_recovery_controller_test.exs
+++ b/test/hexpm_web/controllers/tfa_recovery_controller_test.exs
@@ -39,5 +39,28 @@ defmodule HexpmWeb.TFARecoveryControllerTest do
 
       assert redirected_to(conn) == "/"
     end
+
+    test "with valid code and non-path return falls back to user profile", c do
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "https://example.com"
+        })
+        |> post("/tfa/recovery", %{"code" => "1234-1234-1234-1234"})
+
+      assert redirected_to(conn) == "/users/#{c.user.username}"
+    end
+
+    test "with valid code and protocol-relative return falls back to user profile", c do
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "//example.com"})
+        |> post("/tfa/recovery", %{"code" => "1234-1234-1234-1234"})
+
+      assert redirected_to(conn) == "/users/#{c.user.username}"
+    end
   end
 end


### PR DESCRIPTION
Validate the stored return value before redirecting after TFA recovery, matching the standard TFA authentication flow. Invalid absolute and protocol-relative return values now fall back to the user's profile instead of raising after a recovery code has been accepted.

Adds controller coverage for both invalid return forms. Verified with `mix test test/hexpm_web/controllers/tfa_recovery_controller_test.exs` (5 tests, 0 failures) and `mix format`.
