### PR TITLE
Fix docs publishing for tarballs with write-protected files

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -52,6 +52,6 @@ config :hexpm, Oban,
        {"*/30 * * * *", Hexpm.Security.Updater}
      ],
      timezone: "Etc/UTC"},
-    {Oban.Plugins.Pruner, max_age: 7 * 24 * 60 * 60},
+    {Oban.Plugins.Pruner, max_age: 30 * 24 * 60 * 60},
     {Oban.Plugins.Lifeline, interval: 60_000, rescue_after: 360_000}
   ]

--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -656,4 +656,29 @@ defmodule Hexpm.AdminTasks do
 
     :ok
   end
+
+  @doc """
+  Retries discarded Oban jobs, optionally filtered by worker.
+
+  ## Examples
+
+      iex> AdminTasks.retry_oban_jobs()
+      {:ok, 3}
+
+      iex> AdminTasks.retry_oban_jobs(worker: "Hexpm.Hexdocs.Workers.Upload")
+      {:ok, 1}
+  """
+  @spec retry_oban_jobs(keyword()) :: {:ok, non_neg_integer()}
+  def retry_oban_jobs(opts \\ []) do
+    query = from(j in Oban.Job, where: j.state == "discarded")
+
+    query =
+      if worker = opts[:worker] do
+        from(j in query, where: j.worker == ^worker)
+      else
+        query
+      end
+
+    Oban.retry_all_jobs(query)
+  end
 end

--- a/lib/hexpm/diff/generator.ex
+++ b/lib/hexpm/diff/generator.ex
@@ -42,7 +42,7 @@ defmodule Hexpm.Diff.Generator do
 
     case :hex_tarball.unpack({:file, to_charlist(tarball)}, to_charlist(path)) do
       {:ok, _} ->
-        Hexpm.TmpDir.ensure_readable(path)
+        Hexpm.TmpDir.ensure_accessible(path)
         {:ok, path}
 
       {:error, reason} ->

--- a/lib/hexpm/hexdocs/tar.ex
+++ b/lib/hexpm/hexdocs/tar.ex
@@ -18,7 +18,7 @@ defmodule Hexpm.Hexdocs.Tar do
 
     case :hex_tarball.unpack_docs({:file, to_charlist(path)}, to_charlist(output_dir)) do
       :ok ->
-        Hexpm.TmpDir.ensure_readable(output_dir)
+        Hexpm.TmpDir.ensure_accessible(output_dir)
 
         files =
           output_dir

--- a/lib/hexpm/preview/preview.ex
+++ b/lib/hexpm/preview/preview.ex
@@ -118,7 +118,7 @@ defmodule Hexpm.Preview do
 
         case :hex_tarball.unpack({:file, to_charlist(tarball_path)}, to_charlist(output_dir)) do
           {:ok, _metadata} ->
-            Hexpm.TmpDir.ensure_readable(output_dir)
+            Hexpm.TmpDir.ensure_accessible(output_dir)
 
             {
               output_dir,

--- a/lib/hexpm/tmp_dir.ex
+++ b/lib/hexpm/tmp_dir.ex
@@ -23,19 +23,19 @@ defmodule Hexpm.TmpDir do
     path
   end
 
-  def ensure_readable(path), do: ensure_readable_path(path)
+  def ensure_accessible(path), do: ensure_accessible_path(path)
 
-  defp ensure_readable_path(path) do
+  defp ensure_accessible_path(path) do
     case File.lstat(path) do
       {:ok, %{type: :directory, mode: mode}} ->
-        if band(mode, 0o500) != 0o500, do: File.chmod!(path, bor(band(mode, 0o7777), 0o500))
+        if band(mode, 0o700) != 0o700, do: File.chmod!(path, bor(band(mode, 0o7777), 0o700))
 
         path
         |> File.ls!()
-        |> Enum.each(&ensure_readable_path(Path.join(path, &1)))
+        |> Enum.each(&ensure_accessible_path(Path.join(path, &1)))
 
       {:ok, %{type: :regular, mode: mode}} ->
-        if band(mode, 0o400) == 0, do: File.chmod!(path, bor(band(mode, 0o7777), 0o400))
+        if band(mode, 0o600) != 0o600, do: File.chmod!(path, bor(band(mode, 0o7777), 0o600))
 
       {:ok, _other} ->
         :ok

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -585,4 +585,46 @@ defmodule Hexpm.AdminTasksTest do
       assert updated_key.revoke_at != nil
     end
   end
+
+  describe "retry_oban_jobs/1" do
+    alias Hexpm.Hexdocs.Workers
+
+    test "retries discarded jobs" do
+      discarded = insert_discarded_job(Workers.Upload, %{key: "docs/retried-1.0.0.tar.gz"})
+      {:ok, available} = Oban.insert(Workers.Upload.new(%{key: "docs/untouched-1.0.0.tar.gz"}))
+
+      assert {:ok, 1} = AdminTasks.retry_oban_jobs()
+
+      discarded = Repo.get!(Oban.Job, discarded.id)
+      assert discarded.state == "available"
+      assert discarded.max_attempts == 6
+      assert Repo.get!(Oban.Job, available.id).state == "available"
+    end
+
+    test "retries only the given worker" do
+      upload = insert_discarded_job(Workers.Upload, %{key: "docs/filtered-1.0.0.tar.gz"})
+      search = insert_discarded_job(Workers.Search, %{key: "docs/filtered-1.0.0.tar.gz"})
+
+      assert {:ok, 1} = AdminTasks.retry_oban_jobs(worker: "Hexpm.Hexdocs.Workers.Upload")
+
+      assert Repo.get!(Oban.Job, upload.id).state == "available"
+      assert Repo.get!(Oban.Job, search.id).state == "discarded"
+    end
+  end
+
+  defp insert_discarded_job(worker, args) do
+    {:ok, job} = Oban.insert(worker.new(args))
+
+    {1, _} =
+      from(j in Oban.Job, where: j.id == ^job.id)
+      |> Repo.update_all(
+        set: [
+          state: "discarded",
+          attempt: job.max_attempts,
+          discarded_at: DateTime.utc_now()
+        ]
+      )
+
+    job
+  end
 end

--- a/test/hexpm/hexdocs/workers_test.exs
+++ b/test/hexpm/hexdocs/workers_test.exs
@@ -25,6 +25,21 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") == nil
   end
 
+  test "upload succeeds for archives with write-protected file modes" do
+    package = insert(:package, name: "readonly_docs", docs_updated_at: DateTime.utc_now())
+    release = insert(:release, package: package, version: "1.0.0", has_docs: true)
+    key = "docs/#{package.name}-#{release.version}.tar.gz"
+
+    Hexpm.Store.put(
+      :repo_bucket,
+      key,
+      create_docs_tar([{"index.html", "<html><head></head></html>"}], 0o000)
+    )
+
+    assert :ok = perform_job(Workers.Upload, %{key: key})
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") =~ "plausible"
+  end
+
   test "search succeeds for archives without search data" do
     package = insert(:package, name: "search_docs")
     release = insert(:release, package: package, version: "1.0.0", has_docs: true)

--- a/test/hexpm/oban_config_test.exs
+++ b/test/hexpm/oban_config_test.exs
@@ -42,7 +42,7 @@ defmodule Hexpm.ObanConfigTest do
     end
   end
 
-  test "production schedules periodic work and retains completed jobs for seven days" do
+  test "production schedules periodic work and retains completed jobs for thirty days" do
     prod = Config.Reader.read!("config/prod.exs", env: :prod)
     oban = prod[:hexpm][Oban]
 
@@ -58,7 +58,7 @@ defmodule Hexpm.ObanConfigTest do
              {"*/30 * * * *", Hexpm.Security.Updater}
            ]
 
-    assert {Oban.Plugins.Pruner, [max_age: 604_800]} in oban[:plugins]
+    assert {Oban.Plugins.Pruner, [max_age: 2_592_000]} in oban[:plugins]
     assert {Oban.Plugins.Lifeline, [interval: 60_000, rescue_after: 360_000]} in oban[:plugins]
     assert oban[:queues] == [periodic: 2, heavy: 3]
   end

--- a/test/hexpm/tmp_dir_test.exs
+++ b/test/hexpm/tmp_dir_test.exs
@@ -123,27 +123,28 @@ defmodule Hexpm.TmpDirTest do
     assert File.dir?(dir)
   end
 
-  test "ensure_readable/1 adds required owner permissions without changing existing modes" do
+  test "ensure_accessible/1 adds required owner permissions without changing existing modes" do
     dir = Hexpm.TmpDir.tmp_dir("permissions")
     nested = Path.join(dir, "nested")
     file = Path.join(nested, "file.txt")
     File.mkdir!(nested)
     File.write!(file, "contents")
     File.chmod!(nested, 0o300)
-    File.chmod!(file, 0o200)
+    File.chmod!(file, 0o000)
 
-    Hexpm.TmpDir.ensure_readable(dir)
+    Hexpm.TmpDir.ensure_accessible(dir)
 
     assert band(File.stat!(nested).mode, 0o777) == 0o700
     assert band(File.stat!(file).mode, 0o777) == 0o600
     assert File.read!(file) == "contents"
+    assert File.write!(file, "rewritten") == :ok
 
     executable = Path.join(dir, "executable")
     File.write!(executable, "#!/bin/sh\n")
     File.chmod!(executable, 0o111)
 
-    Hexpm.TmpDir.ensure_readable(dir)
+    Hexpm.TmpDir.ensure_accessible(dir)
 
-    assert band(File.stat!(executable).mode, 0o777) == 0o511
+    assert band(File.stat!(executable).mode, 0o777) == 0o711
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -38,6 +38,23 @@ defmodule Hexpm.TestHelpers do
     tarball
   end
 
+  def create_docs_tar(files, mode) do
+    path = Path.join(@tmp, "docs-#{Base.encode16(:crypto.strong_rand_bytes(4))}.tar")
+    {:ok, tar} = :hex_erl_tar.open(String.to_charlist(path), [:write])
+
+    try do
+      Enum.each(files, fn {name, contents} ->
+        :ok = :hex_erl_tar.add(tar, contents, String.to_charlist(name), mode: mode)
+      end)
+    after
+      :ok = :hex_erl_tar.close(tar)
+    end
+
+    tarball = path |> File.read!() |> :zlib.gzip()
+    File.rm!(path)
+    tarball
+  end
+
   def rel_meta(params) do
     params = params(params)
 


### PR DESCRIPTION
Docs published from Gleam-built tarballs stopped being processed after #1711. Gleam creates docs tarballs whose entries have mode 0000. The old standalone Hexdocs service chmodded unpacked files to 0644 (hexpm/hexdocs@6d12b51), but the port into Hexpm replaced that with TmpDir.ensure_readable, which only adds the owner read bit. FileRewriter.rewrite_files/2 then fails with :eacces when rewriting files in place, the Upload job exhausts its 5 attempts without any error surfacing anywhere, and the docs never reach the bucket while hex.pm reports success. Reported in #1725.

ensure_readable is now ensure_accessible and guarantees owner read/write on files and read/write/traverse on directories, restoring the old behavior. This also keeps File.rm_rf cleanup from getting stuck on write-protected directories. The regression test runs the Upload worker end to end on a tarball with mode 0000 entries and fails with the exact production error on the old code.

Since discarded jobs are the only record of these failures, Oban Pruner retention is raised from 7 to 30 days and a new Hexpm.AdminTasks.retry_oban_jobs/1 task moves discarded jobs back to available, optionally filtered by worker:

    Hexpm.AdminTasks.retry_oban_jobs(worker: "Hexpm.Hexdocs.Workers.Upload")

After deploy the affected uploads can be rerun with the task: sitemapb 1.0.0, kdleam 1.0.0, svg_path 0.14.1/0.14.2/0.15.0, atproto_codegen 0.3.0, midas_browser 1.2.0 and possum_tangled 1.1.0.