### PR TITLE
Remove password reset API endpoint

### DIFF
--- a/lib/hexpm_web/controllers/api/user_controller.ex
+++ b/lib/hexpm_web/controllers/api/user_controller.ex
@@ -66,14 +66,6 @@ defmodule HexpmWeb.API.UserController do
     show(conn, params)
   end
 
-  def reset(conn, %{"name" => name}) do
-    Users.password_reset_init(name, audit: audit_data(conn))
-
-    conn
-    |> api_cache(:private)
-    |> send_resp(204, "")
-  end
-
   defp email_param(params) do
     if email = params["email"] do
       Map.put_new(params, "emails", [%{"email" => email}])

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -364,7 +364,6 @@ defmodule HexpmWeb.Router do
     get "/users/:name", UserController, :show
     # NOTE: Deprecated (2018-05-21)
     get "/users/:name/test", UserController, :test
-    post "/users/:name/reset", UserController, :reset
 
     get "/orgs", OrganizationController, :index
     get "/orgs/:organization", OrganizationController, :show

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -240,30 +240,17 @@ defmodule HexpmWeb.API.UserControllerTest do
   end
 
   describe "POST /api/users/:name/reset" do
-    test "email is sent with reset_token when password is reset" do
+    test "password reset endpoint is not available" do
       user = insert(:user)
 
-      # initiate reset requests
       conn = post(build_conn(), "/api/users/#{user.username}/reset", %{})
-      assert conn.status == 204
-
-      # initiate second reset request
-      conn = post(build_conn(), "/api/users/#{user.username}/reset", %{})
-      assert conn.status == 204
+      assert conn.status == 404
 
       user =
         Hexpm.Repo.get_by!(User, username: user.username)
         |> Hexpm.Repo.preload([:emails, :password_resets])
 
-      assert [reset1, reset2] = user.password_resets
-
-      # check email was sent with correct token
-      assert_email_sent(Hexpm.Emails.password_reset_request(user, reset1))
-      assert_email_sent(Hexpm.Emails.password_reset_request(user, reset2))
-
-      # check reset will succeed
-      assert User.can_reset_password?(user, reset1.key)
-      assert User.can_reset_password?(user, reset2.key)
+      assert user.password_resets == []
     end
   end
 


### PR DESCRIPTION
Remove the legacy password reset API route and controller action. Password resets remain available through the web flow, while the retired API endpoint now returns 404 without creating reset records.
