### PR TITLE
Support private packages in preview files, diffs, and readmes

### DIFF
--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -658,15 +658,20 @@ defmodule Hexpm.AdminTasks do
   end
 
   @doc """
-  Retries discarded Oban jobs, optionally filtered by worker.
+  Retries discarded Oban jobs at priority 8, optionally filtered by worker.
+
+  ## Options
+
+  - `:worker` - Only retry discarded jobs for this worker
+  - `:uniq` - Retry only one job per worker and args (default: `false`)
 
   ## Examples
 
       iex> AdminTasks.retry_oban_jobs()
-      {:ok, 3}
+      {:ok, 12}
 
-      iex> AdminTasks.retry_oban_jobs(worker: "Hexpm.Hexdocs.Workers.Upload")
-      {:ok, 1}
+      iex> AdminTasks.retry_oban_jobs(worker: "Hexpm.Diff.Worker", uniq: true)
+      {:ok, 3}
   """
   @spec retry_oban_jobs(keyword()) :: {:ok, non_neg_integer()}
   def retry_oban_jobs(opts \\ []) do
@@ -675,6 +680,15 @@ defmodule Hexpm.AdminTasks do
     query =
       if worker = opts[:worker] do
         from(j in query, where: j.worker == ^worker)
+      else
+        query
+      end
+
+    Repo.update_all(query, set: [priority: 8])
+
+    query =
+      if opts[:uniq] do
+        from(j in query, distinct: [j.worker, j.args])
       else
         query
       end

--- a/lib/hexpm/diff.ex
+++ b/lib/hexpm/diff.ex
@@ -16,7 +16,7 @@ defmodule Hexpm.Diff do
     @opaque t :: %__MODULE__{id: String.t(), key: String.t(), file: String.t() | nil}
   end
 
-  defdelegate prepare(package, from, to, opts), to: Request
+  defdelegate prepare(repository, package, from, to, opts), to: Request
   defdelegate fetch(request), to: Cache
   defdelegate fetch_piece(piece), to: Cache
   def piece_id(%Piece{id: id}), do: id

--- a/lib/hexpm/diff/cache.ex
+++ b/lib/hexpm/diff/cache.ex
@@ -36,12 +36,15 @@ defmodule Hexpm.Diff.Cache do
   end
 
   def metadata_key(%Request{} = request, hash) do
-    "metadata/#{request.package}-#{request.from}-#{request.to}-#{hash}.json"
+    "#{repo_prefix(request)}metadata/#{request.package}-#{request.from}-#{request.to}-#{hash}.json"
   end
 
   def diff_key(%Request{} = request, hash, index) when is_integer(index) do
-    "diffs/#{request.package}-#{request.from}-#{request.to}-#{hash}-diff-#{index}.json"
+    "#{repo_prefix(request)}diffs/#{request.package}-#{request.from}-#{request.to}-#{hash}-diff-#{index}.json"
   end
+
+  defp repo_prefix(%Request{repository: "hexpm"}), do: ""
+  defp repo_prefix(%Request{repository: repository}), do: "repos/#{repository}/"
 
   defp fetch_legacy(%Request{canonical_hash: hash, legacy_hash: hash}), do: :miss
 

--- a/lib/hexpm/diff/request.ex
+++ b/lib/hexpm/diff/request.ex
@@ -1,5 +1,6 @@
 defmodule Hexpm.Diff.Request do
   @enforce_keys [
+    :repository,
     :package,
     :package_record,
     :from,
@@ -17,19 +18,20 @@ defmodule Hexpm.Diff.Request do
   ]
   defstruct @enforce_keys
 
-  alias Hexpm.Repository.{Package, Packages, Release, Releases, Repository}
+  alias Hexpm.Repository.{Package, Packages, Release, Releases}
 
-  def prepare(package_name, from, to, opts) when is_binary(package_name) and is_list(opts) do
+  def prepare(repository, package_name, from, to, opts)
+      when is_binary(repository) and is_binary(package_name) and is_list(opts) do
     cache_version = Application.fetch_env!(:hexpm, :diff_cache_version)
-    prepare(package_name, from, to, opts, cache_version)
+    prepare(repository, package_name, from, to, opts, cache_version)
   end
 
-  def prepare(_, _, _, _), do: {:error, :invalid_request}
+  def prepare(_, _, _, _, _), do: {:error, :invalid_request}
 
-  defp prepare(package_name, from, to, opts, cache_version) do
+  defp prepare(repository, package_name, from, to, opts, cache_version) do
     with {:ok, from} <- parse_version(from),
          {:ok, to} <- parse_optional_version(to),
-         {:ok, package} <- fetch_package(package_name),
+         {:ok, package} <- fetch_package(repository, package_name),
          {:ok, releases} <- fetch_releases(package),
          {:ok, to} <- resolve_to(to, releases),
          :ok <- ensure_distinct(from, to),
@@ -41,6 +43,7 @@ defmodule Hexpm.Diff.Request do
 
       {:ok,
        %__MODULE__{
+         repository: repository,
          package: package.name,
          package_record: package,
          from: from,
@@ -63,6 +66,7 @@ defmodule Hexpm.Diff.Request do
   end
 
   def from_args(%{
+        "repository" => repository,
         "package" => package,
         "from" => from,
         "to" => to,
@@ -71,13 +75,14 @@ defmodule Hexpm.Diff.Request do
         "cache_version" => cache_version,
         "ignore_whitespace" => ignore_whitespace
       })
-      when is_binary(package) and is_binary(from) and is_binary(to) and
+      when is_binary(repository) and is_binary(package) and is_binary(from) and is_binary(to) and
              is_binary(from_checksum) and is_binary(to_checksum) and is_integer(cache_version) and
              is_boolean(ignore_whitespace) do
     with {:ok, decoded_from} <- Base.decode16(from_checksum, case: :mixed),
          {:ok, decoded_to} <- Base.decode16(to_checksum, case: :mixed),
          {:ok, request} <-
            prepare(
+             repository,
              package,
              from,
              to,
@@ -103,6 +108,7 @@ defmodule Hexpm.Diff.Request do
 
   def to_args(%__MODULE__{} = request) do
     %{
+      repository: request.repository,
       package: request.package,
       from: request.from,
       to: request.to,
@@ -143,8 +149,8 @@ defmodule Hexpm.Diff.Request do
   defp ensure_distinct(version, version), do: {:error, :identical_versions}
   defp ensure_distinct(_, _), do: :ok
 
-  defp fetch_package(package_name) do
-    case Packages.get(Repository.hexpm(), package_name) do
+  defp fetch_package(repository, package_name) do
+    case Packages.get(repository, package_name) do
       %Package{} = package -> {:ok, package}
       nil -> {:error, :package_not_found}
     end

--- a/lib/hexpm/diff/worker.ex
+++ b/lib/hexpm/diff/worker.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Diff.Worker do
   use Oban.Worker,
     queue: :heavy,
-    priority: 3,
+    priority: 1,
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 

--- a/lib/hexpm/hexdocs/workers.ex
+++ b/lib/hexpm/hexdocs/workers.ex
@@ -1,6 +1,7 @@
 defmodule Hexpm.Hexdocs.Workers.Upload do
   use Oban.Worker,
     queue: :heavy,
+    priority: 3,
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
@@ -14,6 +15,7 @@ end
 defmodule Hexpm.Hexdocs.Workers.Search do
   use Oban.Worker,
     queue: :heavy,
+    priority: 3,
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
@@ -27,6 +29,7 @@ end
 defmodule Hexpm.Hexdocs.Workers.Delete do
   use Oban.Worker,
     queue: :heavy,
+    priority: 3,
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
@@ -40,6 +43,7 @@ end
 defmodule Hexpm.Hexdocs.Workers.Sitemap do
   use Oban.Worker,
     queue: :heavy,
+    priority: 3,
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 

--- a/lib/hexpm/preview/bucket.ex
+++ b/lib/hexpm/preview/bucket.ex
@@ -1,6 +1,10 @@
 defmodule Hexpm.Preview.Bucket do
-  def get_tarball_to_file(package, version) do
-    key = "tarballs/#{package}-#{version}.tar"
+  def tarball_key(repository, package, version) do
+    repo_prefix(repository) <> "tarballs/#{package}-#{version}.tar"
+  end
+
+  def get_tarball_to_file(repository, package, version) do
+    key = tarball_key(repository, package, version)
     path = Hexpm.TmpDir.tmp_file("preview-tarball")
 
     case Hexpm.Store.get_to_file(:repo_bucket, key, path) do
@@ -9,20 +13,20 @@ defmodule Hexpm.Preview.Bucket do
     end
   end
 
-  def put_files(package, version, dir, file_paths) do
-    prefix = Path.join(["files", package, version]) <> "/"
+  def put_files(repository, package, version, dir, file_paths) do
+    prefix = repo_prefix(repository) <> Path.join(["files", package, version]) <> "/"
     original_file_list = Hexpm.Store.list(:preview_bucket, prefix)
 
     file_entries =
       Enum.map(file_paths, fn filename ->
-        {Path.join(["files", package, version, filename]), filename}
+        {repo_prefix(repository) <> Path.join(["files", package, version, filename]), filename}
       end)
 
     file_entries
     |> Task.async_stream(
       fn {key, filename} ->
         source = Path.join(dir, filename)
-        opts = put_opts(package, version) ++ content_type(filename)
+        opts = put_opts(repository, package, version) ++ content_type(filename)
         Hexpm.Store.put_file(:preview_bucket, key, source, opts)
       end,
       max_concurrency: 10,
@@ -31,73 +35,101 @@ defmodule Hexpm.Preview.Bucket do
     |> Hexpm.Utils.raise_async_stream_error()
     |> Stream.run()
 
-    file_list_key = Path.join("file_lists", "#{package}-#{version}.json")
-
     Hexpm.Store.put(
       :preview_bucket,
-      file_list_key,
+      file_list_key(repository, package, version),
       Jason.encode!(file_paths),
-      put_opts(package, version)
+      put_opts(repository, package, version)
     )
 
     new_keys = Enum.map(file_entries, &elem(&1, 0))
     Hexpm.Store.delete_many(:preview_bucket, Enum.to_list(original_file_list) -- new_keys)
   end
 
-  def delete_files(package, version) do
-    file_list_key = Path.join("file_lists", "#{package}-#{version}.json")
-    prefix = Path.join(["files", package, version]) <> "/"
+  def delete_files(repository, package, version) do
+    prefix = repo_prefix(repository) <> Path.join(["files", package, version]) <> "/"
     keys = Hexpm.Store.list(:preview_bucket, prefix)
-    Hexpm.Store.delete_many(:preview_bucket, [file_list_key | Enum.to_list(keys)])
+
+    Hexpm.Store.delete_many(
+      :preview_bucket,
+      [file_list_key(repository, package, version) | Enum.to_list(keys)]
+    )
   end
 
-  def get_file_list(package, version) do
-    key = Path.join("file_lists", "#{package}-#{version}.json")
-
-    case Hexpm.Store.get(:preview_bucket, key) do
+  def get_file_list(repository, package, version) do
+    case Hexpm.Store.get(:preview_bucket, file_list_key(repository, package, version)) do
       nil -> nil
       json -> json |> Jason.decode!() |> Enum.uniq()
     end
   end
 
-  def get_file(package, version, filename) do
-    Hexpm.Store.get(:preview_bucket, Path.join(["files", package, version, filename]))
+  def get_file(repository, package, version, filename) do
+    Hexpm.Store.get(:preview_bucket, file_key(repository, package, version, filename))
   end
 
-  def file_size(package, version, filename) do
-    Hexpm.Store.size(:preview_bucket, Path.join(["files", package, version, filename]))
+  def file_size(repository, package, version, filename) do
+    Hexpm.Store.size(:preview_bucket, file_key(repository, package, version, filename))
   end
 
-  def update_latest_version(package, version) do
+  def update_latest_version(repository, package, version) do
     Hexpm.Store.put(
       :preview_bucket,
-      Path.join("latest_versions", package),
+      latest_version_key(repository, package),
       to_string(version),
-      put_opts("preview/package/#{package}")
+      put_opts(repository, "preview/package/#{surrogate_package(repository, package)}")
     )
   end
 
-  def get_latest_version(package) do
-    Hexpm.Store.get(:preview_bucket, Path.join("latest_versions", package))
+  def get_latest_version(repository, package) do
+    Hexpm.Store.get(:preview_bucket, latest_version_key(repository, package))
   end
 
-  def delete_latest_version(package) do
-    Hexpm.Store.delete(:preview_bucket, Path.join("latest_versions", package))
+  def delete_latest_version(repository, package) do
+    Hexpm.Store.delete(:preview_bucket, latest_version_key(repository, package))
   end
 
-  defp put_opts(package, version) do
-    put_opts("preview/package/#{package}/version/#{version}")
+  def surrogate_keys(repository, package, version) do
+    base = "preview/package/#{surrogate_package(repository, package)}"
+    [base, "#{base}/version/#{version}"]
   end
 
-  defp put_opts(key) do
+  defp repo_prefix("hexpm"), do: ""
+  defp repo_prefix(repository), do: "repos/#{repository}/"
+
+  defp surrogate_package("hexpm", package), do: package
+  defp surrogate_package(repository, package), do: "#{repository}-#{package}"
+
+  defp file_key(repository, package, version, filename) do
+    repo_prefix(repository) <> Path.join(["files", package, version, filename])
+  end
+
+  defp file_list_key(repository, package, version) do
+    repo_prefix(repository) <> Path.join("file_lists", "#{package}-#{version}.json")
+  end
+
+  defp latest_version_key(repository, package) do
+    repo_prefix(repository) <> Path.join("latest_versions", package)
+  end
+
+  defp put_opts(repository, package, version) do
+    put_opts(
+      repository,
+      "preview/package/#{surrogate_package(repository, package)}/version/#{version}"
+    )
+  end
+
+  defp put_opts(repository, key) do
     [
-      cache_control: "public, max-age=3600",
+      cache_control: cache_control(repository),
       meta: [
         {"surrogate-key", "preview #{key}"},
         {"surrogate-control", "public, max-age=604800"}
       ]
     ]
   end
+
+  defp cache_control("hexpm"), do: "public, max-age=3600"
+  defp cache_control(_repository), do: "private, max-age=3600"
 
   defp content_type(path) do
     case Path.extname(path) do

--- a/lib/hexpm/preview/preview.ex
+++ b/lib/hexpm/preview/preview.ex
@@ -8,28 +8,41 @@ defmodule Hexpm.Preview do
   @max_file_size 200 * 1000
   @readme_filenames ~w(README.md readme.md README.markdown readme.markdown README.txt readme.txt README readme)
 
-  def source(package, version, requested_filename \\ nil) do
-    with [_ | _] = files <- Bucket.get_file_list(package, version),
+  def source(repository, package, version, requested_filename \\ nil) do
+    with [_ | _] = files <- Bucket.get_file_list(repository, package, version),
          filename when is_binary(filename) <- selected_file(files, requested_filename),
-         size when is_integer(size) <- Bucket.file_size(package, version, filename),
-         result when is_map(result) <- source_result(package, version, filename, size) do
+         size when is_integer(size) <- Bucket.file_size(repository, package, version, filename),
+         result when is_map(result) <-
+           source_result(repository, package, version, filename, size) do
       {:ok, Map.merge(result, %{files: files, filename: filename})}
     else
       _ -> :error
     end
   end
 
-  def readme(package, version) do
-    with files when is_list(files) <- Bucket.get_file_list(package, version),
+  def readme(repository, package, version) do
+    with files when is_list(files) <- Bucket.get_file_list(repository, package, version),
          filename when is_binary(filename) <- Enum.find(@readme_filenames, &(&1 in files)),
-         contents when is_binary(contents) <- Bucket.get_file(package, version, filename) do
+         contents when is_binary(contents) <-
+           Bucket.get_file(repository, package, version, filename) do
       {:ok, filename, contents}
     else
       _ -> :error
     end
   end
 
-  def get_latest_version(package), do: Bucket.get_latest_version(package)
+  def raw_file(repository, package, version, filename) do
+    with files when is_list(files) <- Bucket.get_file_list(repository, package, version),
+         true <- filename in files,
+         contents when is_binary(contents) <-
+           Bucket.get_file(repository, package, version, filename) do
+      {:ok, contents}
+    else
+      _ -> :error
+    end
+  end
+
+  def get_latest_version(repository, package), do: Bucket.get_latest_version(repository, package)
 
   defp default_file(files) do
     Enum.min_by(files, &default_file_priority/1)
@@ -41,8 +54,8 @@ defmodule Hexpm.Preview do
 
   def package_sitemap(base_url, package) do
     with %DateTime{} = updated_at <- RepositorySitemaps.public_package_updated_at(package),
-         version when is_binary(version) <- Bucket.get_latest_version(package),
-         [_ | _] = files <- Bucket.get_file_list(package, version) do
+         version when is_binary(version) <- Bucket.get_latest_version("hexpm", package),
+         [_ | _] = files <- Bucket.get_file_list("hexpm", package, version) do
       {:ok, Sitemaps.render_package(base_url, package, version, files, updated_at)}
     else
       _ -> :error
@@ -50,35 +63,35 @@ defmodule Hexpm.Preview do
   end
 
   def upload(key) do
-    {package, version} = key_components!(key)
+    {repository, package, version} = key_components!(key)
     start = System.monotonic_time(:millisecond)
     Logger.info("UPLOAD #{key}")
 
-    if release_exists?(package, version) do
-      {dir, file_paths, checksum} = download_and_unpack!(package, version)
-      Bucket.put_files(package, version, dir, file_paths)
+    if release_exists?(repository, package, version) do
+      {dir, file_paths, checksum} = download_and_unpack!(repository, package, version)
+      Bucket.put_files(repository, package, version, dir, file_paths)
 
-      reconcile_uploaded_release(package, version, checksum)
+      reconcile_uploaded_release(repository, package, version, checksum)
     else
-      delete_contents(package, version)
+      delete_contents(repository, package, version)
     end
 
-    purge(package, version)
+    purge(repository, package, version)
     elapsed = System.monotonic_time(:millisecond) - start
     Logger.info("FINISHED UPLOADING PREVIEW #{key} #{elapsed}ms")
     :ok
   end
 
   def delete(key) do
-    {package, version} = key_components!(key)
+    {repository, package, version} = key_components!(key)
     start = System.monotonic_time(:millisecond)
     Logger.info("DELETE #{key}")
 
-    if release_exists?(package, version) do
+    if release_exists?(repository, package, version) do
       upload(key)
     else
-      delete_contents(package, version)
-      purge(package, version)
+      delete_contents(repository, package, version)
+      purge(repository, package, version)
     end
 
     elapsed = System.monotonic_time(:millisecond) - start
@@ -88,16 +101,25 @@ defmodule Hexpm.Preview do
 
   def key_components(key) do
     case Path.split(key) do
-      ["tarballs", file] -> release_components(file)
-      _other -> :error
+      ["tarballs", file] ->
+        release_components("hexpm", file)
+
+      ["repos", repository, "tarballs", file] when repository != "" ->
+        release_components(repository, file)
+
+      _other ->
+        :error
     end
   end
 
-  defp release_components(file) do
+  defp release_components(repository, file) do
     if String.ends_with?(file, ".tar") do
       case String.split(Path.basename(file, ".tar"), "-", parts: 2) do
-        [package, version] when package != "" and version != "" -> {:ok, package, version}
-        _other -> :error
+        [package, version] when package != "" and version != "" ->
+          {:ok, repository, package, version}
+
+        _other ->
+          :error
       end
     else
       :error
@@ -106,13 +128,13 @@ defmodule Hexpm.Preview do
 
   defp key_components!(key) do
     case key_components(key) do
-      {:ok, package, version} -> {package, version}
+      {:ok, repository, package, version} -> {repository, package, version}
       :error -> raise ArgumentError, "invalid Preview object key: #{inspect(key)}"
     end
   end
 
-  defp download_and_unpack!(package, version) do
-    case Bucket.get_tarball_to_file(package, version) do
+  defp download_and_unpack!(repository, package, version) do
+    case Bucket.get_tarball_to_file(repository, package, version) do
       {:ok, tarball_path} ->
         output_dir = Hexpm.TmpDir.tmp_dir("preview-package")
 
@@ -122,20 +144,20 @@ defmodule Hexpm.Preview do
 
             {
               output_dir,
-              file_paths(output_dir, package, version),
+              file_paths(output_dir, repository, package, version),
               Assets.file_checksum(tarball_path)
             }
 
           {:error, reason} ->
-            raise "Failed to unpack Preview tarball #{package} #{version}: #{inspect(reason)}"
+            raise "Failed to unpack Preview tarball #{repository} #{package} #{version}: #{inspect(reason)}"
         end
 
       :error ->
-        raise "Preview tarball not found in store: tarballs/#{package}-#{version}.tar"
+        raise "Preview tarball not found in store: #{Bucket.tarball_key(repository, package, version)}"
     end
   end
 
-  defp file_paths(output_dir, package, version) do
+  defp file_paths(output_dir, repository, package, version) do
     output_dir
     |> Path.join("**")
     |> Path.wildcard(match_dot: true)
@@ -151,7 +173,7 @@ defmodule Hexpm.Preview do
             [path]
 
           :error ->
-            Logger.error("Unsafe path from #{package} #{version}: #{relative}")
+            Logger.error("Unsafe path from #{repository} #{package} #{version}: #{relative}")
             []
         end
       end
@@ -160,107 +182,104 @@ defmodule Hexpm.Preview do
     |> Enum.sort()
   end
 
-  defp latest_version?(package, version) do
-    case latest_version(package) do
+  defp latest_version?(repository, package, version) do
+    case latest_version(repository, package) do
       nil -> false
       latest -> Version.compare(latest, version) == :eq
     end
   end
 
-  defp delete_contents(package, version) do
-    Bucket.delete_files(package, version)
+  defp delete_contents(repository, package, version) do
+    Bucket.delete_files(repository, package, version)
 
-    if Bucket.get_latest_version(package) == version do
-      reconcile_latest(package)
+    if Bucket.get_latest_version(repository, package) == version do
+      reconcile_latest(repository, package)
     end
 
-    if release_exists?(package, version) do
-      upload("tarballs/#{package}-#{version}.tar")
+    if release_exists?(repository, package, version) do
+      upload(Bucket.tarball_key(repository, package, version))
     end
   end
 
-  defp reconcile_uploaded_release(package, version, checksum) do
+  defp reconcile_uploaded_release(repository, package, version, checksum) do
     cond do
-      not release_exists?(package, version) ->
-        delete_contents(package, version)
+      not release_exists?(repository, package, version) ->
+        delete_contents(repository, package, version)
 
-      not tarball_current?(package, version, checksum) ->
-        raise "Preview tarball changed while processing: tarballs/#{package}-#{version}.tar"
+      not tarball_current?(repository, package, version, checksum) ->
+        raise "Preview tarball changed while processing: #{Bucket.tarball_key(repository, package, version)}"
 
-      latest_version?(package, version) ->
-        Bucket.update_latest_version(package, version)
-        reconcile_latest_after_publish(package, version, checksum)
+      latest_version?(repository, package, version) ->
+        Bucket.update_latest_version(repository, package, version)
+        reconcile_latest_after_publish(repository, package, version, checksum)
 
       true ->
         :ok
     end
   end
 
-  defp reconcile_latest_after_publish(package, version, checksum) do
+  defp reconcile_latest_after_publish(repository, package, version, checksum) do
     cond do
-      not release_exists?(package, version) ->
-        delete_contents(package, version)
+      not release_exists?(repository, package, version) ->
+        delete_contents(repository, package, version)
 
-      not tarball_current?(package, version, checksum) ->
-        raise "Preview tarball changed while processing: tarballs/#{package}-#{version}.tar"
+      not tarball_current?(repository, package, version, checksum) ->
+        raise "Preview tarball changed while processing: #{Bucket.tarball_key(repository, package, version)}"
 
-      not latest_version?(package, version) ->
-        reconcile_latest(package)
+      not latest_version?(repository, package, version) ->
+        reconcile_latest(repository, package)
 
       true ->
         :ok
     end
   end
 
-  defp reconcile_latest(package) do
-    case latest_version(package) do
+  defp reconcile_latest(repository, package) do
+    case latest_version(repository, package) do
       nil ->
-        Bucket.delete_latest_version(package)
+        Bucket.delete_latest_version(repository, package)
 
       latest ->
         latest = to_string(latest)
-        {dir, file_paths, checksum} = download_and_unpack!(package, latest)
-        Bucket.put_files(package, latest, dir, file_paths)
+        {dir, file_paths, checksum} = download_and_unpack!(repository, package, latest)
+        Bucket.put_files(repository, package, latest, dir, file_paths)
 
         cond do
-          not release_exists?(package, latest) ->
-            Bucket.delete_files(package, latest)
-            reconcile_latest(package)
+          not release_exists?(repository, package, latest) ->
+            Bucket.delete_files(repository, package, latest)
+            reconcile_latest(repository, package)
 
-          not tarball_current?(package, latest, checksum) ->
-            raise "Preview tarball changed while processing: tarballs/#{package}-#{latest}.tar"
+          not tarball_current?(repository, package, latest, checksum) ->
+            raise "Preview tarball changed while processing: #{Bucket.tarball_key(repository, package, latest)}"
 
-          not latest_version?(package, latest) ->
-            reconcile_latest(package)
+          not latest_version?(repository, package, latest) ->
+            reconcile_latest(repository, package)
 
           true ->
-            Bucket.update_latest_version(package, latest)
-            purge(package, latest)
-            reconcile_latest_after_publish(package, latest, checksum)
+            Bucket.update_latest_version(repository, package, latest)
+            purge(repository, package, latest)
+            reconcile_latest_after_publish(repository, package, latest, checksum)
         end
     end
   end
 
-  defp tarball_current?(package, version, checksum) do
-    case Bucket.get_tarball_to_file(package, version) do
+  defp tarball_current?(repository, package, version, checksum) do
+    case Bucket.get_tarball_to_file(repository, package, version) do
       {:ok, path} -> Assets.file_checksum(path) == checksum
       :error -> false
     end
   end
 
-  defp purge(package, version) do
-    Hexpm.CDN.purge_key(:fastly_hexrepo, [
-      "preview/package/#{package}",
-      "preview/package/#{package}/version/#{version}"
-    ])
+  defp purge(repository, package, version) do
+    Hexpm.CDN.purge_key(:fastly_hexrepo, Bucket.surrogate_keys(repository, package, version))
   end
 
-  defp release_exists?(package, version) do
-    Releases.exists?("hexpm", package, version)
+  defp release_exists?(repository, package, version) do
+    Releases.exists?(repository, package, version)
   end
 
-  defp latest_version(package) do
-    Releases.latest_version("hexpm", package,
+  defp latest_version(repository, package) do
+    Releases.latest_version(repository, package,
       only_stable: true,
       unstable_fallback: true
     )
@@ -272,12 +291,13 @@ defmodule Hexpm.Preview do
     if requested_filename in files, do: requested_filename
   end
 
-  defp source_result(_package, _version, _filename, size) when size > @max_file_size do
+  defp source_result(_repository, _package, _version, _filename, size)
+       when size > @max_file_size do
     %{contents: nil, type: {:too_large, size}}
   end
 
-  defp source_result(package, version, filename, _size) do
-    case Bucket.get_file(package, version, filename) do
+  defp source_result(repository, package, version, filename, _size) do
+    case Bucket.get_file(repository, package, version, filename) do
       nil -> :error
       contents when is_binary(contents) -> source_contents(contents)
     end

--- a/lib/hexpm/preview/workers.ex
+++ b/lib/hexpm/preview/workers.ex
@@ -1,6 +1,7 @@
 defmodule Hexpm.Preview.Workers.Upload do
   use Oban.Worker,
     queue: :heavy,
+    priority: 3,
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
@@ -14,6 +15,7 @@ end
 defmodule Hexpm.Preview.Workers.Delete do
   use Oban.Worker,
     queue: :heavy,
+    priority: 3,
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -604,18 +604,14 @@ defmodule HexpmWeb.Components.PackageLayout do
   defp files_tab(%{current_release: nil}), do: []
 
   defp files_tab(assigns) do
-    if ViewHelpers.main_repository?(assigns.package) do
-      [
-        %{
-          active: assigns.active_tab == :files,
-          icon: "code-bracket",
-          label: "Files",
-          path: files_path(assigns)
-        }
-      ]
-    else
-      []
-    end
+    [
+      %{
+        active: assigns.active_tab == :files,
+        icon: "code-bracket",
+        label: "Files",
+        path: files_path(assigns)
+      }
+    ]
   end
 
   defp owners_tab(assigns) do
@@ -736,15 +732,16 @@ defmodule HexpmWeb.Components.PackageLayout do
     do: ViewHelpers.path_for_release(package, release)
 
   defp source_path(package, release) do
-    ~p"/packages/#{package.name}/#{to_string(release.version)}/files"
+    ViewHelpers.path_for_files(package, to_string(release.version))
   end
 
   defp source_path(package, release, filename) do
-    ~p"/packages/#{package.name}/#{to_string(release.version)}/files/#{Path.split(filename)}"
+    ViewHelpers.path_for_file(package, to_string(release.version), filename)
   end
 
   defp source_version_path(package, release, filename) do
-    ~p"/packages/#{package.name}/#{to_string(release.version)}/files/#{Path.split(filename)}?fallback=default"
+    ViewHelpers.path_for_file(package, to_string(release.version), filename) <>
+      "?fallback=default"
   end
 
   defp version_item_class(true),

--- a/lib/hexpm_web/controllers/diff_controller.ex
+++ b/lib/hexpm_web/controllers/diff_controller.ex
@@ -21,7 +21,10 @@ defmodule HexpmWeb.DiffController do
   defp parse_comparison(comparison) when is_binary(comparison) do
     case String.split(comparison, ":", parts: 3) do
       [package, from, to] when package != "" and from != "" and to != "" ->
-        [{package, from, to}]
+        case parse_package(package) do
+          {:ok, repository, package} -> [{repository, package, from, to}]
+          :error -> []
+        end
 
       _other ->
         []
@@ -29,4 +32,12 @@ defmodule HexpmWeb.DiffController do
   end
 
   defp parse_comparison(_comparison), do: []
+
+  defp parse_package(package) do
+    case String.split(package, "/") do
+      [package] -> {:ok, nil, package}
+      [repository, package] when repository != "" and package != "" -> {:ok, repository, package}
+      _other -> :error
+    end
+  end
 end

--- a/lib/hexpm_web/controllers/diff_redirect_controller.ex
+++ b/lib/hexpm_web/controllers/diff_redirect_controller.ex
@@ -8,13 +8,15 @@ defmodule HexpmWeb.DiffRedirectController do
       [] ->
         permanent_redirect(conn, "/packages", "")
 
-      [{package, from, to}] ->
-        permanent_redirect(conn, ~p"/diff/#{package}/#{from <> ".." <> to}", extra_query(params))
+      [{repository, package, from, to}] ->
+        permanent_redirect(conn, diff_path(repository, package, from, to), extra_query(params))
 
       comparisons ->
         query =
           comparisons
-          |> Enum.map(fn {package, from, to} -> {"diffs[]", "#{package}:#{from}:#{to}"} end)
+          |> Enum.map(fn {repository, package, from, to} ->
+            {"diffs[]", encode_comparison(repository, package, from, to)}
+          end)
           |> URI.encode_query()
 
         permanent_redirect(conn, ~p"/diffs", join_query(query, extra_query(params)))
@@ -26,6 +28,19 @@ defmodule HexpmWeb.DiffRedirectController do
   end
 
   def path(conn, _params), do: permanent_redirect(conn, "/packages", "")
+
+  defp diff_path(nil, package, from, to) do
+    ~p"/diff/#{package}/#{from <> ".." <> to}"
+  end
+
+  defp diff_path(repository, package, from, to) do
+    ~p"/diff/#{repository}/#{package}/#{from <> ".." <> to}"
+  end
+
+  defp encode_comparison(nil, package, from, to), do: "#{package}:#{from}:#{to}"
+
+  defp encode_comparison(repository, package, from, to),
+    do: "#{repository}/#{package}:#{from}:#{to}"
 
   defp extra_query(params) do
     params

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -207,17 +207,16 @@ defmodule HexpmWeb.PackageController do
 
   defp access_package(conn, params, fun) do
     %{"repository" => repository, "name" => name} = params
-    organizations = Users.all_organizations(conn.assigns.current_user)
-    repositories = Map.new(organizations, &{&1.repository.name, &1.repository})
 
-    if repository = repositories[repository] do
-      package = repository && Packages.get(repository, name)
-
-      # Should have access even though organization does not have active billing
-      if package do
+    # Should have access even though organization does not have active billing
+    case HexpmWeb.RepositoryAccess.fetch_package(conn.assigns.current_user, repository, name) do
+      {:ok, package} ->
+        organizations = Users.all_organizations(conn.assigns.current_user)
         fun.(package, Enum.map(organizations, & &1.repository))
-      end
-    end || not_found(conn)
+
+      :error ->
+        not_found(conn)
+    end
   end
 
   defp matching_release(releases, version) do

--- a/lib/hexpm_web/controllers/preview_image_controller.ex
+++ b/lib/hexpm_web/controllers/preview_image_controller.ex
@@ -1,0 +1,59 @@
+defmodule HexpmWeb.PreviewImageController do
+  use HexpmWeb, :controller
+
+  alias HexpmWeb.ReadmeToken
+
+  @content_types %{
+    "png" => "image/png",
+    "jpg" => "image/jpeg",
+    "jpeg" => "image/jpeg",
+    "gif" => "image/gif",
+    "svg" => "image/svg+xml",
+    "webp" => "image/webp",
+    "ico" => "image/x-icon"
+  }
+
+  def show(
+        conn,
+        %{
+          "repository" => repository,
+          "name" => name,
+          "version" => version,
+          "filename" => [_ | _] = filename_parts
+        } = params
+      ) do
+    filename = Path.join(filename_parts)
+
+    with :ok <- ReadmeToken.verify(params["token"], repository, name, version),
+         content_type when is_binary(content_type) <- content_type(filename),
+         {:ok, contents} <- Hexpm.Preview.raw_file(repository, name, version, filename) do
+      send_image(conn, content_type, contents)
+    else
+      _ -> not_found(conn)
+    end
+  end
+
+  def show(conn, _params) do
+    not_found(conn)
+  end
+
+  defp content_type(filename) do
+    case filename |> Path.extname() |> String.downcase() do
+      "." <> extension -> Map.get(@content_types, extension)
+      _other -> nil
+    end
+  end
+
+  # Images are token-authorized and fetched anonymously by the image proxy, so
+  # unlike the raw endpoint they carry a real image content type. The sandbox
+  # CSP keeps a directly-navigated SVG inert in an opaque origin while leaving
+  # <img> rendering unaffected.
+  defp send_image(conn, content_type, contents) do
+    conn
+    |> put_resp_header("content-type", content_type)
+    |> put_resp_header("content-security-policy", "sandbox; default-src 'none'")
+    |> put_resp_header("x-content-type-options", "nosniff")
+    |> put_resp_header("cache-control", "private, no-store")
+    |> send_resp(200, contents)
+  end
+end

--- a/lib/hexpm_web/controllers/preview_raw_controller.ex
+++ b/lib/hexpm_web/controllers/preview_raw_controller.ex
@@ -1,0 +1,55 @@
+defmodule HexpmWeb.PreviewRawController do
+  use HexpmWeb, :controller
+
+  alias HexpmWeb.RepositoryAccess
+
+  def show(conn, %{
+        "repository" => repository,
+        "name" => name,
+        "version" => version,
+        "filename" => [_ | _] = filename_parts
+      }) do
+    filename = Path.join(filename_parts)
+
+    with {:ok, package} <-
+           RepositoryAccess.fetch_package(conn.assigns.current_user, repository, name),
+         release when not is_nil(release) <- find_release(package, version),
+         {:ok, contents} <- Hexpm.Preview.raw_file(repository, name, version, filename) do
+      send_raw(conn, filename, contents)
+    else
+      _ -> not_found(conn)
+    end
+  end
+
+  def show(conn, _params) do
+    not_found(conn)
+  end
+
+  defp find_release(package, version) do
+    package
+    |> Releases.all()
+    |> Enum.find(&(to_string(&1.version) == version))
+  end
+
+  # Raw files are untrusted package contents served from the hex.pm origin,
+  # so the content type is never derived from the file and rendering is
+  # locked down to keep them inert in the browser.
+  defp send_raw(conn, filename, contents) do
+    {content_type, disposition} =
+      if String.valid?(contents) do
+        {"text/plain; charset=utf-8", "inline"}
+      else
+        {"application/octet-stream", "attachment"}
+      end
+
+    basename = filename |> Path.basename() |> String.replace(~r/[^\w.-]/, "_")
+
+    conn
+    |> put_resp_header("content-type", content_type)
+    |> put_resp_header("content-disposition", ~s(#{disposition}; filename="#{basename}"))
+    |> put_resp_header("content-security-policy", "sandbox; default-src 'none'")
+    |> put_resp_header("x-content-type-options", "nosniff")
+    |> put_resp_header("cache-control", "private, no-store")
+    |> send_resp(200, contents)
+  end
+end

--- a/lib/hexpm_web/controllers/preview_redirect_controller.ex
+++ b/lib/hexpm_web/controllers/preview_redirect_controller.ex
@@ -50,7 +50,7 @@ defmodule HexpmWeb.PreviewRedirectController do
   def path(conn, _params), do: permanent_redirect(conn, conn.request_path)
 
   defp redirect_latest(conn, package, filename) do
-    case Preview.get_latest_version(package) do
+    case Preview.get_latest_version("hexpm", package) do
       version when is_binary(version) -> redirect_source(conn, package, version, filename)
       _ -> send_resp(conn, 404, "Not Found")
     end

--- a/lib/hexpm_web/controllers/readme_controller.ex
+++ b/lib/hexpm_web/controllers/readme_controller.ex
@@ -3,14 +3,34 @@ defmodule HexpmWeb.ReadmeController do
 
   alias Hexpm.Preview
   alias HexpmWeb.Readme.Renderer
+  alias HexpmWeb.ReadmeToken
 
   plug :put_root_layout, false
   plug :put_layout, false
+
+  @private_cache_control "private, no-store"
 
   def not_found(conn, _params) do
     conn
     |> put_resp_content_type("text/plain")
     |> send_resp(404, "Not Found")
+  end
+
+  def show(conn, %{"repository" => repository, "version" => version, "token" => token} = params) do
+    name = params["name"]
+
+    with :ok <- ReadmeToken.verify(token, repository, name, version),
+         package when not is_nil(package) <- Packages.get(repository, name),
+         release when not is_nil(release) <-
+           Enum.find(Releases.all(package), &(to_string(&1.version) == version)) do
+      serve_readme(conn, repository, package, release, @private_cache_control)
+    else
+      _ -> send_no_readme(conn, @private_cache_control)
+    end
+  end
+
+  def show(conn, %{"repository" => _repository} = params) do
+    not_found(conn, params)
   end
 
   def show(conn, %{"version" => version} = params) do
@@ -21,7 +41,7 @@ defmodule HexpmWeb.ReadmeController do
       release = Enum.find(Releases.all(package), &(to_string(&1.version) == version))
 
       if release do
-        serve_readme(conn, package, release)
+        serve_readme(conn, "hexpm", package, release, "public, max-age=86400")
       else
         send_no_readme(conn)
       end
@@ -55,29 +75,29 @@ defmodule HexpmWeb.ReadmeController do
     end
   end
 
-  defp serve_readme(conn, package, release) do
+  defp serve_readme(conn, repository, package, release, cache_control) do
     version = to_string(release.version)
 
-    case Preview.readme(package.name, version) do
+    case Preview.readme(repository, package.name, version) do
       {:ok, filename, content} ->
-        html = render_readme(filename, content, package.name, version)
+        html = render_readme(repository, filename, content, package.name, version)
 
         conn
-        |> put_resp_header("cache-control", "public, max-age=86400")
+        |> put_resp_header("cache-control", cache_control)
         |> render(:show, readme_html: html, parent_origins: parent_origins())
 
       :error ->
-        send_no_readme(conn)
+        send_no_readme(conn, cache_control)
     end
   end
 
-  defp render_readme(filename, content, package_name, version) do
-    Renderer.render(filename, content, package_name, version)
+  defp render_readme(repository, filename, content, package_name, version) do
+    Renderer.render(repository, filename, content, package_name, version)
   end
 
-  defp send_no_readme(conn) do
+  defp send_no_readme(conn, cache_control \\ "public, max-age=3600") do
     conn
-    |> put_resp_header("cache-control", "public, max-age=3600")
+    |> put_resp_header("cache-control", cache_control)
     |> render(:no_readme, parent_origins: parent_origins())
   end
 

--- a/lib/hexpm_web/live/diff_live.ex
+++ b/lib/hexpm_web/live/diff_live.ex
@@ -9,19 +9,23 @@ defmodule HexpmWeb.DiffLive do
   alias HexpmWeb.Components.FileSelector
   alias HexpmWeb.PackageLayoutAssigns
   alias HexpmWeb.Plugs.Attack
+  alias HexpmWeb.RepositoryAccess
 
   @batch_size 5
   @poll_interval 1_000
 
   @impl Phoenix.LiveView
   def mount(%{"package" => package, "versions" => versions} = params, session, socket) do
+    repository = params["repository"] || "hexpm"
     socket = assign(socket, base_assigns())
     socket = assign(socket, diff_identity: diff_identity(socket, session))
     ignore_whitespace = params["w"] == "1"
 
     with {:ok, from, to} <- parse_versions(versions),
+         {:ok, _repository} <-
+           fetch_repository(socket.assigns.current_user, repository),
          {:ok, request} <-
-           Hexpm.Diff.prepare(package, from, to, ignore_whitespace: ignore_whitespace) do
+           Hexpm.Diff.prepare(repository, package, from, to, ignore_whitespace: ignore_whitespace) do
       release = Releases.preload(request.to_release, [:requirements])
 
       layout_assigns =
@@ -38,6 +42,7 @@ defmodule HexpmWeb.DiffLive do
         |> assign(layout_assigns)
         |> assign(
           request: request,
+          repository: repository,
           package: request.package,
           from: request.from,
           to: request.to,
@@ -48,7 +53,13 @@ defmodule HexpmWeb.DiffLive do
           page_title: "#{request.package} #{request.from}..#{request.to} diff",
           description: "Compare #{request.package} #{request.from} with #{request.to} on Hex.",
           canonical_url:
-            canonical_url(request.package, request.from, request.to, ignore_whitespace),
+            canonical_url(
+              repository,
+              request.package,
+              request.from,
+              request.to,
+              ignore_whitespace
+            ),
           container: "container"
         )
 
@@ -117,13 +128,21 @@ defmodule HexpmWeb.DiffLive do
     else
       {:noreply,
        push_navigate(socket,
-         to: diff_path(socket.assigns.package, from, to, socket.assigns.ignore_whitespace)
+         to:
+           diff_path(
+             socket.assigns.repository,
+             socket.assigns.package,
+             from,
+             to,
+             socket.assigns.ignore_whitespace
+           )
        )}
     end
   end
 
   def handle_event("retry", _params, socket) do
     case Hexpm.Diff.prepare(
+           socket.assigns.repository,
            socket.assigns.package,
            socket.assigns.from,
            socket.assigns.to,
@@ -441,6 +460,13 @@ defmodule HexpmWeb.DiffLive do
     end
   end
 
+  defp fetch_repository(current_user, repository) do
+    case RepositoryAccess.fetch_repository(current_user, repository) do
+      {:ok, repository} -> {:ok, repository}
+      :error -> {:error, :package_not_found}
+    end
+  end
+
   defp parse_versions(versions) when is_binary(versions) do
     case String.split(versions, "..", parts: 2) do
       [from, to] when from != "" -> {:ok, from, to}
@@ -453,6 +479,7 @@ defmodule HexpmWeb.DiffLive do
   defp base_assigns do
     [
       request: nil,
+      repository: nil,
       package: nil,
       from: nil,
       to: nil,
@@ -491,14 +518,23 @@ defmodule HexpmWeb.DiffLive do
     "Could not load diff cache. Try again later."
   end
 
-  def diff_path(package, from, to, ignore_whitespace) do
+  def diff_path(repository, package, from, to, ignore_whitespace) do
     query = if ignore_whitespace, do: [w: 1], else: []
-    ~p"/diff/#{package}/#{from <> ".." <> to}?#{query}"
+
+    case repository do
+      "hexpm" -> ~p"/diff/#{package}/#{from <> ".." <> to}?#{query}"
+      _other -> ~p"/diff/#{repository}/#{package}/#{from <> ".." <> to}?#{query}"
+    end
   end
 
-  defp canonical_url(package, from, to, ignore_whitespace) do
-    url(~p"/diff/#{package}/#{from <> ".." <> to}") <>
-      if(ignore_whitespace, do: "?w=1", else: "")
+  defp canonical_url(repository, package, from, to, ignore_whitespace) do
+    url =
+      case repository do
+        "hexpm" -> url(~p"/diff/#{package}/#{from <> ".." <> to}")
+        _other -> url(~p"/diff/#{repository}/#{package}/#{from <> ".." <> to}")
+      end
+
+    url <> if(ignore_whitespace, do: "?w=1", else: "")
   end
 
   def job_state_title(:running), do: "Generating diff"

--- a/lib/hexpm_web/live/diff_live.html.heex
+++ b/lib/hexpm_web/live/diff_live.html.heex
@@ -28,7 +28,7 @@
             />
             <.link
               id="whitespace-toggle"
-              navigate={diff_path(@package, @from, @to, not @ignore_whitespace)}
+              navigate={diff_path(@repository, @package, @from, @to, not @ignore_whitespace)}
               class="inline-flex items-center gap-2 rounded-lg border border-grey-200 bg-white px-3 py-2 text-sm font-medium text-grey-700 shadow-sm transition-colors hover:border-grey-300 hover:bg-grey-50 dark:border-grey-700 dark:bg-grey-800 dark:text-grey-100 dark:hover:bg-grey-700"
             >
               {icon(:heroicon, "arrows-right-left", class: "size-4")}

--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -3,9 +3,10 @@ defmodule HexpmWeb.PreviewLive do
 
   import HexpmWeb.Components.PackageLayout
 
-  alias Hexpm.Repository.{Packages, Releases}
+  alias Hexpm.Repository.Releases
   alias HexpmWeb.Components.FileSelector
   alias HexpmWeb.PackageLayoutAssigns
+  alias HexpmWeb.RepositoryAccess
 
   defmodule NotFoundError do
     defexception message: "Package file not found", plug_status: 404
@@ -15,6 +16,7 @@ defmodule HexpmWeb.PreviewLive do
   def mount(params, _session, socket) do
     {:ok,
      assign(socket,
+       repository: nil,
        package: nil,
        package_name: params["package"],
        version: nil,
@@ -37,24 +39,27 @@ defmodule HexpmWeb.PreviewLive do
 
   @impl true
   def handle_params(params, _uri, socket) do
+    repository = params["repository"] || "hexpm"
     package_name = params["package"]
     version = params["version"]
     requested_filename = filename(params["filename"])
 
-    with package when not is_nil(package) <- Packages.get("hexpm", package_name),
+    with {:ok, package} <-
+           RepositoryAccess.fetch_package(socket.assigns.current_user, repository, package_name),
          [_ | _] = releases <- Releases.all(package),
          release when not is_nil(release) <- find_release(releases, version),
          {:ok, source, replace_path?} <-
-           source(package_name, version, requested_filename, params["fallback"]) do
+           source(repository, package_name, version, requested_filename, params["fallback"]) do
       socket =
         socket
+        |> assign(repository: repository)
         |> assign_package(package, release, releases)
-        |> assign_source(package_name, version, source)
+        |> assign_source(repository, package_name, version, source)
 
       socket =
         if replace_path? do
           push_patch(socket,
-            to: ~p"/packages/#{package_name}/#{version}/files/#{Path.split(source.filename)}",
+            to: files_path(repository, package_name, version, source.filename),
             replace: true
           )
         else
@@ -87,6 +92,22 @@ defmodule HexpmWeb.PreviewLive do
     {:noreply, assign(socket, expanded_paths: expanded_paths)}
   end
 
+  def files_path("hexpm", package, version) do
+    ~p"/packages/#{package}/#{version}/files"
+  end
+
+  def files_path(repository, package, version) do
+    ~p"/packages/#{repository}/#{package}/#{version}/files"
+  end
+
+  def files_path("hexpm", package, version, filename) do
+    ~p"/packages/#{package}/#{version}/files/#{Path.split(filename)}"
+  end
+
+  def files_path(repository, package, version, filename) do
+    ~p"/packages/#{repository}/#{package}/#{version}/files/#{Path.split(filename)}"
+  end
+
   defp assign_package(socket, package, release, releases) do
     version = to_string(release.version)
 
@@ -112,7 +133,7 @@ defmodule HexpmWeb.PreviewLive do
     end
   end
 
-  defp assign_source(socket, package, version, source) do
+  defp assign_source(socket, repository, package, version, source) do
     {highlighted, message} = render_contents(package, version, source)
     filename = source.filename
 
@@ -127,11 +148,11 @@ defmodule HexpmWeb.PreviewLive do
       query: "",
       highlighted: highlighted,
       message: message,
-      raw_url: raw_url(package, version, filename),
+      raw_url: raw_url(repository, package, version, filename),
       title: "#{filename} - #{package} #{version}",
       page_title: "#{filename} - #{package} #{version} | Hex",
       description: description(package, version, filename),
-      canonical_url: canonical_url(package, version, filename)
+      canonical_url: HexpmWeb.Endpoint.url() <> files_path(repository, package, version, filename)
     )
   end
 
@@ -141,13 +162,13 @@ defmodule HexpmWeb.PreviewLive do
 
   defp find_release(_releases, _version), do: nil
 
-  defp source(package, version, requested_filename, fallback) do
-    case Hexpm.Preview.source(package, version, requested_filename) do
+  defp source(repository, package, version, requested_filename, fallback) do
+    case Hexpm.Preview.source(repository, package, version, requested_filename) do
       {:ok, source} ->
         {:ok, source, fallback == "default"}
 
       :error when fallback == "default" ->
-        case Hexpm.Preview.source(package, version) do
+        case Hexpm.Preview.source(repository, package, version) do
           {:ok, source} -> {:ok, source, true}
           :error -> :error
         end
@@ -180,11 +201,7 @@ defmodule HexpmWeb.PreviewLive do
   defp filename([_ | _] = parts), do: Path.join(parts)
   defp filename(_filename), do: nil
 
-  defp canonical_url(package, version, filename) do
-    url(~p"/packages/#{package}/#{version}/files/#{Path.split(filename)}")
-  end
-
-  defp raw_url(package, version, filename) do
+  defp raw_url("hexpm", package, version, filename) do
     Application.fetch_env!(:hexpm, :cdn_url) <>
       "/preview/" <>
       encode_path(package) <>
@@ -192,6 +209,10 @@ defmodule HexpmWeb.PreviewLive do
       encode_path(version) <>
       "/" <>
       encode_path(filename)
+  end
+
+  defp raw_url(repository, package, version, filename) do
+    ~p"/packages/#{repository}/#{package}/#{version}/raw/#{Path.split(filename)}"
   end
 
   defp encode_path(path) do
@@ -240,6 +261,7 @@ defmodule HexpmWeb.PreviewLive do
 
   attr :nodes, :list, required: true
   attr :filename, :string, required: true
+  attr :repository, :string, required: true
   attr :package_name, :string, required: true
   attr :version, :string, required: true
   attr :expanded_paths, :any, required: true
@@ -271,6 +293,7 @@ defmodule HexpmWeb.PreviewLive do
             <.source_tree
               nodes={node.children}
               filename={@filename}
+              repository={@repository}
               package_name={@package_name}
               version={@version}
               expanded_paths={@expanded_paths}
@@ -281,7 +304,7 @@ defmodule HexpmWeb.PreviewLive do
         </li>
         <li :if={node.type == :file}>
           <.link
-            patch={~p"/packages/#{@package_name}/#{@version}/files/#{Path.split(node.path)}"}
+            patch={files_path(@repository, @package_name, @version, node.path)}
             phx-click={if @close_modal?, do: hide_modal(@modal_id)}
             aria-current={if node.path == @filename, do: "page"}
             class={[
@@ -303,6 +326,7 @@ defmodule HexpmWeb.PreviewLive do
 
   attr :files, :list, required: true
   attr :filename, :string, required: true
+  attr :repository, :string, required: true
   attr :package_name, :string, required: true
   attr :version, :string, required: true
   attr :close_modal?, :boolean, default: false
@@ -316,7 +340,7 @@ defmodule HexpmWeb.PreviewLive do
     >
       <:item :let={result}>
         <.link
-          patch={~p"/packages/#{@package_name}/#{@version}/files/#{Path.split(result.item)}"}
+          patch={files_path(@repository, @package_name, @version, result.item)}
           phx-click={if @close_modal?, do: hide_modal(@modal_id)}
           aria-current={if result.item == @filename, do: "page"}
           class={result.class}

--- a/lib/hexpm_web/live/preview_live.html.heex
+++ b/lib/hexpm_web/live/preview_live.html.heex
@@ -10,7 +10,7 @@
       <div class="flex flex-wrap items-center justify-between gap-3">
         <div class="flex min-w-0 items-center gap-2 font-mono text-xs text-grey-500 dark:text-grey-300">
           <.link
-            patch={~p"/packages/#{@package_name}/#{@version}/files"}
+            patch={files_path(@repository, @package_name, @version)}
             class="shrink-0 font-semibold text-grey-800 hover:text-primary-600 dark:text-grey-100 dark:hover:text-primary-300"
           >
             {@package_name}
@@ -51,6 +51,7 @@
             <.source_tree
               nodes={@file_tree}
               filename={@filename}
+              repository={@repository}
               package_name={@package_name}
               version={@version}
               expanded_paths={@expanded_paths}
@@ -61,6 +62,7 @@
             <.source_results
               files={@filtered_files}
               filename={@filename}
+              repository={@repository}
               package_name={@package_name}
               version={@version}
               close_modal?={selector.close_modal?}

--- a/lib/hexpm_web/readme/renderer.ex
+++ b/lib/hexpm_web/readme/renderer.ex
@@ -22,7 +22,7 @@ defmodule HexpmWeb.Readme.Renderer do
   @doc """
   Converts README content to sanitized, URL-rewritten HTML.
   """
-  def render(filename, content, package_name, version) do
+  def render(repository, filename, content, package_name, version) do
     ext = Path.extname(filename) |> String.downcase()
     content = scrub_invalid_utf8(content)
 
@@ -50,7 +50,7 @@ defmodule HexpmWeb.Readme.Renderer do
     |> protect_pre_whitespace()
     |> Floki.parse_document!()
     |> Sanitizer.sanitize()
-    |> URLRewriter.rewrite(package_name, version)
+    |> URLRewriter.rewrite(repository, package_name, version)
     |> Floki.raw_html()
   end
 

--- a/lib/hexpm_web/readme/url_rewriter.ex
+++ b/lib/hexpm_web/readme/url_rewriter.ex
@@ -4,41 +4,56 @@ defmodule HexpmWeb.Readme.URLRewriter do
 
   - Resolves relative paths using the preview service (repo.hex.pm/preview/)
   - Rewrites all image URLs to go through the img.hex.pm HMAC-signed proxy
+
+  Private packages resolve relative links against the authenticated raw
+  endpoint on the main host (session auth works when the user clicks), and
+  relative images against a token-signed image endpoint. The image proxy
+  fetches images anonymously, so the token — not the session cookie — is what
+  authorizes the fetch.
   """
+
+  alias HexpmWeb.ReadmeToken
 
   @doc """
   Rewrites URLs in a Floki HTML tree.
-
-  Relative paths are resolved against the preview service for the given
-  package and version.
   """
-  def rewrite(tree, package_name, version) do
+  def rewrite(tree, "hexpm", package_name, version) do
     cdn_url = Application.fetch_env!(:hexpm, :cdn_url)
     base_url = "#{cdn_url}/preview/#{package_name}/#{version}"
-    rewrite_nodes(tree, base_url)
+    rewrite_nodes(tree, %{link: base_url, image: base_url, image_token: nil})
   end
 
-  defp rewrite_nodes(nodes, base_url) when is_list(nodes) do
-    Enum.map(nodes, &rewrite_node(&1, base_url))
+  def rewrite(tree, repository, package_name, version) do
+    base_url = HexpmWeb.Endpoint.url() <> "/packages/#{repository}/#{package_name}/#{version}"
+
+    rewrite_nodes(tree, %{
+      link: "#{base_url}/raw",
+      image: "#{base_url}/readme-image",
+      image_token: ReadmeToken.sign(repository, package_name, version)
+    })
   end
 
-  defp rewrite_node({tag, attrs, children}, base_url) do
-    attrs = rewrite_attrs(tag, attrs, base_url)
-    children = rewrite_nodes(children, base_url)
+  defp rewrite_nodes(nodes, urls) when is_list(nodes) do
+    Enum.map(nodes, &rewrite_node(&1, urls))
+  end
+
+  defp rewrite_node({tag, attrs, children}, urls) do
+    attrs = rewrite_attrs(tag, attrs, urls)
+    children = rewrite_nodes(children, urls)
     {tag, attrs, children}
   end
 
-  defp rewrite_node(other, _base_url), do: other
+  defp rewrite_node(other, _urls), do: other
 
   @color_scheme_fragments %{
     "gh-light-mode-only" => "color-scheme-light",
     "gh-dark-mode-only" => "color-scheme-dark"
   }
 
-  defp rewrite_attrs("img", attrs, base_url) do
+  defp rewrite_attrs("img", attrs, urls) do
     case List.keytake(attrs, "src", 0) do
       {{"src", src_value}, attrs} ->
-        src_value = resolve_url(src_value, base_url)
+        src_value = resolve_image_url(src_value, urls)
         {class, src_value} = extract_color_scheme_class(src_value)
         attrs = [{"src", proxy_image_url(src_value)} | attrs]
         if class, do: [{"class", class} | attrs], else: attrs
@@ -48,14 +63,14 @@ defmodule HexpmWeb.Readme.URLRewriter do
     end
   end
 
-  defp rewrite_attrs("a", attrs, base_url) do
+  defp rewrite_attrs("a", attrs, urls) do
     Enum.map(attrs, fn
-      {"href", href} -> {"href", resolve_url(href, base_url)}
+      {"href", href} -> {"href", resolve_url(href, urls.link)}
       attr -> attr
     end)
   end
 
-  defp rewrite_attrs(_tag, attrs, _base_url), do: attrs
+  defp rewrite_attrs(_tag, attrs, _urls), do: attrs
 
   defp extract_color_scheme_class(url) do
     uri = URI.parse(url)
@@ -63,6 +78,16 @@ defmodule HexpmWeb.Readme.URLRewriter do
     case Map.get(@color_scheme_fragments, uri.fragment) do
       nil -> {nil, url}
       class -> {class, %{uri | fragment: nil} |> URI.to_string()}
+    end
+  end
+
+  defp resolve_image_url(url, urls) do
+    resolved = resolve_url(url, urls.image)
+
+    if urls.image_token && String.starts_with?(resolved, urls.image) do
+      resolved <> "?token=" <> urls.image_token
+    else
+      resolved
     end
   end
 

--- a/lib/hexpm_web/readme_token.ex
+++ b/lib/hexpm_web/readme_token.ex
@@ -1,0 +1,29 @@
+defmodule HexpmWeb.ReadmeToken do
+  @moduledoc """
+  Signed tokens authorizing readme access for a single private package version.
+
+  The readme host never receives the hex.pm session cookie, so the package
+  page mints a token after its own authorization check and embeds it in the
+  iframe URL.
+  """
+
+  @salt "private readme"
+  @max_age 30 * 60
+
+  def sign(repository, package, version) do
+    Phoenix.Token.sign(
+      HexpmWeb.Endpoint,
+      @salt,
+      {repository, package, to_string(version)}
+    )
+  end
+
+  def verify(token, repository, package, version) when is_binary(token) do
+    case Phoenix.Token.verify(HexpmWeb.Endpoint, @salt, token, max_age: @max_age) do
+      {:ok, {^repository, ^package, ^version}} -> :ok
+      _other -> :error
+    end
+  end
+
+  def verify(_token, _repository, _package, _version), do: :error
+end

--- a/lib/hexpm_web/repository_access.ex
+++ b/lib/hexpm_web/repository_access.ex
@@ -1,0 +1,27 @@
+defmodule HexpmWeb.RepositoryAccess do
+  @moduledoc """
+  Resolves repositories and packages against the repositories the given user
+  has access to. Missing and unauthorized resources are indistinguishable.
+  """
+
+  alias Hexpm.Accounts.Users
+  alias Hexpm.Repository.{Package, Packages}
+
+  def fetch_repository(current_user, repository_name) do
+    organizations = Users.all_organizations(current_user)
+
+    case Enum.find(organizations, &(&1.repository.name == repository_name)) do
+      nil -> :error
+      organization -> {:ok, organization.repository}
+    end
+  end
+
+  def fetch_package(current_user, repository_name, package_name) do
+    with {:ok, repository} <- fetch_repository(current_user, repository_name),
+         %Package{} = package <- Packages.get(repository, package_name) do
+      {:ok, package}
+    else
+      _ -> :error
+    end
+  end
+end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -114,6 +114,7 @@ defmodule HexpmWeb.Router do
   scope "/", HexpmWeb, host: "readme." do
     pipe_through :readme
 
+    get "/:repository/:name/:version", ReadmeController, :show
     get "/:name/:version", ReadmeController, :show
     get "/:name", ReadmeController, :show
     match :*, "/*path", ReadmeController, :not_found
@@ -208,6 +209,7 @@ defmodule HexpmWeb.Router do
       session: {HexpmWeb.Live.InitAssigns, :session, []} do
       live "/packages", PackageLive.Index, :index
       live "/diff/:package/:versions", DiffLive, :show
+      live "/diff/:repository/:package/:versions", DiffLive, :show
     end
 
     get "/diffs", DiffController, :index
@@ -220,6 +222,8 @@ defmodule HexpmWeb.Router do
     live_session :preview, on_mount: {HexpmWeb.Live.InitAssigns, :default} do
       live "/packages/:package/:version/files", PreviewLive, :files
       live "/packages/:package/:version/files/*filename", PreviewLive, :files
+      live "/packages/:repository/:package/:version/files", PreviewLive, :files
+      live "/packages/:repository/:package/:version/files/*filename", PreviewLive, :files
     end
 
     get "/packages/:name/owners", PackageOwnerController, :index
@@ -243,6 +247,12 @@ defmodule HexpmWeb.Router do
     get "/packages/:repository/:name/versions", PackageController, :versions
     get "/packages/:repository/:name/advisories", PackageController, :advisories
     get "/packages/:repository/:name/:version/dependencies", PackageController, :dependencies
+    get "/packages/:repository/:name/:version/raw/*filename", PreviewRawController, :show
+
+    get "/packages/:repository/:name/:version/readme-image/*filename",
+        PreviewImageController,
+        :show
+
     get "/packages/:repository/:name/:version", PackageController, :show
 
     get "/blog", BlogController, :index

--- a/lib/hexpm_web/templates/diff/index.html.heex
+++ b/lib/hexpm_web/templates/diff/index.html.heex
@@ -18,22 +18,30 @@
           </td>
         </tr>
         <tr
-          :for={{package, from, to} <- @diffs}
+          :for={{repository, package, from, to} <- @diffs}
           class="transition-colors hover:bg-grey-50 dark:hover:bg-grey-700/40"
         >
           <td class="px-6 py-3">
             <a
-              href={~p"/packages/#{package}/#{to}"}
+              href={
+                if repository,
+                  do: ~p"/packages/#{repository}/#{package}/#{to}",
+                  else: ~p"/packages/#{package}/#{to}"
+              }
               class="font-mono font-semibold text-primary-700 transition-colors hover:text-primary-900 dark:text-primary-400 dark:hover:text-primary-300"
             >
-              {package}
+              {if repository, do: "#{repository}/#{package}", else: package}
             </a>
           </td>
           <td class="px-4 py-3 font-mono text-xs text-grey-500 dark:text-grey-300">{from}</td>
           <td class="px-4 py-3 font-mono text-xs text-grey-500 dark:text-grey-300">{to}</td>
           <td class="px-4 py-3 text-right">
             <a
-              href={~p"/diff/#{package}/#{from <> ".." <> to}"}
+              href={
+                if repository,
+                  do: ~p"/diff/#{repository}/#{package}/#{from <> ".." <> to}",
+                  else: ~p"/diff/#{package}/#{from <> ".." <> to}"
+              }
               class="inline-flex items-center rounded-md bg-primary-600 px-3 py-1 text-xs font-semibold text-white transition-colors hover:bg-primary-700"
             >
               View diff

--- a/lib/hexpm_web/templates/package/show.html.heex
+++ b/lib/hexpm_web/templates/package/show.html.heex
@@ -3,7 +3,7 @@
 <.package_layout {@package_layout} active_tab={:readme} version_pinned?={@version_pinned?}>
   <:inner_content>
     <div class="bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-6">
-      <%= if ViewHelpers.main_repository?(@package) and @current_release do %>
+      <%= if @current_release do %>
         <div
           id="readme-loading"
           class="flex items-center justify-center py-12 text-grey-400 dark:text-grey-300"
@@ -39,7 +39,7 @@
 
         <iframe
           id="readme-frame"
-          src={"#{ViewHelpers.readme_url(@package.name, @current_release.version)}"}
+          src={"#{ViewHelpers.readme_url(@package, @current_release.version)}"}
           sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
           loading="lazy"
           referrerpolicy="no-referrer"

--- a/lib/hexpm_web/templates/package/versions.html.heex
+++ b/lib/hexpm_web/templates/package/versions.html.heex
@@ -17,8 +17,8 @@ version_rows =
   end)
 
 compare_path =
-  case {ViewHelpers.main_repository?(@package), versions} do
-    {true, [version, previous_version | _]} ->
+  case versions do
+    [version, previous_version | _] ->
       ViewHelpers.path_for_diff(@package, version, previous_version)
 
     _ ->
@@ -126,7 +126,7 @@ compare_path =
                   {HexpmWeb.ViewIcons.icon(:heroicon, "cloud-arrow-down", class: "size-4")}
                 </a>
               <% end %>
-              <%= if row.previous_version && ViewHelpers.main_repository?(@package) do %>
+              <%= if row.previous_version do %>
                 <a
                   href={
                     ViewHelpers.path_for_diff(
@@ -141,15 +141,13 @@ compare_path =
                   {HexpmWeb.ViewIcons.icon(:heroicon, "arrows-right-left", class: "size-4")}
                 </a>
               <% end %>
-              <%= if ViewHelpers.main_repository?(@package) do %>
-                <a
-                  href={~p"/packages/#{@package.name}/#{to_string(row.release.version)}/files"}
-                  title="Browse files"
-                  class="text-grey-400 dark:text-grey-300 hover:text-purple-600 dark:hover:text-primary-300 transition-colors"
-                >
-                  {HexpmWeb.ViewIcons.icon(:heroicon, "code-bracket", class: "size-4")}
-                </a>
-              <% end %>
+              <a
+                href={ViewHelpers.path_for_files(@package, to_string(row.release.version))}
+                title="Browse files"
+                class="text-grey-400 dark:text-grey-300 hover:text-purple-600 dark:hover:text-primary-300 transition-colors"
+              >
+                {HexpmWeb.ViewIcons.icon(:heroicon, "code-bracket", class: "size-4")}
+              </a>
             </div>
           </div>
         <% end %>
@@ -261,7 +259,7 @@ compare_path =
                       {HexpmWeb.ViewIcons.icon(:heroicon, "cloud-arrow-down", class: "size-4")}
                     </a>
                   <% end %>
-                  <%= if row.previous_version && ViewHelpers.main_repository?(@package) do %>
+                  <%= if row.previous_version do %>
                     <a
                       href={
                         ViewHelpers.path_for_diff(
@@ -276,17 +274,13 @@ compare_path =
                       {HexpmWeb.ViewIcons.icon(:heroicon, "arrows-right-left", class: "size-4")}
                     </a>
                   <% end %>
-                  <%= if ViewHelpers.main_repository?(@package) do %>
-                    <a
-                      href={
-                        ~p"/packages/#{@package.name}/#{to_string(row.release.version)}/files"
-                      }
-                      title="Browse files"
-                      class="text-grey-400 dark:text-grey-300 hover:text-purple-600 dark:hover:text-primary-300 transition-colors"
-                    >
-                      {HexpmWeb.ViewIcons.icon(:heroicon, "code-bracket", class: "size-4")}
-                    </a>
-                  <% end %>
+                  <a
+                    href={ViewHelpers.path_for_files(@package, to_string(row.release.version))}
+                    title="Browse files"
+                    class="text-grey-400 dark:text-grey-300 hover:text-purple-600 dark:hover:text-primary-300 transition-colors"
+                  >
+                    {HexpmWeb.ViewIcons.icon(:heroicon, "code-bracket", class: "size-4")}
+                  </a>
                 </div>
               </td>
             </tr>

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -57,6 +57,27 @@ defmodule HexpmWeb.ViewHelpers do
     ~p"/diff/#{package}/#{versions}"
   end
 
+  def path_for_diff(%Package{} = package, version, previous_version) do
+    versions = "#{previous_version}..#{version}"
+    ~p"/diff/#{package.repository}/#{package}/#{versions}"
+  end
+
+  def path_for_files(%Package{repository_id: 1} = package, version) do
+    ~p"/packages/#{package}/#{version}/files"
+  end
+
+  def path_for_files(%Package{} = package, version) do
+    ~p"/packages/#{package.repository}/#{package}/#{version}/files"
+  end
+
+  def path_for_file(%Package{repository_id: 1} = package, version, filename) do
+    ~p"/packages/#{package}/#{version}/files/#{Path.split(filename)}"
+  end
+
+  def path_for_file(%Package{} = package, version, filename) do
+    ~p"/packages/#{package.repository}/#{package}/#{version}/files/#{Path.split(filename)}"
+  end
+
   def path_for_owners(%Package{repository_id: 1} = package) do
     ~p"/packages/#{package}/owners"
   end
@@ -530,9 +551,17 @@ defmodule HexpmWeb.ViewHelpers do
   def main_repository?(%{repository_id: 1}), do: true
   def main_repository?(_), do: false
 
-  def readme_url(package_name, version) do
+  def readme_url(%Package{repository_id: 1} = package, version) do
     readme_url = Application.fetch_env!(:hexpm, :readme_url)
-    "#{readme_url}/#{package_name}/#{version}"
+    "#{readme_url}/#{package.name}/#{version}"
+  end
+
+  def readme_url(%Package{} = package, version) do
+    readme_url = Application.fetch_env!(:hexpm, :readme_url)
+    repository = package.repository.name
+    version = to_string(version)
+    token = HexpmWeb.ReadmeToken.sign(repository, package.name, version)
+    "#{readme_url}/#{repository}/#{package.name}/#{version}?token=#{token}"
   end
 
   def safe_url(url) when is_binary(url) do

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -1,5 +1,6 @@
 defmodule Hexpm.AdminTasksTest do
   use Hexpm.DataCase, async: true
+  use Oban.Testing, repo: Hexpm.RepoBase
   import Swoosh.TestAssertions
 
   alias Hexpm.AdminTasks
@@ -589,42 +590,75 @@ defmodule Hexpm.AdminTasksTest do
   describe "retry_oban_jobs/1" do
     alias Hexpm.Hexdocs.Workers
 
-    test "retries discarded jobs" do
+    test "retries discarded jobs at priority 8" do
       discarded = insert_discarded_job(Workers.Upload, %{key: "docs/retried-1.0.0.tar.gz"})
       {:ok, available} = Oban.insert(Workers.Upload.new(%{key: "docs/untouched-1.0.0.tar.gz"}))
 
       assert {:ok, 1} = AdminTasks.retry_oban_jobs()
 
-      discarded = Repo.get!(Oban.Job, discarded.id)
-      assert discarded.state == "available"
-      assert discarded.max_attempts == 6
+      retried = Repo.get!(Oban.Job, discarded.id)
+      assert retried.state == "available"
+      assert retried.priority == 8
+
+      # A job that was never discarded is left alone.
       assert Repo.get!(Oban.Job, available.id).state == "available"
     end
 
+    test "with uniq: true retries one job per worker and args" do
+      insert_discarded_job(Workers.Upload, %{key: "docs/dup-1.0.0.tar.gz"})
+      insert_discarded_job(Workers.Upload, %{key: "docs/dup-1.0.0.tar.gz"})
+
+      assert {:ok, 1} = AdminTasks.retry_oban_jobs(uniq: true)
+
+      assert Repo.aggregate(available_uploads(), :count) == 1
+      assert Repo.aggregate(discarded_uploads(), :count) == 1
+    end
+
+    test "without uniq retries every discarded job" do
+      insert_discarded_job(Workers.Upload, %{key: "docs/dup-1.0.0.tar.gz"})
+      insert_discarded_job(Workers.Upload, %{key: "docs/dup-1.0.0.tar.gz"})
+
+      assert {:ok, 2} = AdminTasks.retry_oban_jobs()
+
+      assert Repo.aggregate(available_uploads(), :count) == 2
+    end
+
     test "retries only the given worker" do
-      upload = insert_discarded_job(Workers.Upload, %{key: "docs/filtered-1.0.0.tar.gz"})
+      insert_discarded_job(Workers.Upload, %{key: "docs/filtered-1.0.0.tar.gz"})
       search = insert_discarded_job(Workers.Search, %{key: "docs/filtered-1.0.0.tar.gz"})
 
       assert {:ok, 1} = AdminTasks.retry_oban_jobs(worker: "Hexpm.Hexdocs.Workers.Upload")
 
-      assert Repo.get!(Oban.Job, upload.id).state == "available"
+      assert Repo.aggregate(available_uploads(), :count) == 1
       assert Repo.get!(Oban.Job, search.id).state == "discarded"
     end
-  end
 
-  defp insert_discarded_job(worker, args) do
-    {:ok, job} = Oban.insert(worker.new(args))
+    defp insert_discarded_job(worker, args) do
+      {:ok, job} = Oban.insert(worker.new(args))
 
-    {1, _} =
-      from(j in Oban.Job, where: j.id == ^job.id)
-      |> Repo.update_all(
-        set: [
-          state: "discarded",
-          attempt: job.max_attempts,
-          discarded_at: DateTime.utc_now()
-        ]
+      {1, _} =
+        from(j in Oban.Job, where: j.id == ^job.id)
+        |> Repo.update_all(
+          set: [
+            state: "discarded",
+            attempt: job.max_attempts,
+            discarded_at: DateTime.utc_now()
+          ]
+        )
+
+      job
+    end
+
+    defp available_uploads do
+      from(j in Oban.Job,
+        where: j.worker == "Hexpm.Hexdocs.Workers.Upload" and j.state == "available"
       )
+    end
 
-    job
+    defp discarded_uploads do
+      from(j in Oban.Job,
+        where: j.worker == "Hexpm.Hexdocs.Workers.Upload" and j.state == "discarded"
+      )
+    end
   end
 end

--- a/test/hexpm/diff/generator_test.exs
+++ b/test/hexpm/diff/generator_test.exs
@@ -25,7 +25,7 @@ defmodule Hexpm.Diff.GeneratorTest do
       "huge.bin" => String.duplicate("b", 200_001)
     })
 
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     assert :ok = Generator.generate(request)
 
     assert {:ok, metadata, pieces} = Hexpm.Diff.fetch(request)
@@ -67,13 +67,38 @@ defmodule Hexpm.Diff.GeneratorTest do
     assert Enum.map(repeated_pieces, & &1.key) == Enum.map(pieces, & &1.key)
   end
 
+  test "generates diffs for private repository releases from namespaced tarballs" do
+    repository = insert(:repository)
+    package = insert(:package, repository_id: repository.id, name: "generator_private")
+
+    insert_tarball_release(package, "1.0.0", %{"lib.ex" => "old = 1\n"},
+      repository: repository.name
+    )
+
+    insert_tarball_release(package, "2.0.0", %{"lib.ex" => "new = 2\n"},
+      repository: repository.name
+    )
+
+    {:ok, request} = Hexpm.Diff.prepare(repository.name, package.name, "1.0.0", "2.0.0", [])
+    assert :ok = perform_job(Worker, Hexpm.Diff.Request.to_args(request))
+
+    assert {:ok, metadata, pieces} = Hexpm.Diff.fetch(request)
+    assert metadata.files == ["lib.ex"]
+
+    assert Enum.all?(pieces, fn piece ->
+             String.starts_with?(piece.key, "repos/#{repository.name}/diffs/")
+           end)
+  end
+
   test "whitespace mode has a distinct cache and suppresses whitespace-only changes" do
     package = insert(:package, name: "generator_whitespace")
     insert_tarball_release(package, "1.0.0", %{"space.ex" => "value = 1\n"})
     insert_tarball_release(package, "2.0.0", %{"space.ex" => "value    =    1\n"})
 
-    {:ok, normal} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
-    {:ok, ignored} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", ignore_whitespace: true)
+    {:ok, normal} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
+
+    {:ok, ignored} =
+      Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", ignore_whitespace: true)
 
     assert :ok = Generator.generate(normal)
     assert {:ok, %{total_diffs: 1}, [_]} = Hexpm.Diff.fetch(normal)
@@ -88,7 +113,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     insert_tarball_release(package, "1.0.0", %{"huge.bin" => contents})
     insert_tarball_release(package, "2.0.0", %{"huge.bin" => contents})
 
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     assert :ok = Generator.generate(request)
     assert {:ok, %{total_diffs: 0, files_changed: 0}, []} = Hexpm.Diff.fetch(request)
   end
@@ -98,7 +123,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     insert_tarball_release(package, "1.0.0", %{"script" => {"same\n", 0o511}})
     insert_tarball_release(package, "2.0.0", %{"script" => {"same\n", 0o644}})
 
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     assert :ok = Generator.generate(request)
     assert {:ok, %{total_diffs: 1}, [piece]} = Hexpm.Diff.fetch(request)
     assert {:ok, {:diff, diff, _, _}} = Hexpm.Diff.fetch_piece(piece)
@@ -111,7 +136,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     insert_tarball_release(package, "1.0.0", %{"same" => "one"})
     insert_tarball_release(package, "2.0.0", %{"same" => "two"})
 
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     request = %{request | from_checksum: <<0::256>>}
 
     assert {:error, :checksum_mismatch} = Generator.generate(request)
@@ -123,7 +148,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     package = insert(:package, name: "generator_retry")
     insert_tarball_release(package, "1.0.0", %{"a.txt" => "old a", "b.txt" => "old b"})
     insert_tarball_release(package, "2.0.0", %{"a.txt" => "new a", "b.txt" => "new b"})
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     original_bucket = Application.fetch_env!(:hexpm, :diff_bucket)
     Application.put_env(:hexpm, :diff_bucket, {Hexpm.Diff.TestStore, "diff_bucket"})
@@ -155,7 +180,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     package = insert(:package, name: "generator_metadata_failure")
     insert_tarball_release(package, "1.0.0", %{"a.txt" => "old"})
     insert_tarball_release(package, "2.0.0", %{"a.txt" => "new"})
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     original_bucket = Application.fetch_env!(:hexpm, :diff_bucket)
     Application.put_env(:hexpm, :diff_bucket, {Hexpm.Diff.TestStore, "diff_bucket"})
@@ -201,7 +226,7 @@ defmodule Hexpm.Diff.GeneratorTest do
       []
     )
 
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     assert {:error, :tarball_not_found} = Generator.generate(request)
 
     assert {:discard, :tarball_not_found} =
@@ -235,7 +260,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     package = insert(:package, name: "generator_cache_version")
     insert_tarball_release(package, "1.0.0", %{"a" => "old"})
     insert_tarball_release(package, "2.0.0", %{"a" => "new"})
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     args = Hexpm.Diff.Request.to_args(request)
 
     original_cache_version = Application.fetch_env!(:hexpm, :diff_cache_version)
@@ -250,7 +275,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     package = insert(:package, name: "generator_worker")
     insert_tarball_release(package, "1.0.0", %{"a" => "old"})
     insert_tarball_release(package, "2.0.0", %{"a" => "new"})
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     assert :ok = perform_job(Worker, Hexpm.Diff.Request.to_args(request))
 
@@ -264,7 +289,7 @@ defmodule Hexpm.Diff.GeneratorTest do
     package = insert(:package, name: "generator_worker_discard")
     insert_tarball_release(package, "1.0.0", %{"a" => "old"})
     insert_tarball_release(package, "2.0.0", %{"a" => "new"})
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     stale_args =
       request
@@ -284,7 +309,7 @@ defmodule Hexpm.Diff.GeneratorTest do
       Hexpm.Store.put(:repo_bucket, "tarballs/#{package.name}-#{version}.tar", invalid, [])
     end
 
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     assert {:discard, {:invalid_tarball, _reason}} =
              perform_job(Worker, Hexpm.Diff.Request.to_args(request))

--- a/test/hexpm/diff_test.exs
+++ b/test/hexpm/diff_test.exs
@@ -12,7 +12,7 @@ defmodule Hexpm.DiffTest do
   end
 
   test "prepares canonical and legacy standalone cache hashes", %{package: package} do
-    assert {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    assert {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     assert request.package_record.id == package.id
     assert MapSet.new(request.versions) == MapSet.new(["1.0.0", "2.0.0"])
@@ -22,7 +22,7 @@ defmodule Hexpm.DiffTest do
     assert request.legacy_hash == :erlang.phash2({1, [<<2::256>>, <<1::256>>]})
 
     assert {:ok, whitespace} =
-             Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", ignore_whitespace: true)
+             Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", ignore_whitespace: true)
 
     assert whitespace.canonical_hash ==
              :erlang.phash2({{1, [<<1::256>>, <<2::256>>]}, [ignore_whitespace: true]})
@@ -31,7 +31,7 @@ defmodule Hexpm.DiffTest do
   end
 
   test "reads canonical cache objects before reversed legacy objects", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     legacy_metadata = %{total_diffs: 1, total_additions: 3, total_deletions: 2, files_changed: 1}
     legacy_piece = %{"type" => "too_large", "file" => "legacy.bin"}
 
@@ -66,7 +66,7 @@ defmodule Hexpm.DiffTest do
   end
 
   test "keeps standalone object names and raw JSON format", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     piece =
       Cache.put_piece!(request, 4, %{
@@ -92,8 +92,37 @@ defmodule Hexpm.DiffTest do
              "metadata/#{package.name}-1.0.0-2.0.0-#{request.canonical_hash}.json"
   end
 
+  test "namespaces private repository requests and cache objects" do
+    repository = insert(:repository)
+    package = insert(:package, repository_id: repository.id, name: "private_diff_cache")
+    insert(:release, package: package, version: "1.0.0", outer_checksum: <<1::256>>)
+    insert(:release, package: package, version: "2.0.0", outer_checksum: <<2::256>>)
+
+    assert {:ok, request} =
+             Hexpm.Diff.prepare(repository.name, package.name, "1.0.0", "2.0.0", [])
+
+    assert request.repository == repository.name
+    assert request.package_record.id == package.id
+
+    assert Cache.metadata_key(request, request.canonical_hash) ==
+             "repos/#{repository.name}/metadata/#{package.name}-1.0.0-2.0.0-#{request.canonical_hash}.json"
+
+    assert Cache.diff_key(request, request.canonical_hash, 0) ==
+             "repos/#{repository.name}/diffs/#{package.name}-1.0.0-2.0.0-#{request.canonical_hash}-diff-0.json"
+
+    args = Request.to_args(request)
+    assert args.repository == repository.name
+
+    args = args |> Jason.encode!() |> Jason.decode!()
+    assert {:ok, rebuilt} = Request.from_args(args)
+    assert rebuilt.repository == repository.name
+    assert rebuilt.canonical_hash == request.canonical_hash
+
+    assert {:error, :invalid_args} = Request.from_args(Map.delete(args, "repository"))
+  end
+
   test "reads optional file manifests and rejects malformed manifests", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     Cache.put_metadata!(request, %{
       total_diffs: 1,
@@ -126,43 +155,45 @@ defmodule Hexpm.DiffTest do
     insert(:release, package: private_package, version: "1.0.0")
 
     assert {:error, :package_not_found} =
-             Hexpm.Diff.prepare(private_package.name, "1.0.0", "2.0.0", [])
+             Hexpm.Diff.prepare("hexpm", private_package.name, "1.0.0", "2.0.0", [])
 
-    assert {:error, :package_not_found} = Hexpm.Diff.prepare("missing", "1.0.0", "2.0.0", [])
+    assert {:error, :package_not_found} =
+             Hexpm.Diff.prepare("hexpm", "missing", "1.0.0", "2.0.0", [])
 
     assert {:error, :release_not_found} =
-             Hexpm.Diff.prepare(package.name, "0.1.0", "2.0.0", [])
+             Hexpm.Diff.prepare("hexpm", package.name, "0.1.0", "2.0.0", [])
 
-    assert {:error, :invalid_version} = Hexpm.Diff.prepare(package.name, "bad", "2.0.0", [])
+    assert {:error, :invalid_version} =
+             Hexpm.Diff.prepare("hexpm", package.name, "bad", "2.0.0", [])
 
     assert {:error, :identical_versions} =
-             Hexpm.Diff.prepare(package.name, "1.0.0", "1.0.0", [])
+             Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "1.0.0", [])
   end
 
   test "blank target resolves to latest stable with unstable fallback", %{package: package} do
     insert(:release, package: package, version: "2.1.0-rc.1")
 
-    assert {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "", [])
+    assert {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "", [])
     assert request.to == "2.0.0"
 
     unstable = insert(:package, name: "unstable_only")
     insert(:release, package: unstable, version: "0.1.0-rc.1")
     insert(:release, package: unstable, version: "0.2.0-rc.1")
 
-    assert {:ok, request} = Hexpm.Diff.prepare(unstable.name, "0.1.0-rc.1", "", [])
+    assert {:ok, request} = Hexpm.Diff.prepare("hexpm", unstable.name, "0.1.0-rc.1", "", [])
     assert request.to == "0.2.0-rc.1"
   end
 
   test "rejects packages without releases" do
     package = insert(:package, name: "diff_without_releases")
-    assert {:error, :no_releases} = Hexpm.Diff.prepare(package.name, "1.0.0", "", [])
+    assert {:error, :no_releases} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "", [])
   end
 
   test "enqueues one incomplete job and includes all cache identity arguments", %{
     package: package,
     to: to
   } do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     jobs =
       1..4
@@ -180,7 +211,7 @@ defmodule Hexpm.DiffTest do
 
     replacement_checksum = <<3::256>>
     to |> Ecto.Changeset.change(outer_checksum: replacement_checksum) |> Repo.update!()
-    {:ok, replacement} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, replacement} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     assert {:ok, replacement_job} = Hexpm.Diff.enqueue(replacement)
     refute replacement_job.id == hd(jobs).id
 
@@ -188,15 +219,17 @@ defmodule Hexpm.DiffTest do
     Application.put_env(:hexpm, :diff_cache_version, old_cache_version + 1)
     on_exit(fn -> Application.put_env(:hexpm, :diff_cache_version, old_cache_version) end)
 
-    {:ok, recached} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, recached} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     assert {:ok, recached_job} = Hexpm.Diff.enqueue(recached)
     refute recached_job.id in [hd(jobs).id, replacement_job.id]
   end
 
-  test "bounds incomplete jobs and gives Diff work lower priority", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+  test "bounds incomplete jobs and prioritizes Diff work above background jobs", %{
+    package: package
+  } do
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
-    assert Ecto.Changeset.get_field(Worker.new(Request.to_args(request)), :priority) == 3
+    assert Ecto.Changeset.get_field(Worker.new(Request.to_args(request)), :priority) == 1
 
     for cache_version <- 100..119 do
       request
@@ -210,7 +243,7 @@ defmodule Hexpm.DiffTest do
   end
 
   test "serializes concurrent admission at the incomplete job limit", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     for cache_version <- 100..118 do
       request
@@ -245,7 +278,7 @@ defmodule Hexpm.DiffTest do
   end
 
   test "reports domain job states without exposing Oban to callers", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     {:ok, job} = Hexpm.Diff.enqueue(request)
 
     assert Hexpm.Diff.job_status(job) == :queued
@@ -267,7 +300,7 @@ defmodule Hexpm.DiffTest do
   end
 
   test "rejects malformed cache metadata and pieces", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     Hexpm.Store.put(
       :diff_bucket,

--- a/test/hexpm/preview/preview_test.exs
+++ b/test/hexpm/preview/preview_test.exs
@@ -4,36 +4,36 @@ defmodule Hexpm.PreviewTest do
   alias Hexpm.Preview
 
   test "source selects known files and rejects invalid paths" do
-    put_release("source_package", "1.0.0", [
+    put_release("hexpm", "source_package", "1.0.0", [
       {"mix.exs", "mix"},
       {"README.md", "readme"},
       {"lib/source.ex", "source"}
     ])
 
-    assert {:ok, source} = Preview.source("source_package", "1.0.0", "lib/source.ex")
+    assert {:ok, source} = Preview.source("hexpm", "source_package", "1.0.0", "lib/source.ex")
     assert source.filename == "lib/source.ex"
     assert source.contents == "source"
     assert source.type == :text
 
-    assert Preview.source("source_package", "1.0.0", "../other/file") == :error
+    assert Preview.source("hexpm", "source_package", "1.0.0", "../other/file") == :error
   end
 
   test "source reports binary and oversized files without returning their contents" do
-    put_release("special_files", "1.0.0", [
+    put_release("hexpm", "special_files", "1.0.0", [
       {"binary.bin", <<0xFF, 0xFE>>},
       {"large.txt", String.duplicate("x", 200_001)}
     ])
 
     assert {:ok, %{type: :binary, contents: nil}} =
-             Preview.source("special_files", "1.0.0", "binary.bin")
+             Preview.source("hexpm", "special_files", "1.0.0", "binary.bin")
 
     assert {:ok, %{type: {:too_large, 200_001}, contents: nil}} =
-             Preview.source("special_files", "1.0.0", "large.txt")
+             Preview.source("hexpm", "special_files", "1.0.0", "large.txt")
   end
 
   test "source and readme return error for missing data" do
-    assert Preview.source("missing", "1.0.0") == :error
-    assert Preview.readme("missing", "1.0.0") == :error
+    assert Preview.source("hexpm", "missing", "1.0.0") == :error
+    assert Preview.readme("hexpm", "missing", "1.0.0") == :error
 
     Hexpm.Store.put(
       :preview_bucket,
@@ -41,17 +41,17 @@ defmodule Hexpm.PreviewTest do
       Jason.encode!(["README.md"])
     )
 
-    assert Preview.source("incomplete", "1.0.0") == :error
-    assert Preview.readme("incomplete", "1.0.0") == :error
+    assert Preview.source("hexpm", "incomplete", "1.0.0") == :error
+    assert Preview.readme("hexpm", "incomplete", "1.0.0") == :error
   end
 
   test "readme uses the established filename priority" do
-    put_release("readme_package", "1.0.0", [
+    put_release("hexpm", "readme_package", "1.0.0", [
       {"readme.txt", "lower"},
       {"README.md", "preferred"}
     ])
 
-    assert Preview.readme("readme_package", "1.0.0") ==
+    assert Preview.readme("hexpm", "readme_package", "1.0.0") ==
              {:ok, "README.md", "preferred"}
   end
 
@@ -66,23 +66,76 @@ defmodule Hexpm.PreviewTest do
 
     for {files, expected} <- defaults do
       package = "default_#{Path.rootname(expected)}"
-      put_release(package, "1.0.0", Enum.map(files, &{&1, &1}))
+      put_release("hexpm", package, "1.0.0", Enum.map(files, &{&1, &1}))
 
-      assert {:ok, %{filename: ^expected}} = Preview.source(package, "1.0.0")
+      assert {:ok, %{filename: ^expected}} = Preview.source("hexpm", package, "1.0.0")
     end
   end
 
-  defp put_release(package, version, files) do
+  test "source, readme, and raw_file are scoped to the repository" do
+    put_release("acme", "scoped", "1.0.0", [
+      {"mix.exs", "private mix"},
+      {"README.md", "private readme"}
+    ])
+
+    assert {:ok, source} = Preview.source("acme", "scoped", "1.0.0", "mix.exs")
+    assert source.contents == "private mix"
+
+    assert Preview.readme("acme", "scoped", "1.0.0") == {:ok, "README.md", "private readme"}
+    assert Preview.raw_file("acme", "scoped", "1.0.0", "mix.exs") == {:ok, "private mix"}
+
+    assert Preview.source("hexpm", "scoped", "1.0.0", "mix.exs") == :error
+    assert Preview.readme("hexpm", "scoped", "1.0.0") == :error
+    assert Preview.raw_file("hexpm", "scoped", "1.0.0", "mix.exs") == :error
+  end
+
+  test "raw_file only serves files from the file list" do
+    put_release("hexpm", "raw_package", "1.0.0", [{"lib/raw.ex", "raw"}])
+
+    Hexpm.Store.put(
+      :preview_bucket,
+      "files/raw_package/1.0.0/unlisted.ex",
+      "unlisted"
+    )
+
+    assert Preview.raw_file("hexpm", "raw_package", "1.0.0", "lib/raw.ex") == {:ok, "raw"}
+    assert Preview.raw_file("hexpm", "raw_package", "1.0.0", "unlisted.ex") == :error
+    assert Preview.raw_file("hexpm", "raw_package", "1.0.0", "../secrets") == :error
+  end
+
+  test "surrogate keys are namespaced per repository" do
+    assert Hexpm.Preview.Bucket.surrogate_keys("hexpm", "phoenix", "1.0.0") ==
+             ["preview/package/phoenix", "preview/package/phoenix/version/1.0.0"]
+
+    assert Hexpm.Preview.Bucket.surrogate_keys("acme", "phoenix", "1.0.0") ==
+             ["preview/package/acme-phoenix", "preview/package/acme-phoenix/version/1.0.0"]
+  end
+
+  test "get_latest_version is scoped to the repository" do
+    Hexpm.Store.put(:preview_bucket, "latest_versions/scoped", "1.0.0")
+    Hexpm.Store.put(:preview_bucket, "repos/acme/latest_versions/scoped", "2.0.0")
+
+    assert Preview.get_latest_version("hexpm", "scoped") == "1.0.0"
+    assert Preview.get_latest_version("acme", "scoped") == "2.0.0"
+    assert Preview.get_latest_version("other", "scoped") == nil
+  end
+
+  defp put_release(repository, package, version, files) do
+    prefix = if repository == "hexpm", do: "", else: "repos/#{repository}/"
     filenames = Enum.map(files, &elem(&1, 0))
 
     Hexpm.Store.put(
       :preview_bucket,
-      "file_lists/#{package}-#{version}.json",
+      "#{prefix}file_lists/#{package}-#{version}.json",
       Jason.encode!(filenames)
     )
 
     for {filename, contents} <- files do
-      Hexpm.Store.put(:preview_bucket, "files/#{package}/#{version}/#{filename}", contents)
+      Hexpm.Store.put(
+        :preview_bucket,
+        "#{prefix}files/#{package}/#{version}/#{filename}",
+        contents
+      )
     end
   end
 end

--- a/test/hexpm/preview/queue_test.exs
+++ b/test/hexpm/preview/queue_test.exs
@@ -99,8 +99,22 @@ defmodule Hexpm.Preview.QueueTest do
     assert all_enqueued() == []
   end
 
+  test "inserts create and removal jobs for private repository keys" do
+    key = "repos/acme/tarballs/demo-1.0.0.tar"
+
+    assert %{status: :ok} =
+             handle(%{"Records" => [created("repos%2Facme%2Ftarballs%2Fdemo-1.0.0.tar")]})
+
+    assert_enqueued(worker: Workers.Upload, args: %{key: key, generation: "0001"})
+
+    assert %{status: :ok} = handle(%{"Records" => [removed(key)]})
+    assert_enqueued(worker: Workers.Delete, args: %{key: key, generation: "0001"})
+  end
+
   test "acknowledges unrelated object keys without inserting jobs" do
     assert %{status: :ok} = handle(%{"Records" => [created("docs/demo-1.0.0.tar.gz")]})
+    assert %{status: :ok} = handle(%{"Records" => [created("repos/acme/docs/demo-1.0.0.tar.gz")]})
+    assert %{status: :ok} = handle(%{"Records" => [created("repos/acme/demo-1.0.0.tar")]})
     assert all_enqueued() == []
   end
 

--- a/test/hexpm/preview/workers_test.exs
+++ b/test/hexpm/preview/workers_test.exs
@@ -121,9 +121,55 @@ defmodule Hexpm.Preview.WorkersTest do
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/new.txt") == "new"
   end
 
-  test "upload ignores private repository releases and removes stale public Preview files" do
+  test "upload builds private repository previews under the repository prefix" do
     repository = insert(:repository)
     package = insert(:package, repository_id: repository.id, name: "private_preview")
+    release = insert(:release, package: package, version: "1.0.0")
+    key = "repos/#{repository.name}/tarballs/#{package.name}-#{release.version}.tar"
+    put_tarball(key, package.name, to_string(release.version), [{"README.md", "private"}])
+
+    assert :ok = perform_job(Workers.Upload, %{key: key})
+
+    prefix = "repos/#{repository.name}/"
+
+    assert Jason.decode!(
+             Hexpm.Store.get(:preview_bucket, "#{prefix}file_lists/#{package.name}-1.0.0.json")
+           ) == ["README.md"]
+
+    assert Hexpm.Store.get(:preview_bucket, "#{prefix}files/#{package.name}/1.0.0/README.md") ==
+             "private"
+
+    assert Hexpm.Store.get(:preview_bucket, "#{prefix}latest_versions/#{package.name}") == "1.0.0"
+
+    assert Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json") == nil
+    assert Hexpm.Store.get(:preview_bucket, "latest_versions/#{package.name}") == nil
+  end
+
+  test "delete removes private repository previews under the repository prefix" do
+    repository = insert(:repository)
+    package = insert(:package, repository_id: repository.id, name: "private_delete_preview")
+    release = insert(:release, package: package, version: "1.0.0")
+    key = "repos/#{repository.name}/tarballs/#{package.name}-#{release.version}.tar"
+    put_tarball(key, package.name, to_string(release.version), [{"README.md", "private"}])
+    assert :ok = perform_job(Workers.Upload, %{key: key})
+    Ecto.Changeset.change(release) |> Repo.delete!()
+
+    assert :ok = perform_job(Workers.Delete, %{key: key})
+
+    prefix = "repos/#{repository.name}/"
+
+    assert Hexpm.Store.get(:preview_bucket, "#{prefix}file_lists/#{package.name}-1.0.0.json") ==
+             nil
+
+    assert Hexpm.Store.get(:preview_bucket, "#{prefix}files/#{package.name}/1.0.0/README.md") ==
+             nil
+
+    assert Hexpm.Store.get(:preview_bucket, "#{prefix}latest_versions/#{package.name}") == nil
+  end
+
+  test "upload with a public key for a private-only package removes stale public Preview files" do
+    repository = insert(:repository)
+    package = insert(:package, repository_id: repository.id, name: "private_stale_preview")
     release = insert(:release, package: package, version: "1.0.0")
     key = "tarballs/#{package.name}-#{release.version}.tar"
     file_key = "files/#{package.name}/#{release.version}/README.md"

--- a/test/hexpm_web/controllers/diff_controller_test.exs
+++ b/test/hexpm_web/controllers/diff_controller_test.exs
@@ -24,6 +24,42 @@ defmodule HexpmWeb.DiffControllerTest do
     refute html =~ "invalid"
   end
 
+  test "renders a repo-scoped link for a repo-qualified comparison" do
+    conn = get(build_conn(), "/diffs?diffs[]=acme%2Facme_core%3A1.0.0%3A1.1.0")
+    html = html_response(conn, 200)
+
+    assert html =~ "/diff/acme/acme_core/1.0.0..1.1.0"
+    assert html =~ "/packages/acme/acme_core/1.1.0"
+    assert html =~ "acme/acme_core"
+  end
+
+  test "renders both public and repo-scoped links in a mixed list" do
+    conn =
+      get(
+        build_conn(),
+        "/diffs?diffs[]=acme%2Facme_core%3A1.0.0%3A1.1.0&diffs[]=decimal%3A2.1.1%3A2.3.0"
+      )
+
+    html = html_response(conn, 200)
+
+    assert html =~ "/diff/acme/acme_core/1.0.0..1.1.0"
+    assert html =~ "/diff/decimal/2.1.1..2.3.0"
+  end
+
+  test "skips repo-qualified comparisons with an empty package or extra segments" do
+    conn =
+      get(
+        build_conn(),
+        "/diffs?diffs[]=acme%2F%3A1.0.0%3A1.1.0&diffs[]=a%2Fb%2Fc%3A1.0.0%3A1.1.0" <>
+          "&diffs[]=ecto%3A3.0.0%3A3.1.0"
+      )
+
+    html = html_response(conn, 200)
+
+    assert html =~ "/diff/ecto/3.0.0..3.1.0"
+    refute html =~ "1.0.0..1.1.0"
+  end
+
   test "shows an empty state without comparisons" do
     conn = get(build_conn(), "/diffs")
 

--- a/test/hexpm_web/controllers/diff_redirect_controller_test.exs
+++ b/test/hexpm_web/controllers/diff_redirect_controller_test.exs
@@ -36,6 +36,22 @@ defmodule HexpmWeb.DiffRedirectControllerTest do
              "http://localhost:5000/diff/ecto/3.0.0..3.1.0?w=1"
   end
 
+  test "redirects a repo-qualified single comparison to its repo-scoped diff" do
+    conn = request("/diffs?diffs[]=acme%2Facme_core%3A1.0.0%3A1.1.0")
+
+    assert redirected_to(conn, 301) ==
+             "http://localhost:5000/diff/acme/acme_core/1.0.0..1.1.0"
+  end
+
+  test "preserves repo qualification when redirecting a comparison list" do
+    conn =
+      request("/diffs?diffs[]=acme%2Facme_core%3A1.0.0%3A1.1.0&diffs[]=plug%3A1.0.0%3A1.1.0")
+
+    assert redirected_to(conn, 301) ==
+             "http://localhost:5000/diffs?" <>
+               "diffs%5B%5D=acme%2Facme_core%3A1.0.0%3A1.1.0&diffs%5B%5D=plug%3A1.0.0%3A1.1.0"
+  end
+
   test "redirects unsupported or malformed Diff paths to packages" do
     assert request("/diffs?diffs[]=invalid") |> redirected_to(301) ==
              "http://localhost:5000/packages"

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -367,8 +367,19 @@ defmodule HexpmWeb.PackageControllerTest do
         |> test_login(user1)
         |> get("/packages/#{repository1.name}/#{package3.name}")
 
-      assert response(conn, 200) =~
+      body = response(conn, 200)
+
+      assert body =~
                escape(~s({:#{package3.name}, "~> 0.0.1", organization: "#{repository1.name}"}))
+
+      assert [readme_url] =
+               body
+               |> Floki.parse_document!()
+               |> Floki.attribute("#readme-frame", "src")
+
+      assert readme_url =~ "/#{repository1.name}/#{package3.name}/0.0.1?token="
+      [_url, token] = String.split(readme_url, "token=")
+      assert :ok = HexpmWeb.ReadmeToken.verify(token, repository1.name, package3.name, "0.0.1")
     end
 
     test "dont show private package", %{

--- a/test/hexpm_web/controllers/package_versions_controller_test.exs
+++ b/test/hexpm_web/controllers/package_versions_controller_test.exs
@@ -95,7 +95,18 @@ defmodule HexpmWeb.PackageVersionsControllerTest do
       assert result =~ "0.1.0"
       assert result =~ "1.0.0"
       assert result =~ package2.name
-      refute result =~ ~s(id="compare-versions")
+
+      assert {:ok, document} = Floki.parse_document(result)
+
+      assert Floki.attribute(document, "#compare-versions", "href") == [
+               "/diff/#{repository1.name}/#{package2.name}/0.1.0..1.0.0"
+             ]
+
+      assert [_ | _] =
+               Floki.find(
+                 document,
+                 ~s(a[href="/packages/#{repository1.name}/#{package2.name}/1.0.0/files"])
+               )
     end
 
     test "hides compare action when the package has one version" do

--- a/test/hexpm_web/controllers/preview_image_controller_test.exs
+++ b/test/hexpm_web/controllers/preview_image_controller_test.exs
@@ -1,0 +1,110 @@
+defmodule HexpmWeb.PreviewImageControllerTest do
+  use HexpmWeb.ConnCase, async: true
+
+  setup do
+    repository = insert(:repository)
+    package = insert(:package, repository_id: repository.id, name: "private_image")
+    insert(:release, package: package, version: "1.0.0")
+
+    files = [
+      {"assets/logo.png", <<0x89, "PNG", 0x0D>>},
+      {"assets/diagram.svg", "<svg xmlns=\"http://www.w3.org/2000/svg\"></svg>"},
+      {"README.md", "# readme"}
+    ]
+
+    prefix = "repos/#{repository.name}/"
+
+    Hexpm.Store.put(
+      :preview_bucket,
+      "#{prefix}file_lists/#{package.name}-1.0.0.json",
+      Jason.encode!(Enum.map(files, &elem(&1, 0)))
+    )
+
+    for {filename, contents} <- files do
+      Hexpm.Store.put(
+        :preview_bucket,
+        "#{prefix}files/#{package.name}/1.0.0/#{filename}",
+        contents
+      )
+    end
+
+    %{repository: repository, package: package}
+  end
+
+  defp token(repository, package, version \\ "1.0.0") do
+    HexpmWeb.ReadmeToken.sign(repository.name, package.name, version)
+  end
+
+  test "serves an image with its real content type and hardened headers", %{
+    repository: repository,
+    package: package
+  } do
+    conn =
+      get(
+        build_conn(),
+        "/packages/#{repository.name}/#{package.name}/1.0.0/readme-image/assets/logo.png?token=#{token(repository, package)}"
+      )
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-type") == ["image/png"]
+    assert get_resp_header(conn, "content-security-policy") == ["sandbox; default-src 'none'"]
+    assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+    assert get_resp_header(conn, "cache-control") == ["private, no-store"]
+  end
+
+  test "serves svg as image/svg+xml", %{repository: repository, package: package} do
+    conn =
+      get(
+        build_conn(),
+        "/packages/#{repository.name}/#{package.name}/1.0.0/readme-image/assets/diagram.svg?token=#{token(repository, package)}"
+      )
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-type") == ["image/svg+xml"]
+    assert get_resp_header(conn, "content-security-policy") == ["sandbox; default-src 'none'"]
+  end
+
+  test "requires no session and works anonymously with a valid token", %{
+    repository: repository,
+    package: package
+  } do
+    # No test_login — the image proxy fetches anonymously.
+    conn =
+      get(
+        build_conn(),
+        "/packages/#{repository.name}/#{package.name}/1.0.0/readme-image/assets/logo.png?token=#{token(repository, package)}"
+      )
+
+    assert conn.status == 200
+  end
+
+  test "404s for missing, mismatched, and expired tokens", %{
+    repository: repository,
+    package: package
+  } do
+    path = "/packages/#{repository.name}/#{package.name}/1.0.0/readme-image/assets/logo.png"
+
+    assert get(build_conn(), path).status == 404
+
+    other = HexpmWeb.ReadmeToken.sign(repository.name, "other_package", "1.0.0")
+    assert get(build_conn(), "#{path}?token=#{other}").status == 404
+
+    wrong_version = HexpmWeb.ReadmeToken.sign(repository.name, package.name, "2.0.0")
+    assert get(build_conn(), "#{path}?token=#{wrong_version}").status == 404
+  end
+
+  test "404s for non-image extensions and files not in the list", %{
+    repository: repository,
+    package: package
+  } do
+    readme_path =
+      "/packages/#{repository.name}/#{package.name}/1.0.0/readme-image/README.md?token=#{token(repository, package)}"
+
+    assert get(build_conn(), readme_path).status == 404
+
+    missing_path =
+      "/packages/#{repository.name}/#{package.name}/1.0.0/readme-image/assets/missing.png?token=#{token(repository, package)}"
+
+    assert get(build_conn(), missing_path).status == 404
+  end
+end

--- a/test/hexpm_web/controllers/preview_raw_controller_test.exs
+++ b/test/hexpm_web/controllers/preview_raw_controller_test.exs
@@ -1,0 +1,116 @@
+defmodule HexpmWeb.PreviewRawControllerTest do
+  use HexpmWeb.ConnCase, async: true
+
+  setup do
+    repository = insert(:repository)
+    user = insert(:user)
+    insert(:organization_user, user: user, organization: repository.organization)
+    package = insert(:package, repository_id: repository.id, name: "private_raw")
+    insert(:release, package: package, version: "1.0.0")
+
+    files = [
+      {"lib/raw.ex", "defmodule Raw do\nend\n"},
+      {"index.html", "<script>alert(1)</script>"},
+      {"binary.bin", <<0xFF, 0xFE, 0x00>>}
+    ]
+
+    prefix = "repos/#{repository.name}/"
+
+    Hexpm.Store.put(
+      :preview_bucket,
+      "#{prefix}file_lists/#{package.name}-1.0.0.json",
+      Jason.encode!(Enum.map(files, &elem(&1, 0)))
+    )
+
+    for {filename, contents} <- files do
+      Hexpm.Store.put(
+        :preview_bucket,
+        "#{prefix}files/#{package.name}/1.0.0/#{filename}",
+        contents
+      )
+    end
+
+    %{repository: repository, package: package, user: user}
+  end
+
+  test "serves text files as inline plain text with hardened headers", %{
+    repository: repository,
+    package: package,
+    user: user
+  } do
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> get("/packages/#{repository.name}/#{package.name}/1.0.0/raw/lib/raw.ex")
+
+    assert conn.status == 200
+    assert conn.resp_body == "defmodule Raw do\nend\n"
+    assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+    assert get_resp_header(conn, "content-disposition") == [~s(inline; filename="raw.ex")]
+    assert get_resp_header(conn, "x-content-type-options") == ["nosniff"]
+    assert get_resp_header(conn, "content-security-policy") == ["sandbox; default-src 'none'"]
+    assert get_resp_header(conn, "cache-control") == ["private, no-store"]
+  end
+
+  test "never serves HTML files with an HTML content type", %{
+    repository: repository,
+    package: package,
+    user: user
+  } do
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> get("/packages/#{repository.name}/#{package.name}/1.0.0/raw/index.html")
+
+    assert conn.status == 200
+    assert get_resp_header(conn, "content-type") == ["text/plain; charset=utf-8"]
+  end
+
+  test "serves binary files as octet-stream attachments", %{
+    repository: repository,
+    package: package,
+    user: user
+  } do
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> get("/packages/#{repository.name}/#{package.name}/1.0.0/raw/binary.bin")
+
+    assert conn.status == 200
+    assert [content_type] = get_resp_header(conn, "content-type")
+    assert content_type =~ "application/octet-stream"
+    assert get_resp_header(conn, "content-disposition") == [~s(attachment; filename="binary.bin")]
+  end
+
+  test "returns 404 for non-members, anonymous users, and unknown files", %{
+    repository: repository,
+    package: package,
+    user: user
+  } do
+    other_user = insert(:user)
+
+    conn = get(build_conn(), "/packages/#{repository.name}/#{package.name}/1.0.0/raw/lib/raw.ex")
+    assert conn.status == 404
+
+    conn =
+      build_conn()
+      |> test_login(other_user)
+      |> get("/packages/#{repository.name}/#{package.name}/1.0.0/raw/lib/raw.ex")
+
+    assert conn.status == 404
+
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> get("/packages/#{repository.name}/#{package.name}/1.0.0/raw/unlisted.ex")
+
+    assert conn.status == 404
+
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> get("/packages/#{repository.name}/#{package.name}/2.0.0/raw/lib/raw.ex")
+
+    assert conn.status == 404
+  end
+end

--- a/test/hexpm_web/controllers/readme_controller_test.exs
+++ b/test/hexpm_web/controllers/readme_controller_test.exs
@@ -32,6 +32,82 @@ defmodule HexpmWeb.ReadmeControllerTest do
     )
   end
 
+  describe "show/2 for private packages" do
+    setup do
+      repository = insert(:repository)
+      package = insert(:package, repository_id: repository.id, name: "private_readme")
+
+      insert(
+        :release,
+        package: package,
+        version: "1.0.0",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      Hexpm.Store.put(
+        :preview_bucket,
+        "repos/#{repository.name}/file_lists/#{package.name}-1.0.0.json",
+        Jason.encode!(["README.md"])
+      )
+
+      Hexpm.Store.put(
+        :preview_bucket,
+        "repos/#{repository.name}/files/#{package.name}/1.0.0/README.md",
+        "# Private Package"
+      )
+
+      %{repository: repository, private_package: package}
+    end
+
+    test "renders README with a valid token", %{
+      repository: repository,
+      private_package: package
+    } do
+      token = HexpmWeb.ReadmeToken.sign(repository.name, package.name, "1.0.0")
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{repository.name}/#{package.name}/1.0.0?token=#{token}")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Private Package"
+      assert get_resp_header(conn, "cache-control") == ["private, no-store"]
+    end
+
+    test "shows no README for missing, mismatched, or expired tokens", %{
+      repository: repository,
+      private_package: package
+    } do
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{repository.name}/#{package.name}/1.0.0")
+
+      assert conn.status == 404
+
+      other_token = HexpmWeb.ReadmeToken.sign(repository.name, "other_package", "1.0.0")
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{repository.name}/#{package.name}/1.0.0?token=#{other_token}")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+      assert get_resp_header(conn, "cache-control") == ["private, no-store"]
+
+      version_token = HexpmWeb.ReadmeToken.sign(repository.name, package.name, "2.0.0")
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{repository.name}/#{package.name}/1.0.0?token=#{version_token}")
+
+      assert conn.resp_body =~ "readme-not-found"
+    end
+  end
+
   describe "show/2" do
     test "renders README for package with version", %{package: package} do
       mock_file_list_and_readme(

--- a/test/hexpm_web/live/diff_live_test.exs
+++ b/test/hexpm_web/live/diff_live_test.exs
@@ -26,7 +26,7 @@ defmodule HexpmWeb.DiffLiveTest do
   test "cache hit renders five pieces initially and lazy-loads the next batch", %{
     package: package
   } do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "7.0.0", [])
     put_ready_cache(request, 6)
 
     {:ok, view, html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
@@ -75,7 +75,7 @@ defmodule HexpmWeb.DiffLiveTest do
   test "changed-file selector filters and loads only the selected unloaded file", %{
     package: package
   } do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "7.0.0", [])
     put_ready_cache(request, 7)
 
     {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
@@ -103,7 +103,7 @@ defmodule HexpmWeb.DiffLiveTest do
   test "sidebar jumps create ordered gaps that load toward the selected file", %{
     package: package
   } do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "7.0.0", [])
     put_ready_cache(request, 12)
 
     {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
@@ -132,7 +132,7 @@ defmodule HexpmWeb.DiffLiveTest do
   test "backward gaps load at most five files nearest the selected file", %{
     package: package
   } do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "7.0.0", [])
     put_ready_cache(request, 12)
 
     {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
@@ -153,7 +153,7 @@ defmodule HexpmWeb.DiffLiveTest do
   end
 
   test "stale and invalid gap events do not load pieces", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "7.0.0", [])
     put_ready_cache(request, 7)
 
     {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..7.0.0")
@@ -179,7 +179,7 @@ defmodule HexpmWeb.DiffLiveTest do
       Application.delete_env(:hexpm, :diff_test_store_get)
     end)
 
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "7.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "7.0.0", [])
 
     for index <- 0..6 do
       Cache.put_piece!(request, index, %{type: "too_large", file: "legacy-#{index}.bin"})
@@ -219,7 +219,7 @@ defmodule HexpmWeb.DiffLiveTest do
   test "cached patches are highlighted through Lumis with stable line anchors", %{
     package: package
   } do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     Cache.put_piece!(request, 0, %{
       "diff" => """
@@ -252,7 +252,7 @@ defmodule HexpmWeb.DiffLiveTest do
   end
 
   test "mode-only changes render as changed files", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     Cache.put_piece!(request, 0, %{
       "diff" => """
@@ -278,7 +278,7 @@ defmodule HexpmWeb.DiffLiveTest do
   end
 
   test "missing cache pieces render an in-page file error", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
 
     Cache.put_metadata!(request, %{
       total_diffs: 1,
@@ -472,7 +472,7 @@ defmodule HexpmWeb.DiffLiveTest do
     path = "/diff/#{package.name}/3.0.0..4.0.0"
     {:ok, view, _html} = live(build_conn(), path)
     job = Repo.one!(from job in Oban.Job, where: job.worker == "Hexpm.Diff.Worker")
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "3.0.0", "4.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "3.0.0", "4.0.0", [])
     put_ready_cache(request, 1)
     set_job_state(job, "completed")
 
@@ -488,7 +488,7 @@ defmodule HexpmWeb.DiffLiveTest do
          package: package
        } do
     {:ok, request} =
-      Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", ignore_whitespace: true)
+      Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", ignore_whitespace: true)
 
     put_ready_cache(request, 0)
     {:ok, view, html} = live(build_conn(), "/diff/#{package.name}/1.0.0..2.0.0?w=1")
@@ -510,7 +510,7 @@ defmodule HexpmWeb.DiffLiveTest do
   end
 
   test "selector rejects a crafted identical pair", %{package: package} do
-    {:ok, request} = Hexpm.Diff.prepare(package.name, "1.0.0", "2.0.0", [])
+    {:ok, request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "2.0.0", [])
     put_ready_cache(request, 0)
     {:ok, view, _html} = live(build_conn(), "/diff/#{package.name}/1.0.0..2.0.0")
 
@@ -525,7 +525,7 @@ defmodule HexpmWeb.DiffLiveTest do
   test "blank target resolves latest and invalid requests render in-page errors", %{
     package: package
   } do
-    {:ok, latest_request} = Hexpm.Diff.prepare(package.name, "1.0.0", "", [])
+    {:ok, latest_request} = Hexpm.Diff.prepare("hexpm", package.name, "1.0.0", "", [])
     put_ready_cache(latest_request, 0)
 
     {:ok, _view, html} = live(build_conn(), "/diff/#{package.name}/1.0.0..")
@@ -557,6 +557,73 @@ defmodule HexpmWeb.DiffLiveTest do
 
     assert html =~ ~s(href="/diff/#{package.name}/1.0.0..2.0.0")
     refute html =~ "http://localhost:5004/diff/"
+  end
+
+  test "renders private package diffs for organization members" do
+    %{repository: repository, package: package, user: user} =
+      private_package("private_live_diff")
+
+    {:ok, request} = Hexpm.Diff.prepare(repository.name, package.name, "1.0.0", "2.0.0", [])
+    put_ready_cache(request, 2)
+
+    {:ok, _view, html} =
+      build_conn()
+      |> test_login(user)
+      |> live("/diff/#{repository.name}/#{package.name}/1.0.0..2.0.0")
+
+    assert html =~ "#{package.name} 1.0.0..2.0.0 diff"
+    assert html =~ ~s(href="/diff/#{repository.name}/#{package.name}/1.0.0..2.0.0?w=1")
+  end
+
+  test "private package diffs are not found for non-members and anonymous users" do
+    %{repository: repository, package: package} = private_package("private_denied_diff")
+    other_user = insert(:user)
+
+    {:ok, _view, html} =
+      live(build_conn(), "/diff/#{repository.name}/#{package.name}/1.0.0..2.0.0")
+
+    assert html =~ "Package not found"
+
+    {:ok, _view, html} =
+      build_conn()
+      |> test_login(other_user)
+      |> live("/diff/#{repository.name}/#{package.name}/1.0.0..2.0.0")
+
+    assert html =~ "Package not found"
+
+    {:ok, _view, html} = live(build_conn(), "/diff/#{package.name}/1.0.0..2.0.0")
+    assert html =~ "Package not found"
+  end
+
+  test "private package version links use repository-scoped diff and files routes" do
+    %{repository: repository, package: package, user: user} =
+      private_package("private_versions_diff")
+
+    html =
+      build_conn()
+      |> test_login(user)
+      |> get("/packages/#{repository.name}/#{package.name}/versions")
+      |> response(200)
+
+    assert html =~ ~s(href="/diff/#{repository.name}/#{package.name}/1.0.0..2.0.0")
+    assert html =~ ~s(href="/packages/#{repository.name}/#{package.name}/2.0.0/files")
+  end
+
+  defp private_package(name) do
+    repository = insert(:repository)
+    user = insert(:user)
+    insert(:organization_user, user: user, organization: repository.organization)
+    package = insert(:package, repository_id: repository.id, name: name)
+
+    for major <- 1..2 do
+      insert(:release,
+        package: package,
+        version: "#{major}.0.0",
+        outer_checksum: :crypto.hash(:sha256, "#{name}-#{major}")
+      )
+    end
+
+    %{repository: repository, package: package, user: user}
   end
 
   defp put_ready_cache(request, count) do

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -172,6 +172,75 @@ defmodule HexpmWeb.PreviewLiveTest do
     end
   end
 
+  test "renders private package files for organization members", %{conn: conn} do
+    %{repository: repository, user: user} = private_release("private_live_preview", "1.0.0")
+
+    {:ok, view, _html} =
+      conn
+      |> test_login(user)
+      |> live("/packages/#{repository.name}/private_live_preview/1.0.0/files/mix.exs")
+
+    assert has_element?(view, "h2", "mix.exs")
+
+    assert has_element?(
+             view,
+             ~s(a[href="/packages/#{repository.name}/private_live_preview/1.0.0/files/lib/private.ex"]),
+             "private.ex"
+           )
+
+    assert has_element?(
+             view,
+             ~s(a[href="/packages/#{repository.name}/private_live_preview/1.0.0/raw/mix.exs"]),
+             "Raw"
+           )
+  end
+
+  test "returns 404 for private packages to non-members and anonymous users", %{conn: conn} do
+    %{repository: repository} = private_release("private_denied_preview", "1.0.0")
+    other_user = insert(:user)
+
+    assert_raise HexpmWeb.PreviewLive.NotFoundError, fn ->
+      live(conn, "/packages/#{repository.name}/private_denied_preview/1.0.0/files")
+    end
+
+    assert_raise HexpmWeb.PreviewLive.NotFoundError, fn ->
+      conn
+      |> test_login(other_user)
+      |> live("/packages/#{repository.name}/private_denied_preview/1.0.0/files")
+    end
+
+    assert_raise HexpmWeb.PreviewLive.NotFoundError, fn ->
+      live(conn, "/packages/private_denied_preview/1.0.0/files")
+    end
+  end
+
+  defp private_release(package_name, version) do
+    repository = insert(:repository)
+    user = insert(:user)
+    insert(:organization_user, user: user, organization: repository.organization)
+    package = insert(:package, repository_id: repository.id, name: package_name)
+    insert(:release, package: package, version: version)
+
+    files = [{"mix.exs", "mix"}, {"lib/private.ex", "private"}]
+    prefix = "repos/#{repository.name}/"
+
+    Hexpm.Store.put(
+      :preview_bucket,
+      "#{prefix}file_lists/#{package_name}-#{version}.json",
+      Jason.encode!(Enum.map(files, &elem(&1, 0)))
+    )
+
+    for {filename, contents} <- files do
+      Hexpm.Store.put(
+        :preview_bucket,
+        "#{prefix}files/#{package_name}/#{version}/#{filename}",
+        contents
+      )
+    end
+
+    %{repository: repository, user: user, package: package}
+  end
+
   defp put_release(package_name, version, files, package \\ nil) do
     package = package || insert(:package, name: package_name)
     insert(:release, package: package, version: version)

--- a/test/hexpm_web/readme/renderer_test.exs
+++ b/test/hexpm_web/readme/renderer_test.exs
@@ -4,7 +4,7 @@ defmodule HexpmWeb.Readme.RendererTest do
   alias HexpmWeb.Readme.Renderer
 
   defp render(content) do
-    Renderer.render("README.md", content, "my_package", "1.0.0")
+    Renderer.render("hexpm", "README.md", content, "my_package", "1.0.0")
   end
 
   test "author fragment links resolve to the anchored heading id" do
@@ -57,7 +57,7 @@ defmodule HexpmWeb.Readme.RendererTest do
   test "invalid UTF-8 bytes in plain text readmes are replaced" do
     content = "caf\xE9 au lait"
 
-    result = Renderer.render("README", content, "my_package", "1.0.0")
+    result = Renderer.render("hexpm", "README", content, "my_package", "1.0.0")
 
     assert result =~ "<pre>caf� au lait</pre>"
   end

--- a/test/hexpm_web/readme/url_rewriter_test.exs
+++ b/test/hexpm_web/readme/url_rewriter_test.exs
@@ -6,7 +6,7 @@ defmodule HexpmWeb.Readme.URLRewriterTest do
   defp rewrite(html, package, version) do
     html
     |> Floki.parse_document!()
-    |> URLRewriter.rewrite(package, version)
+    |> URLRewriter.rewrite("hexpm", package, version)
     |> Floki.raw_html()
   end
 
@@ -33,6 +33,48 @@ defmodule HexpmWeb.Readme.URLRewriterTest do
       result = rewrite(html, "my_package", "1.0.0")
 
       assert result =~ "http://localhost:5000/preview/my_package/1.0.0/CHANGELOG.md"
+    end
+
+    test "resolves private package relative links to the raw endpoint" do
+      html = ~s[<a href="CHANGELOG.md">Changelog</a>]
+
+      result =
+        html
+        |> Floki.parse_document!()
+        |> URLRewriter.rewrite("acme", "my_package", "1.0.0")
+        |> Floki.raw_html()
+
+      assert result =~
+               HexpmWeb.Endpoint.url() <> "/packages/acme/my_package/1.0.0/raw/CHANGELOG.md"
+    end
+
+    test "resolves private package relative images to a tokenized image endpoint via the proxy" do
+      html = ~s[<img src="docs/logo.png">]
+
+      result =
+        html
+        |> Floki.parse_document!()
+        |> URLRewriter.rewrite("acme", "my_package", "1.0.0")
+        |> Floki.raw_html()
+
+      [proxied] =
+        result
+        |> Floki.parse_fragment!()
+        |> Floki.attribute("img", "src")
+
+      assert String.starts_with?(proxied, Application.fetch_env!(:hexpm, :img_url) <> "/fetch/")
+
+      encoded = proxied |> String.split("/") |> List.last()
+      decoded = Base.decode16!(encoded, case: :lower)
+
+      assert String.starts_with?(
+               decoded,
+               HexpmWeb.Endpoint.url() <>
+                 "/packages/acme/my_package/1.0.0/readme-image/docs/logo.png?token="
+             )
+
+      token = decoded |> String.split("token=") |> List.last()
+      assert HexpmWeb.ReadmeToken.verify(token, "acme", "my_package", "1.0.0") == :ok
     end
 
     test "prefixes fragment-only links with user-content-" do

--- a/test/support/diff_helpers.ex
+++ b/test/support/diff_helpers.ex
@@ -1,5 +1,6 @@
 defmodule Hexpm.DiffHelpers do
-  def insert_tarball_release(package, version, files) do
+  def insert_tarball_release(package, version, files, opts \\ []) do
+    repository = Keyword.get(opts, :repository, "hexpm")
     root = Hexpm.TmpDir.tmp_dir("diff-fixture")
 
     tarball_files =
@@ -35,7 +36,7 @@ defmodule Hexpm.DiffHelpers do
 
     Hexpm.Store.put(
       :repo_bucket,
-      "tarballs/#{package.name}-#{version}.tar",
+      "#{repo_prefix(repository)}tarballs/#{package.name}-#{version}.tar",
       result.tarball,
       []
     )
@@ -44,6 +45,9 @@ defmodule Hexpm.DiffHelpers do
   end
 
   def cache_object(key), do: Hexpm.Store.get(:diff_bucket, key)
+
+  defp repo_prefix("hexpm"), do: ""
+  defp repo_prefix(repository), do: "repos/#{repository}/"
 
   defp normalize_file({content, mode}), do: {content, mode}
   defp normalize_file(content), do: {content, 0o644}


### PR DESCRIPTION
Preview files, version diffs, and readmes now work for private packages. The preview pipeline accepts repos/<org>/tarballs/ keys and stores preview objects under repos/<org>/ prefixes in the preview bucket, with private cache-control and org-prefixed surrogate keys. Public keys are unchanged. The diff cache is namespaced the same way and diff job args now carry the repository.

On the website, organization members get the Files tab, version diffs at /diff/:repository/:package/:versions, and the readme iframe. Source files are served from hex.pm at /packages/:repository/:name/:version/raw/* under session auth, forced to text/plain or octet-stream with nosniff, a sandbox CSP, and no-store since the content is untrusted. README relative images are served from /packages/:repository/:name/:version/readme-image/*: the image proxy fetches anonymously, so a short-lived signed token (not the session cookie) authorizes the fetch, and the endpoint serves real image content types hardened with nosniff and a sandbox CSP. The readme host never receives the session cookie, so the package page signs a 30 minute token that the readme controller verifies. Access checks follow the access_package pattern where missing and unauthorized are both 404.

Diff jobs now run at priority 1 on the shared :heavy queue, above the eventual-consistency preview and hexdocs jobs (moved to priority 3), since a user is waiting on a diff in the UI.

Requires the companion hexpm-ops change: hexpm/hexpm-ops#208.

## Rollout

1. Deploy this app first. The currently-deployed preview queue consumer positively acks (and discards) any key it cannot parse, so it must understand repos/ keys before the S3 notification starts routing them — otherwise events in the window are lost, not retried.
2. Apply the hexpm-ops terraform (staging, then prod) to route repos/ tarball events to the preview queue.
3. Backfill existing private releases from a prod iex session. This also covers anything published between steps 1 and 2. Jobs are inserted at Oban priority 9 (lowest) so the backfill yields to event-driven preview builds, hexdocs, and interactive diffs on the shared :heavy queue; job uniqueness dedupes already-queued keys, so rerunning is safe:

```elixir
import Ecto.Query

from(r in Hexpm.Repository.Release,
  join: p in assoc(r, :package),
  join: repo in assoc(p, :repository),
  where: repo.id != 1,
  preload: [package: {p, repository: repo}]
)
|> Hexpm.Repo.all()
|> Enum.each(fn release ->
  %{key: Hexpm.Repository.Assets.tarball_store_key(release)}
  |> Hexpm.Preview.Workers.Upload.new(priority: 9)
  |> Oban.insert!()
end)
```

Diff job args now require the repository. During the rolling deploy, diff jobs enqueued by a new node and picked up by an old node are discarded (they resolve against the public repo and fail the checksum check — no wrong content is ever cached). Once the rollout completes, re-enqueue them with:

```elixir
Hexpm.AdminTasks.retry_oban_jobs(worker: "Hexpm.Diff.Worker")
```

