### PR TITLE
Include Gleam revert+retire instructions in email

### DIFF
--- a/lib/hexpm_web/templates/email/package_published.html.eex
+++ b/lib/hexpm_web/templates/email/package_published.html.eex
@@ -27,3 +27,14 @@
     </td>
   </tr>
 </table>
+
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="margin: 16px 0; background-color: #1c2a3a; border-radius: 4px;">
+  <tr>
+    <td style="padding: 20px;">
+      <p style="color: #f0f5f9; font-size: 20px; line-height: 28px; font-weight: 500; margin: 0 0 8px 0;">
+        <%= Common.for_gleam_label() %>
+      </p>
+      <pre style="color: #f0f5f9; font-family: 'JetBrains Mono', 'Courier New', monospace; font-size: 14px; line-height: 20px; margin: 0; white-space: pre-wrap;"><%= PackagePublished.gleam_code(@package, @version) %></pre>
+    </td>
+  </tr>
+</table>

--- a/lib/hexpm_web/templates/email/package_published.text.eex
+++ b/lib/hexpm_web/templates/email/package_published.text.eex
@@ -7,3 +7,7 @@
 <%= Common.for_rebar3_label() %>
 
 <%= PackagePublished.rebar3_code(@package, @version) %>
+
+<%= Common.for_gleam_label() %>
+
+<%= PackagePublished.gleam_code(@package, @version) %>

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -34,6 +34,7 @@ defmodule HexpmWeb.EmailView do
     # Common labels for build tools
     def for_mix_label(), do: "For mix:"
     def for_rebar3_label(), do: "For rebar3:"
+    def for_gleam_label(), do: "For gleam:"
 
     # URL follow pattern for verification/reset emails
     def follow_link_instruction(url, :html) do
@@ -293,6 +294,14 @@ defmodule HexpmWeb.EmailView do
       cd #{package}; rebar3 hex publish --revert #{version}
       # or
       rebar3 hex retire #{package} #{version} security --message "Not published by owners"
+      """
+    end
+
+    def gleam_code(package, version) do
+      """
+      gleam hex revert --package #{package} --version #{version}
+      # or
+      gleam hex retire --package #{package} --version #{version} security --message "Not published by owners"
       """
     end
   end


### PR DESCRIPTION
Hello!

I figured since Gleam instructions are now included in other parts of the site it would be good to have instructions in this email too. I hope that's alright!

Thanks,
Louis