### PR TITLE
Limit preview and diff rendering to 200 KB

### DIFF
--- a/lib/hexpm/diff/generator.ex
+++ b/lib/hexpm/diff/generator.ex
@@ -4,7 +4,7 @@ defmodule Hexpm.Diff.Generator do
   alias Hexpm.Diff.{Cache, Request}
   alias Hexpm.Repository.Assets
 
-  @max_file_size 1024 * 1024
+  @max_file_size 200 * 1000
 
   def generate(%Request{} = request) do
     with {:ok, from_path} <- download(request.from_release, request.from_checksum),

--- a/lib/hexpm/preview/preview.ex
+++ b/lib/hexpm/preview/preview.ex
@@ -5,7 +5,7 @@ defmodule Hexpm.Preview do
   alias Hexpm.Repository.{Assets, Releases}
   alias Hexpm.Repository.Sitemaps, as: RepositorySitemaps
 
-  @max_file_size 2 * 1000 * 1000
+  @max_file_size 200 * 1000
   @readme_filenames ~w(README.md readme.md README.markdown readme.markdown README.txt readme.txt README readme)
 
   def source(package, version, requested_filename \\ nil) do

--- a/lib/hexpm_web/live/diff_component.ex
+++ b/lib/hexpm_web/live/diff_component.ex
@@ -70,7 +70,7 @@ defmodule HexpmWeb.DiffComponent do
       <div class="ghd-file-header ghd-file-header-static">
         <span><span class="ghd-file-status ghd-file-status-unknown">unknown</span>{@file}</span>
       </div>
-      <div class="ghd-diff ghd-diff-error">File is too large to be displayed (1 MiB limit).</div>
+      <div class="ghd-diff ghd-diff-error">File is too large to be displayed (200 KB limit).</div>
     </div>
     """
   end

--- a/test/hexpm/diff/generator_test.exs
+++ b/test/hexpm/diff/generator_test.exs
@@ -14,7 +14,7 @@ defmodule Hexpm.Diff.GeneratorTest do
       "removed.txt" => "removed\n",
       "invalid.bin" => <<"old", 0xFF, "\n">>,
       "mode.sh" => {"echo same\n", 0o644},
-      "huge.bin" => String.duplicate("a", 1024 * 1024 + 1)
+      "huge.bin" => String.duplicate("a", 200_001)
     })
 
     insert_tarball_release(package, "2.0.0", %{
@@ -22,7 +22,7 @@ defmodule Hexpm.Diff.GeneratorTest do
       "added.txt" => "added\n",
       "invalid.bin" => <<"new", 0xFE, "\n">>,
       "mode.sh" => {"echo same\n", 0o755},
-      "huge.bin" => String.duplicate("b", 1024 * 1024 + 1)
+      "huge.bin" => String.duplicate("b", 200_001)
     })
 
     {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])

--- a/test/hexpm/preview/preview_test.exs
+++ b/test/hexpm/preview/preview_test.exs
@@ -21,13 +21,13 @@ defmodule Hexpm.PreviewTest do
   test "source reports binary and oversized files without returning their contents" do
     put_release("special_files", "1.0.0", [
       {"binary.bin", <<0xFF, 0xFE>>},
-      {"large.txt", String.duplicate("x", 2_000_001)}
+      {"large.txt", String.duplicate("x", 200_001)}
     ])
 
     assert {:ok, %{type: :binary, contents: nil}} =
              Preview.source("special_files", "1.0.0", "binary.bin")
 
-    assert {:ok, %{type: {:too_large, 2_000_001}, contents: nil}} =
+    assert {:ok, %{type: {:too_large, 200_001}, contents: nil}} =
              Preview.source("special_files", "1.0.0", "large.txt")
   end
 

--- a/test/hexpm_web/live/diff_component_test.exs
+++ b/test/hexpm_web/live/diff_component_test.exs
@@ -70,7 +70,7 @@ defmodule HexpmWeb.DiffComponentTest do
     end
 
     oversized = render_component(&DiffComponent.too_large/1, file: "large.bin")
-    assert oversized =~ "File is too large to be displayed (1 MiB limit)."
+    assert oversized =~ "File is too large to be displayed (200 KB limit)."
     assert oversized =~ "unknown"
     assert oversized =~ "ghd-file-status-unknown"
     refute oversized =~ "ghd-file-status-too-large"

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -73,7 +73,7 @@ defmodule HexpmWeb.PreviewLiveTest do
   test "renders binary and oversized file messages", %{conn: conn} do
     put_release("message_preview", "1.0.0", [
       {"binary.bin", <<0xFF>>},
-      {"large.txt", String.duplicate("x", 2_000_001)}
+      {"large.txt", String.duplicate("x", 200_001)}
     ])
 
     {:ok, _view, html} =
@@ -82,7 +82,7 @@ defmodule HexpmWeb.PreviewLiveTest do
     assert html =~ "Contents for binary files are not shown."
 
     {:ok, _view, html} = live(conn, "/packages/message_preview/1.0.0/files/large.txt")
-    assert html =~ "File is too large to be displayed (2.0 MB)."
+    assert html =~ "File is too large to be displayed (0.2 MB)."
   end
 
   test "searches a manifest containing hundreds of files", %{conn: conn} do


### PR DESCRIPTION
Lower preview and diff file rendering limits to 200 KB. This keeps large source files out of Lumis after a 904 KB minified JavaScript file was found to reproducibly crash the native highlighter with SIGSEGV. Oversized previews and diff pieces continue to use the existing too-large UI.