### PR TITLE
Clarify pricing and dependency policy tiers

### DIFF
--- a/lib/hexpm_web/components/pricing.ex
+++ b/lib/hexpm_web/components/pricing.ex
@@ -37,6 +37,7 @@ defmodule HexpmWeb.Components.Pricing do
   attr :description, :string, required: true
   attr :icon_bg, :string, required: true, values: ["blue", "green", "purple"]
   attr :icon_src, :string, required: true
+  attr :per_user, :boolean, default: false
   attr :price_monthly, :integer, default: nil
   attr :price_yearly, :integer, default: nil
   attr :price_text, :string, default: nil
@@ -68,14 +69,18 @@ defmodule HexpmWeb.Components.Pricing do
             <span class="text-grey-900 dark:text-white text-5xl font-bold">
               ${@price_monthly}
             </span>
-            <span class="text-grey-500 dark:text-grey-300">/mo</span>
+            <span class="text-grey-500 dark:text-grey-300">
+              {if @per_user, do: "/ user / month", else: "/mo"}
+            </span>
           </div>
           <%!-- Yearly Price --%>
           <div class="price-display hidden items-baseline gap-2 mb-4">
             <span class="text-grey-900 dark:text-white text-5xl font-bold">
               ${@price_yearly}
             </span>
-            <span class="text-grey-500 dark:text-grey-300">/yr</span>
+            <span class="text-grey-500 dark:text-grey-300">
+              {if @per_user, do: "/ user / year", else: "/yr"}
+            </span>
           </div>
         <% end %>
       </div>

--- a/lib/hexpm_web/templates/page/index.html.heex
+++ b/lib/hexpm_web/templates/page/index.html.heex
@@ -97,7 +97,7 @@
   <%!-- Getting Started Section --%>
   <div class="bg-white dark:bg-grey-950 py-4">
     <div class="max-w-7xl mx-auto px-4">
-      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <.feature_card icon="cloud-arrow-down" title="Getting started" href={~p"/docs/usage"}>
           Fetch dependencies from Hex without creating an account. Hex is usable out of the box in Elixir with
           <.text_link href={~p"/docs/usage"} variant="purple">Mix</.text_link>
@@ -121,9 +121,19 @@
 
         <.feature_card icon="shield-check" title="Private packages" href={~p"/pricing"}>
           Publish private packages by <.text_link href={~p"/dashboard/orgs"} variant="purple">creating an organization</.text_link>.
-          Your private packages will get the same features as public packages such as fast dependency fetching, HexDocs, and run on the same reliable infrastructure that serves millions of packages daily. See our
+          Private packages cost $7 / user / month after a free 30-day trial and include fast dependency fetching and HexDocs on the same reliable infrastructure that serves millions of packages daily. See our
           <.text_link href={~p"/pricing"} variant="purple">pricing page</.text_link>
           for more details.
+        </.feature_card>
+
+        <.feature_card
+          icon="adjustments-horizontal"
+          title="Dependency policies"
+          href={~p"/docs/dependency-policies"}
+        >
+          Keep dependency rules consistent across projects with signed, organization-managed policies. Free organizations can publish public policies for public Hex packages. Paid organizations can also publish private policies covering public and private packages, visible only to organization members. See the
+          <.text_link href={~p"/docs/dependency-policies"} variant="purple">policy guide</.text_link>
+          for details.
         </.feature_card>
       </div>
     </div>
@@ -263,7 +273,7 @@
           </.button_link>
           <div class="text-center">
             <.text_link href={~p"/pricing"} variant="primary">
-              Private Packages @ $7/month
+              Private Packages @ $7 / user / month
             </.text_link>
           </div>
         </div>
@@ -290,7 +300,7 @@
               Get Started for FREE
             </.button_link>
             <.text_link href={~p"/pricing"} variant="primary">
-              Private Packages @ $7/month
+              Private Packages @ $7 / user / month
             </.text_link>
           </div>
         </div>

--- a/lib/hexpm_web/templates/page/pricing.html.heex
+++ b/lib/hexpm_web/templates/page/pricing.html.heex
@@ -18,6 +18,7 @@
     <.pricing_card
       icon_src={~p"/images/pricing/open-source-icon.svg"}
       icon_bg="blue"
+      per_user={true}
       price_monthly={0}
       price_yearly={0}
       title="Open Source"
@@ -28,12 +29,14 @@
       <:feature>Unlimited number of public packages</:feature>
       <:feature>Public Packages Documentation</:feature>
       <:feature>Multiple Package Owners</:feature>
+      <:feature>Public Dependency Policies</:feature>
     </.pricing_card>
 
     <%!-- Private Packages Card --%>
     <.pricing_card
       icon_src={~p"/images/pricing/lock-icon.svg"}
       icon_bg="green"
+      per_user={true}
       price_monthly={7}
       price_yearly={70}
       title="Private Packages"
@@ -44,6 +47,7 @@
       <:feature>Unlimited Private Packages</:feature>
       <:feature>Private Packages Documentation</:feature>
       <:feature>Republish and Delete Packages</:feature>
+      <:feature>Private Dependency Policies</:feature>
     </.pricing_card>
 
     <%!-- Enterprise Card --%>
@@ -109,6 +113,22 @@
               </p>
               <p>
                 Organizations on the annual plan are billed each year from the day the subscription was started. The subscription is invoiced and charged in advance when the next billing period starts. Changes in the number of open seats in the plan are pro-rated and charged when the number of seats change.
+              </p>
+            </:answer>
+          </.faq_item>
+
+          <.faq_item>
+            <:question>
+              How do dependency policies work for free and paid organizations?
+            </:question>
+            <:answer>
+              <p>
+                Every organization can publish public policies for public Hex packages, and any project can opt into them. Paid organizations can also publish private policies that are visible only to organization members and govern both public Hex packages and packages in the organization's private repository. See the
+                <a
+                  href={~p"/docs/dependency-policies"}
+                  class="text-blue-500 dark:text-blue-300 underline"
+                >dependency policy guide</a>
+                for details.
               </p>
             </:answer>
           </.faq_item>

--- a/test/hexpm_web/controllers/page_controller_test.exs
+++ b/test/hexpm_web/controllers/page_controller_test.exs
@@ -66,6 +66,13 @@ defmodule HexpmWeb.PageControllerTest do
     assert package1.latest_release.version == "0.1.0"
     assert package2.id == c.package2.id
     assert package2.latest_release.version == "0.0.2"
+
+    html = response(conn, 200)
+    assert html =~ "$7 / user / month"
+    assert html =~ "Free organizations can publish public policies for public Hex packages"
+
+    assert html =~
+             "Paid organizations can also publish private policies covering public and private packages"
   end
 
   test "index renders relative time for new and recently updated packages" do
@@ -74,6 +81,27 @@ defmodule HexpmWeb.PageControllerTest do
     refute html =~ ~r/<span[^>]*title="[^"]+">\s*<span[^>]*title="[^"]+">/
 
     assert html =~ ~r/(week|weeks|day|days|hour|hours|minute|minutes) ago/
+  end
+
+  test "pricing identifies per-user pricing and organization policy tiers" do
+    html = build_conn() |> get("/pricing") |> response(200)
+
+    document = Floki.parse_document!(html)
+
+    assert prices(document, ".monthly-active") == [
+             "$0 / user / month",
+             "$7 / user / month"
+           ]
+
+    assert prices(document, ".price-display.hidden") == [
+             "$0 / user / year",
+             "$70 / user / year"
+           ]
+
+    assert html =~ "Private Dependency Policies"
+    refute html =~ "Public and Private Dependency Policies"
+    assert html =~ "Every organization can publish public policies for public Hex packages"
+    assert html =~ "Paid organizations can also publish private policies"
   end
 
   test "index renders long package names without overlapping version and time" do
@@ -93,5 +121,16 @@ defmodule HexpmWeb.PageControllerTest do
 
     assert html =~ long_name
     assert html =~ "truncate"
+  end
+
+  defp prices(document, selector) do
+    document
+    |> Floki.find(selector)
+    |> Enum.map(fn element ->
+      element
+      |> Floki.text()
+      |> String.replace(~r/\s+/, " ")
+      |> String.trim()
+    end)
   end
 end


### PR DESCRIPTION
Clarifies that the free and private organization plans are priced per user on both the homepage and pricing page, including consistent monthly and annual amounts.

Adds dependency policy features and an FAQ describing public policies for free organizations and private policies for paid organizations. Page controller coverage verifies the exact price labels and tier copy.