### PR TITLE
Update organization pricing and announce increase

### DIFF
--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -39,9 +39,15 @@ defmodule Hexpm.AdminTasks do
       # Remove a package
       iex> AdminTasks.remove_package("hexpm", "malicious_pkg")
       :ok
+
+      # Send an email
+      iex> AdminTasks.send_email(["bob@example.com"], "Hex.pm - Subject", "Body")
+      {:ok, 1}
   """
 
   use Hexpm.Context
+
+  require Logger
 
   defp find_user(username_or_email) do
     case Users.get(username_or_email, [:emails]) do
@@ -694,5 +700,46 @@ defmodule Hexpm.AdminTasks do
       end
 
     Oban.retry_all_jobs(query)
+  end
+
+  @doc """
+  Sends an email with an arbitrary subject and body.
+
+  Every recipient gets a separate email so addresses are not disclosed between
+  recipients. Duplicate addresses are only sent to once. Failed deliveries are
+  logged and do not stop the remaining sends, the returned count is the number
+  of emails delivered.
+
+  ## Arguments
+
+  - `recipients` - Email addresses to send to
+  - `subject` - Subject line, a leading `"Hex.pm - "` is dropped from the heading
+  - `body` - Plain text body, blank lines separate paragraphs
+
+  ## Examples
+
+      iex> AdminTasks.send_email(["bob@example.com"], "Hex.pm - Service update", "We are ...")
+      {:ok, 1}
+  """
+  @spec send_email([String.t()], String.t(), String.t()) :: {:ok, non_neg_integer()}
+  def send_email(recipients, subject, body) do
+    sent =
+      recipients
+      |> List.wrap()
+      |> Enum.uniq()
+      |> Enum.count(&deliver_email(&1, subject, body))
+
+    {:ok, sent}
+  end
+
+  defp deliver_email(recipient, subject, body) do
+    case Mailer.deliver(Emails.announcement(recipient, subject, body)) do
+      {:ok, _} ->
+        true
+
+      {:error, reason} ->
+        Logger.error("Could not send email to #{recipient}: #{inspect(reason)}")
+        false
+    end
   end
 end

--- a/lib/hexpm/billing/local.ex
+++ b/lib/hexpm/billing/local.ex
@@ -12,7 +12,7 @@ defmodule Hexpm.Billing.Local do
     # used in dev (see config/config.exs). Production uses Billing.Hexpm.
     # Note: create/1 and update/2 are no-ops, so form submissions don't persist locally.
     now = DateTime.utc_now()
-    period_end = now |> DateTime.add(30, :day) |> DateTime.to_unix()
+    period_end = now |> DateTime.add(60, :day) |> DateTime.to_unix()
     last_month = now |> DateTime.add(-30, :day) |> DateTime.to_unix()
 
     %{
@@ -20,6 +20,9 @@ defmodule Hexpm.Billing.Local do
       "monthly_cost" => 700,
       "email" => "billing@example.com",
       "plan_id" => "organization-monthly",
+      "plan_unit_amount" => 700,
+      "pending_plan_unit_amount" => 900,
+      "plan_price_change_at" => period_end,
       "quantity" => 1,
       "subscription" => %{
         "status" => "active",

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -201,6 +201,15 @@ defmodule Hexpm.Emails do
     |> render_body(:report_state_changed)
   end
 
+  def announcement(receiver, subject, body) do
+    base_email()
+    |> email_to(receiver)
+    |> subject(subject)
+    |> assign(:subject, subject)
+    |> assign(:body, body)
+    |> render_body(:announcement)
+  end
+
   defp email_to(email, to) do
     recipients =
       to

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -983,6 +983,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       checkout_html: nil,
       billing_email: nil,
       plan_id: "organization-monthly",
+      plan_unit_amount: nil,
+      pending_plan_unit_amount: nil,
+      plan_price_change_at: nil,
       subscription: nil,
       monthly_cost: nil,
       amount_with_tax: nil,
@@ -1010,6 +1013,10 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       checkout_html: customer["checkout_html"],
       billing_email: customer["email"],
       plan_id: customer["plan_id"],
+      plan_unit_amount:
+        customer["plan_unit_amount"] || legacy_plan_unit_amount(customer["plan_id"]),
+      pending_plan_unit_amount: customer["pending_plan_unit_amount"],
+      plan_price_change_at: customer["plan_price_change_at"],
       proration_amount: customer["proration_amount"],
       proration_days: customer["proration_days"],
       subscription: customer["subscription"],
@@ -1028,6 +1035,9 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       stripe_publishable_key: customer["stripe_publishable_key"]
     ]
   end
+
+  defp legacy_plan_unit_amount("organization-annually"), do: 7_000
+  defp legacy_plan_unit_amount(_plan_id), do: 700
 
   defp access_organization(conn, organization, role, fun) do
     user = conn.assigns.current_user

--- a/lib/hexpm_web/templates/blog/024-organization-pricing-update.html.md
+++ b/lib/hexpm_web/templates/blog/024-organization-pricing-update.html.md
@@ -9,11 +9,10 @@ and private packages went live in 2018.
 Private packages first entered beta in 2017, and when organizations went live the
 following year the price was $7 per user / month. Since then, we have added private
 HexDocs, organization-owned keys for CI, annual billing, management of public packages,
-organization audit logs, and signed dependency policies. We are also about to ship
-file previews and package diffs for private packages, and we are actively working on
-single sign-on for organizations. Throughout this time, we have continued to develop
-Hex and operate the package infrastructure used by the Erlang, Elixir, and Gleam
-communities.
+organization audit logs, signed dependency policies, and most recently file previews
+and package diffs for private packages. We are actively working on single sign-on for
+organizations. Throughout this time, we have continued to develop Hex and operate the
+package infrastructure used by the Erlang, Elixir, and Gleam communities.
 
 ### What is changing
 

--- a/lib/hexpm_web/templates/blog/024-organization-pricing-update.html.md
+++ b/lib/hexpm_web/templates/blog/024-organization-pricing-update.html.md
@@ -1,0 +1,53 @@
+## Updating organization pricing
+
+<div class="subtitle"><time datetime="2026-07-16T00:00:00Z">16 July, 2026</time> · by Eric Meadows-Jönsson</div>
+
+We are updating the price of Hex.pm organizations to **$9 per user / month** or
+**$90 per user / year**. This is the first price increase since paid organizations
+and private packages went live in 2018.
+
+Private packages first entered beta in 2017, and when organizations went live the
+following year the price was $7 per user / month. Since then, we have added private
+HexDocs, organization-owned keys for CI, annual billing, management of public packages,
+organization audit logs, and signed dependency policies. We are also about to ship
+file previews and package diffs for private packages. Throughout this time, we have
+continued to develop Hex and operate the package infrastructure used by the Erlang,
+Elixir, and Gleam communities.
+
+### What is changing
+
+New organization subscriptions will use the new pricing immediately. Existing
+subscriptions will keep their current price for at least 60 days and move to the new
+price at their first regular renewal after that grace period.
+
+The increase will not be applied in the middle of a billing period, and it will not
+change an organization's renewal date. Existing customers will see their current
+price, new price, and the date of the change in the organization billing dashboard.
+
+### Investing in Hex
+
+We are grateful to our [sponsors](/sponsors) and to the organizations paying for
+private packages. Recent grants have also funded specific security projects.
+[Alpha-Omega](https://alpha-omega.dev/) funded our
+[first comprehensive third-party security audit](/blog/security-audit) through the
+[Erlang Ecosystem Foundation's Ægis initiative](https://security.erlef.org/aegis/).
+
+Grants and sponsorships make important projects like the audit possible, but
+organization subscriptions primarily fund Hex.pm's ongoing infrastructure,
+operations, and development. That work has grown substantially, particularly as we
+spend more time reviewing vulnerability reports, coordinating fixes, and improving
+package publishing and supply chain security.
+
+Recent improvements include requiring two-factor authentication for publishing,
+OAuth-based CLI authentication, and additional protection for sensitive account
+actions. Following the security audit, we also addressed many of the vulnerabilities
+and hardening gaps it uncovered.
+
+Hex 2.5 added security advisory warnings directly to dependency fetching, release-age
+cooldowns, and signed dependency policies that organizations can enforce consistently
+across their projects. These features help teams reduce the chance that a vulnerable,
+malicious, or newly compromised release reaches production.
+
+The new pricing helps us sustain that work while keeping Hex free for public packages
+and open source users. Thank you to every organization that supports Hex.pm and the
+BEAM ecosystem.

--- a/lib/hexpm_web/templates/blog/024-organization-pricing-update.html.md
+++ b/lib/hexpm_web/templates/blog/024-organization-pricing-update.html.md
@@ -10,9 +10,10 @@ Private packages first entered beta in 2017, and when organizations went live th
 following year the price was $7 per user / month. Since then, we have added private
 HexDocs, organization-owned keys for CI, annual billing, management of public packages,
 organization audit logs, and signed dependency policies. We are also about to ship
-file previews and package diffs for private packages. Throughout this time, we have
-continued to develop Hex and operate the package infrastructure used by the Erlang,
-Elixir, and Gleam communities.
+file previews and package diffs for private packages, and we are actively working on
+single sign-on for organizations. Throughout this time, we have continued to develop
+Hex and operate the package infrastructure used by the Erlang, Elixir, and Gleam
+communities.
 
 ### What is changing
 

--- a/lib/hexpm_web/templates/dashboard/organization/components/billing_helpers.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/billing_helpers.ex
@@ -2,13 +2,29 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingHelpers do
   import Phoenix.HTML, only: [raw: 1]
   import HexpmWeb.ViewHelpers, only: [pretty_date: 1]
 
-  def plan("organization-monthly"), do: "Organization, monthly billed ($7.00 per user / month)"
-  def plan("organization-annually"), do: "Organization, annually billed ($70.00 per user / year)"
-  def plan(_), do: "Organization, monthly billed ($7.00 per user / month)"
+  def plan(plan_id, unit_amount \\ nil)
 
-  def plan_price("organization-monthly"), do: "$7.00"
-  def plan_price("organization-annually"), do: "$70.00"
-  def plan_price(_), do: "$7.00"
+  def plan("organization-monthly", unit_amount),
+    do:
+      "Organization, monthly billed (#{plan_price("organization-monthly", unit_amount)} per user / month)"
+
+  def plan("organization-annually", unit_amount),
+    do:
+      "Organization, annually billed (#{plan_price("organization-annually", unit_amount)} per user / year)"
+
+  def plan(_, unit_amount), do: plan("organization-monthly", unit_amount)
+
+  def plan_price(plan_id, unit_amount \\ nil)
+
+  def plan_price(_plan_id, unit_amount) when is_integer(unit_amount),
+    do: dollar_money(unit_amount)
+
+  def plan_price("organization-monthly", nil), do: "$9.00"
+  def plan_price("organization-annually", nil), do: "$90.00"
+  def plan_price(_, nil), do: "$9.00"
+
+  def plan_interval("organization-annually"), do: "year"
+  def plan_interval(_), do: "month"
 
   def payment_date(nil), do: ""
 

--- a/lib/hexpm_web/templates/dashboard/organization/components/billing_subscription.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/billing_subscription.ex
@@ -18,6 +18,9 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
   attr :current_user, :map, required: true
   attr :organization, :map, required: true
   attr :plan_id, :string, default: nil
+  attr :plan_unit_amount, :integer, default: nil
+  attr :pending_plan_unit_amount, :integer, default: nil
+  attr :plan_price_change_at, :any, default: nil
   attr :quantity, :integer, default: nil
   attr :member_count, :integer, default: 0
   attr :subscription, :map, default: nil
@@ -61,13 +64,23 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
 
       <div class="px-6 py-5">
         <%= if @subscription do %>
+          <%= if @pending_plan_unit_amount && @plan_price_change_at do %>
+            <div class="mb-5 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-900/20 dark:text-blue-100">
+              Your price will change to {BillingHelpers.plan_price(
+                @plan_id,
+                @pending_plan_unit_amount
+              )} per user / {BillingHelpers.plan_interval(@plan_id)} on {BillingHelpers.payment_date(
+                @plan_price_change_at
+              )}.
+            </div>
+          <% end %>
           <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
             <div>
               <dt class="text-xs font-medium text-grey-500 dark:text-grey-300 uppercase tracking-wider mb-1">
                 Plan
               </dt>
               <dd class="text-sm text-grey-900 dark:text-white">
-                <p>{BillingHelpers.plan(@plan_id)}</p>
+                <p>{BillingHelpers.plan(@plan_id, @plan_unit_amount)}</p>
                 <div class="mt-2">
                   <.button
                     type="button"
@@ -110,7 +123,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
                 {if @plan_id == "organization-annually", do: "Annual cost", else: "Monthly cost"}
               </dt>
               <dd class="text-sm text-grey-900 dark:text-white">
-                {BillingHelpers.plan_price(@plan_id)} x {@safe_quantity} user(s)
+                {BillingHelpers.plan_price(@plan_id, @plan_unit_amount)} x {@safe_quantity} user(s)
                 <%= if @tax_rate && @tax_rate != 0 do %>
                   x {@tax_rate}% VAT
                 <% end %>
@@ -211,6 +224,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
             current_user={@current_user}
             organization={@organization}
             plan_id={@plan_id}
+            plan_unit_amount={@plan_unit_amount}
             quantity={@safe_quantity}
             member_count={@member_count}
             proration_amount={@proration_amount}
@@ -223,6 +237,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
             quantity={@safe_quantity}
             member_count={@member_count}
             plan_id={@plan_id}
+            plan_unit_amount={@plan_unit_amount}
           />
           <.change_plan_modal
             current_user={@current_user}
@@ -363,7 +378,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
           </p>
           <p class="text-sm text-grey-600 dark:text-grey-300 mb-6">
             Subscription cost is
-            <strong class="text-grey-900 dark:text-white">$7.00 per user / month</strong>
+            <strong class="text-grey-900 dark:text-white">$9.00 per user / month</strong>
             + local VAT when applicable.
           </p>
           <script nonce={@script_src_nonce}>
@@ -463,6 +478,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
   attr :current_user, :map, required: true
   attr :organization, :map, required: true
   attr :plan_id, :string, default: nil
+  attr :plan_unit_amount, :integer, default: nil
   attr :quantity, :integer, default: 0
   attr :member_count, :integer, default: 0
   attr :proration_amount, :integer, default: 0
@@ -502,7 +518,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
               class="w-24 h-10 px-3 border border-grey-200 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-600"
             />
             <span class="text-sm text-grey-600 dark:text-grey-300">
-              seat(s) @ {BillingHelpers.plan_price(@plan_id)}
+              seat(s) @ {BillingHelpers.plan_price(@plan_id, @plan_unit_amount)}
             </span>
           </div>
         </div>
@@ -535,6 +551,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
   attr :quantity, :integer, default: 0
   attr :member_count, :integer, default: 0
   attr :plan_id, :string, default: nil
+  attr :plan_unit_amount, :integer, default: nil
 
   defp remove_seats_modal(assigns) do
     ~H"""
@@ -568,7 +585,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
                 <% end %>
               </select>
               <span class="text-sm text-grey-600 dark:text-grey-300">
-                seat(s) @ {BillingHelpers.plan_price(@plan_id)}
+                seat(s) @ {BillingHelpers.plan_price(@plan_id, @plan_unit_amount)}
               </span>
             </div>
           </div>

--- a/lib/hexpm_web/templates/dashboard/organization/components/billing_tab.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/billing_tab.ex
@@ -17,6 +17,9 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingTab do
   attr :billing_started?, :boolean, default: false
   attr :billing_email, :string, default: nil
   attr :plan_id, :string, default: nil
+  attr :plan_unit_amount, :integer, default: nil
+  attr :pending_plan_unit_amount, :integer, default: nil
+  attr :plan_price_change_at, :any, default: nil
   attr :quantity, :integer, default: nil
   attr :max_period_quantity, :integer, default: nil
   attr :subscription, :map, default: nil
@@ -50,6 +53,9 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingTab do
           current_user={@current_user}
           organization={@organization}
           plan_id={@plan_id}
+          plan_unit_amount={@plan_unit_amount}
+          pending_plan_unit_amount={@pending_plan_unit_amount}
+          plan_price_change_at={@plan_price_change_at}
           quantity={@quantity}
           member_count={@member_count}
           subscription={@subscription}
@@ -108,7 +114,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingTab do
         <p class="text-sm text-amber-800 dark:text-amber-100">
           Add a payment method to continue using organizations after the trial.
           Subscription cost is
-          <strong class="text-amber-900 dark:text-amber-50">$7.00 per user / month</strong>
+          <strong class="text-amber-900 dark:text-amber-50">$9.00 per user / month</strong>
           + local VAT when applicable.
           Enter your billing information below to enable the payment method form.
         </p>
@@ -121,7 +127,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingTab do
         </p>
         <p class="text-sm text-amber-800 dark:text-amber-100">
           Subscription cost is
-          <strong class="text-amber-900 dark:text-amber-50">$7.00 per user / month</strong>
+          <strong class="text-amber-900 dark:text-amber-50">$9.00 per user / month</strong>
           + local VAT when applicable.
           Enter your billing information below to enable the payment method form.
         </p>

--- a/lib/hexpm_web/templates/dashboard/organization/components/create_organization_modal.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/create_organization_modal.ex
@@ -21,7 +21,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.CreateOrganizationModal do
       <p class="text-sm text-grey-500 dark:text-grey-300 mb-6">
         With organizations you can manage public packages with fine-grained
         access control for your members. Private packages are available on
-        paid plans at <strong class="text-grey-700 dark:text-grey-100">$7.00 per user / month</strong>.
+        paid plans at <strong class="text-grey-700 dark:text-grey-100">$9.00 per user / month</strong>.
       </p>
 
       <.sudo_form current_user={@current_user} action="/dashboard/orgs" id="create-org-form">

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.heex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.heex
@@ -74,6 +74,9 @@
                 params={@params}
                 person={@person}
                 plan_id={@plan_id}
+                plan_unit_amount={@plan_unit_amount}
+                pending_plan_unit_amount={@pending_plan_unit_amount}
+                plan_price_change_at={@plan_price_change_at}
                 pending_action_html={@pending_action_html}
                 post_action={@post_action}
                 proration_amount={@proration_amount}

--- a/lib/hexpm_web/templates/dashboard/organization/new.html.heex
+++ b/lib/hexpm_web/templates/dashboard/organization/new.html.heex
@@ -26,7 +26,7 @@
             <p class="text-sm text-grey-600 dark:text-grey-300 mb-6">
               For private packages the first month is free and you don't need to enter any payment
               information to try it out. After the first month the cost to use private packages with
-              organizations is <strong class="font-semibold text-grey-900 dark:text-white">$7.00 per user / month</strong>. If you wish to continue with
+              organizations is <strong class="font-semibold text-grey-900 dark:text-white">$9.00 per user / month</strong>. If you wish to continue with
               private packages after the trial period add your billing details on the <a
                 href={~p"/dashboard/orgs"}
                 class="text-blue-600 dark:text-blue-300 hover:text-blue-500 dark:hover:text-blue-200"

--- a/lib/hexpm_web/templates/docs/faq.html.md
+++ b/lib/hexpm_web/templates/docs/faq.html.md
@@ -158,4 +158,4 @@ We will keep all your data for a minimum of 90 days. You can contact
 #### Can I pay annually instead of monthly?
 
 Yes, we offer an annual plan that is billed once a year and includes a 2 month discount over the
-monthly plan for a price of $70 / per user / per year.
+monthly plan for a price of $90 / per user / per year.

--- a/lib/hexpm_web/templates/email/announcement.html.eex
+++ b/lib/hexpm_web/templates/email/announcement.html.eex
@@ -1,0 +1,9 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  <%= Announcement.title(@subject) %>
+</h1>
+
+<%= for paragraph <- Announcement.paragraphs(@body) do %>
+  <p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+    <%= paragraph %>
+  </p>
+<% end %>

--- a/lib/hexpm_web/templates/email/announcement.text.eex
+++ b/lib/hexpm_web/templates/email/announcement.text.eex
@@ -1,0 +1,3 @@
+<%= Announcement.title(@subject) %>
+
+<%= @body %>

--- a/lib/hexpm_web/templates/page/index.html.heex
+++ b/lib/hexpm_web/templates/page/index.html.heex
@@ -121,7 +121,7 @@
 
         <.feature_card icon="shield-check" title="Private packages" href={~p"/pricing"}>
           Publish private packages by <.text_link href={~p"/dashboard/orgs"} variant="purple">creating an organization</.text_link>.
-          Private packages cost $7 / user / month after a free 30-day trial and include fast dependency fetching and HexDocs on the same reliable infrastructure that serves millions of packages daily. See our
+          Private packages cost $9 / user / month after a free 30-day trial and include fast dependency fetching and HexDocs on the same reliable infrastructure that serves millions of packages daily. See our
           <.text_link href={~p"/pricing"} variant="purple">pricing page</.text_link>
           for more details.
         </.feature_card>
@@ -273,7 +273,7 @@
           </.button_link>
           <div class="text-center">
             <.text_link href={~p"/pricing"} variant="primary">
-              Private Packages @ $7 / user / month
+              Private Packages @ $9 / user / month
             </.text_link>
           </div>
         </div>
@@ -300,7 +300,7 @@
               Get Started for FREE
             </.button_link>
             <.text_link href={~p"/pricing"} variant="primary">
-              Private Packages @ $7 / user / month
+              Private Packages @ $9 / user / month
             </.text_link>
           </div>
         </div>

--- a/lib/hexpm_web/templates/page/pricing.html.heex
+++ b/lib/hexpm_web/templates/page/pricing.html.heex
@@ -37,8 +37,8 @@
       icon_src={~p"/images/pricing/lock-icon.svg"}
       icon_bg="green"
       per_user={true}
-      price_monthly={7}
-      price_yearly={70}
+      price_monthly={9}
+      price_yearly={90}
       title="Private Packages"
       description="For Private Projects with teams of users"
       cta_text="Try FREE for 30 days"
@@ -171,7 +171,7 @@
             <:question>Can I pay annually instead of monthly?</:question>
             <:answer>
               <p>
-                Yes, we offer an annual plan that is billed once a year and includes a 2 month discount over the monthly plan for a price of $70 / per user / per year.
+                Yes, we offer an annual plan that is billed once a year and includes a 2 month discount over the monthly plan for a price of $90 / per user / per year.
               </p>
             </:answer>
           </.faq_item>

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -75,6 +75,18 @@ defmodule HexpmWeb.EmailView do
     end
   end
 
+  defmodule Announcement do
+    def title("Hex.pm - " <> title), do: title
+    def title(subject), do: subject
+
+    def paragraphs(body) do
+      body
+      |> String.split(~r/\n\s*\n/, trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+    end
+  end
+
   defmodule BuildTools do
     def mix_hex_user_auth(), do: "mix hex.user auth"
     def rebar3_hex_user_auth(), do: "rebar3 hex user auth"

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -661,4 +661,45 @@ defmodule Hexpm.AdminTasksTest do
       )
     end
   end
+
+  describe "send_email/3" do
+    test "sends a separate email to each recipient" do
+      assert {:ok, 2} =
+               AdminTasks.send_email(
+                 ["bob@example.com", "jane@example.com"],
+                 "Hex.pm - Service update",
+                 "First paragraph.\n\nSecond paragraph."
+               )
+
+      assert_email_sent(fn email ->
+        assert email.to == [{"", "bob@example.com"}]
+        assert email.subject == "Hex.pm - Service update"
+        assert email.text_body =~ "First paragraph."
+        assert email.text_body =~ "Second paragraph."
+        assert email.html_body =~ "Service update"
+        assert email.html_body =~ "<p"
+      end)
+
+      assert_email_sent(fn email -> assert email.to == [{"", "jane@example.com"}] end)
+    end
+
+    test "only sends once to duplicate recipients" do
+      assert {:ok, 1} =
+               AdminTasks.send_email(
+                 ["bob@example.com", "bob@example.com"],
+                 "Hex.pm - Service update",
+                 "Body"
+               )
+    end
+
+    test "escapes the body in the html email" do
+      assert {:ok, 1} =
+               AdminTasks.send_email(["bob@example.com"], "Subject", "<script>alert(1)</script>")
+
+      assert_email_sent(fn email ->
+        refute email.html_body =~ "<script>"
+        assert email.html_body =~ "&lt;script&gt;"
+      end)
+    end
+  end
 end

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -543,6 +543,131 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       assert response(conn, 200) =~ "Billing"
     end
 
+    test "shows the effective legacy price and upcoming price change", %{
+      user: user,
+      organization: organization
+    } do
+      insert(:organization_user, organization: organization, user: user, role: "admin")
+
+      stub(Hexpm.Billing.Mock, :get, fn token, _opts ->
+        assert organization.name == token
+
+        %{
+          "checkout_html" => "",
+          "invoices" => [],
+          "subscription" => %{
+            "status" => "active",
+            "current_period_end" => "2026-09-30T00:00:00Z",
+            "cancel_at_period_end" => false
+          },
+          "plan_id" => "organization-monthly",
+          "plan_unit_amount" => 700,
+          "pending_plan_unit_amount" => 900,
+          "plan_price_change_at" => "2026-09-30T00:00:00Z",
+          "amount_with_tax" => 1_400,
+          "quantity" => 2,
+          "max_period_quantity" => 2,
+          "proration_amount" => 0,
+          "proration_days" => 0,
+          "tax_rate" => 0
+        }
+      end)
+
+      body =
+        build_conn()
+        |> test_login(user)
+        |> get("/dashboard/orgs/#{organization.name}/billing")
+        |> response(200)
+
+      text =
+        body |> Floki.parse_document!() |> Floki.text(sep: " ") |> String.replace(~r/\s+/, " ")
+
+      assert text =~ "Organization, monthly billed ($7.00 per user / month)"
+      assert text =~ "$7.00 x 2 user(s)"
+      assert text =~ "Your price will change to $9.00 per user / month on September 30, 2026."
+      assert text =~ "Switch to the annual plan and save with $90.00 per user / year"
+    end
+
+    test "uses the legacy rate when an older billing instance omits the additive amount field", %{
+      user: user,
+      organization: organization
+    } do
+      insert(:organization_user, organization: organization, user: user, role: "admin")
+
+      stub(Hexpm.Billing.Mock, :get, fn _token, _opts ->
+        %{
+          "checkout_html" => "",
+          "invoices" => [],
+          "subscription" => %{
+            "status" => "active",
+            "current_period_end" => "2026-09-30T00:00:00Z",
+            "cancel_at_period_end" => false
+          },
+          "plan_id" => "organization-monthly",
+          "amount_with_tax" => 1_400,
+          "quantity" => 2,
+          "max_period_quantity" => 2,
+          "proration_amount" => 0,
+          "proration_days" => 0,
+          "tax_rate" => 0
+        }
+      end)
+
+      text =
+        build_conn()
+        |> test_login(user)
+        |> get("/dashboard/orgs/#{organization.name}/billing")
+        |> response(200)
+        |> Floki.parse_document!()
+        |> Floki.text(sep: " ")
+        |> String.replace(~r/\s+/, " ")
+
+      assert text =~ "Organization, monthly billed ($7.00 per user / month)"
+      assert text =~ "$7.00 x 2 user(s)"
+    end
+
+    test "shows an annual effective rate and annual upcoming-price notice", %{
+      user: user,
+      organization: organization
+    } do
+      insert(:organization_user, organization: organization, user: user, role: "admin")
+
+      stub(Hexpm.Billing.Mock, :get, fn _token, _opts ->
+        %{
+          "checkout_html" => "",
+          "invoices" => [],
+          "subscription" => %{
+            "status" => "active",
+            "current_period_end" => "2027-01-15T00:00:00Z",
+            "cancel_at_period_end" => false
+          },
+          "plan_id" => "organization-annually",
+          "plan_unit_amount" => 7_000,
+          "pending_plan_unit_amount" => 9_000,
+          "plan_price_change_at" => "2027-01-15T00:00:00Z",
+          "amount_with_tax" => 14_000,
+          "quantity" => 2,
+          "max_period_quantity" => 2,
+          "proration_amount" => 0,
+          "proration_days" => 0,
+          "tax_rate" => 0
+        }
+      end)
+
+      text =
+        build_conn()
+        |> test_login(user)
+        |> get("/dashboard/orgs/#{organization.name}/billing")
+        |> response(200)
+        |> Floki.parse_document!()
+        |> Floki.text(sep: " ")
+        |> String.replace(~r/\s+/, " ")
+
+      assert text =~ "Organization, annually billed ($70.00 per user / year)"
+      assert text =~ "$70.00 x 2 user(s)"
+      assert text =~ "Your price will change to $90.00 per user / year on January 15, 2027."
+    end
+
     test "returns 400 for non-admin member", %{user: user, organization: organization} do
       mock_customer(organization)
       insert(:organization_user, organization: organization, user: user, role: "read")

--- a/test/hexpm_web/controllers/page_controller_test.exs
+++ b/test/hexpm_web/controllers/page_controller_test.exs
@@ -68,7 +68,7 @@ defmodule HexpmWeb.PageControllerTest do
     assert package2.latest_release.version == "0.0.2"
 
     html = response(conn, 200)
-    assert html =~ "$7 / user / month"
+    assert html =~ "$9 / user / month"
     assert html =~ "Free organizations can publish public policies for public Hex packages"
 
     assert html =~
@@ -90,12 +90,12 @@ defmodule HexpmWeb.PageControllerTest do
 
     assert prices(document, ".monthly-active") == [
              "$0 / user / month",
-             "$7 / user / month"
+             "$9 / user / month"
            ]
 
     assert prices(document, ".price-display.hidden") == [
              "$0 / user / year",
-             "$70 / user / year"
+             "$90 / user / year"
            ]
 
     assert html =~ "Private Dependency Policies"

--- a/test/hexpm_web/templates/dashboard/organization/components/billing_helpers_test.exs
+++ b/test/hexpm_web/templates/dashboard/organization/components/billing_helpers_test.exs
@@ -81,6 +81,20 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingHelpersTest do
     end
   end
 
+  describe "plan pricing" do
+    test "uses the current catalog price for new subscriptions and plan switches" do
+      assert BillingHelpers.plan_price("organization-monthly") == "$9.00"
+      assert BillingHelpers.plan_price("organization-annually") == "$90.00"
+    end
+
+    test "uses the API-provided effective amount for an existing subscription" do
+      assert BillingHelpers.plan_price("organization-monthly", 700) == "$7.00"
+
+      assert BillingHelpers.plan("organization-monthly", 700) ==
+               "Organization, monthly billed ($7.00 per user / month)"
+    end
+  end
+
   describe "subscription_badge_label/1" do
     test "active non-cancelling subscription" do
       assert BillingHelpers.subscription_badge_label(%{


### PR DESCRIPTION
- Update organization pricing across public pages, signup, organization creation, and cadence-switch flows to $9 per user monthly or $90 per user annually.
- Keep existing customers' dashboards on their effective current price, show the scheduled amount and renewal date, and tolerate rolling deployments where the billing API has not exposed the additive pricing fields yet.
- Add an announcement covering the first increase since organizations launched in 2018, the 60-day grace period, organization features and security investment, sponsor support, and the Alpha-Omega audit grant arranged with help from EEF.
- Add `AdminTasks.send_email/3` for sending an email with an arbitrary subject and body, one message per recipient so addresses are not disclosed between them.

Validated with warnings-as-errors compilation, formatting, the database setup against an isolated database, and the full suite of 2,096 tests and 28 properties.

## Deployment

Deploy this before hexpm/hexpm_billing#65: in that order the site briefly advertises $9 while billing still creates $7 subscriptions, which is harmless and self-resolving. The reverse order would charge $9 while the site still says $7. The dashboard tolerates the old billing API during the window and falls back to displaying the legacy price.

Before merging, update the blog post date from 2026-07-16 to the actual publish date. The 60-day grace period for existing subscriptions is anchored to the manual scheduling step documented in the billing PR, which must run at or after publication so the promise of at least 60 days from the announcement holds.

## Announcement email

Once the blog post is live, send the announcement from a production iex session. The first step collects the primary verified email of every admin of an organization that is paying or trialing, deduplicated across organizations:

```elixir
import Ecto.Query
alias Hexpm.Accounts.Organization
alias Hexpm.{AdminTasks, Repo}

recipients =
  from(o in Organization,
    join: ou in assoc(o, :organization_users),
    join: u in assoc(ou, :user),
    join: e in assoc(u, :emails),
    where: o.billing_active or o.trial_end > ^DateTime.utc_now(),
    where: ou.role == "admin",
    where: e.primary and e.verified,
    distinct: true,
    select: e.email
  )
  |> Repo.all()

length(recipients)
```

Check the count, then send:

```elixir
subject = "Hex.pm - Organization pricing update"

body = """
We are updating the price of Hex.pm organizations to $9 per user / month or $90 per user / year.

Your organization keeps its current price for at least 60 days. The new price applies from your first regular renewal after that. The increase is not applied in the middle of a billing period and does not change your renewal date.

Your current price, the new price, and the date of the change are shown on the billing page of your organization in the Hex.pm dashboard at https://hex.pm/dashboard.

The full announcement is at https://hex.pm/blog/organization-pricing-update.
"""

AdminTasks.send_email(recipients, subject, body)
```

`send_email/3` returns `{:ok, count}` with the number of emails delivered, and logs an error naming the address for any that failed. Rerunning it sends to everyone in the list again, so on a partial failure narrow `recipients` to the addresses from the error logs rather than repeating the whole run.
