### PR TITLE
Load package diff gaps on demand

### DIFF
--- a/assets/js/hooks/diff.js
+++ b/assets/js/hooks/diff.js
@@ -5,7 +5,7 @@ export const InfiniteScroll = {
       ([entry]) => {
         if (entry.isIntersecting && !this.pending) {
           this.pending = true;
-          this.pushEvent("load-more", {});
+          this.loadGap();
         }
       },
       { rootMargin: "100px", threshold: 0.1 },
@@ -20,11 +20,19 @@ export const InfiniteScroll = {
   updated() {
     this.pending = false;
     requestAnimationFrame(() => {
-      const visible = this.el.getBoundingClientRect().top <= window.innerHeight;
+      const rect = this.el.getBoundingClientRect();
+      const visible = rect.top <= window.innerHeight + 100 && rect.bottom >= -100;
       if (visible && !this.pending) {
         this.pending = true;
-        this.pushEvent("load-more", {});
+        this.loadGap();
       }
+    });
+  },
+
+  loadGap() {
+    this.pushEvent("load-gap", {
+      start: this.el.dataset.start,
+      last: this.el.dataset.last,
     });
   },
 };

--- a/lib/hexpm_web/live/diff_live.ex
+++ b/lib/hexpm_web/live/diff_live.ex
@@ -64,9 +64,17 @@ defmodule HexpmWeb.DiffLive do
   end
 
   @impl Phoenix.LiveView
-  def handle_event("load-more", _params, socket) do
-    {:noreply, load_next_batch(socket)}
+  def handle_event("load-gap", %{"start" => start, "last" => last}, socket) do
+    with {:ok, start} <- parse_index(start),
+         {:ok, last} <- parse_index(last),
+         true <- start >= 0 and start <= last do
+      {:noreply, load_gap(socket, start, last)}
+    else
+      _ -> {:noreply, socket}
+    end
   end
+
+  def handle_event("load-gap", _params, socket), do: {:noreply, socket}
 
   def handle_event("filter_files", %{"query" => query}, socket) do
     files = socket.assigns.files
@@ -82,7 +90,7 @@ defmodule HexpmWeb.DiffLive do
     if Enum.any?(socket.assigns.files, &(&1.id == id)) do
       socket =
         socket
-        |> load_through_piece(id)
+        |> ensure_piece_loaded(id)
         |> assign(selected_file: id)
         |> push_event("scroll-to-file", %{id: "#{id}-container"})
 
@@ -214,7 +222,44 @@ defmodule HexpmWeb.DiffLive do
     |> add_loaded_pieces(batch)
   end
 
-  defp load_through_piece(%{assigns: %{loaded_pieces: loaded}} = socket, id) do
+  defp load_gap(socket, start, last) do
+    case current_gap_direction(socket, start, last) do
+      nil ->
+        socket
+
+      direction ->
+        pieces =
+          socket.assigns.remaining_pieces
+          |> Enum.filter(fn piece ->
+            index = Map.fetch!(socket.assigns.piece_order, Hexpm.Diff.piece_id(piece))
+            index >= start and index <= last
+          end)
+          |> take_gap_batch(direction)
+
+        socket
+        |> assign(
+          remaining_pieces:
+            Enum.reject(socket.assigns.remaining_pieces, &Enum.member?(pieces, &1))
+        )
+        |> add_loaded_pieces(pieces)
+    end
+  end
+
+  defp take_gap_batch(pieces, :backward), do: Enum.take(pieces, -@batch_size)
+  defp take_gap_batch(pieces, :forward), do: Enum.take(pieces, @batch_size)
+
+  defp parse_index(index) when is_integer(index), do: {:ok, index}
+
+  defp parse_index(index) when is_binary(index) do
+    case Integer.parse(index) do
+      {index, ""} -> {:ok, index}
+      _ -> :error
+    end
+  end
+
+  defp parse_index(_index), do: :error
+
+  defp ensure_piece_loaded(%{assigns: %{loaded_pieces: loaded}} = socket, id) do
     if Enum.any?(loaded, &(elem(&1, 0) == id)) do
       socket
     else
@@ -251,6 +296,45 @@ defmodule HexpmWeb.DiffLive do
       files: files,
       filtered_files: filter_diff_files(files, socket.assigns.query)
     )
+  end
+
+  defp diff_entries(all_pieces, loaded_pieces, piece_order, selected_file) do
+    loaded_pieces = Map.new(loaded_pieces)
+    selected_index = Map.get(piece_order, selected_file)
+
+    all_pieces
+    |> Enum.chunk_by(&Map.has_key?(loaded_pieces, Hexpm.Diff.piece_id(&1)))
+    |> Enum.flat_map(fn pieces ->
+      if Map.has_key?(loaded_pieces, pieces |> hd() |> Hexpm.Diff.piece_id()) do
+        Enum.map(pieces, fn piece ->
+          id = Hexpm.Diff.piece_id(piece)
+          {:piece, id, Map.fetch!(loaded_pieces, id)}
+        end)
+      else
+        start = pieces |> hd() |> Hexpm.Diff.piece_id() |> then(&Map.fetch!(piece_order, &1))
+
+        last =
+          pieces |> List.last() |> Hexpm.Diff.piece_id() |> then(&Map.fetch!(piece_order, &1))
+
+        direction =
+          if is_integer(selected_index) and last < selected_index, do: :backward, else: :forward
+
+        [{:gap, start, last, direction}]
+      end
+    end)
+  end
+
+  defp current_gap_direction(socket, start, last) do
+    socket.assigns.all_pieces
+    |> diff_entries(
+      socket.assigns.loaded_pieces,
+      socket.assigns.piece_order,
+      socket.assigns.selected_file
+    )
+    |> Enum.find_value(fn
+      {:gap, ^start, ^last, direction} -> direction
+      _entry -> nil
+    end)
   end
 
   defp loaded_file({id, {:too_large, file}}), do: [%{id: id, path: file}]

--- a/lib/hexpm_web/live/diff_live.html.heex
+++ b/lib/hexpm_web/live/diff_live.html.heex
@@ -156,27 +156,39 @@
                 data-line-selector=".ghd-line"
                 data-selected-class="selected"
               >
-                <div :for={{id, content} <- @loaded_pieces} id={"#{id}-container"}>
-                  <%= case content do %>
-                    <% {:diff, diff, highlights} -> %>
-                      <HexpmWeb.DiffComponent.diff id={id} diff={diff} highlights={highlights} />
-                    <% {:too_large, file} -> %>
-                      <HexpmWeb.DiffComponent.too_large file={file} />
-                    <% {:error, _reason} -> %>
-                      <div class="ghd-diff-error">Failed to load diff</div>
+                <%= for entry <- diff_entries(@all_pieces, @loaded_pieces, @piece_order, @selected_file) do %>
+                  <%= case entry do %>
+                    <% {:piece, id, content} -> %>
+                      <div id={"#{id}-container"}>
+                        <%= case content do %>
+                          <% {:diff, diff, highlights} -> %>
+                            <HexpmWeb.DiffComponent.diff
+                              id={id}
+                              diff={diff}
+                              highlights={highlights}
+                            />
+                          <% {:too_large, file} -> %>
+                            <HexpmWeb.DiffComponent.too_large file={file} />
+                          <% {:error, _reason} -> %>
+                            <div class="ghd-diff-error">Failed to load diff</div>
+                        <% end %>
+                      </div>
+                    <% {:gap, start, last, direction} -> %>
+                      <div
+                        id={"diff-gap-#{start}-#{last}"}
+                        class="flex h-16 items-center justify-center rounded-lg border border-grey-200 bg-white text-sm text-grey-400 dark:border-grey-700 dark:bg-grey-800"
+                        role="status"
+                        phx-hook="InfiniteScroll"
+                        data-start={start}
+                        data-last={last}
+                        data-direction={direction}
+                      >
+                        {if direction == :backward,
+                          do: "Loading previous files…",
+                          else: "Loading more files…"}
+                      </div>
                   <% end %>
-                </div>
-
-                <div
-                  :if={@remaining_pieces != []}
-                  id="diff-loading-trigger"
-                  class="flex h-16 items-center justify-center rounded-lg border border-grey-200 bg-white text-sm text-grey-400 dark:border-grey-700 dark:bg-grey-800"
-                  role="status"
-                  phx-hook="InfiniteScroll"
-                  data-loaded={length(@loaded_pieces)}
-                >
-                  Loading more files…
-                </div>
+                <% end %>
 
                 <div
                   :if={@metadata.total_diffs == 0}

--- a/test/hexpm_web/live/diff_live_test.exs
+++ b/test/hexpm_web/live/diff_live_test.exs
@@ -58,15 +58,16 @@ defmodule HexpmWeb.DiffLiveTest do
     assert html =~ "Hide whitespace"
     assert html =~ ~s(aria-label="Changed files")
     assert html =~ ~s(id="diff-files-tree-search")
-    assert html =~ ~s(id="diff-loading-trigger")
+    assert html =~ ~s(id="diff-gap-5-5")
+    assert has_element?(view, "#diff-gap-5-5[data-direction='forward']")
 
     assert Floki.attribute(document, "#whitespace-toggle", "href") == [
              "/diff/#{package.name}/1.0.0..7.0.0?w=1"
            ]
 
-    html = render_hook(view, "load-more")
+    html = render_hook(view, "load-gap", %{"start" => "5", "last" => "5"})
     assert has_element?(view, "#diff-5-container", "file-5.bin")
-    refute html =~ ~s(id="diff-loading-trigger")
+    refute html =~ ~s(id="diff-gap-")
   end
 
   test "changed-file selector filters and loads only the selected unloaded file", %{
@@ -93,7 +94,74 @@ defmodule HexpmWeb.DiffLiveTest do
     assert has_element?(view, "#diff-6-container", "file-6.bin")
     assert has_element?(view, ~s(button[aria-current="true"]), "file-6.bin")
     refute has_element?(view, "#diff-5-container")
-    assert has_element?(view, "#diff-loading-trigger")
+    assert has_element?(view, "#diff-gap-5-5[data-direction='backward']")
+  end
+
+  test "sidebar jumps create ordered gaps that load toward the selected file", %{
+    package: package
+  } do
+    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    put_ready_cache(request, 12)
+
+    {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
+
+    view
+    |> element("#diff-files-tree button", "file-11.bin")
+    |> render_click()
+
+    assert has_element?(view, "#diff-gap-5-10[data-direction='backward']")
+
+    view
+    |> element("#diff-files-tree button", "file-8.bin")
+    |> render_click()
+
+    assert has_element?(view, "#diff-gap-5-7[data-direction='backward']")
+    assert has_element?(view, "#diff-gap-9-10[data-direction='forward']")
+
+    render_hook(view, "load-gap", %{"start" => "5", "last" => "7"})
+    render_hook(view, "load-gap", %{"start" => "9", "last" => "10"})
+
+    assert diff_container_ids(view) == Enum.map(0..11, &"diff-#{&1}-container")
+    refute has_element?(view, "[id^='diff-gap-']")
+  end
+
+  test "backward gaps load at most five files nearest the selected file", %{
+    package: package
+  } do
+    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    put_ready_cache(request, 12)
+
+    {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
+
+    view
+    |> element("#diff-files-tree button", "file-11.bin")
+    |> render_click()
+
+    render_hook(view, "load-gap", %{"start" => "5", "last" => "10"})
+
+    refute has_element?(view, "#diff-5-container")
+
+    for index <- 6..11 do
+      assert has_element?(view, "#diff-#{index}-container")
+    end
+
+    assert has_element?(view, "#diff-gap-5-5[data-direction='backward']")
+  end
+
+  test "stale and invalid gap events do not load pieces", %{package: package} do
+    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    put_ready_cache(request, 7)
+
+    {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
+
+    render_hook(view, "load-gap", %{"start" => "0", "last" => "6"})
+    render_hook(view, "load-gap", %{"start" => "invalid", "last" => "6"})
+    render_hook(view, "load-gap", %{})
+
+    assert has_element?(view, "#diff-4-container")
+    refute has_element?(view, "#diff-5-container")
+    refute has_element?(view, "#diff-6-container")
+    assert has_element?(view, "#diff-gap-5-6[data-direction='forward']")
   end
 
   test "legacy metadata populates the file selector without eagerly fetching every piece", %{
@@ -141,7 +209,7 @@ defmodule HexpmWeb.DiffLiveTest do
     assert has_element?(view, "#diff-6-container", "legacy-6.bin")
     assert has_element?(view, "#diff-files-tree button", "legacy-6.bin")
     refute has_element?(view, "#diff-5-container")
-    assert has_element?(view, "#diff-loading-trigger")
+    assert has_element?(view, "#diff-gap-5-5[data-direction='forward']")
   end
 
   test "cached patches are highlighted through Lumis with stable line anchors", %{
@@ -477,6 +545,14 @@ defmodule HexpmWeb.DiffLiveTest do
 
   defp zero_based_range(0), do: []
   defp zero_based_range(count), do: 0..(count - 1)
+
+  defp diff_container_ids(view) do
+    view
+    |> render()
+    |> Floki.parse_fragment!()
+    |> Floki.find("#diff-list > [id$='-container']")
+    |> Floki.attribute("id")
+  end
 
   defp set_job_state(job, state) do
     job


### PR DESCRIPTION
Package diff navigation can load individual files out of sequence, leaving unloaded ranges that the previous single end-of-list sentinel could not fill while scrolling upward.

This renders a lazy-loading sentinel for every contiguous unloaded range. Ranges before the selected file load backward and ranges after it load forward, with each request capped at five files. Loaded pieces remain in canonical order, and stale gap events are ignored.

Validated with the focused Diff LiveView tests, the full Hexpm suite (28 properties and 2,088 tests), formatting, `git diff --check`, and `mix assets.deploy`.