### PR TITLE
Update git_diff to fix mode-only change parsing

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -58,7 +58,7 @@ defmodule Hexpm.MixProject do
       {:lasso, "~> 0.1.4", only: :test},
       {:libcluster, "~> 3.0"},
       {:logster, "~> 1.0"},
-      {:git_diff, github: "ericmj/git_diff", ref: "e4ee06cfd139b8a911d07e42d0ff3b15eee2b740"},
+      {:git_diff, github: "ericmj/git_diff", ref: "d47473d661ff0073ce4080ae04db1a439d78a62b"},
       {:mdex, "~> 0.13"},
       {:mdex_gfm, "~> 0.1"},
       {:lumis, "~> 0.6"},

--- a/mix.lock
+++ b/mix.lock
@@ -25,7 +25,7 @@
   "fine": {:hex, :fine, "0.1.6", "4bf7151493443c454aac9f2fa2f34f5fefd0346a83fb5586a016c4a135c63247", [:mix], [], "hexpm", "5638eb4495488e885ebec167fa57973e5c35e1a50c344eb7666c90ec1c4e3b12"},
   "floki": {:hex, :floki, "0.38.4", "10f98971e892aed2c2f1b3a0f928e488e3797e1c6dd3dfd98db40b14e9a78bcf", [:mix], [], "hexpm", "bdb34645eee8e79845c7edaca2d4099a52804ee4d4a3ecc683a69451f0244973"},
   "gen_stage": {:hex, :gen_stage, "1.3.2", "7c77e5d1e97de2c6c2f78f306f463bca64bf2f4c3cdd606affc0100b89743b7b", [:mix], [], "hexpm", "0ffae547fa777b3ed889a6b9e1e64566217413d018cabd825f786e843ffe63e7"},
-  "git_diff": {:git, "https://github.com/ericmj/git_diff.git", "e4ee06cfd139b8a911d07e42d0ff3b15eee2b740", [ref: "e4ee06cfd139b8a911d07e42d0ff3b15eee2b740"]},
+  "git_diff": {:git, "https://github.com/ericmj/git_diff.git", "d47473d661ff0073ce4080ae04db1a439d78a62b", [ref: "d47473d661ff0073ce4080ae04db1a439d78a62b"]},
   "goth": {:hex, :goth, "1.4.5", "ee37f96e3519bdecd603f20e7f10c758287088b6d77c0147cd5ee68cf224aade", [:mix], [{:finch, "~> 0.17", [hex: :finch, repo: "hexpm", optional: false]}, {:jason, "~> 1.1", [hex: :jason, repo: "hexpm", optional: false]}, {:jose, "~> 1.11", [hex: :jose, repo: "hexpm", optional: false]}], "hexpm", "0fc2dce5bd710651ed179053d0300ce3a5d36afbdde11e500d57f05f398d5ed5"},
   "hex_core": {:git, "https://github.com/hexpm/hex_core.git", "19001bbdfc38274165e30150c784cfe9b14a34b7", []},
   "hpax": {:hex, :hpax, "1.0.4", "777de5d433b0fbdc7c418159c8055910faa8047ffdb3d6b31098d2a46cd7685c", [:mix], [], "hexpm", "afc7cb142ebcc2d01ce7816190b98ce5dd49e799111b24249f3443d730f377ca"},

--- a/test/hexpm_web/live/diff_live_test.exs
+++ b/test/hexpm_web/live/diff_live_test.exs
@@ -251,6 +251,32 @@ defmodule HexpmWeb.DiffLiveTest do
     refute html =~ "<script>"
   end
 
+  test "mode-only changes render as changed files", %{package: package} do
+    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+
+    Cache.put_piece!(request, 0, %{
+      "diff" => """
+      diff --git a/tmp/diff-live_diff-1.0.0-AAAAAAAA/bin/run b/tmp/diff-live_diff-2.0.0-BBBBBBBB/bin/run
+      old mode 100644
+      new mode 100755
+      """,
+      "path_from" => "/tmp/diff-live_diff-1.0.0-AAAAAAAA",
+      "path_to" => "/tmp/diff-live_diff-2.0.0-BBBBBBBB"
+    })
+
+    Cache.put_metadata!(request, %{
+      total_diffs: 1,
+      total_additions: 0,
+      total_deletions: 0,
+      files_changed: 1
+    })
+
+    {:ok, _view, html} = live(build_conn(), "/diff/#{package.name}/1.0.0..2.0.0")
+
+    assert html =~ "ghd-file-status-changed"
+    assert html =~ "bin/run"
+  end
+
   test "missing cache pieces render an in-page file error", %{package: package} do
     {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
 


### PR DESCRIPTION
Rendering a diff crashed with a FunctionClauseError in DiffComponent.diff_status/1 when a file changed only its executable bit. git emits such patches with old mode/new mode headers and no ---/+++ lines, and git_diff relativized the from path against the to directory, producing mismatched from/to paths that match no diff_status clause.

Bumps git_diff to the fixed commit (upstream PR: mononym/git_diff#15) and adds a regression test that renders a cached mode-only patch through DiffLive. Cached pieces are parsed at read time, so existing diffs render correctly without regeneration.

Sentry: https://hexpm.sentry.io/issues/7618896937/