### PR TITLE
Fix actions for dotted usernames

### DIFF
--- a/lib/hexpm_web/templates/dashboard/organization/components/members_tab.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/members_tab.ex
@@ -86,7 +86,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.MembersTab do
                   <.sudo_form
                     current_user={@current_user}
                     action={~p"/dashboard/orgs/#{@organization}"}
-                    id={"change-role-form-#{org_user.user.username}"}
+                    id={"change-role-form-#{org_user.user.id}"}
                     phx-hook="AutoSubmit"
                   >
                     <input type="hidden" name="action" value="change_role" />
@@ -96,7 +96,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.MembersTab do
                       value={org_user.user.username}
                     />
                     <.select_input
-                      id={"role-#{org_user.user.username}"}
+                      id={"role-#{org_user.user.id}"}
                       name="organization_user[role]"
                       value={org_user.role}
                       options={role_options()}
@@ -111,7 +111,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.MembersTab do
                       icon="x-mark"
                       variant="danger"
                       aria-label="Remove member"
-                      phx-click={show_modal("remove-member-#{org_user.user.username}")}
+                      phx-click={show_modal("remove-member-#{org_user.user.id}")}
                     />
                   <% end %>
                 <% else %>
@@ -131,7 +131,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.MembersTab do
       <%!-- Remove member confirmation modals (one per removable member) --%>
       <%= if admin?(@current_user, @organization) do %>
         <%= for org_user <- @organization.organization_users, org_user.user.id != @current_user.id do %>
-          <.modal id={"remove-member-#{org_user.user.username}"} title="Remove member?" max_width="sm">
+          <.modal id={"remove-member-#{org_user.user.id}"} title="Remove member?" max_width="sm">
             <p class="text-sm text-grey-600 dark:text-grey-300">
               Are you sure you want to remove
               <strong class="font-semibold text-grey-900 dark:text-white">
@@ -145,14 +145,14 @@ defmodule HexpmWeb.Dashboard.Organization.Components.MembersTab do
               <.button
                 type="button"
                 variant="secondary"
-                phx-click={hide_modal("remove-member-#{org_user.user.username}")}
+                phx-click={hide_modal("remove-member-#{org_user.user.id}")}
               >
                 Cancel
               </.button>
               <.sudo_form
                 current_user={@current_user}
                 action={~p"/dashboard/orgs/#{@organization}"}
-                id={"remove-member-form-#{org_user.user.username}"}
+                id={"remove-member-form-#{org_user.user.id}"}
               >
                 <input type="hidden" name="action" value="remove_member" />
                 <input

--- a/lib/hexpm_web/templates/package_owner/index.html.heex
+++ b/lib/hexpm_web/templates/package_owner/index.html.heex
@@ -52,13 +52,13 @@
                   icon="pencil-square"
                   variant="default"
                   aria-label={"Edit role for #{owner.user.username}"}
-                  phx-click={show_modal("edit-role-#{owner.user.username}")}
+                  phx-click={show_modal("edit-role-#{owner.user.id}")}
                 />
                 <.icon_button
                   icon="x-mark"
                   variant="danger"
                   aria-label={"Remove #{owner.user.username}"}
-                  phx-click={show_modal("remove-owner-#{owner.user.username}")}
+                  phx-click={show_modal("remove-owner-#{owner.user.id}")}
                 />
               <% end %>
             </div>
@@ -69,12 +69,12 @@
 
     <%!-- Edit role + Remove modals (one per owner, only when more than one) --%>
     <%= for owner <- @owners, length(@owners) > 1 do %>
-      <.modal id={"edit-role-#{owner.user.username}"} title="Change role" max_width="md">
+      <.modal id={"edit-role-#{owner.user.id}"} title="Change role" max_width="md">
         <.sudo_form
           current_user={@current_user}
           action={HexpmWeb.ViewHelpers.path_for_owner(@package, owner.user.username)}
           method="put"
-          id={"role-form-#{owner.user.username}"}
+          id={"role-form-#{owner.user.id}"}
         >
           <p class="text-sm text-grey-600 dark:text-grey-300 mb-4">
             Update the role for
@@ -86,14 +86,14 @@
 
           <div>
             <label
-              for={"role-select-#{owner.user.username}"}
+              for={"role-select-#{owner.user.id}"}
               class="block text-small font-medium text-grey-900 dark:text-grey-100 mb-[6px]"
             >
               Role
             </label>
             <div class="relative">
               <select
-                id={"role-select-#{owner.user.username}"}
+                id={"role-select-#{owner.user.id}"}
                 name="level"
                 class="w-full h-10 text-sm bg-white dark:bg-grey-700 border border-grey-200 dark:border-grey-600 rounded-lg pl-3 pr-8 text-grey-800 dark:text-white cursor-pointer appearance-none focus:outline-none focus:ring-2 focus:ring-primary-500"
               >
@@ -112,7 +112,7 @@
             <.button
               type="button"
               variant="secondary"
-              phx-click={hide_modal("edit-role-#{owner.user.username}")}
+              phx-click={hide_modal("edit-role-#{owner.user.id}")}
             >
               Cancel
             </.button>
@@ -121,7 +121,7 @@
         </.sudo_form>
       </.modal>
 
-      <.modal id={"remove-owner-#{owner.user.username}"} title="Remove owner?" max_width="md">
+      <.modal id={"remove-owner-#{owner.user.id}"} title="Remove owner?" max_width="md">
         <%= if owner.user.id == @current_user.id do %>
           <p class="text-sm text-grey-600 dark:text-grey-300">
             You are about to remove
@@ -143,13 +143,13 @@
           current_user={@current_user}
           action={HexpmWeb.ViewHelpers.path_for_owner(@package, owner.user.username)}
           method="delete"
-          id={"remove-form-#{owner.user.username}"}
+          id={"remove-form-#{owner.user.id}"}
         >
           <div class="flex justify-end gap-3 mt-6">
             <.button
               type="button"
               variant="secondary"
-              phx-click={hide_modal("remove-owner-#{owner.user.username}")}
+              phx-click={hide_modal("remove-owner-#{owner.user.id}")}
             >
               Cancel
             </.button>

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -147,6 +147,41 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       assert response(conn, 200) =~ "Members"
     end
 
+    test "uses selector-safe modal IDs for members with dots in their usernames", %{
+      user: user,
+      organization: organization
+    } do
+      insert(:organization_user, organization: organization, user: user, role: "admin")
+      member = insert(:user, username: "member.with.dots")
+      insert(:organization_user, organization: organization, user: member)
+      mock_customer(organization)
+
+      html =
+        build_conn()
+        |> test_login(user)
+        |> get("/dashboard/orgs/#{organization.name}/members")
+        |> html_response(200)
+
+      {:ok, document} = Floki.parse_document(html)
+      modal_id = "remove-member-#{member.id}"
+
+      assert [_role_form] = Floki.find(document, "#change-role-form-#{member.id}")
+      assert [_role_select] = Floki.find(document, "#role-#{member.id}")
+      assert [_modal] = Floki.find(document, "##{modal_id}")
+
+      assert [remove_button] =
+               Floki.find(document, ~s(button[aria-label="Remove member"]))
+
+      assert Floki.attribute(remove_button, "phx-click")
+             |> List.first()
+             |> String.contains?("##{modal_id}")
+
+      assert ["member.with.dots"] =
+               document
+               |> Floki.find(~s(##{modal_id} input[name="organization_user[username]"]))
+               |> Floki.attribute("value")
+    end
+
     test "returns 404 for non-members", %{user: user, organization: organization} do
       conn =
         build_conn()

--- a/test/hexpm_web/controllers/package_owner_controller_test.exs
+++ b/test/hexpm_web/controllers/package_owner_controller_test.exs
@@ -30,6 +30,44 @@ defmodule HexpmWeb.PackageOwnerControllerTest do
       assert html_response(conn, 200) =~ "Current owners"
     end
 
+    test "uses selector-safe modal IDs for owners with dots in their usernames", %{
+      full_owner: full_owner,
+      package: package
+    } do
+      owner = insert(:user, username: "owner.with.dots")
+      insert(:package_owner, package: package, user: owner, level: "maintainer")
+
+      html =
+        build_conn()
+        |> test_login(full_owner)
+        |> get("/packages/#{package.name}/owners")
+        |> html_response(200)
+
+      {:ok, document} = Floki.parse_document(html)
+      edit_modal_id = "edit-role-#{owner.id}"
+      remove_modal_id = "remove-owner-#{owner.id}"
+
+      assert [_edit_modal] = Floki.find(document, "##{edit_modal_id}")
+      assert [_remove_modal] = Floki.find(document, "##{remove_modal_id}")
+      assert [_role_form] = Floki.find(document, "#role-form-#{owner.id}")
+      assert [_role_select] = Floki.find(document, "#role-select-#{owner.id}")
+      assert [_remove_form] = Floki.find(document, "#remove-form-#{owner.id}")
+
+      assert [edit_button] =
+               Floki.find(document, ~s(button[aria-label="Edit role for owner.with.dots"]))
+
+      assert Floki.attribute(edit_button, "phx-click")
+             |> List.first()
+             |> String.contains?("##{edit_modal_id}")
+
+      assert [remove_button] =
+               Floki.find(document, ~s(button[aria-label="Remove owner.with.dots"]))
+
+      assert Floki.attribute(remove_button, "phx-click")
+             |> List.first()
+             |> String.contains?("##{remove_modal_id}")
+    end
+
     test "redirects to /sudo when no sudo mode", %{full_owner: full_owner, package: package} do
       conn =
         build_conn()


### PR DESCRIPTION
Use numeric user IDs for organization-member and package-owner DOM targets while preserving usernames in submitted parameters, labels, and routes. Dotted usernames were being interpreted as CSS selectors, leaving the modal hidden after body scrolling was disabled.

Regression coverage verifies selector-safe role and removal controls for dotted usernames across both dashboard paths. The focused controller suites and formatter check pass.