### PR TITLE
Fix diff gap loading behavior

### DIFF
--- a/assets/js/hooks/diff.js
+++ b/assets/js/hooks/diff.js
@@ -1,5 +1,18 @@
 const loadedGapChains = new Set();
-let lastGapLoadAt = 0;
+let gapLoadLocked = false;
+let gapLoadUnlockTimer;
+
+function lockGapLoading() {
+  gapLoadLocked = true;
+  clearTimeout(gapLoadUnlockTimer);
+  gapLoadUnlockTimer = setTimeout(() => {
+    gapLoadLocked = false;
+  }, 150);
+}
+
+function extendGapLoadLock() {
+  if (gapLoadLocked) lockGapLoading();
+}
 
 function gapChain(el) {
   const boundary =
@@ -19,12 +32,13 @@ export const InfiniteScroll = {
     this.onScroll = () => {
       const scrollY = window.scrollY;
       const delta = scrollY - this.lastScrollY;
+      extendGapLoadLock();
 
       if (
         this.blocked &&
         this.intersecting &&
         !this.pending &&
-        Date.now() - lastGapLoadAt > 300 &&
+        !gapLoadLocked &&
         ((this.el.dataset.direction === "backward" && delta < -50) ||
           (this.el.dataset.direction === "forward" && delta > 50))
       ) {
@@ -38,6 +52,16 @@ export const InfiniteScroll = {
       }
     };
 
+    this.onGapLoad = ({ detail }) => {
+      this.lastScrollY = window.scrollY;
+
+      if (detail?.id === this.el.id && !this.pending) {
+        this.blocked = false;
+        this.pending = true;
+        this.loadGap();
+      }
+    };
+
     this.onFileScroll = () => {
       this.blocked = true;
       loadedGapChains.add(this.chain);
@@ -45,6 +69,7 @@ export const InfiniteScroll = {
     };
 
     window.addEventListener("scroll", this.onScroll, { passive: true });
+    window.addEventListener("hexpm:load-diff-gap", this.onGapLoad);
     window.addEventListener("hexpm:scroll-to-diff", this.onFileScroll);
     this.observer = new IntersectionObserver(
       ([entry]) => {
@@ -66,6 +91,7 @@ export const InfiniteScroll = {
   destroyed() {
     this.observer?.disconnect();
     window.removeEventListener("scroll", this.onScroll);
+    window.removeEventListener("hexpm:load-diff-gap", this.onGapLoad);
     window.removeEventListener("hexpm:scroll-to-diff", this.onFileScroll);
   },
 
@@ -77,7 +103,7 @@ export const InfiniteScroll = {
   },
 
   loadGap() {
-    lastGapLoadAt = Date.now();
+    lockGapLoading();
     loadedGapChains.add(this.chain);
     this.pushEvent("load-gap", {
       start: this.el.dataset.start,

--- a/assets/js/hooks/line_highlight.js
+++ b/assets/js/hooks/line_highlight.js
@@ -33,18 +33,17 @@ const LineHighlight = {
       requestAnimationFrame(() => {
         const file = document.getElementById(id);
         if (file && this.el.contains(file)) {
-          const previous = file.previousElementSibling;
-          const gapOffset = previous?.id.startsWith("diff-gap-")
-            ? previous.getBoundingClientRect().height
-            : 0;
-
-          window.dispatchEvent(new Event("hexpm:scroll-to-diff"));
           window.history.replaceState(null, "", `#${id}`);
-          window.scrollTo({
-            top:
-              file.getBoundingClientRect().top + window.scrollY - gapOffset,
-            behavior: "instant",
-          });
+          const gap = this.scrollToFile(file, true);
+
+          if (gap) {
+            this.pendingScroll = { fileId: id, gapId: gap.id };
+            window.dispatchEvent(
+              new CustomEvent("hexpm:load-diff-gap", {
+                detail: { id: gap.id },
+              }),
+            );
+          }
         }
       });
     });
@@ -55,6 +54,19 @@ const LineHighlight = {
   updated() {
     this.prepareLines();
     this.requestHashTarget();
+
+    if (this.pendingScroll) {
+      requestAnimationFrame(() => {
+        const { fileId, gapId } = this.pendingScroll;
+        const file = document.getElementById(fileId);
+        const previous = file?.previousElementSibling;
+
+        if (file && previous?.id !== gapId) {
+          this.pendingScroll = null;
+          this.scrollToFile(file, false);
+        }
+      });
+    }
   },
 
   destroyed() {
@@ -66,6 +78,24 @@ const LineHighlight = {
   selectLine(line) {
     window.history.replaceState(null, "", `#${line.id}`);
     this.highlightLine();
+  },
+
+  scrollToFile(file, showGap) {
+    const previous = file.previousElementSibling;
+    const gap = previous?.id.startsWith("diff-gap-") ? previous : null;
+    const gapOffset =
+      showGap && gap
+        ? gap.getBoundingClientRect().height +
+          Number.parseFloat(getComputedStyle(gap).marginBottom)
+        : 0;
+
+    window.dispatchEvent(new Event("hexpm:scroll-to-diff"));
+    window.scrollTo({
+      top: file.getBoundingClientRect().top + window.scrollY - gapOffset,
+      behavior: "instant",
+    });
+
+    return gap;
   },
 
   requestHashTarget() {

--- a/lib/hexpm_web/live/diff_live.html.heex
+++ b/lib/hexpm_web/live/diff_live.html.heex
@@ -176,7 +176,7 @@
                     <% {:gap, start, last, direction} -> %>
                       <div
                         id={"diff-gap-#{start}-#{last}"}
-                        class="flex h-16 items-center justify-center rounded-lg border border-grey-200 bg-white text-sm text-grey-400 dark:border-grey-700 dark:bg-grey-800"
+                        class="mb-4 flex h-16 items-center justify-center rounded-lg border border-grey-200 bg-white text-sm text-grey-400 dark:border-grey-700 dark:bg-grey-800"
                         role="status"
                         phx-hook="InfiniteScroll"
                         data-start={start}

--- a/test/hexpm_web/live/diff_live_test.exs
+++ b/test/hexpm_web/live/diff_live_test.exs
@@ -60,7 +60,7 @@ defmodule HexpmWeb.DiffLiveTest do
     assert html =~ ~s(id="diff-files-tree-search")
     assert html =~ "5 of 6 files loaded"
     assert html =~ ~s(id="diff-gap-5-5")
-    assert has_element?(view, "#diff-gap-5-5[data-direction='forward']")
+    assert has_element?(view, "#diff-gap-5-5.mb-4[data-direction='forward']")
 
     assert Floki.attribute(document, "#whitespace-toggle", "href") == [
              "/diff/#{package.name}/1.0.0..7.0.0?w=1"
@@ -96,7 +96,7 @@ defmodule HexpmWeb.DiffLiveTest do
     assert has_element?(view, "#diff-6-container", "file-6.bin")
     assert has_element?(view, ~s(button[aria-current="true"]), "file-6.bin")
     refute has_element?(view, "#diff-5-container")
-    assert has_element?(view, "#diff-gap-5-5[data-direction='backward']")
+    assert has_element?(view, "#diff-gap-5-5.mb-4[data-direction='backward']")
     assert render(view) =~ "6 of 7 files loaded"
   end
 


### PR DESCRIPTION
Fix follow-up issues in package diff lazy loading after direct file selection.

Selecting an unloaded file now explicitly starts the preceding gap request, then keeps the selected file in view after the batch is inserted. Programmatic scrolling remains guarded so only the intended gap loads. Gap indicators also have consistent spacing from the following file.

The fixed request cooldown is replaced with a scroll-idle lock, preventing one continuous scroll gesture from triggering multiple remounted gap batches while allowing the next gesture to continue loading.

Validated with `mix format --check-formatted`, the focused Diff LiveView tests (23 tests), and the 18-file browser fixture at 1440x900. Direct selection loaded files 12–16 immediately, the first upward gesture loaded 7–11 without repeating, and the next gesture loaded 5–6 in canonical order.
