### PR TITLE
Add read-only OAuth token fallback

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -464,6 +464,10 @@ defmodule Hexpm.Accounts.AuditLog do
     {nil, token}
   end
 
+  defp extract_auth_credential(%Hexpm.OAuth.MachineToken{key: key}) do
+    {key, nil}
+  end
+
   defp extract_auth_credential(_) do
     {nil, nil}
   end

--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -508,6 +508,10 @@ defmodule Hexpm.Accounts.AuditLog do
     {nil, token}
   end
 
+  defp extract_auth_credential(%Hexpm.OAuth.MachineToken{key: key}) do
+    {key, nil}
+  end
+
   defp extract_auth_credential(_) do
     {nil, nil}
   end

--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -3,7 +3,8 @@ defmodule Hexpm.Accounts.Auth do
   import HexpmWeb.RequestHelpers, only: [parse_ip: 1, parse_user_agent: 1]
 
   alias Hexpm.Accounts.{Key, Keys, Organization, Organizations, User, Users, UserProviders}
-  alias Hexpm.OAuth.{Tokens, JWT}
+  alias Hexpm.OAuth.{JWT, MachineToken, Tokens}
+  alias Hexpm.Permissions
 
   def key_auth(user_secret, usage_info, opts \\ []) do
     app_secret = Application.get_env(:hexpm, :secret)
@@ -97,17 +98,58 @@ defmodule Hexpm.Accounts.Auth do
   def gen_password(password), do: Bcrypt.hash_pwd_salt(password)
 
   def oauth_token_auth(jwt_token, _usage_info) do
-    with {:ok, claims} <- JWT.verify_and_decode(jwt_token),
-         subject when not is_nil(subject) <- Map.get(claims, "sub"),
+    with {:ok, claims} <- JWT.verify_and_decode(jwt_token) do
+      authenticate_oauth_claims(jwt_token, claims)
+    else
+      _ -> :error
+    end
+  end
+
+  defp authenticate_oauth_claims(_jwt_token, %{"token_use" => "machine"} = claims) do
+    with key_id when is_integer(key_id) <- Map.get(claims, "key_id"),
+         scope when is_binary(scope) <- Map.get(claims, "scope"),
+         scopes = String.split(scope, " ", trim: true),
+         :ok <- Permissions.validate_scopes(scopes),
+         subject when is_binary(subject) <- Map.get(claims, "sub"),
          {:ok, subject_type, subject_id} <- parse_subject(subject),
          {:ok, entity} <- load_entity(subject_type, subject_id),
-         valid_auth when valid_auth == true <- validate_entity_auth(entity),
+         true <- validate_entity_auth(entity),
+         %Key{} = key <- Keys.get(key_id),
+         false <- Key.revoked?(key),
+         true <- key_owner?(key, entity) do
+      build_auth_result(entity, MachineToken.new(key, scopes))
+    else
+      _ -> :error
+    end
+  end
+
+  defp authenticate_oauth_claims(jwt_token, claims) do
+    if Map.has_key?(claims, "token_use") do
+      :error
+    else
+      authenticate_persisted_oauth_token(jwt_token, claims)
+    end
+  end
+
+  defp authenticate_persisted_oauth_token(jwt_token, claims) do
+    with subject when is_binary(subject) <- Map.get(claims, "sub"),
+         {:ok, subject_type, subject_id} <- parse_subject(subject),
+         {:ok, entity} <- load_entity(subject_type, subject_id),
+         true <- validate_entity_auth(entity),
          {:ok, oauth_token} <- Tokens.lookup(jwt_token, :access, preload: []) do
       build_auth_result(entity, oauth_token)
     else
       _ -> :error
     end
   end
+
+  defp key_owner?(%Key{user_id: user_id}, %User{id: user_id}) when not is_nil(user_id), do: true
+
+  defp key_owner?(%Key{organization_id: organization_id}, %Organization{id: organization_id})
+       when not is_nil(organization_id),
+       do: true
+
+  defp key_owner?(_key, _entity), do: false
 
   defp parse_subject(subject) when is_binary(subject) do
     case String.split(subject, ":", parts: 2) do

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -78,8 +78,8 @@ defmodule Hexpm.Application do
   end
 
   defp read_only_mode() do
-    mode = System.get_env("HEXPM_READ_ONLY_MODE") == "1"
-    Application.put_env(:hexpm, :read_only_mode, mode)
+    read_only? = System.get_env("HEXPM_READ_ONLY_MODE") == "1"
+    Hexpm.OAuth.ReadOnly.configure!(read_only?)
   end
 
   defp setup_tmp_dir() do

--- a/lib/hexpm/oauth/clients.ex
+++ b/lib/hexpm/oauth/clients.ex
@@ -77,7 +77,8 @@ defmodule Hexpm.OAuth.Clients do
   def supports_scopes?(%Client{allowed_scopes: allowed_scopes}, requested_scopes) do
     Enum.all?(requested_scopes, fn scope ->
       scope in allowed_scopes or api_scope_allowed_by_full_api?(scope, allowed_scopes) or
-        resource_scope_allowed_by_base?(scope, allowed_scopes)
+        resource_scope_allowed_by_base?(scope, allowed_scopes) or
+        repository_scope_allowed_by_wildcard?(scope, allowed_scopes)
     end)
   end
 
@@ -95,6 +96,12 @@ defmodule Hexpm.OAuth.Clients do
       false
     end
   end
+
+  defp repository_scope_allowed_by_wildcard?("repository:" <> _repository, allowed_scopes) do
+    "repositories" in allowed_scopes
+  end
+
+  defp repository_scope_allowed_by_wildcard?(_scope, _allowed_scopes), do: false
 
   @doc """
   Validates that the redirect URI is allowed for this client.

--- a/lib/hexpm/oauth/jwt.ex
+++ b/lib/hexpm/oauth/jwt.ex
@@ -18,6 +18,23 @@ defmodule Hexpm.OAuth.JWT do
   Generates a JWT access token for a subject (user or organization) with the given scopes.
   """
   def generate_access_token(subject_name, subject_type, scopes, opts \\ []) do
+    generate_token(subject_name, subject_type, scopes, opts)
+  end
+
+  @doc """
+  Generates a row-less access token tied to an API key.
+  """
+  def generate_machine_token(subject_name, subject_type, scopes, key_id, opts \\ []) do
+    opts =
+      Keyword.put(opts, :claims, %{
+        "token_use" => "machine",
+        "key_id" => key_id
+      })
+
+    generate_token(subject_name, subject_type, scopes, opts)
+  end
+
+  defp generate_token(subject_name, subject_type, scopes, opts) do
     jti = generate_jti()
     now = unix_now()
 
@@ -28,6 +45,8 @@ defmodule Hexpm.OAuth.JWT do
       "nbf" => now - 30,
       "scope" => Enum.join(scopes, " ")
     }
+
+    extra_claims = Map.merge(Keyword.get(opts, :claims, %{}), extra_claims)
 
     expires_in = Keyword.get(opts, :expires_in, 30 * 60)
 

--- a/lib/hexpm/oauth/machine_token.ex
+++ b/lib/hexpm/oauth/machine_token.ex
@@ -1,0 +1,10 @@
+defmodule Hexpm.OAuth.MachineToken do
+  alias Hexpm.Accounts.Key
+
+  @enforce_keys [:id, :key, :scopes]
+  defstruct [:id, :key, :scopes]
+
+  def new(%Key{} = key, scopes) when is_list(scopes) do
+    %__MODULE__{id: key.id, key: key, scopes: scopes}
+  end
+end

--- a/lib/hexpm/oauth/read_only.ex
+++ b/lib/hexpm/oauth/read_only.ex
@@ -1,0 +1,5 @@
+defmodule Hexpm.OAuth.ReadOnly do
+  def configure!(read_only?) when is_boolean(read_only?) do
+    Application.put_env(:hexpm, :read_only_mode, read_only?)
+  end
+end

--- a/lib/hexpm/oauth/tokens.ex
+++ b/lib/hexpm/oauth/tokens.ex
@@ -2,6 +2,7 @@ defmodule Hexpm.OAuth.Tokens do
   use Hexpm.Context
 
   alias Hexpm.UserSessions
+  alias Hexpm.Accounts.{Organization, User}
   alias Hexpm.OAuth.{Token, JWT}
   alias Hexpm.Permissions
 
@@ -127,7 +128,7 @@ defmodule Hexpm.OAuth.Tokens do
   end
 
   defp create_for_user_or_org(
-         %Hexpm.Accounts.User{} = user,
+         %User{} = user,
          client_id,
          scopes,
          grant_type,
@@ -138,17 +139,17 @@ defmodule Hexpm.OAuth.Tokens do
   end
 
   defp create_for_user_or_org(
-         %Hexpm.Accounts.Organization{} = org,
+         %Organization{} = organization,
          client_id,
          scopes,
          grant_type,
          grant_reference,
          opts
        ) do
-    create_for_org(org, client_id, scopes, grant_type, grant_reference, opts)
+    create_for_org(organization, client_id, scopes, grant_type, grant_reference, opts)
   end
 
-  defp create_for_org(org, client_id, scopes, grant_type, grant_reference, opts) do
+  defp create_for_org(organization, client_id, scopes, grant_type, grant_reference, opts) do
     expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
     expires_at = DateTime.add(DateTime.utc_now(), expires_in, :second)
 
@@ -158,7 +159,7 @@ defmodule Hexpm.OAuth.Tokens do
     ]
 
     {:ok, access_token, jti} =
-      JWT.generate_access_token(org.name, "org", scopes, jwt_opts)
+      JWT.generate_access_token(organization.name, "org", scopes, jwt_opts)
 
     attrs = %{
       jti: jti,
@@ -168,7 +169,7 @@ defmodule Hexpm.OAuth.Tokens do
       expires_at: expires_at,
       grant_type: grant_type,
       grant_reference: grant_reference,
-      organization_id: org.id,
+      organization_id: organization.id,
       client_id: client_id,
       user_session_id: Keyword.get(opts, :user_session_id)
     }
@@ -193,55 +194,34 @@ defmodule Hexpm.OAuth.Tokens do
 
   @doc """
   Creates a session and token for an API key.
-
-  Unlike user tokens, API key tokens:
-  - Have session lifetime matching access token lifetime (no long-lived session)
-  - Do not include refresh tokens (client can exchange API key again)
-  - Use the API key's user/organization for authentication
   """
   def create_session_and_token_for_api_key(
         user_or_org,
         client_id,
         scopes,
-        grant_type,
-        grant_reference \\ nil,
         opts \\ []
       ) do
-    # For API key tokens, session expires with the access token (30 minutes)
     expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
     session_expires_at = DateTime.add(DateTime.utc_now(), expires_in, :second)
 
     {user, organization} =
       case user_or_org do
-        %Hexpm.Accounts.User{} = u -> {u, nil}
-        %Hexpm.Accounts.Organization{} = o -> {nil, o}
+        %User{} = user -> {user, nil}
+        %Organization{} = organization -> {nil, organization}
       end
 
-    max_sessions =
-      if organization do
-        UserSessions.get_organization_session_limit(organization)
-      else
-        UserSessions.max_user_sessions()
-      end
-
-    # Enforce session limit outside transaction
-    UserSessions.enforce_session_limit(user_or_org, max_sessions)
-
-    # Pre-compute JWT outside the transaction (CPU-intensive ES256 signing)
-    token_opts =
-      Keyword.merge(opts, expires_in: expires_in, with_refresh_token: false)
+    token_opts = Keyword.merge(opts, expires_in: expires_in, with_refresh_token: false)
 
     token_changeset =
       create_for_user_or_org(
         user_or_org,
         client_id,
         scopes,
-        grant_type,
-        grant_reference,
+        "client_credentials",
+        nil,
         token_opts
       )
 
-    # Build flat Multi (no nested transactions, last_use folded into INSERT)
     UserSessions.build_api_key_session_multi(user, organization, client_id, session_expires_at,
       name: Keyword.get(opts, :name),
       usage_info: Keyword.get(opts, :usage_info),
@@ -260,6 +240,46 @@ defmodule Hexpm.OAuth.Tokens do
   end
 
   @doc """
+  Creates a row-less access token tied to an API key.
+  """
+  def create_machine_token(user_or_org, client_id, scopes, key_id, opts \\ []) do
+    expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
+    expires_at = DateTime.add(DateTime.utc_now(), expires_in, :second)
+
+    {subject_name, subject_type, owner_attrs} =
+      case user_or_org do
+        %User{} = user ->
+          {user.username, "user", %{user_id: user.id}}
+
+        %Organization{} = organization ->
+          {organization.name, "org", %{organization_id: organization.id}}
+      end
+
+    {:ok, access_token, jti} =
+      JWT.generate_machine_token(subject_name, subject_type, scopes, key_id,
+        expires_in: expires_in
+      )
+
+    %{
+      jti: jti,
+      access_token: access_token,
+      scopes: scopes,
+      granted_scopes: scopes,
+      expires_at: expires_at,
+      grant_type: "client_credentials",
+      client_id: client_id
+    }
+    |> Map.merge(owner_attrs)
+    |> build_rowless_token()
+  end
+
+  defp build_rowless_token(attrs) do
+    %Token{}
+    |> Token.changeset(attrs)
+    |> Ecto.Changeset.apply_action(:insert)
+  end
+
+  @doc """
   Creates a session and token for a user atomically within a transaction.
   """
   def create_session_and_token_for_user(
@@ -270,9 +290,6 @@ defmodule Hexpm.OAuth.Tokens do
         grant_reference \\ nil,
         opts \\ []
       ) do
-    # Enforce session limit outside transaction
-    UserSessions.enforce_session_limit(user)
-
     # Compute session expiration upfront (used for both session and refresh token)
     session_expires_at =
       DateTime.add(DateTime.utc_now(), UserSessions.default_session_expires_in(), :second)

--- a/lib/hexpm/oauth/tokens.ex
+++ b/lib/hexpm/oauth/tokens.ex
@@ -3,6 +3,7 @@ defmodule Hexpm.OAuth.Tokens do
 
   alias Hexpm.Accounts.{Organization, User}
   alias Hexpm.UserSessions
+  alias Hexpm.Accounts.{Organization, User}
   alias Hexpm.OAuth.{Token, JWT}
   alias Hexpm.Permissions
 
@@ -184,55 +185,34 @@ defmodule Hexpm.OAuth.Tokens do
 
   @doc """
   Creates a session and token for an API key.
-
-  Unlike user tokens, API key tokens:
-  - Have session lifetime matching access token lifetime (no long-lived session)
-  - Do not include refresh tokens (client can exchange API key again)
-  - Use the API key's user/organization for authentication
   """
   def create_session_and_token_for_api_key(
         user_or_org,
         client_id,
         scopes,
-        grant_type,
-        grant_reference \\ nil,
         opts \\ []
       ) do
-    # For API key tokens, session expires with the access token (30 minutes)
     expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
     session_expires_at = DateTime.add(DateTime.utc_now(), expires_in, :second)
 
     {user, organization} =
       case user_or_org do
-        %Hexpm.Accounts.User{} = u -> {u, nil}
-        %Hexpm.Accounts.Organization{} = o -> {nil, o}
+        %User{} = user -> {user, nil}
+        %Organization{} = organization -> {nil, organization}
       end
 
-    max_sessions =
-      if organization do
-        UserSessions.get_organization_session_limit(organization)
-      else
-        UserSessions.max_user_sessions()
-      end
-
-    # Enforce session limit outside transaction
-    UserSessions.enforce_session_limit(user_or_org, max_sessions)
-
-    # Pre-compute JWT outside the transaction (CPU-intensive ES256 signing)
-    token_opts =
-      Keyword.merge(opts, expires_in: expires_in, with_refresh_token: false)
+    token_opts = Keyword.merge(opts, expires_in: expires_in, with_refresh_token: false)
 
     token_changeset =
       create_for_user_or_org(
         user_or_org,
         client_id,
         scopes,
-        grant_type,
-        grant_reference,
+        "client_credentials",
+        nil,
         token_opts
       )
 
-    # Build flat Multi (no nested transactions, last_use folded into INSERT)
     UserSessions.build_api_key_session_multi(user, organization, client_id, session_expires_at,
       name: Keyword.get(opts, :name),
       usage_info: Keyword.get(opts, :usage_info)
@@ -250,6 +230,40 @@ defmodule Hexpm.OAuth.Tokens do
   end
 
   @doc """
+  Creates a row-less access token tied to an API key.
+  """
+  def create_machine_token(user_or_org, client_id, scopes, key_id, opts \\ []) do
+    expires_in = Keyword.get(opts, :expires_in, @default_expires_in)
+    expires_at = DateTime.add(DateTime.utc_now(), expires_in, :second)
+
+    {subject_name, subject_type} = subject(user_or_org)
+    owner_attrs = principal_id(user_or_org)
+
+    {:ok, access_token, jti} =
+      JWT.generate_machine_token(subject_name, subject_type, scopes, key_id,
+        expires_in: expires_in
+      )
+
+    %{
+      jti: jti,
+      access_token: access_token,
+      scopes: scopes,
+      granted_scopes: scopes,
+      expires_at: expires_at,
+      grant_type: "client_credentials",
+      client_id: client_id
+    }
+    |> Map.merge(owner_attrs)
+    |> build_rowless_token()
+  end
+
+  defp build_rowless_token(attrs) do
+    %Token{}
+    |> Token.changeset(attrs)
+    |> Ecto.Changeset.apply_action(:insert)
+  end
+
+  @doc """
   Creates a session and token for a user atomically within a transaction.
   """
   def create_session_and_token_for_user(
@@ -260,9 +274,6 @@ defmodule Hexpm.OAuth.Tokens do
         grant_reference \\ nil,
         opts \\ []
       ) do
-    # Enforce session limit outside transaction
-    UserSessions.enforce_session_limit(user)
-
     # Compute session expiration upfront (used for both session and refresh token)
     session_expires_at =
       DateTime.add(DateTime.utc_now(), UserSessions.default_session_expires_in(), :second)

--- a/lib/hexpm/permissions.ex
+++ b/lib/hexpm/permissions.ex
@@ -8,7 +8,7 @@ defmodule Hexpm.Permissions do
   """
 
   alias Hexpm.Accounts.{Key, KeyPermission, User, Users, Organization}
-  alias Hexpm.OAuth.Token
+  alias Hexpm.OAuth.{MachineToken, Token}
   alias Hexpm.Repository.Package
 
   # Consolidated scope definitions - single source of truth
@@ -186,6 +186,10 @@ defmodule Hexpm.Permissions do
 
   def verify_access?(%Token{} = token, domain, resource) do
     verify_access?(token.scopes, domain, resource)
+  end
+
+  def verify_access?(%MachineToken{key: key, scopes: scopes}, domain, resource) do
+    verify_access?(scopes, domain, resource) and verify_access?(key, domain, resource)
   end
 
   @doc """
@@ -389,74 +393,63 @@ defmodule Hexpm.Permissions do
       iex> expand_repositories_scope(user, ["api:read"])
       ["api:read"]
   """
-  def expand_repositories_scope(user, scopes, api_key \\ nil)
+  def expand_repositories_scope(user_or_org, scopes, api_key \\ nil)
 
-  def expand_repositories_scope(%Organization{} = org, scopes, api_key) do
-    if "repositories" in scopes do
-      allowed_repos = get_allowed_repositories_from_key(api_key.permissions)
-
-      repo_scopes =
-        if :all in allowed_repos or org.name in allowed_repos do
-          ["repository:#{org.name}"]
-        else
-          []
-        end
+  def expand_repositories_scope(user_or_org, scopes, api_key)
+      when is_list(scopes) do
+    if Enum.any?(scopes, &repository_scope?/1) do
+      eligible_repositories = eligible_repositories(user_or_org)
+      allowed_repositories = allowed_repositories(api_key)
 
       scopes
-      |> Enum.reject(&(&1 == "repositories"))
-      |> Kernel.++(repo_scopes)
+      |> Enum.flat_map(fn
+        "repositories" ->
+          eligible_repositories
+          |> Enum.filter(&repository_allowed?(&1, allowed_repositories))
+          |> Enum.map(&"repository:#{&1}")
+
+        "repository:" <> repository = scope ->
+          if repository in eligible_repositories and
+               repository_allowed?(repository, allowed_repositories) do
+            [scope]
+          else
+            []
+          end
+
+        scope ->
+          [scope]
+      end)
+      |> Enum.uniq()
     else
       scopes
     end
   end
 
-  def expand_repositories_scope(%User{} = user, scopes, nil) do
-    if "repositories" in scopes do
-      # Ensure organizations are preloaded
-      user = Hexpm.Repo.preload(user, :organizations)
-
-      # Get all organizations the user has access to
-      organizations = Users.all_organizations(user)
-
-      # Create individual repository scopes
-      repo_scopes = Enum.map(organizations, fn org -> "repository:#{org.name}" end)
-
-      # Replace "repositories" with individual scopes
-      scopes
-      |> Enum.reject(&(&1 == "repositories"))
-      |> Kernel.++(repo_scopes)
-    else
-      scopes
-    end
+  defp eligible_repositories(%User{} = user) do
+    user
+    |> Hexpm.Repo.preload(:organizations)
+    |> Users.all_organizations()
+    |> Enum.filter(&Organization.billing_active?/1)
+    |> Enum.map(& &1.name)
   end
 
-  def expand_repositories_scope(%User{} = user, scopes, api_key) do
-    if "repositories" in scopes do
-      # Ensure organizations are preloaded
-      user = Hexpm.Repo.preload(user, :organizations)
+  defp eligible_repositories(%Organization{} = organization) do
+    if Organization.billing_active?(organization), do: [organization.name], else: []
+  end
 
-      # Get all organizations the user has access to
-      organizations = Users.all_organizations(user)
+  defp allowed_repositories(nil), do: :all
 
-      # Filter organizations based on API key permissions
-      allowed_repos = get_allowed_repositories_from_key(api_key.permissions)
+  defp allowed_repositories(%Key{} = api_key),
+    do: get_allowed_repositories_from_key(api_key.permissions)
 
-      repo_scopes =
-        organizations
-        |> Enum.map(fn org -> org.name end)
-        |> Enum.filter(fn org_name ->
-          # Allow if key has "repositories" permission or specific "repository:org_name" permission
-          :all in allowed_repos or org_name in allowed_repos
-        end)
-        |> Enum.map(fn org_name -> "repository:#{org_name}" end)
+  defp repository_scope?("repositories"), do: true
+  defp repository_scope?("repository:" <> _repository), do: true
+  defp repository_scope?(_scope), do: false
 
-      # Replace "repositories" with individual scopes
-      scopes
-      |> Enum.reject(&(&1 == "repositories"))
-      |> Kernel.++(repo_scopes)
-    else
-      scopes
-    end
+  defp repository_allowed?(_repository, :all), do: true
+
+  defp repository_allowed?(repository, allowed_repositories) do
+    :all in allowed_repositories or repository in allowed_repositories
   end
 
   defp get_allowed_repositories_from_key(permissions) do

--- a/lib/hexpm/permissions.ex
+++ b/lib/hexpm/permissions.ex
@@ -8,7 +8,7 @@ defmodule Hexpm.Permissions do
   """
 
   alias Hexpm.Accounts.{Key, KeyPermission, User, Users, Organization}
-  alias Hexpm.OAuth.Token
+  alias Hexpm.OAuth.{MachineToken, Token}
   alias Hexpm.Repository.Package
 
   # Consolidated scope definitions - single source of truth
@@ -190,6 +190,10 @@ defmodule Hexpm.Permissions do
 
   def verify_access?(%Token{} = token, domain, resource) do
     verify_access?(token.scopes, domain, resource)
+  end
+
+  def verify_access?(%MachineToken{key: key, scopes: scopes}, domain, resource) do
+    verify_access?(scopes, domain, resource) and verify_access?(key, domain, resource)
   end
 
   @doc """
@@ -391,74 +395,63 @@ defmodule Hexpm.Permissions do
       iex> expand_repositories_scope(user, ["api:read"])
       ["api:read"]
   """
-  def expand_repositories_scope(user, scopes, api_key \\ nil)
+  def expand_repositories_scope(user_or_org, scopes, api_key \\ nil)
 
-  def expand_repositories_scope(%Organization{} = org, scopes, api_key) do
-    if "repositories" in scopes do
-      allowed_repos = get_allowed_repositories_from_key(api_key.permissions)
-
-      repo_scopes =
-        if :all in allowed_repos or org.name in allowed_repos do
-          ["repository:#{org.name}"]
-        else
-          []
-        end
+  def expand_repositories_scope(user_or_org, scopes, api_key)
+      when is_list(scopes) do
+    if Enum.any?(scopes, &repository_scope?/1) do
+      eligible_repositories = eligible_repositories(user_or_org)
+      allowed_repositories = allowed_repositories(api_key)
 
       scopes
-      |> Enum.reject(&(&1 == "repositories"))
-      |> Kernel.++(repo_scopes)
+      |> Enum.flat_map(fn
+        "repositories" ->
+          eligible_repositories
+          |> Enum.filter(&repository_allowed?(&1, allowed_repositories))
+          |> Enum.map(&"repository:#{&1}")
+
+        "repository:" <> repository = scope ->
+          if repository in eligible_repositories and
+               repository_allowed?(repository, allowed_repositories) do
+            [scope]
+          else
+            []
+          end
+
+        scope ->
+          [scope]
+      end)
+      |> Enum.uniq()
     else
       scopes
     end
   end
 
-  def expand_repositories_scope(%User{} = user, scopes, nil) do
-    if "repositories" in scopes do
-      # Ensure organizations are preloaded
-      user = Hexpm.Repo.preload(user, :organizations)
-
-      # Get all organizations the user has access to
-      organizations = Users.all_organizations(user)
-
-      # Create individual repository scopes
-      repo_scopes = Enum.map(organizations, fn org -> "repository:#{org.name}" end)
-
-      # Replace "repositories" with individual scopes
-      scopes
-      |> Enum.reject(&(&1 == "repositories"))
-      |> Kernel.++(repo_scopes)
-    else
-      scopes
-    end
+  defp eligible_repositories(%User{} = user) do
+    user
+    |> Hexpm.Repo.preload(:organizations)
+    |> Users.all_organizations()
+    |> Enum.filter(&Organization.billing_active?/1)
+    |> Enum.map(& &1.name)
   end
 
-  def expand_repositories_scope(%User{} = user, scopes, api_key) do
-    if "repositories" in scopes do
-      # Ensure organizations are preloaded
-      user = Hexpm.Repo.preload(user, :organizations)
+  defp eligible_repositories(%Organization{} = organization) do
+    if Organization.billing_active?(organization), do: [organization.name], else: []
+  end
 
-      # Get all organizations the user has access to
-      organizations = Users.all_organizations(user)
+  defp allowed_repositories(nil), do: :all
 
-      # Filter organizations based on API key permissions
-      allowed_repos = get_allowed_repositories_from_key(api_key.permissions)
+  defp allowed_repositories(%Key{} = api_key),
+    do: get_allowed_repositories_from_key(api_key.permissions)
 
-      repo_scopes =
-        organizations
-        |> Enum.map(fn org -> org.name end)
-        |> Enum.filter(fn org_name ->
-          # Allow if key has "repositories" permission or specific "repository:org_name" permission
-          :all in allowed_repos or org_name in allowed_repos
-        end)
-        |> Enum.map(fn org_name -> "repository:#{org_name}" end)
+  defp repository_scope?("repositories"), do: true
+  defp repository_scope?("repository:" <> _repository), do: true
+  defp repository_scope?(_scope), do: false
 
-      # Replace "repositories" with individual scopes
-      scopes
-      |> Enum.reject(&(&1 == "repositories"))
-      |> Kernel.++(repo_scopes)
-    else
-      scopes
-    end
+  defp repository_allowed?(_repository, :all), do: true
+
+  defp repository_allowed?(repository, allowed_repositories) do
+    :all in allowed_repositories or repository in allowed_repositories
   end
 
   defp get_allowed_repositories_from_key(permissions) do

--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -215,3 +215,8 @@ defmodule Hexpm.WriteInReadOnlyMode do
     "tried to write in read-only mode"
   end
 end
+
+defimpl Plug.Exception, for: Hexpm.WriteInReadOnlyMode do
+  def status(_exception), do: 503
+  def actions(_exception), do: []
+end

--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -202,3 +202,8 @@ defmodule Hexpm.WriteInReadOnlyMode do
     "tried to write in read-only mode"
   end
 end
+
+defimpl Plug.Exception, for: Hexpm.WriteInReadOnlyMode do
+  def status(_exception), do: 503
+  def actions(_exception), do: []
+end

--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -29,8 +29,9 @@ defmodule Hexpm.UserSessions do
   require Ecto.Query
   import Hexpm.Accounts.AuditLog, only: [audit: 4]
 
-  alias Hexpm.UserSession
+  alias Hexpm.Accounts.{Organization, User}
   alias Hexpm.OAuth.Token
+  alias Hexpm.UserSession
 
   @max_user_sessions 5
   @min_org_sessions 5
@@ -59,8 +60,6 @@ defmodule Hexpm.UserSessions do
   Requires audit data for security logging.
   """
   def create_browser_session(user, opts) do
-    enforce_session_limit(user)
-
     session_token = :crypto.strong_rand_bytes(32)
     name = Keyword.get(opts, :name, "Browser Session")
     expires_at = DateTime.add(DateTime.utc_now(), @default_session_expires_in, :second)
@@ -76,7 +75,7 @@ defmodule Hexpm.UserSessions do
     changeset = UserSession.changeset(%UserSession{}, attrs)
 
     multi =
-      Ecto.Multi.new()
+      build_session_limit_multi(user)
       |> Ecto.Multi.insert(:session, changeset)
       |> audit(Keyword.fetch!(opts, :audit), "session.create", fn %{session: session} ->
         session
@@ -94,8 +93,6 @@ defmodule Hexpm.UserSessions do
   Requires audit data for security logging.
   """
   def create_oauth_session(user, client_id, opts) do
-    enforce_session_limit(user)
-
     expires_at = DateTime.add(DateTime.utc_now(), @default_session_expires_in, :second)
 
     attrs = %{
@@ -109,7 +106,7 @@ defmodule Hexpm.UserSessions do
     changeset = UserSession.changeset(%UserSession{}, attrs)
 
     multi =
-      Ecto.Multi.new()
+      build_session_limit_multi(user)
       |> Ecto.Multi.insert(:session, changeset)
       |> Ecto.Multi.run(:preload, fn _repo, %{session: session} ->
         {:ok, Repo.preload(session, :client)}
@@ -143,7 +140,6 @@ defmodule Hexpm.UserSessions do
       end
 
     owner = user || organization
-    enforce_session_limit(owner, max_sessions)
 
     owner_attrs =
       if user do
@@ -163,7 +159,7 @@ defmodule Hexpm.UserSessions do
     changeset = UserSession.changeset(%UserSession{}, attrs)
 
     multi =
-      Ecto.Multi.new()
+      build_session_limit_multi(owner, max_sessions)
       |> Ecto.Multi.insert(:session, changeset)
       |> Ecto.Multi.run(:preload, fn _repo, %{session: session} ->
         {:ok, Repo.preload(session, :client)}
@@ -197,14 +193,16 @@ defmodule Hexpm.UserSessions do
         DateTime.add(DateTime.utc_now(), @default_session_expires_in, :second)
       )
 
-    %{
+    attrs = %{
       user_id: user.id,
       type: "oauth",
       client_id: client_id,
       name: Keyword.get(opts, :name),
       expires_at: expires_at
     }
-    |> build_session_multi(opts)
+
+    build_session_limit_multi(user)
+    |> build_session_multi(attrs, opts)
   end
 
   @doc """
@@ -216,6 +214,15 @@ defmodule Hexpm.UserSessions do
   Returns the Multi (caller is responsible for executing the transaction).
   """
   def build_api_key_session_multi(user, organization, client_id, expires_at, opts) do
+    owner = user || organization
+
+    max_sessions =
+      if organization do
+        get_organization_session_limit(organization)
+      else
+        @max_user_sessions
+      end
+
     owner_attrs =
       if user do
         %{user_id: user.id}
@@ -223,16 +230,19 @@ defmodule Hexpm.UserSessions do
         %{organization_id: organization.id}
       end
 
-    Map.merge(owner_attrs, %{
-      type: "oauth",
-      client_id: client_id,
-      name: Keyword.get(opts, :name),
-      expires_at: expires_at
-    })
-    |> build_session_multi(opts)
+    attrs =
+      Map.merge(owner_attrs, %{
+        type: "oauth",
+        client_id: client_id,
+        name: Keyword.get(opts, :name),
+        expires_at: expires_at
+      })
+
+    build_session_limit_multi(owner, max_sessions)
+    |> build_session_multi(attrs, opts)
   end
 
-  defp build_session_multi(attrs, opts) do
+  defp build_session_multi(multi, attrs, opts) do
     changeset = UserSession.changeset(%UserSession{}, attrs)
 
     changeset =
@@ -242,7 +252,7 @@ defmodule Hexpm.UserSessions do
         changeset
       end
 
-    multi = Ecto.Multi.new() |> Ecto.Multi.insert(:session, changeset)
+    multi = Ecto.Multi.insert(multi, :session, changeset)
 
     if audit_data = Keyword.get(opts, :audit) do
       audit(multi, audit_data, "session.create", fn %{session: session} -> session end)
@@ -397,7 +407,14 @@ defmodule Hexpm.UserSessions do
   The max_sessions parameter allows overriding the default limit (e.g., for organizations).
   """
   def enforce_session_limit(user_or_org, max_sessions \\ @max_user_sessions) do
-    revoke_lru_sessions(owner_filter(user_or_org), max_sessions - 1)
+    case Repo.transaction(build_session_limit_multi(user_or_org, max_sessions)) do
+      {:ok, _changes} -> :ok
+      {:error, _operation, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  def build_session_limit_multi(user_or_org, max_sessions \\ @max_user_sessions) do
+    build_keep_sessions_multi(user_or_org, max_sessions - 1)
   end
 
   @doc """
@@ -406,7 +423,20 @@ defmodule Hexpm.UserSessions do
   """
   def revoke_excess_sessions_for_organization(organization, new_seat_limit) do
     max_sessions = max(@min_org_sessions, new_seat_limit)
-    revoke_lru_sessions(owner_filter(organization), max_sessions)
+
+    case Repo.transaction(build_keep_sessions_multi(organization, max_sessions)) do
+      {:ok, _changes} -> :ok
+      {:error, _operation, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  defp build_keep_sessions_multi(user_or_org, keep_count) do
+    Ecto.Multi.new()
+    |> Ecto.Multi.run(:session_limit, fn _repo, _changes ->
+      lock_session_owner(user_or_org)
+      revoke_lru_sessions(owner_filter(user_or_org), keep_count)
+      {:ok, nil}
+    end)
   end
 
   # Revokes any active sessions beyond `keep_count`, ranked most-recently-used first.
@@ -415,43 +445,50 @@ defmodule Hexpm.UserSessions do
   # `Tokens.revoke_and_create_token`, which locks the old token before
   # touching its session (FK insert and last_use update). Acquiring the
   # locks in the same order across both flows avoids circular waits.
-  # The `is_nil(revoked_at)` filter on each update keeps concurrent
-  # enforcers idempotent without needing a SELECT FOR UPDATE.
+  # The owner row lock serializes session-limit enforcement and creation.
   defp revoke_lru_sessions(owner_filter, keep_count) do
     now = DateTime.utc_now()
 
-    Repo.transaction(fn ->
-      session_ids =
+    session_ids =
+      from(s in UserSession,
+        where: ^owner_filter,
+        where: is_nil(s.revoked_at) and s.expires_at > ^now,
+        order_by: [
+          desc_nulls_last: fragment("(last_use->>'used_at')::timestamptz"),
+          desc: s.inserted_at
+        ],
+        offset: ^keep_count,
+        select: s.id
+      )
+      |> Repo.all()
+
+    if session_ids != [] do
+      Repo.update_all(
+        from(t in Token,
+          where: t.user_session_id in ^session_ids and is_nil(t.revoked_at)
+        ),
+        set: [revoked_at: now, updated_at: now]
+      )
+
+      Repo.update_all(
         from(s in UserSession,
-          where: ^owner_filter,
-          where: is_nil(s.revoked_at) and s.expires_at > ^now,
-          order_by: [
-            desc_nulls_last: fragment("(last_use->>'used_at')::timestamptz"),
-            desc: s.inserted_at
-          ],
-          offset: ^keep_count,
-          select: s.id
-        )
-        |> Repo.all()
-
-      if session_ids != [] do
-        Repo.update_all(
-          from(t in Token,
-            where: t.user_session_id in ^session_ids and is_nil(t.revoked_at)
-          ),
-          set: [revoked_at: now, updated_at: now]
-        )
-
-        Repo.update_all(
-          from(s in UserSession,
-            where: s.id in ^session_ids and is_nil(s.revoked_at)
-          ),
-          set: [revoked_at: now, updated_at: now]
-        )
-      end
-    end)
+          where: s.id in ^session_ids and is_nil(s.revoked_at)
+        ),
+        set: [revoked_at: now, updated_at: now]
+      )
+    end
 
     :ok
+  end
+
+  defp lock_session_owner(%User{id: id}) do
+    from(user in User, where: user.id == ^id, lock: "FOR UPDATE")
+    |> Repo.one!()
+  end
+
+  defp lock_session_owner(%Organization{id: id}) do
+    from(organization in Organization, where: organization.id == ^id, lock: "FOR UPDATE")
+    |> Repo.one!()
   end
 
   defp owner_filter(%Hexpm.Accounts.User{} = user) do

--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -29,8 +29,9 @@ defmodule Hexpm.UserSessions do
   require Ecto.Query
   import Hexpm.Accounts.AuditLog, only: [audit: 4]
 
-  alias Hexpm.UserSession
+  alias Hexpm.Accounts.{Organization, User}
   alias Hexpm.OAuth.Token
+  alias Hexpm.UserSession
 
   @max_user_sessions 5
   @min_org_sessions 5
@@ -59,8 +60,6 @@ defmodule Hexpm.UserSessions do
   Requires audit data for security logging.
   """
   def create_browser_session(user, opts) do
-    enforce_session_limit(user)
-
     session_token = :crypto.strong_rand_bytes(32)
     name = Keyword.get(opts, :name, "Browser Session")
     expires_at = DateTime.add(DateTime.utc_now(), @default_session_expires_in, :second)
@@ -76,7 +75,7 @@ defmodule Hexpm.UserSessions do
     changeset = UserSession.changeset(%UserSession{}, attrs)
 
     multi =
-      Ecto.Multi.new()
+      build_session_limit_multi(user)
       |> Ecto.Multi.insert(:session, changeset)
       |> audit(Keyword.fetch!(opts, :audit), "session.create", fn %{session: session} ->
         session
@@ -94,8 +93,6 @@ defmodule Hexpm.UserSessions do
   Requires audit data for security logging.
   """
   def create_oauth_session(user, client_id, opts) do
-    enforce_session_limit(user)
-
     expires_at = DateTime.add(DateTime.utc_now(), @default_session_expires_in, :second)
 
     attrs = %{
@@ -109,7 +106,7 @@ defmodule Hexpm.UserSessions do
     changeset = UserSession.changeset(%UserSession{}, attrs)
 
     multi =
-      Ecto.Multi.new()
+      build_session_limit_multi(user)
       |> Ecto.Multi.insert(:session, changeset)
       |> Ecto.Multi.run(:preload, fn _repo, %{session: session} ->
         {:ok, Repo.preload(session, :client)}
@@ -145,7 +142,6 @@ defmodule Hexpm.UserSessions do
       end
 
     owner = user || organization
-    enforce_session_limit(owner, max_sessions)
 
     owner_attrs =
       if user do
@@ -162,8 +158,16 @@ defmodule Hexpm.UserSessions do
         expires_at: expires_at
       })
 
-    UserSession.changeset(%UserSession{}, attrs)
-    |> Repo.insert()
+    changeset = UserSession.changeset(%UserSession{}, attrs)
+
+    multi =
+      build_session_limit_multi(owner, max_sessions)
+      |> Ecto.Multi.insert(:session, changeset)
+
+    case Repo.transaction(multi) do
+      {:ok, %{session: session}} -> {:ok, session}
+      {:error, :session, changeset, _} -> {:error, changeset}
+    end
   end
 
   @doc """
@@ -185,14 +189,16 @@ defmodule Hexpm.UserSessions do
         DateTime.add(DateTime.utc_now(), @default_session_expires_in, :second)
       )
 
-    %{
+    attrs = %{
       user_id: user.id,
       type: "oauth",
       client_id: client_id,
       name: Keyword.get(opts, :name),
       expires_at: expires_at
     }
-    |> build_session_multi(opts)
+
+    build_session_limit_multi(user)
+    |> build_session_multi(attrs, opts)
   end
 
   @doc """
@@ -205,6 +211,15 @@ defmodule Hexpm.UserSessions do
   Returns the Multi (caller is responsible for executing the transaction).
   """
   def build_api_key_session_multi(user, organization, client_id, expires_at, opts) do
+    owner = user || organization
+
+    max_sessions =
+      if organization do
+        get_organization_session_limit(organization)
+      else
+        @max_user_sessions
+      end
+
     owner_attrs =
       if user do
         %{user_id: user.id}
@@ -212,16 +227,19 @@ defmodule Hexpm.UserSessions do
         %{organization_id: organization.id}
       end
 
-    Map.merge(owner_attrs, %{
-      type: "oauth",
-      client_id: client_id,
-      name: Keyword.get(opts, :name),
-      expires_at: expires_at
-    })
-    |> build_session_multi(Keyword.delete(opts, :audit))
+    attrs =
+      Map.merge(owner_attrs, %{
+        type: "oauth",
+        client_id: client_id,
+        name: Keyword.get(opts, :name),
+        expires_at: expires_at
+      })
+
+    build_session_limit_multi(owner, max_sessions)
+    |> build_session_multi(attrs, Keyword.delete(opts, :audit))
   end
 
-  defp build_session_multi(attrs, opts) do
+  defp build_session_multi(multi, attrs, opts) do
     changeset = UserSession.changeset(%UserSession{}, attrs)
 
     changeset =
@@ -231,7 +249,7 @@ defmodule Hexpm.UserSessions do
         changeset
       end
 
-    multi = Ecto.Multi.new() |> Ecto.Multi.insert(:session, changeset)
+    multi = Ecto.Multi.insert(multi, :session, changeset)
 
     if audit_data = Keyword.get(opts, :audit) do
       audit(multi, audit_data, "session.create", fn %{session: session} -> session end)
@@ -387,7 +405,14 @@ defmodule Hexpm.UserSessions do
   The max_sessions parameter allows overriding the default limit (e.g., for organizations).
   """
   def enforce_session_limit(user_or_org, max_sessions \\ @max_user_sessions) do
-    revoke_lru_sessions(owner_filter(user_or_org), max_sessions - 1)
+    case Repo.transaction(build_session_limit_multi(user_or_org, max_sessions)) do
+      {:ok, _changes} -> :ok
+      {:error, _operation, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  def build_session_limit_multi(user_or_org, max_sessions \\ @max_user_sessions) do
+    build_keep_sessions_multi(user_or_org, max_sessions - 1)
   end
 
   @doc """
@@ -396,7 +421,20 @@ defmodule Hexpm.UserSessions do
   """
   def revoke_excess_sessions_for_organization(organization, new_seat_limit) do
     max_sessions = max(@min_org_sessions, new_seat_limit)
-    revoke_lru_sessions(owner_filter(organization), max_sessions)
+
+    case Repo.transaction(build_keep_sessions_multi(organization, max_sessions)) do
+      {:ok, _changes} -> :ok
+      {:error, _operation, reason, _changes} -> {:error, reason}
+    end
+  end
+
+  defp build_keep_sessions_multi(user_or_org, keep_count) do
+    Ecto.Multi.new()
+    |> Ecto.Multi.run(:session_limit, fn _repo, _changes ->
+      lock_session_owner(user_or_org)
+      revoke_lru_sessions(owner_filter(user_or_org), keep_count)
+      {:ok, nil}
+    end)
   end
 
   # Revokes any active sessions beyond `keep_count`, ranked most-recently-used first.
@@ -405,43 +443,50 @@ defmodule Hexpm.UserSessions do
   # `Tokens.revoke_and_create_token`, which locks the old token before
   # touching its session (FK insert and last_use update). Acquiring the
   # locks in the same order across both flows avoids circular waits.
-  # The `is_nil(revoked_at)` filter on each update keeps concurrent
-  # enforcers idempotent without needing a SELECT FOR UPDATE.
+  # The owner row lock serializes session-limit enforcement and creation.
   defp revoke_lru_sessions(owner_filter, keep_count) do
     now = DateTime.utc_now()
 
-    Repo.transaction(fn ->
-      session_ids =
+    session_ids =
+      from(s in UserSession,
+        where: ^owner_filter,
+        where: is_nil(s.revoked_at) and s.expires_at > ^now,
+        order_by: [
+          desc_nulls_last: fragment("(last_use->>'used_at')::timestamptz"),
+          desc: s.inserted_at
+        ],
+        offset: ^keep_count,
+        select: s.id
+      )
+      |> Repo.all()
+
+    if session_ids != [] do
+      Repo.update_all(
+        from(t in Token,
+          where: t.user_session_id in ^session_ids and is_nil(t.revoked_at)
+        ),
+        set: [revoked_at: now, updated_at: now]
+      )
+
+      Repo.update_all(
         from(s in UserSession,
-          where: ^owner_filter,
-          where: is_nil(s.revoked_at) and s.expires_at > ^now,
-          order_by: [
-            desc_nulls_last: fragment("(last_use->>'used_at')::timestamptz"),
-            desc: s.inserted_at
-          ],
-          offset: ^keep_count,
-          select: s.id
-        )
-        |> Repo.all()
-
-      if session_ids != [] do
-        Repo.update_all(
-          from(t in Token,
-            where: t.user_session_id in ^session_ids and is_nil(t.revoked_at)
-          ),
-          set: [revoked_at: now, updated_at: now]
-        )
-
-        Repo.update_all(
-          from(s in UserSession,
-            where: s.id in ^session_ids and is_nil(s.revoked_at)
-          ),
-          set: [revoked_at: now, updated_at: now]
-        )
-      end
-    end)
+          where: s.id in ^session_ids and is_nil(s.revoked_at)
+        ),
+        set: [revoked_at: now, updated_at: now]
+      )
+    end
 
     :ok
+  end
+
+  defp lock_session_owner(%User{id: id}) do
+    from(user in User, where: user.id == ^id, lock: "FOR UPDATE")
+    |> Repo.one!()
+  end
+
+  defp lock_session_owner(%Organization{id: id}) do
+    from(organization in Organization, where: organization.id == ^id, lock: "FOR UPDATE")
+    |> Repo.one!()
   end
 
   defp owner_filter(%Hexpm.Accounts.User{} = user) do

--- a/lib/hexpm_web/auth_helpers.ex
+++ b/lib/hexpm_web/auth_helpers.ex
@@ -5,7 +5,7 @@ defmodule HexpmWeb.AuthHelpers do
   alias Hexpm.Accounts.{Auth, Organization, Organizations, User, TFA}
   alias Hexpm.Permissions
   alias Hexpm.Repository.{Package, Packages, PackageOwner, Repository}
-  alias Hexpm.OAuth.Token
+  alias Hexpm.OAuth.{MachineToken, Token}
   alias HexpmWeb.Plugs.Attack
 
   def authorize(conn, opts) do
@@ -98,6 +98,23 @@ defmodule HexpmWeb.AuthHelpers do
 
   # TOTP validation for write operations
   defp validate_totp_for_write_access(conn, %User{} = user, %Token{} = _token, domains) do
+    validate_oauth_totp(conn, user, domains)
+  end
+
+  defp validate_totp_for_write_access(
+         conn,
+         %User{} = user,
+         %MachineToken{} = _token,
+         domains
+       ) do
+    validate_oauth_totp(conn, user, domains)
+  end
+
+  defp validate_totp_for_write_access(_conn, _user_or_org, _auth_credential, _domains) do
+    nil
+  end
+
+  defp validate_oauth_totp(conn, %User{} = user, domains) do
     if requires_write_access?(domains) do
       if not User.tfa_enabled?(user) do
         {:error, :tfa_not_enabled}
@@ -107,11 +124,6 @@ defmodule HexpmWeb.AuthHelpers do
     else
       nil
     end
-  end
-
-  defp validate_totp_for_write_access(_conn, _user_or_org, _auth_credential, _domains) do
-    # Not an OAuth token, skip validation
-    nil
   end
 
   defp requires_write_access?(domains) do

--- a/lib/hexpm_web/auth_helpers.ex
+++ b/lib/hexpm_web/auth_helpers.ex
@@ -5,7 +5,7 @@ defmodule HexpmWeb.AuthHelpers do
   alias Hexpm.Accounts.{Auth, Organization, Organizations, User, TFA}
   alias Hexpm.Permissions
   alias Hexpm.Repository.{Package, Packages, PackageOwner, Repository}
-  alias Hexpm.OAuth.Token
+  alias Hexpm.OAuth.{MachineToken, Token}
   alias HexpmWeb.BasicAuth
   alias HexpmWeb.Plugs.Attack
 
@@ -99,6 +99,23 @@ defmodule HexpmWeb.AuthHelpers do
 
   # TOTP validation for write operations
   defp validate_totp_for_write_access(conn, %User{} = user, %Token{} = _token, domains) do
+    validate_oauth_totp(conn, user, domains)
+  end
+
+  defp validate_totp_for_write_access(
+         conn,
+         %User{} = user,
+         %MachineToken{} = _token,
+         domains
+       ) do
+    validate_oauth_totp(conn, user, domains)
+  end
+
+  defp validate_totp_for_write_access(_conn, _user_or_org, _auth_credential, _domains) do
+    nil
+  end
+
+  defp validate_oauth_totp(conn, %User{} = user, domains) do
     if requires_write_access?(domains) do
       if not User.tfa_enabled?(user) do
         {:error, :tfa_not_enabled}
@@ -108,11 +125,6 @@ defmodule HexpmWeb.AuthHelpers do
     else
       nil
     end
-  end
-
-  defp validate_totp_for_write_access(_conn, _user_or_org, _auth_credential, _domains) do
-    # Not an OAuth token, skip validation
-    nil
   end
 
   defp requires_write_access?(domains) do

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -4,7 +4,8 @@ defmodule HexpmWeb.API.OAuthController do
   import HexpmWeb.RequestHelpers, only: [build_usage_info: 1]
 
   alias Hexpm.UserSessions
-  alias Hexpm.OAuth.{Clients, Tokens, AuthorizationCodes, DeviceCodes}
+  alias Hexpm.OAuth.{AuthorizationCodes, Clients, DeviceCodes, Tokens}
+  alias HexpmWeb.Plugs.Attack
 
   defp safe_param(params, key), do: safe_string(params[key])
 
@@ -15,13 +16,13 @@ defmodule HexpmWeb.API.OAuthController do
   def token(conn, params) do
     case get_grant_type(params) do
       "authorization_code" ->
-        handle_authorization_code_grant(conn, params)
+        with_write_mode(conn, fn -> handle_authorization_code_grant(conn, params) end)
 
       "urn:ietf:params:oauth:grant-type:device_code" ->
-        handle_device_code_grant(conn, params)
+        with_write_mode(conn, fn -> handle_device_code_grant(conn, params) end)
 
       "refresh_token" ->
-        handle_refresh_token_grant(conn, params)
+        with_write_mode(conn, fn -> handle_refresh_token_grant(conn, params) end)
 
       "client_credentials" ->
         handle_client_credentials_grant(conn, params)
@@ -39,45 +40,47 @@ defmodule HexpmWeb.API.OAuthController do
   Device authorization endpoint for device flow.
   """
   def device_authorization(conn, params) do
-    with {:ok, client} <- validate_client(safe_param(params, "client_id")),
-         :ok <-
-           validate_client_supports_grant(client, "urn:ietf:params:oauth:grant-type:device_code"),
-         {:ok, scopes} <- validate_scopes(client, params["scope"]) do
-      case DeviceCodes.initiate_device_authorization(conn, client.client_id, scopes,
-             name: safe_param(params, "name")
-           ) do
-        {:ok, response} ->
-          render(conn, :device_authorization, device_response: response)
+    with_write_mode(conn, fn ->
+      with {:ok, client} <- validate_client(safe_param(params, "client_id")),
+           :ok <-
+             validate_client_supports_grant(
+               client,
+               "urn:ietf:params:oauth:grant-type:device_code"
+             ),
+           {:ok, scopes} <- validate_scopes(client, params["scope"]) do
+        case DeviceCodes.initiate_device_authorization(conn, client.client_id, scopes,
+               name: safe_param(params, "name")
+             ) do
+          {:ok, response} ->
+            render(conn, :device_authorization, device_response: response)
 
-        {:error, reason} ->
-          render_oauth_error(
-            conn,
-            :server_error,
-            "Failed to initiate device authorization: #{reason}"
-          )
+          {:error, reason} ->
+            render_oauth_error(
+              conn,
+              :server_error,
+              "Failed to initiate device authorization: #{reason}"
+            )
+        end
+      else
+        {:error, error, description} ->
+          render_oauth_error(conn, error, description)
+
+        {:error, error} ->
+          render_oauth_error(conn, :invalid_client, error)
       end
-    else
-      {:error, error, description} ->
-        render_oauth_error(conn, error, description)
-
-      {:error, error} ->
-        render_oauth_error(conn, :invalid_client, error)
-    end
+    end)
   end
 
   @doc """
   OAuth 2.0 token revocation endpoint (RFC 7009).
   """
   def revoke(conn, params) do
-    case revoke_token(params) do
-      :ok ->
-        # RFC 7009 specifies 200 OK for successful revocation
-        send_resp(conn, 200, "")
-
-      {:error, _reason} ->
-        # RFC 7009 specifies 200 OK even for invalid tokens (security)
-        send_resp(conn, 200, "")
-    end
+    with_write_mode(conn, fn ->
+      case revoke_token(params) do
+        :ok -> send_resp(conn, 200, "")
+        {:error, _reason} -> send_resp(conn, 200, "")
+      end
+    end)
   end
 
   @doc """
@@ -85,14 +88,12 @@ defmodule HexpmWeb.API.OAuthController do
   Allows revocation of the session and all its tokens when the actual token value is not available.
   """
   def revoke_by_hash(conn, params) do
-    case revoke_token_by_hash(params) do
-      :ok ->
-        send_resp(conn, 200, "")
-
-      {:error, _reason} ->
-        # Return 200 OK even for invalid tokens (security per RFC 7009)
-        send_resp(conn, 200, "")
-    end
+    with_write_mode(conn, fn ->
+      case revoke_token_by_hash(params) do
+        :ok -> send_resp(conn, 200, "")
+        {:error, _reason} -> send_resp(conn, 200, "")
+      end
+    end)
   end
 
   defp get_grant_type(%{"grant_type" => grant_type}), do: grant_type
@@ -166,33 +167,9 @@ defmodule HexpmWeb.API.OAuthController do
     with {:ok, client} <- authenticate_client(params),
          :ok <- validate_client_supports_grant(client, "refresh_token"),
          {:ok, token} <-
-           validate_refresh_token(safe_param(params, "refresh_token"), client.client_id) do
-      usage_info = build_usage_info(conn)
-
-      # Refresh from the originally granted scopes so dynamic scopes
-      # ("repositories") are re-expanded against current organization
-      # memberships, instead of carrying the expansion frozen at session
-      # creation for the session's whole lifetime.
-      case Tokens.revoke_and_create_token(
-             token,
-             client.client_id,
-             token.granted_scopes,
-             "refresh_token",
-             params["refresh_token"],
-             with_refresh_token: true,
-             user_session_id: token.user_session_id,
-             usage_info: usage_info
-           ) do
-        {:ok, new_token} ->
-          render(conn, :token, token: new_token)
-
-        {:error, changeset} ->
-          render_oauth_error(
-            conn,
-            :server_error,
-            "Failed to create token: #{inspect(changeset.errors)}"
-          )
-      end
+           validate_refresh_token(safe_param(params, "refresh_token"), client.client_id),
+         :ok <- validate_client_supports_scopes(client, token.granted_scopes) do
+      refresh_token(conn, params, client, token)
     else
       {:error, error, description} ->
         render_oauth_error(conn, error, description)
@@ -202,32 +179,42 @@ defmodule HexpmWeb.API.OAuthController do
   defp handle_client_credentials_grant(conn, params) do
     with {:ok, client} <- validate_client(safe_param(params, "client_id")),
          :ok <- validate_client_supports_grant(client, "client_credentials"),
+         :ok <- validate_client_supports_scopes(client, params["scope"]),
          {:ok, api_key_secret} <- validate_api_key_secret(safe_param(params, "client_secret")),
          {:ok, auth_info} <- authenticate_api_key(api_key_secret, conn),
+         {:ok, conn} <- throttle_machine_token_exchange(conn, auth_info.auth_credential.id),
          {:ok, scopes} <- expand_and_validate_scopes(params["scope"], auth_info) do
-      usage_info = build_usage_info(conn)
-
-      # Determine user or organization from the API key
       user_or_org = auth_info.user || auth_info.organization
 
-      # Build audit data with the authenticated user/org
-      audit_data = %{
-        user: user_or_org,
-        auth_credential: auth_info.auth_credential,
-        user_agent: conn.assigns.user_agent,
-        remote_ip: HexpmWeb.RequestHelpers.parse_ip(conn.remote_ip)
-      }
+      result =
+        if Hexpm.Repo.write_mode?() do
+          usage_info = build_usage_info(conn)
 
-      case Tokens.create_session_and_token_for_api_key(
-             user_or_org,
-             client.client_id,
-             scopes,
-             "client_credentials",
-             api_key_secret,
-             name: safe_param(params, "name"),
-             usage_info: usage_info,
-             audit: audit_data
-           ) do
+          audit_data = %{
+            user: user_or_org,
+            auth_credential: auth_info.auth_credential,
+            user_agent: conn.assigns.user_agent,
+            remote_ip: HexpmWeb.RequestHelpers.parse_ip(conn.remote_ip)
+          }
+
+          Tokens.create_session_and_token_for_api_key(
+            user_or_org,
+            client.client_id,
+            scopes,
+            name: safe_param(params, "name"),
+            usage_info: usage_info,
+            audit: audit_data
+          )
+        else
+          Tokens.create_machine_token(
+            user_or_org,
+            client.client_id,
+            scopes,
+            auth_info.auth_credential.id
+          )
+        end
+
+      case result do
         {:ok, token} ->
           render(conn, :token, token: token)
 
@@ -239,6 +226,9 @@ defmodule HexpmWeb.API.OAuthController do
           )
       end
     else
+      {:error, :rate_limited, conn} ->
+        render_oauth_error(conn, :slow_down, "API key token exchange rate limit exceeded")
+
       {:error, error} when is_atom(error) ->
         render_oauth_error(conn, error, error_description(error))
 
@@ -256,6 +246,85 @@ defmodule HexpmWeb.API.OAuthController do
     else
       {:error, :unauthorized_client, "Client not authorized for this grant type"}
     end
+  end
+
+  defp refresh_token(conn, params, client, token) do
+    usage_info = build_usage_info(conn)
+
+    case Tokens.revoke_and_create_token(
+           token,
+           client.client_id,
+           token.granted_scopes,
+           "refresh_token",
+           params["refresh_token"],
+           with_refresh_token: true,
+           user_session_id: token.user_session_id,
+           usage_info: usage_info
+         ) do
+      {:ok, new_token} ->
+        render(conn, :token, token: new_token)
+
+      {:error, changeset} ->
+        render_oauth_error(
+          conn,
+          :server_error,
+          "Failed to create token: #{inspect(changeset.errors)}"
+        )
+    end
+  end
+
+  defp throttle_machine_token_exchange(conn, key_id) do
+    case Attack.machine_token_exchange_throttle(key_id) do
+      {:allow, {:throttle, data}} ->
+        {:ok, Attack.put_throttling_headers(conn, data)}
+
+      {:block, {:throttle, data}} ->
+        retry_after =
+          max(div(data[:expires_at] - System.system_time(:millisecond) + 999, 1000), 1)
+
+        conn =
+          conn
+          |> Attack.put_throttling_headers(data)
+          |> put_resp_header("retry-after", Integer.to_string(retry_after))
+
+        {:error, :rate_limited, conn}
+    end
+  end
+
+  defp validate_client_supports_scopes(client, scope_string)
+       when is_binary(scope_string) or is_nil(scope_string) do
+    scopes = String.split(scope_string || "", " ", trim: true)
+
+    with :ok <- Hexpm.Permissions.validate_scopes(scopes),
+         true <- Clients.supports_scopes?(client, scopes) do
+      :ok
+    else
+      _ -> {:error, :invalid_scope, "Invalid scope"}
+    end
+  end
+
+  defp validate_client_supports_scopes(client, scopes) when is_list(scopes) do
+    if Clients.supports_scopes?(client, scopes) do
+      :ok
+    else
+      {:error, :invalid_scope, "Invalid scope"}
+    end
+  end
+
+  defp validate_client_supports_scopes(_client, _scopes) do
+    {:error, :invalid_scope, "Invalid scope"}
+  end
+
+  defp with_write_mode(conn, fun) do
+    if Hexpm.Repo.write_mode?(), do: fun.(), else: temporarily_unavailable(conn)
+  end
+
+  defp temporarily_unavailable(conn) do
+    render_oauth_error(
+      conn,
+      :temporarily_unavailable,
+      "OAuth operation unavailable while the service is read-only"
+    )
   end
 
   defp validate_api_key_secret(nil), do: {:error, :invalid_request}
@@ -286,7 +355,8 @@ defmodule HexpmWeb.API.OAuthController do
 
     # Final validation: check that all requested scopes are allowed
     # This validates non-repository scopes (like "api")
-    if validate_scopes_against_key(expanded_scopes, api_key.permissions) do
+    if expanded_scopes != [] and
+         validate_scopes_against_key(expanded_scopes, api_key.permissions) do
       {:ok, expanded_scopes}
     else
       {:error, :invalid_scope, "Requested scopes exceed API key permissions"}
@@ -496,6 +566,8 @@ defmodule HexpmWeb.API.OAuthController do
   defp error_status(:invalid_scope), do: 400
   defp error_status(:access_denied), do: 403
   defp error_status(:server_error), do: 500
+  defp error_status(:temporarily_unavailable), do: 503
+  defp error_status(:slow_down), do: 429
   defp error_status(:authorization_pending), do: 400
   defp error_status(:expired_token), do: 400
   defp error_status(_), do: 400

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -5,7 +5,8 @@ defmodule HexpmWeb.API.OAuthController do
 
   alias Hexpm.Accounts.Organization
   alias Hexpm.UserSessions
-  alias Hexpm.OAuth.{Clients, Tokens, AuthorizationCodes, DeviceCodes}
+  alias Hexpm.OAuth.{AuthorizationCodes, Clients, DeviceCodes, Tokens}
+  alias HexpmWeb.Plugs.Attack
 
   defp safe_param(params, key), do: safe_string(params[key])
 
@@ -16,13 +17,13 @@ defmodule HexpmWeb.API.OAuthController do
   def token(conn, params) do
     case get_grant_type(params) do
       "authorization_code" ->
-        handle_authorization_code_grant(conn, params)
+        with_write_mode(conn, fn -> handle_authorization_code_grant(conn, params) end)
 
       "urn:ietf:params:oauth:grant-type:device_code" ->
-        handle_device_code_grant(conn, params)
+        with_write_mode(conn, fn -> handle_device_code_grant(conn, params) end)
 
       "refresh_token" ->
-        handle_refresh_token_grant(conn, params)
+        with_write_mode(conn, fn -> handle_refresh_token_grant(conn, params) end)
 
       "client_credentials" ->
         handle_client_credentials_grant(conn, params)
@@ -40,45 +41,47 @@ defmodule HexpmWeb.API.OAuthController do
   Device authorization endpoint for device flow.
   """
   def device_authorization(conn, params) do
-    with {:ok, client} <- validate_client(safe_param(params, "client_id")),
-         :ok <-
-           validate_client_supports_grant(client, "urn:ietf:params:oauth:grant-type:device_code"),
-         {:ok, scopes} <- validate_scopes(client, params["scope"]) do
-      case DeviceCodes.initiate_device_authorization(conn, client.client_id, scopes,
-             name: safe_param(params, "name")
-           ) do
-        {:ok, response} ->
-          render(conn, :device_authorization, device_response: response)
+    with_write_mode(conn, fn ->
+      with {:ok, client} <- validate_client(safe_param(params, "client_id")),
+           :ok <-
+             validate_client_supports_grant(
+               client,
+               "urn:ietf:params:oauth:grant-type:device_code"
+             ),
+           {:ok, scopes} <- validate_scopes(client, params["scope"]) do
+        case DeviceCodes.initiate_device_authorization(conn, client.client_id, scopes,
+               name: safe_param(params, "name")
+             ) do
+          {:ok, response} ->
+            render(conn, :device_authorization, device_response: response)
 
-        {:error, reason} ->
-          render_oauth_error(
-            conn,
-            :server_error,
-            "Failed to initiate device authorization: #{reason}"
-          )
+          {:error, reason} ->
+            render_oauth_error(
+              conn,
+              :server_error,
+              "Failed to initiate device authorization: #{reason}"
+            )
+        end
+      else
+        {:error, error, description} ->
+          render_oauth_error(conn, error, description)
+
+        {:error, error} ->
+          render_oauth_error(conn, :invalid_client, error)
       end
-    else
-      {:error, error, description} ->
-        render_oauth_error(conn, error, description)
-
-      {:error, error} ->
-        render_oauth_error(conn, :invalid_client, error)
-    end
+    end)
   end
 
   @doc """
   OAuth 2.0 token revocation endpoint (RFC 7009).
   """
   def revoke(conn, params) do
-    case revoke_token(params) do
-      :ok ->
-        # RFC 7009 specifies 200 OK for successful revocation
-        send_resp(conn, 200, "")
-
-      {:error, _reason} ->
-        # RFC 7009 specifies 200 OK even for invalid tokens (security)
-        send_resp(conn, 200, "")
-    end
+    with_write_mode(conn, fn ->
+      case revoke_token(params) do
+        :ok -> send_resp(conn, 200, "")
+        {:error, _reason} -> send_resp(conn, 200, "")
+      end
+    end)
   end
 
   @doc """
@@ -86,14 +89,12 @@ defmodule HexpmWeb.API.OAuthController do
   Allows revocation of the session and all its tokens when the actual token value is not available.
   """
   def revoke_by_hash(conn, params) do
-    case revoke_token_by_hash(params) do
-      :ok ->
-        send_resp(conn, 200, "")
-
-      {:error, _reason} ->
-        # Return 200 OK even for invalid tokens (security per RFC 7009)
-        send_resp(conn, 200, "")
-    end
+    with_write_mode(conn, fn ->
+      case revoke_token_by_hash(params) do
+        :ok -> send_resp(conn, 200, "")
+        {:error, _reason} -> send_resp(conn, 200, "")
+      end
+    end)
   end
 
   defp get_grant_type(%{"grant_type" => grant_type}), do: grant_type
@@ -167,33 +168,9 @@ defmodule HexpmWeb.API.OAuthController do
     with {:ok, client} <- authenticate_client(params),
          :ok <- validate_client_supports_grant(client, "refresh_token"),
          {:ok, token} <-
-           validate_refresh_token(safe_param(params, "refresh_token"), client.client_id) do
-      usage_info = build_usage_info(conn)
-
-      # Refresh from the originally granted scopes so dynamic scopes
-      # ("repositories") are re-expanded against current organization
-      # memberships, instead of carrying the expansion frozen at session
-      # creation for the session's whole lifetime.
-      case Tokens.revoke_and_create_token(
-             token,
-             client.client_id,
-             token.granted_scopes,
-             "refresh_token",
-             params["refresh_token"],
-             with_refresh_token: true,
-             user_session_id: token.user_session_id,
-             usage_info: usage_info
-           ) do
-        {:ok, new_token} ->
-          render(conn, :token, token: new_token)
-
-        {:error, changeset} ->
-          render_oauth_error(
-            conn,
-            :server_error,
-            "Failed to create token: #{inspect(changeset.errors)}"
-          )
-      end
+           validate_refresh_token(safe_param(params, "refresh_token"), client.client_id),
+         :ok <- validate_client_supports_scopes(client, token.granted_scopes) do
+      refresh_token(conn, params, client, token)
     else
       {:error, error, description} ->
         render_oauth_error(conn, error, description)
@@ -203,23 +180,32 @@ defmodule HexpmWeb.API.OAuthController do
   defp handle_client_credentials_grant(conn, params) do
     with {:ok, client} <- validate_client(safe_param(params, "client_id")),
          :ok <- validate_client_supports_grant(client, "client_credentials"),
+         :ok <- validate_client_supports_scopes(client, params["scope"]),
          {:ok, api_key_secret} <- validate_api_key_secret(safe_param(params, "client_secret")),
          {:ok, auth_info} <- authenticate_api_key(api_key_secret, conn),
+         {:ok, conn} <- throttle_machine_token_exchange(conn, auth_info.auth_credential.id),
          {:ok, scopes} <- expand_and_validate_scopes(params["scope"], auth_info) do
-      usage_info = build_usage_info(conn)
-
-      # Determine user or organization from the API key
       user_or_org = auth_info.user || auth_info.organization
 
-      case Tokens.create_session_and_token_for_api_key(
-             user_or_org,
-             client.client_id,
-             scopes,
-             "client_credentials",
-             api_key_secret,
-             name: safe_param(params, "name"),
-             usage_info: usage_info
-           ) do
+      result =
+        if Hexpm.Repo.write_mode?() do
+          Tokens.create_session_and_token_for_api_key(
+            user_or_org,
+            client.client_id,
+            scopes,
+            name: safe_param(params, "name"),
+            usage_info: build_usage_info(conn)
+          )
+        else
+          Tokens.create_machine_token(
+            user_or_org,
+            client.client_id,
+            scopes,
+            auth_info.auth_credential.id
+          )
+        end
+
+      case result do
         {:ok, token} ->
           render(conn, :token, token: token)
 
@@ -231,6 +217,9 @@ defmodule HexpmWeb.API.OAuthController do
           )
       end
     else
+      {:error, :rate_limited, conn} ->
+        render_oauth_error(conn, :slow_down, "API key token exchange rate limit exceeded")
+
       {:error, error} when is_atom(error) ->
         render_oauth_error(conn, error, error_description(error))
 
@@ -248,6 +237,85 @@ defmodule HexpmWeb.API.OAuthController do
     else
       {:error, :unauthorized_client, "Client not authorized for this grant type"}
     end
+  end
+
+  defp refresh_token(conn, params, client, token) do
+    usage_info = build_usage_info(conn)
+
+    case Tokens.revoke_and_create_token(
+           token,
+           client.client_id,
+           token.granted_scopes,
+           "refresh_token",
+           params["refresh_token"],
+           with_refresh_token: true,
+           user_session_id: token.user_session_id,
+           usage_info: usage_info
+         ) do
+      {:ok, new_token} ->
+        render(conn, :token, token: new_token)
+
+      {:error, changeset} ->
+        render_oauth_error(
+          conn,
+          :server_error,
+          "Failed to create token: #{inspect(changeset.errors)}"
+        )
+    end
+  end
+
+  defp throttle_machine_token_exchange(conn, key_id) do
+    case Attack.machine_token_exchange_throttle(key_id) do
+      {:allow, {:throttle, data}} ->
+        {:ok, Attack.put_throttling_headers(conn, data)}
+
+      {:block, {:throttle, data}} ->
+        retry_after =
+          max(div(data[:expires_at] - System.system_time(:millisecond) + 999, 1000), 1)
+
+        conn =
+          conn
+          |> Attack.put_throttling_headers(data)
+          |> put_resp_header("retry-after", Integer.to_string(retry_after))
+
+        {:error, :rate_limited, conn}
+    end
+  end
+
+  defp validate_client_supports_scopes(client, scope_string)
+       when is_binary(scope_string) or is_nil(scope_string) do
+    scopes = String.split(scope_string || "", " ", trim: true)
+
+    with :ok <- Hexpm.Permissions.validate_scopes(scopes),
+         true <- Clients.supports_scopes?(client, scopes) do
+      :ok
+    else
+      _ -> {:error, :invalid_scope, "Invalid scope"}
+    end
+  end
+
+  defp validate_client_supports_scopes(client, scopes) when is_list(scopes) do
+    if Clients.supports_scopes?(client, scopes) do
+      :ok
+    else
+      {:error, :invalid_scope, "Invalid scope"}
+    end
+  end
+
+  defp validate_client_supports_scopes(_client, _scopes) do
+    {:error, :invalid_scope, "Invalid scope"}
+  end
+
+  defp with_write_mode(conn, fun) do
+    if Hexpm.Repo.write_mode?(), do: fun.(), else: temporarily_unavailable(conn)
+  end
+
+  defp temporarily_unavailable(conn) do
+    render_oauth_error(
+      conn,
+      :temporarily_unavailable,
+      "OAuth operation unavailable while the service is read-only"
+    )
   end
 
   defp validate_api_key_secret(nil), do: {:error, :invalid_request}
@@ -278,7 +346,8 @@ defmodule HexpmWeb.API.OAuthController do
 
     # Final validation: check that all requested scopes are allowed
     # This validates non-repository scopes (like "api")
-    if validate_scopes_against_key(expanded_scopes, api_key.permissions, user_or_org) do
+    if expanded_scopes != [] and
+         validate_scopes_against_key(expanded_scopes, api_key.permissions, user_or_org) do
       {:ok, expanded_scopes}
     else
       {:error, :invalid_scope, "Requested scopes exceed API key permissions"}
@@ -504,6 +573,8 @@ defmodule HexpmWeb.API.OAuthController do
   defp error_status(:invalid_scope), do: 400
   defp error_status(:access_denied), do: 403
   defp error_status(:server_error), do: 500
+  defp error_status(:temporarily_unavailable), do: 503
+  defp error_status(:slow_down), do: 429
   defp error_status(:authorization_pending), do: 400
   defp error_status(:expired_token), do: 400
   defp error_status(_), do: 400

--- a/lib/hexpm_web/plugs/attack.ex
+++ b/lib/hexpm_web/plugs/attack.ex
@@ -48,7 +48,7 @@ defmodule HexpmWeb.Plugs.Attack do
   end
 
   def allow_action(conn, {:throttle, data}, _opts) do
-    add_throttling_headers(conn, data)
+    put_throttling_headers(conn, data)
   end
 
   def allow_action(conn, _data, _opts) do
@@ -57,7 +57,7 @@ defmodule HexpmWeb.Plugs.Attack do
 
   def block_action(conn, {:throttle, data}, _opts) do
     conn
-    |> add_throttling_headers(data)
+    |> put_throttling_headers(data)
     |> render_error(429, message: "API rate limit exceeded for #{throttled_user(conn)}")
   end
 
@@ -65,7 +65,7 @@ defmodule HexpmWeb.Plugs.Attack do
     render_error(conn, 403, message: "Blocked")
   end
 
-  defp add_throttling_headers(conn, data) do
+  def put_throttling_headers(conn, data) do
     # The expires_at value is a unix time in milliseconds, we want to return one
     # in seconds
     reset = div(data[:expires_at], 1_000)
@@ -117,6 +117,20 @@ defmodule HexpmWeb.Plugs.Attack do
       time: time,
       storage: @storage,
       limit: 500,
+      period: 60_000
+    )
+  end
+
+  def machine_token_exchange_throttle(key_id, opts \\ []) do
+    key = {:machine_token_exchange, key_id}
+    time = opts[:time] || System.system_time(:millisecond)
+    unless opts[:time], do: RateLimitPubSub.broadcast(key, time)
+
+    timed_throttle(
+      key,
+      time: time,
+      storage: @storage,
+      limit: 100,
       period: 60_000
     )
   end

--- a/lib/hexpm_web/plugs/attack.ex
+++ b/lib/hexpm_web/plugs/attack.ex
@@ -49,7 +49,7 @@ defmodule HexpmWeb.Plugs.Attack do
   end
 
   def allow_action(conn, {:throttle, data}, _opts) do
-    add_throttling_headers(conn, data)
+    put_throttling_headers(conn, data)
   end
 
   def allow_action(conn, _data, _opts) do
@@ -58,7 +58,7 @@ defmodule HexpmWeb.Plugs.Attack do
 
   def block_action(conn, {:throttle, data}, _opts) do
     conn
-    |> add_throttling_headers(data)
+    |> put_throttling_headers(data)
     |> render_error(429, message: "API rate limit exceeded for #{throttled_user(conn)}")
   end
 
@@ -66,7 +66,7 @@ defmodule HexpmWeb.Plugs.Attack do
     render_error(conn, 403, message: "Blocked")
   end
 
-  defp add_throttling_headers(conn, data) do
+  def put_throttling_headers(conn, data) do
     # The expires_at value is a unix time in milliseconds, we want to return one
     # in seconds
     reset = div(data[:expires_at], 1_000)
@@ -118,6 +118,20 @@ defmodule HexpmWeb.Plugs.Attack do
       time: time,
       storage: @storage,
       limit: 500,
+      period: 60_000
+    )
+  end
+
+  def machine_token_exchange_throttle(key_id, opts \\ []) do
+    key = {:machine_token_exchange, key_id}
+    time = opts[:time] || System.system_time(:millisecond)
+    unless opts[:time], do: RateLimitPubSub.broadcast(key, time)
+
+    timed_throttle(
+      key,
+      time: time,
+      storage: @storage,
+      limit: 100,
       period: 60_000
     )
   end

--- a/lib/hexpm_web/rate_limit_pub_sub.ex
+++ b/lib/hexpm_web/rate_limit_pub_sub.ex
@@ -35,4 +35,9 @@ defmodule HexpmWeb.RateLimitPubSub do
     Attack.diff_throttle(identity, time: time)
     {:noreply, []}
   end
+
+  def handle_info({:throttle, {:machine_token_exchange, key_id}, time}, []) do
+    Attack.machine_token_exchange_throttle(key_id, time: time)
+    {:noreply, []}
+  end
 end

--- a/lib/hexpm_web/rate_limit_pub_sub.ex
+++ b/lib/hexpm_web/rate_limit_pub_sub.ex
@@ -50,4 +50,9 @@ defmodule HexpmWeb.RateLimitPubSub do
     Attack.sso_callback_ip_throttle(ip, time: time)
     {:noreply, []}
   end
+
+  def handle_info({:throttle, {:machine_token_exchange, key_id}, time}, []) do
+    Attack.machine_token_exchange_throttle(key_id, time: time)
+    {:noreply, []}
+  end
 end

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -2,6 +2,7 @@ defmodule Hexpm.Accounts.AuditLogTest do
   use Hexpm.DataCase, async: true
 
   alias Hexpm.Accounts.AuditLog
+  alias Hexpm.OAuth.MachineToken
 
   setup do
     user = build(:user)
@@ -69,6 +70,27 @@ defmodule Hexpm.Accounts.AuditLogTest do
       assert audit.params.user.id == user.id
       assert audit.params.user.username == user.username
       assert audit.params.user.handles.github == user.handles.github
+    end
+
+    test "machine token actions are attributed to the API key", %{
+      user: user,
+      key: key,
+      package: package
+    } do
+      user = %{user | handles: build(:user_handles, github: user.username)}
+
+      audit_data = %{
+        user: user,
+        auth_credential: MachineToken.new(key, ["api"]),
+        user_agent: "user_agent",
+        remote_ip: "127.0.0.1"
+      }
+
+      audit = AuditLog.build(audit_data, "owner.add", {package, "full", user})
+
+      assert audit.key == key
+      assert audit.key_data.id == key.id
+      assert audit.oauth_token == nil
     end
 
     test "action organization.create", %{user: user, key: key} do

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -2,6 +2,7 @@ defmodule Hexpm.Accounts.AuditLogTest do
   use Hexpm.DataCase, async: true
 
   alias Hexpm.Accounts.AuditLog
+  alias Hexpm.OAuth.MachineToken
 
   setup do
     user = build(:user)
@@ -85,6 +86,27 @@ defmodule Hexpm.Accounts.AuditLogTest do
       assert audit.params.user.id == user.id
       assert audit.params.user.username == user.username
       assert audit.params.user.handles.github == user.handles.github
+    end
+
+    test "machine token actions are attributed to the API key", %{
+      user: user,
+      key: key,
+      package: package
+    } do
+      user = %{user | handles: build(:user_handles, github: user.username)}
+
+      audit_data = %{
+        user: user,
+        auth_credential: MachineToken.new(key, ["api"]),
+        user_agent: "user_agent",
+        remote_ip: "127.0.0.1"
+      }
+
+      audit = AuditLog.build(audit_data, "owner.add", {package, "full", user})
+
+      assert audit.key == key
+      assert audit.key_data.id == key.id
+      assert audit.oauth_token == nil
     end
 
     test "action organization.create", %{user: user, key: key} do

--- a/test/hexpm/accounts/auth_test.exs
+++ b/test/hexpm/accounts/auth_test.exs
@@ -2,6 +2,7 @@ defmodule Hexpm.Accounts.AuthTest do
   use Hexpm.DataCase, async: true
 
   alias Hexpm.Accounts.{Auth, Key}
+  alias Hexpm.OAuth.{JWT, MachineToken}
 
   setup do
     user = insert(:user, password: Auth.gen_password("password"))
@@ -120,6 +121,62 @@ defmodule Hexpm.Accounts.AuthTest do
     test "fails with malformed JWT token" do
       auth_result = Auth.oauth_token_auth("not-a-jwt", %{})
       assert auth_result == :error
+    end
+
+    test "authenticates a machine token against its live API key", %{user: user} do
+      key = insert(:key, user: user)
+      {:ok, token, _jti} = JWT.generate_machine_token(user.username, "user", ["api:read"], key.id)
+
+      assert {:ok, auth_context} = Auth.oauth_token_auth(token, %{})
+      assert auth_context.user.id == user.id
+
+      assert %MachineToken{id: key_id, key: auth_key, scopes: ["api:read"]} =
+               auth_context.auth_credential
+
+      assert key_id == key.id
+      assert auth_key.id == key.id
+    end
+
+    test "rejects a machine token after its API key is revoked", %{user: user} do
+      key = insert(:key, user: user)
+      {:ok, token, _jti} = JWT.generate_machine_token(user.username, "user", ["api"], key.id)
+      Repo.update!(Key.revoke(key))
+
+      assert Auth.oauth_token_auth(token, %{}) == :error
+    end
+
+    test "rejects a machine token whose subject does not own the API key", %{user: user} do
+      other_user = insert(:user)
+      key = insert(:key, user: user)
+
+      {:ok, token, _jti} =
+        JWT.generate_machine_token(other_user.username, "user", ["api"], key.id)
+
+      assert Auth.oauth_token_auth(token, %{}) == :error
+    end
+
+    test "rejects repository-only and unknown token uses", %{user: user} do
+      {:ok, repository_token, _jti} =
+        JWT.generate_access_token(user.username, "user", ["repository:hexpm"],
+          claims: %{"token_use" => "repository_read_only"}
+        )
+
+      {:ok, unknown_token, _jti} =
+        JWT.generate_access_token(user.username, "user", ["api"],
+          claims: %{"token_use" => "unknown"}
+        )
+
+      assert Auth.oauth_token_auth(repository_token, %{}) == :error
+      assert Auth.oauth_token_auth(unknown_token, %{}) == :error
+    end
+
+    test "rejects malformed machine claims", %{user: user} do
+      {:ok, token, _jti} =
+        JWT.generate_access_token(user.username, "user", ["api"],
+          claims: %{"token_use" => "machine", "key_id" => "not-an-integer"}
+        )
+
+      assert Auth.oauth_token_auth(token, %{}) == :error
     end
 
     test "regression test: documents correct JWT sub format for authentication" do

--- a/test/hexpm/oauth/clients_test.exs
+++ b/test/hexpm/oauth/clients_test.exs
@@ -59,6 +59,13 @@ defmodule Hexpm.OAuth.ClientsTest do
       assert Clients.supports_scopes?(client, ["docs:some-organization"])
     end
 
+    test "treats repositories as allowing narrower repository scopes" do
+      client = %Client{allowed_scopes: ["repositories"]}
+
+      assert Clients.supports_scopes?(client, ["repository:acme"])
+      assert Clients.supports_scopes?(client, ["repositories", "repository:acme"])
+    end
+
     test "returns true for multiple resource-specific scopes" do
       client = %Client{allowed_scopes: ["docs", "repository"]}
 

--- a/test/hexpm/oauth/jwt_test.exs
+++ b/test/hexpm/oauth/jwt_test.exs
@@ -80,6 +80,21 @@ defmodule Hexpm.OAuth.JWTTest do
     end
   end
 
+  describe "row-less access tokens" do
+    test "machine token identifies its API key" do
+      {:ok, token, jti} = JWT.generate_machine_token("testuser", "user", ["api:read"], 123)
+
+      assert {:ok, claims} = JWT.verify_and_decode(token)
+      assert claims["jti"] == jti
+      assert claims["sub"] == "user:testuser"
+      assert claims["scope"] == "api:read"
+      assert claims["token_use"] == "machine"
+      assert claims["key_id"] == 123
+      assert claims["iss"] == "hexpm"
+      assert claims["aud"] == "hexpm:api"
+    end
+  end
+
   describe "verify_and_decode/1" do
     test "successfully decodes valid JWT with correct sub format" do
       {:ok, token, _jti} = JWT.generate_access_token("testuser", "user", ["api:read"])

--- a/test/hexpm/permissions_test.exs
+++ b/test/hexpm/permissions_test.exs
@@ -2,7 +2,7 @@ defmodule Hexpm.PermissionsTest do
   use Hexpm.DataCase, async: true
 
   alias Hexpm.Permissions
-  alias Hexpm.OAuth.Token
+  alias Hexpm.OAuth.{MachineToken, Token}
   alias Hexpm.Repository.Package
 
   describe "validate_scopes/1" do
@@ -274,6 +274,61 @@ defmodule Hexpm.PermissionsTest do
       assert Permissions.verify_access?(key, "api", "write")
       refute Permissions.verify_access?(key, "repository", "foo")
       refute Permissions.verify_access?(key, "repositories", nil)
+    end
+
+    test "machine tokens require both signed scopes and current key permissions" do
+      read_key =
+        build(:key, permissions: [build(:key_permission, domain: "api", resource: "read")])
+
+      broad_token = MachineToken.new(read_key, ["api:read", "api:write"])
+      assert Permissions.verify_access?(broad_token, "api", "read")
+      refute Permissions.verify_access?(broad_token, "api", "write")
+
+      full_key = build(:key, permissions: [build(:key_permission, domain: "api")])
+      narrow_token = MachineToken.new(full_key, ["api:read"])
+      assert Permissions.verify_access?(narrow_token, "api", "read")
+      refute Permissions.verify_access?(narrow_token, "api", "write")
+    end
+  end
+
+  describe "expand_repositories_scope/3" do
+    test "intersects explicit repository scopes with current membership and key permissions" do
+      user = insert(:user)
+      current = insert(:organization)
+      former = insert(:organization)
+      insert(:organization_user, user: user, organization: current)
+
+      key =
+        build(:key,
+          user: user,
+          permissions: [build(:key_permission, domain: "repositories")]
+        )
+
+      assert Permissions.expand_repositories_scope(
+               user,
+               ["repository:#{current.name}", "repository:#{former.name}"],
+               key
+             ) == ["repository:#{current.name}"]
+    end
+
+    test "omits repositories without active billing eligibility" do
+      user = insert(:user)
+      organization = insert(:organization, billing_active: false, trial_end: DateTime.utc_now())
+      insert(:organization_user, user: user, organization: organization)
+
+      key =
+        build(:key,
+          user: user,
+          permissions: [
+            build(:key_permission, domain: "repository", resource: organization.name)
+          ]
+        )
+
+      assert Permissions.expand_repositories_scope(
+               user,
+               ["repositories", "repository:#{organization.name}"],
+               key
+             ) == []
     end
   end
 

--- a/test/hexpm/user_sessions_test.exs
+++ b/test/hexpm/user_sessions_test.exs
@@ -118,6 +118,36 @@ defmodule Hexpm.UserSessionsTest do
       end)
     end
 
+    test "rolls back eviction when API key session creation fails" do
+      user = insert(:user)
+
+      sessions =
+        for i <- 1..5 do
+          {:ok, session, _token} =
+            UserSessions.create_browser_session(user,
+              name: "Browser #{i}",
+              audit: audit_data(user)
+            )
+
+          session
+        end
+
+      assert_raise Ecto.ConstraintError, fn ->
+        Hexpm.OAuth.Tokens.create_session_and_token_for_api_key(
+          user,
+          Ecto.UUID.generate(),
+          ["api"],
+          audit: audit_data(user)
+        )
+      end
+
+      assert UserSessions.count_for_user(user) == 5
+
+      Enum.each(sessions, fn session ->
+        assert Repo.get!(Hexpm.UserSession, session.id).revoked_at == nil
+      end)
+    end
+
     test "revokes least recently used session based on last_use" do
       user = insert(:user)
 

--- a/test/hexpm_web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/auth_controller_test.exs
@@ -134,6 +134,93 @@ defmodule HexpmWeb.API.AuthControllerTest do
       |> response(204)
     end
 
+    test "with a machine token", %{user: user, user_full_key: key} do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(user.username, "user", ["api:read"], key.id)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "read")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "write")
+      |> response(401)
+    end
+
+    test "machine token uses current key revocation state", %{user: user, user_full_key: key} do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(user.username, "user", ["api"], key.id)
+
+      Repo.update!(Hexpm.Accounts.Key.revoke(key))
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api")
+      |> response(401)
+    end
+
+    test "machine token uses current key permissions", %{user: user, user_full_key: key} do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(user.username, "user", ["api"], key.id)
+
+      permissions =
+        Enum.map(key.permissions, fn
+          %Hexpm.Accounts.KeyPermission{domain: "api"} = permission ->
+            Ecto.Changeset.change(permission, resource: "read")
+
+          permission ->
+            Ecto.Changeset.change(permission)
+        end)
+
+      key
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_embed(:permissions, permissions)
+      |> Repo.update!()
+
+      reloaded_key = Repo.get!(Hexpm.Accounts.Key, key.id)
+      assert Hexpm.Permissions.verify_access?(reloaded_key, "api", "read")
+      refute Hexpm.Permissions.verify_access?(reloaded_key, "api", "write")
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "read")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "write")
+      |> response(401)
+    end
+
+    test "machine token uses current organization membership", %{
+      user: user,
+      user_full_key: key,
+      owned_org: organization
+    } do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(
+          user.username,
+          "user",
+          ["repository:#{organization.name}"],
+          key.id
+        )
+
+      membership =
+        Repo.get_by!(Hexpm.Accounts.OrganizationUser,
+          user_id: user.id,
+          organization_id: organization.id
+        )
+
+      Repo.delete!(membership)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "repository", resource: organization.name)
+      |> response(403)
+    end
+
     test "authenticate full user key", %{
       user_full_key: key,
       owned_org: owned_org,

--- a/test/hexpm_web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/auth_controller_test.exs
@@ -134,6 +134,93 @@ defmodule HexpmWeb.API.AuthControllerTest do
       |> response(200)
     end
 
+    test "with a machine token", %{user: user, user_full_key: key} do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(user.username, "user", ["api:read"], key.id)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "read")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "write")
+      |> response(401)
+    end
+
+    test "machine token uses current key revocation state", %{user: user, user_full_key: key} do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(user.username, "user", ["api"], key.id)
+
+      Repo.update!(Hexpm.Accounts.Key.revoke(key))
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api")
+      |> response(401)
+    end
+
+    test "machine token uses current key permissions", %{user: user, user_full_key: key} do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(user.username, "user", ["api"], key.id)
+
+      permissions =
+        Enum.map(key.permissions, fn
+          %Hexpm.Accounts.KeyPermission{domain: "api"} = permission ->
+            Ecto.Changeset.change(permission, resource: "read")
+
+          permission ->
+            Ecto.Changeset.change(permission)
+        end)
+
+      key
+      |> Ecto.Changeset.change()
+      |> Ecto.Changeset.put_embed(:permissions, permissions)
+      |> Repo.update!()
+
+      reloaded_key = Repo.get!(Hexpm.Accounts.Key, key.id)
+      assert Hexpm.Permissions.verify_access?(reloaded_key, "api", "read")
+      refute Hexpm.Permissions.verify_access?(reloaded_key, "api", "write")
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "read")
+      |> response(204)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "api", resource: "write")
+      |> response(401)
+    end
+
+    test "machine token uses current organization membership", %{
+      user: user,
+      user_full_key: key,
+      owned_org: organization
+    } do
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(
+          user.username,
+          "user",
+          ["repository:#{organization.name}"],
+          key.id
+        )
+
+      membership =
+        Repo.get_by!(Hexpm.Accounts.OrganizationUser,
+          user_id: user.id,
+          organization_id: organization.id
+        )
+
+      Repo.delete!(membership)
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{token}")
+      |> get("/api/auth", domain: "repository", resource: organization.name)
+      |> response(403)
+    end
+
     test "authenticate full user key", %{
       user_full_key: key,
       owned_org: owned_org,

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -190,6 +190,22 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert [%KeyPermission{domain: "repository", resource: ^repo_name}] = key.permissions
     end
 
+    test "machine token preserves OAuth TOTP requirements", c do
+      key = Key.build(c.eric, %{name: "computer"}) |> Repo.insert!()
+
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(c.eric.username, "user", ["api:write"], key.id)
+
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/keys", %{name: "macbook"})
+
+      assert json_response(conn, 403)["message"] ==
+               "Two-factor authentication must be enabled for API write access"
+    end
+
     test "create repository key for unknown repository is not allowed", c do
       body = %{
         name: "macbook",

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -187,6 +187,22 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert [%KeyPermission{domain: "repository", resource: ^repo_name}] = key.permissions
     end
 
+    test "machine token preserves OAuth TOTP requirements", c do
+      key = Key.build(c.eric, %{name: "computer"}) |> Repo.insert!()
+
+      {:ok, token, _jti} =
+        Hexpm.OAuth.JWT.generate_machine_token(c.eric.username, "user", ["api:write"], key.id)
+
+      conn =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", "Bearer #{token}")
+        |> post("/api/keys", %{name: "macbook"})
+
+      assert json_response(conn, 403)["message"] ==
+               "Two-factor authentication must be enabled for API write access"
+    end
+
     test "create repository key for unknown repository is not allowed", c do
       body = %{
         name: "macbook",

--- a/test/hexpm_web/controllers/api/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/oauth_controller_test.exs
@@ -311,10 +311,41 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       refute response["refresh_token"] == refresh_token
     end
 
-    test "re-expands repositories scope against current memberships", %{client: client} do
+    test "rejects refresh when the client no longer allows the granted scopes", %{
+      client: client,
+      refresh_token: refresh_token
+    } do
+      {:ok, token} = Tokens.lookup(refresh_token, :refresh, validate: false, preload: [])
+
+      client
+      |> Ecto.Changeset.change(allowed_scopes: ["api:read"])
+      |> Repo.update!()
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => refresh_token,
+          "client_id" => client.client_id
+        })
+
+      assert json_response(conn, 400)["error"] == "invalid_scope"
+      assert Repo.get!(Token, token.id).revoked_at == nil
+    end
+
+    test "re-expands repositories scope against current memberships" do
       user = insert(:user)
       org_left = insert(:organization)
       org_user = insert(:organization_user, organization: org_left, user: user)
+
+      client =
+        Client.build(%{
+          client_id: Clients.generate_client_id(),
+          name: "Repository refresh client",
+          client_type: "public",
+          allowed_grant_types: ["refresh_token"],
+          allowed_scopes: ["api", "repositories"]
+        })
+        |> Repo.insert!()
 
       {:ok, token} =
         Tokens.create_and_insert_for_user(
@@ -672,6 +703,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
 
       %{
         user: user,
+        key: key,
         api_key: key.user_secret,
         client: client
       }
@@ -698,6 +730,35 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "api"
       # No refresh token for client_credentials
       refute response["refresh_token"]
+
+      assert {:ok, claims} = Hexpm.OAuth.JWT.verify_and_decode(response["access_token"])
+      refute claims["token_use"]
+      token = Repo.get_by!(Token, jti: claims["jti"])
+      assert token.grant_reference == nil
+    end
+
+    test "rate limits exchanges per API key", %{client: client, key: key, api_key: api_key} do
+      time = System.system_time(:millisecond)
+
+      Enum.each(1..100, fn _ ->
+        assert {:allow, _data} =
+                 HexpmWeb.Plugs.Attack.machine_token_exchange_throttle(key.id, time: time)
+      end)
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => api_key,
+          "scope" => "api"
+        })
+
+      response = json_response(conn, 429)
+      assert response["error"] == "slow_down"
+      assert get_resp_header(conn, "x-ratelimit-limit") == ["100"]
+      assert get_resp_header(conn, "x-ratelimit-remaining") == ["0"]
+      assert [retry_after] = get_resp_header(conn, "retry-after")
+      assert String.to_integer(retry_after) in 1..60
     end
 
     test "creates session with access token expiration", %{
@@ -717,14 +778,13 @@ defmodule HexpmWeb.API.OAuthControllerTest do
 
       assert json_response(conn, 200)
 
-      # Verify session was created with short expiration
-      sessions = Hexpm.UserSessions.all_for_user(user)
-      assert length(sessions) == 1
-      [session] = sessions
-
+      [session] = Hexpm.UserSessions.all_for_user(user)
       latest_expires_at = DateTime.add(DateTime.utc_now(), 30 * 60, :second)
       assert DateTime.compare(session.expires_at, earliest_expires_at) in [:eq, :gt]
       assert DateTime.compare(session.expires_at, latest_expires_at) in [:eq, :lt]
+
+      token = Repo.get_by!(Token, user_id: user.id, grant_type: "client_credentials")
+      assert token.user_session_id == session.id
     end
 
     test "returns error for missing client_secret", %{client: client} do
@@ -807,6 +867,28 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["error"] == "invalid_scope"
     end
 
+    test "returns error for a scope disallowed by the OAuth client", %{api_key: api_key} do
+      client =
+        Client.build(%{
+          client_id: Clients.generate_client_id(),
+          name: "Read-only client",
+          client_type: "public",
+          allowed_grant_types: ["client_credentials"],
+          allowed_scopes: ["api:read"]
+        })
+        |> Repo.insert!()
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => api_key,
+          "scope" => "api"
+        })
+
+      assert json_response(conn, 400)["error"] == "invalid_scope"
+    end
+
     test "supports custom name parameter", %{
       client: client,
       api_key: api_key,
@@ -824,10 +906,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         })
 
       assert json_response(conn, 200)
-
-      # Verify session was created with the custom name
-      sessions = Hexpm.UserSessions.all_for_user(user)
-      [session] = sessions
+      [session] = Hexpm.UserSessions.all_for_user(user)
       assert session.name == name
     end
 
@@ -836,21 +915,21 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       api_key: api_key,
       user: user
     } do
-      # Create 5 sessions via client credentials
       for i <- 1..5 do
-        post(build_conn(), ~p"/api/oauth/token", %{
-          "grant_type" => "client_credentials",
-          "client_id" => client.client_id,
-          "client_secret" => api_key,
-          "scope" => "api",
-          "name" => "Session #{i}"
-        })
+        conn =
+          post(build_conn(), ~p"/api/oauth/token", %{
+            "grant_type" => "client_credentials",
+            "client_id" => client.client_id,
+            "client_secret" => api_key,
+            "scope" => "api",
+            "name" => "Session #{i}"
+          })
+
+        assert json_response(conn, 200)
       end
 
-      # Verify we have 5 sessions
       assert Hexpm.UserSessions.count_for_user(user) == 5
 
-      # Create a 6th session
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
@@ -861,8 +940,6 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         })
 
       assert json_response(conn, 200)
-
-      # Verify we still only have 5 sessions (oldest was revoked)
       assert Hexpm.UserSessions.count_for_user(user) == 5
     end
 
@@ -1214,7 +1291,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "api"
     end
 
-    test "succeeds when api-only key requests 'repositories' scope", %{
+    test "rejects 'repositories' scope for an api-only key", %{
       user: user,
       client: client
     } do
@@ -1233,7 +1310,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           "scope" => "repositories"
         })
 
-      assert json_response(conn, 200)
+      assert json_response(conn, 400)["error"] == "invalid_scope"
     end
 
     test "succeeds for organization key requesting 'repositories' scope", %{client: client} do
@@ -1260,6 +1337,27 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "repository:#{org.name}"
     end
 
+    test "rejects repository scopes for an organization without billing access", %{client: client} do
+      org = insert(:organization, billing_active: false, trial_end: DateTime.utc_now())
+
+      {:ok, %{key: key}} =
+        Hexpm.Accounts.Keys.create(
+          org,
+          %{name: "org_key", permissions: [%{domain: "repository", resource: org.name}]},
+          audit: audit_data(org)
+        )
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => key.user_secret,
+          "scope" => "repository:#{org.name}"
+        })
+
+      assert json_response(conn, 400)["error"] == "invalid_scope"
+    end
+
     test "org key creates session with organization_id", %{client: client} do
       org = insert(:organization)
 
@@ -1277,16 +1375,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         "scope" => "repositories"
       })
 
-      session =
-        Hexpm.Repo.one(
-          from(s in Hexpm.UserSession,
-            where: s.organization_id == ^org.id,
-            order_by: [desc: s.inserted_at],
-            limit: 1
-          )
-        )
-
-      assert session
+      session = Repo.get_by!(Hexpm.UserSession, organization_id: org.id)
       assert session.organization_id == org.id
       assert is_nil(session.user_id)
     end
@@ -1308,16 +1397,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         "scope" => "repositories"
       })
 
-      token =
-        Hexpm.Repo.one(
-          from(t in Hexpm.OAuth.Token,
-            where: t.organization_id == ^org.id,
-            order_by: [desc: t.inserted_at],
-            limit: 1
-          )
-        )
-
-      assert token
+      token = Repo.get_by!(Token, organization_id: org.id, grant_type: "client_credentials")
       assert token.organization_id == org.id
       assert is_nil(token.user_id)
     end
@@ -1332,17 +1412,18 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           audit: audit_data(org)
         )
 
-      # Create max_sessions (5) sessions
       for _ <- 1..5 do
-        post(build_conn(), ~p"/api/oauth/token", %{
-          "grant_type" => "client_credentials",
-          "client_id" => client.client_id,
-          "client_secret" => key.user_secret,
-          "scope" => "repositories"
-        })
+        conn =
+          post(build_conn(), ~p"/api/oauth/token", %{
+            "grant_type" => "client_credentials",
+            "client_id" => client.client_id,
+            "client_secret" => key.user_secret,
+            "scope" => "repositories"
+          })
+
+        assert json_response(conn, 200)
       end
 
-      # 6th should succeed but oldest should be revoked
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
@@ -1354,7 +1435,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert json_response(conn, 200)
 
       active_count =
-        Hexpm.Repo.one(
+        Repo.one(
           from(s in Hexpm.UserSession,
             where:
               s.organization_id == ^org.id and is_nil(s.revoked_at) and

--- a/test/hexpm_web/controllers/api/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/oauth_controller_test.exs
@@ -311,10 +311,41 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       refute response["refresh_token"] == refresh_token
     end
 
-    test "re-expands repositories scope against current memberships", %{client: client} do
+    test "rejects refresh when the client no longer allows the granted scopes", %{
+      client: client,
+      refresh_token: refresh_token
+    } do
+      {:ok, token} = Tokens.lookup(refresh_token, :refresh, validate: false, preload: [])
+
+      client
+      |> Ecto.Changeset.change(allowed_scopes: ["api:read"])
+      |> Repo.update!()
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "refresh_token",
+          "refresh_token" => refresh_token,
+          "client_id" => client.client_id
+        })
+
+      assert json_response(conn, 400)["error"] == "invalid_scope"
+      assert Repo.get!(Token, token.id).revoked_at == nil
+    end
+
+    test "re-expands repositories scope against current memberships" do
       user = insert(:user)
       org_left = insert(:organization)
       org_user = insert(:organization_user, organization: org_left, user: user)
+
+      client =
+        Client.build(%{
+          client_id: Clients.generate_client_id(),
+          name: "Repository refresh client",
+          client_type: "public",
+          allowed_grant_types: ["refresh_token"],
+          allowed_scopes: ["api", "repositories"]
+        })
+        |> Repo.insert!()
 
       {:ok, token} =
         Tokens.create_and_insert_for_user(
@@ -672,6 +703,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
 
       %{
         user: user,
+        key: key,
         api_key: key.user_secret,
         client: client
       }
@@ -698,6 +730,35 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "api"
       # No refresh token for client_credentials
       refute response["refresh_token"]
+
+      assert {:ok, claims} = Hexpm.OAuth.JWT.verify_and_decode(response["access_token"])
+      refute claims["token_use"]
+      token = Repo.get_by!(Token, jti: claims["jti"])
+      assert token.grant_reference == nil
+    end
+
+    test "rate limits exchanges per API key", %{client: client, key: key, api_key: api_key} do
+      time = System.system_time(:millisecond)
+
+      Enum.each(1..100, fn _ ->
+        assert {:allow, _data} =
+                 HexpmWeb.Plugs.Attack.machine_token_exchange_throttle(key.id, time: time)
+      end)
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => api_key,
+          "scope" => "api"
+        })
+
+      response = json_response(conn, 429)
+      assert response["error"] == "slow_down"
+      assert get_resp_header(conn, "x-ratelimit-limit") == ["100"]
+      assert get_resp_header(conn, "x-ratelimit-remaining") == ["0"]
+      assert [retry_after] = get_resp_header(conn, "retry-after")
+      assert String.to_integer(retry_after) in 1..60
     end
 
     test "creates session with access token expiration", %{
@@ -717,14 +778,13 @@ defmodule HexpmWeb.API.OAuthControllerTest do
 
       assert json_response(conn, 200)
 
-      # Verify session was created with short expiration
-      sessions = Hexpm.UserSessions.all_for_user(user)
-      assert length(sessions) == 1
-      [session] = sessions
-
+      [session] = Hexpm.UserSessions.all_for_user(user)
       latest_expires_at = DateTime.add(DateTime.utc_now(), 30 * 60, :second)
       assert DateTime.compare(session.expires_at, earliest_expires_at) in [:eq, :gt]
       assert DateTime.compare(session.expires_at, latest_expires_at) in [:eq, :lt]
+
+      token = Repo.get_by!(Token, user_id: user.id, grant_type: "client_credentials")
+      assert token.user_session_id == session.id
     end
 
     test "returns error for missing client_secret", %{client: client} do
@@ -807,6 +867,28 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["error"] == "invalid_scope"
     end
 
+    test "returns error for a scope disallowed by the OAuth client", %{api_key: api_key} do
+      client =
+        Client.build(%{
+          client_id: Clients.generate_client_id(),
+          name: "Read-only client",
+          client_type: "public",
+          allowed_grant_types: ["client_credentials"],
+          allowed_scopes: ["api:read"]
+        })
+        |> Repo.insert!()
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => api_key,
+          "scope" => "api"
+        })
+
+      assert json_response(conn, 400)["error"] == "invalid_scope"
+    end
+
     test "supports custom name parameter", %{
       client: client,
       api_key: api_key,
@@ -824,10 +906,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         })
 
       assert json_response(conn, 200)
-
-      # Verify session was created with the custom name
-      sessions = Hexpm.UserSessions.all_for_user(user)
-      [session] = sessions
+      [session] = Hexpm.UserSessions.all_for_user(user)
       assert session.name == name
     end
 
@@ -836,21 +915,21 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       api_key: api_key,
       user: user
     } do
-      # Create 5 sessions via client credentials
       for i <- 1..5 do
-        post(build_conn(), ~p"/api/oauth/token", %{
-          "grant_type" => "client_credentials",
-          "client_id" => client.client_id,
-          "client_secret" => api_key,
-          "scope" => "api",
-          "name" => "Session #{i}"
-        })
+        conn =
+          post(build_conn(), ~p"/api/oauth/token", %{
+            "grant_type" => "client_credentials",
+            "client_id" => client.client_id,
+            "client_secret" => api_key,
+            "scope" => "api",
+            "name" => "Session #{i}"
+          })
+
+        assert json_response(conn, 200)
       end
 
-      # Verify we have 5 sessions
       assert Hexpm.UserSessions.count_for_user(user) == 5
 
-      # Create a 6th session
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
@@ -861,8 +940,6 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         })
 
       assert json_response(conn, 200)
-
-      # Verify we still only have 5 sessions (oldest was revoked)
       assert Hexpm.UserSessions.count_for_user(user) == 5
     end
 
@@ -1214,7 +1291,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "api"
     end
 
-    test "succeeds when api-only key requests 'repositories' scope", %{
+    test "rejects 'repositories' scope for an api-only key", %{
       user: user,
       client: client
     } do
@@ -1233,7 +1310,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           "scope" => "repositories"
         })
 
-      assert json_response(conn, 200)
+      assert json_response(conn, 400)["error"] == "invalid_scope"
     end
 
     test "refuses a personal 'repositories' key naming an organization it cannot reach", %{
@@ -1333,6 +1410,27 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "repository:#{org.name}"
     end
 
+    test "rejects repository scopes for an organization without billing access", %{client: client} do
+      org = insert(:organization, billing_active: false, trial_end: DateTime.utc_now())
+
+      {:ok, %{key: key}} =
+        Hexpm.Accounts.Keys.create(
+          org,
+          %{name: "org_key", permissions: [%{domain: "repository", resource: org.name}]},
+          audit: audit_data(org)
+        )
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => key.user_secret,
+          "scope" => "repository:#{org.name}"
+        })
+
+      assert json_response(conn, 400)["error"] == "invalid_scope"
+    end
+
     test "org key creates session with organization_id", %{client: client} do
       org = insert(:organization)
 
@@ -1350,16 +1448,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         "scope" => "repositories"
       })
 
-      session =
-        Hexpm.Repo.one(
-          from(s in Hexpm.UserSession,
-            where: s.organization_id == ^org.id,
-            order_by: [desc: s.inserted_at],
-            limit: 1
-          )
-        )
-
-      assert session
+      session = Repo.get_by!(Hexpm.UserSession, organization_id: org.id)
       assert session.organization_id == org.id
       assert is_nil(session.user_id)
     end
@@ -1381,16 +1470,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
         "scope" => "repositories"
       })
 
-      token =
-        Hexpm.Repo.one(
-          from(t in Hexpm.OAuth.Token,
-            where: t.organization_id == ^org.id,
-            order_by: [desc: t.inserted_at],
-            limit: 1
-          )
-        )
-
-      assert token
+      token = Repo.get_by!(Token, organization_id: org.id, grant_type: "client_credentials")
       assert token.organization_id == org.id
       assert is_nil(token.user_id)
     end
@@ -1405,17 +1485,18 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           audit: audit_data(org)
         )
 
-      # Create max_sessions (5) sessions
       for _ <- 1..5 do
-        post(build_conn(), ~p"/api/oauth/token", %{
-          "grant_type" => "client_credentials",
-          "client_id" => client.client_id,
-          "client_secret" => key.user_secret,
-          "scope" => "repositories"
-        })
+        conn =
+          post(build_conn(), ~p"/api/oauth/token", %{
+            "grant_type" => "client_credentials",
+            "client_id" => client.client_id,
+            "client_secret" => key.user_secret,
+            "scope" => "repositories"
+          })
+
+        assert json_response(conn, 200)
       end
 
-      # 6th should succeed but oldest should be revoked
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
@@ -1427,7 +1508,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert json_response(conn, 200)
 
       active_count =
-        Hexpm.Repo.one(
+        Repo.one(
           from(s in Hexpm.UserSession,
             where:
               s.organization_id == ^org.id and is_nil(s.revoked_at) and

--- a/test/hexpm_web/plugs/attack_test.exs
+++ b/test/hexpm_web/plugs/attack_test.exs
@@ -86,6 +86,36 @@ defmodule HexpmWeb.Plugs.AttackTest do
       assert {:block, _data} = Attack.diff_throttle(identity, time: time)
     end
 
+    test "broadcasts machine token exchange rate limits" do
+      align_to_throttle_bucket()
+      time = System.system_time(:millisecond)
+
+      Phoenix.PubSub.broadcast!(
+        Hexpm.PubSub,
+        "ratelimit",
+        {:throttle, {:machine_token_exchange, 123}, time}
+      )
+
+      :sys.get_state(RateLimitPubSub)
+
+      assert {:allow, {:throttle, data}} =
+               Attack.machine_token_exchange_throttle(123, time: time)
+
+      assert data[:limit] == 100
+      assert data[:remaining] == 98
+    end
+
+    test "limits machine token exchanges per API key" do
+      time = System.system_time(:millisecond)
+
+      Enum.each(1..100, fn _ ->
+        assert {:allow, _data} = Attack.machine_token_exchange_throttle(456, time: time)
+      end)
+
+      assert {:block, _data} = Attack.machine_token_exchange_throttle(456, time: time)
+      assert {:allow, _data} = Attack.machine_token_exchange_throttle(789, time: time)
+    end
+
     test "halts requests when ip limit is exceeded" do
       align_to_throttle_bucket()
 

--- a/test/hexpm_web/plugs/attack_test.exs
+++ b/test/hexpm_web/plugs/attack_test.exs
@@ -116,6 +116,36 @@ defmodule HexpmWeb.Plugs.AttackTest do
       assert callback_data[:remaining] == 48
     end
 
+    test "broadcasts machine token exchange rate limits" do
+      align_to_throttle_bucket()
+      time = System.system_time(:millisecond)
+
+      Phoenix.PubSub.broadcast!(
+        Hexpm.PubSub,
+        "ratelimit",
+        {:throttle, {:machine_token_exchange, 123}, time}
+      )
+
+      :sys.get_state(RateLimitPubSub)
+
+      assert {:allow, {:throttle, data}} =
+               Attack.machine_token_exchange_throttle(123, time: time)
+
+      assert data[:limit] == 100
+      assert data[:remaining] == 98
+    end
+
+    test "limits machine token exchanges per API key" do
+      time = System.system_time(:millisecond)
+
+      Enum.each(1..100, fn _ ->
+        assert {:allow, _data} = Attack.machine_token_exchange_throttle(456, time: time)
+      end)
+
+      assert {:block, _data} = Attack.machine_token_exchange_throttle(456, time: time)
+      assert {:allow, _data} = Attack.machine_token_exchange_throttle(789, time: time)
+    end
+
     test "halts requests when ip limit is exceeded" do
       align_to_throttle_bucket()
 

--- a/test/hexpm_web/read_only_mode_test.exs
+++ b/test/hexpm_web/read_only_mode_test.exs
@@ -1,6 +1,14 @@
 defmodule HexpmWeb.ReadOnlyModeTest do
   use HexpmWeb.ConnCase
 
+  alias Hexpm.Accounts.{Key, Keys}
+  alias Hexpm.OAuth.{Client, Clients, JWT, ReadOnly, Token, Tokens}
+
+  setup do
+    on_exit(fn -> ReadOnly.configure!(false) end)
+    :ok
+  end
+
   test "GET /api/auth" do
     user = insert(:user)
     key = insert(:key, user: user)
@@ -39,5 +47,123 @@ defmodule HexpmWeb.ReadOnlyModeTest do
     end
   after
     Application.put_env(:hexpm, :read_only_mode, false)
+  end
+
+  test "client credentials issue a row-less machine token" do
+    user = insert(:user)
+    {:ok, %{key: key}} = Keys.create(user, %{name: "ci"}, audit: audit_data(user))
+    client = oauth_client(["client_credentials"], ["api"])
+    ReadOnly.configure!(true)
+
+    conn =
+      post(build_conn(), ~p"/api/oauth/token", %{
+        "grant_type" => "client_credentials",
+        "client_id" => client.client_id,
+        "client_secret" => key.user_secret,
+        "scope" => "api"
+      })
+
+    response = json_response(conn, 200)
+    refute response["refresh_token"]
+    assert {:ok, claims} = JWT.verify_and_decode(response["access_token"])
+    assert claims["token_use"] == "machine"
+    assert claims["key_id"] == key.id
+    refute Repo.get_by(Token, jti: claims["jti"])
+    assert Hexpm.UserSessions.all_for_user(user) == []
+    assert Repo.get(Key, key.id).last_use == nil
+  end
+
+  test "read-only refresh is unavailable without changing the grant" do
+    user = insert(:user)
+    client = oauth_client(["refresh_token"], ["repositories"])
+
+    {:ok, token} =
+      Tokens.create_and_insert_for_user(
+        user,
+        client.client_id,
+        ["repositories"],
+        "authorization_code",
+        nil,
+        with_refresh_token: true
+      )
+
+    token_count = Repo.aggregate(Token, :count)
+    ReadOnly.configure!(true)
+
+    conn =
+      post(build_conn(), ~p"/api/oauth/token", %{
+        "grant_type" => "refresh_token",
+        "refresh_token" => token.refresh_token,
+        "client_id" => client.client_id
+      })
+
+    response = json_response(conn, 503)
+    assert response["error"] == "temporarily_unavailable"
+    assert Repo.get!(Token, token.id).revoked_at == nil
+    assert Repo.aggregate(Token, :count) == token_count
+  end
+
+  test "client credentials omit explicit repositories the user can no longer access" do
+    user = insert(:user)
+    organization = insert(:organization)
+    membership = insert(:organization_user, user: user, organization: organization)
+
+    {:ok, %{key: key}} =
+      Keys.create(
+        user,
+        %{
+          name: "former-org",
+          permissions: [%{domain: "repository", resource: organization.name}]
+        },
+        audit: audit_data(user)
+      )
+
+    client = oauth_client(["client_credentials"], ["repositories"])
+    Repo.delete!(membership)
+    ReadOnly.configure!(true)
+
+    conn =
+      post(build_conn(), ~p"/api/oauth/token", %{
+        "grant_type" => "client_credentials",
+        "client_id" => client.client_id,
+        "client_secret" => key.user_secret,
+        "scope" => "repository:#{organization.name}"
+      })
+
+    assert json_response(conn, 400)["error"] == "invalid_scope"
+  end
+
+  test "write-dependent OAuth flows return a retryable error" do
+    client =
+      oauth_client(
+        ["urn:ietf:params:oauth:grant-type:device_code"],
+        ["api"]
+      )
+
+    ReadOnly.configure!(true)
+
+    conn =
+      post(build_conn(), ~p"/api/oauth/device_authorization", %{
+        "client_id" => client.client_id,
+        "scope" => "api"
+      })
+
+    assert json_response(conn, 503)["error"] == "temporarily_unavailable"
+  end
+
+  test "read-only write errors map to service unavailable" do
+    assert Plug.Exception.status(%Hexpm.WriteInReadOnlyMode{}) == 503
+  end
+
+  defp oauth_client(grant_types, scopes) do
+    params = %{
+      client_id: Clients.generate_client_id(),
+      name: "Read-only test client",
+      client_type: "public",
+      allowed_grant_types: grant_types,
+      allowed_scopes: scopes
+    }
+
+    Client.build(params) |> Repo.insert!()
   end
 end


### PR DESCRIPTION
Keep client-credentials exchanges session-backed while PostgreSQL is writable, and issue short-lived rowless machine tokens only during planned read-only windows.

Rowless tokens are verified against the current API key, owner, OAuth client policy, organization memberships, billing eligibility, and token scopes. Read-only refresh grants fail with a retryable response instead of replacing a client's interactive OAuth state.

Session-limit eviction and replacement now commit atomically under an owner lock, new exchanges no longer persist raw API keys in `grant_reference`, and machine exchanges have a distributed per-key rate limit with `Retry-After`.

Validated with `mix format --check-formatted` and the full suite: 28 properties and 2,124 tests with no failures.
