### PR TITLE
Revoke OAuth sessions by refresh token hash

### DIFF
--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -335,6 +335,19 @@ defmodule Hexpm.UserSessions do
   end
 
   @doc """
+  Revokes the OAuth session associated with a token.
+  """
+  def revoke_for_oauth_token(%Token{user_session_id: user_session_id})
+      when not is_nil(user_session_id) do
+    case Repo.get(UserSession, user_session_id) do
+      nil -> {:error, :session_not_found}
+      session -> revoke(session)
+    end
+  end
+
+  def revoke_for_oauth_token(%Token{}), do: {:error, :session_not_found}
+
+  @doc """
   Revokes all sessions for a user (both browser and OAuth).
   Returns a query suitable for use in Multi.update_all.
   For OAuth sessions, associated tokens will also be revoked.

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -3,6 +3,7 @@ defmodule HexpmWeb.API.OAuthController do
 
   import HexpmWeb.RequestHelpers, only: [build_usage_info: 1]
 
+  alias Hexpm.UserSessions
   alias Hexpm.OAuth.{Clients, Tokens, AuthorizationCodes, DeviceCodes}
 
   defp safe_param(params, key), do: safe_string(params[key])
@@ -80,8 +81,8 @@ defmodule HexpmWeb.API.OAuthController do
   end
 
   @doc """
-  Token revocation endpoint using refresh token hash.
-  Allows revocation when the actual token value is not available.
+  OAuth session revocation endpoint using a refresh token hash.
+  Allows revocation of the session and all its tokens when the actual token value is not available.
   """
   def revoke_by_hash(conn, params) do
     case revoke_token_by_hash(params) do
@@ -332,7 +333,7 @@ defmodule HexpmWeb.API.OAuthController do
        when is_binary(token_hash) and token_hash != "" do
     case Tokens.lookup_by_refresh_token_hash(token_hash) do
       {:ok, token} ->
-        case Tokens.revoke(token) do
+        case UserSessions.revoke_for_oauth_token(token) do
           {:ok, _} -> :ok
           {:error, _} -> {:error, :revocation_failed}
         end

--- a/test/hexpm_web/controllers/api/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/oauth_controller_test.exs
@@ -1441,13 +1441,16 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       %{
         hash_user: user,
         hash_client: client,
+        hash_session: session,
         hash_token: token,
         hash_refresh_token: token.refresh_token,
         hash_refresh_token_hash: token.refresh_token_hash
       }
     end
 
-    test "successfully revokes token using valid hash", %{
+    test "successfully revokes session using valid hash", %{
+      hash_user: user,
+      hash_session: session,
       hash_token: token,
       hash_refresh_token_hash: hash
     } do
@@ -1456,7 +1459,37 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       |> response(200)
 
       updated_token = Repo.get(Token, token.id)
+      updated_session = Repo.get(Hexpm.UserSession, session.id)
+
       assert Tokens.revoked?(updated_token)
+      assert updated_session.revoked_at
+      assert Hexpm.UserSessions.all_for_user(user) == []
+    end
+
+    test "revokes the current token when given a rotated token hash", %{
+      hash_client: client,
+      hash_token: token,
+      hash_refresh_token_hash: hash
+    } do
+      token = Repo.preload(token, :user)
+
+      {:ok, current_token} =
+        Tokens.revoke_and_create_token(
+          token,
+          client.client_id,
+          token.granted_scopes,
+          "refresh_token",
+          token.refresh_token,
+          with_refresh_token: true,
+          user_session_id: token.user_session_id
+        )
+
+      build_conn()
+      |> post(~p"/api/oauth/revoke_by_hash", %{token_hash: hash})
+      |> response(200)
+
+      assert Repo.get(Token, current_token.id) |> Tokens.revoked?()
+      assert Repo.get(Hexpm.UserSession, token.user_session_id).revoked_at
     end
 
     test "accepts uppercase hash", %{hash_token: token, hash_refresh_token_hash: hash} do
@@ -1486,7 +1519,8 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       |> response(200)
     end
 
-    test "handles revocation of already revoked token", %{
+    test "revokes the session for an already revoked token", %{
+      hash_session: session,
       hash_token: token,
       hash_refresh_token_hash: hash
     } do
@@ -1495,6 +1529,8 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       build_conn()
       |> post(~p"/api/oauth/revoke_by_hash", %{token_hash: hash})
       |> response(200)
+
+      assert Repo.get(Hexpm.UserSession, session.id).revoked_at
     end
 
     test "hash is computed correctly for new tokens", %{hash_refresh_token: refresh_token} do


### PR DESCRIPTION
Revokes the entire OAuth user session when `/api/oauth/revoke_by_hash` receives a matching refresh-token hash, ensuring rotated descendants are invalidated and stale sessions no longer appear active in the dashboard.

Adds regression coverage for active, already-revoked, and rotated refresh tokens. The complete OAuth controller and user-session test files pass.