### PR TITLE
Restore the multi-comparison diffs view

### DIFF
--- a/lib/hexpm_web/controllers/diff_controller.ex
+++ b/lib/hexpm_web/controllers/diff_controller.ex
@@ -1,0 +1,32 @@
+defmodule HexpmWeb.DiffController do
+  use HexpmWeb, :controller
+
+  def index(conn, params) do
+    render(
+      conn,
+      "index.html",
+      title: "Package Diffs",
+      container: "flex-1 flex flex-col",
+      diffs: comparisons(params)
+    )
+  end
+
+  def comparisons(params) do
+    params
+    |> Map.get("diffs", Map.get(params, "diff", []))
+    |> List.wrap()
+    |> Enum.flat_map(&parse_comparison/1)
+  end
+
+  defp parse_comparison(comparison) when is_binary(comparison) do
+    case String.split(comparison, ":", parts: 3) do
+      [package, from, to] when package != "" and from != "" and to != "" ->
+        [{package, from, to}]
+
+      _other ->
+        []
+    end
+  end
+
+  defp parse_comparison(_comparison), do: []
+end

--- a/lib/hexpm_web/controllers/diff_redirect_controller.ex
+++ b/lib/hexpm_web/controllers/diff_redirect_controller.ex
@@ -1,7 +1,25 @@
 defmodule HexpmWeb.DiffRedirectController do
   use HexpmWeb, :controller
 
-  def index(conn, params), do: redirect_comparison_or_packages(conn, params)
+  alias HexpmWeb.DiffController
+
+  def index(conn, params) do
+    case DiffController.comparisons(params) do
+      [] ->
+        permanent_redirect(conn, "/packages", "")
+
+      [{package, from, to}] ->
+        permanent_redirect(conn, ~p"/diff/#{package}/#{from <> ".." <> to}", extra_query(params))
+
+      comparisons ->
+        query =
+          comparisons
+          |> Enum.map(fn {package, from, to} -> {"diffs[]", "#{package}:#{from}:#{to}"} end)
+          |> URI.encode_query()
+
+        permanent_redirect(conn, ~p"/diffs", join_query(query, extra_query(params)))
+    end
+  end
 
   def show(conn, %{"package" => package, "versions" => versions}) do
     permanent_redirect(conn, ~p"/diff/#{package}/#{versions}")
@@ -9,37 +27,12 @@ defmodule HexpmWeb.DiffRedirectController do
 
   def path(conn, _params), do: permanent_redirect(conn, "/packages", "")
 
-  defp redirect_comparison_or_packages(conn, params) do
-    case first_comparison(params) do
-      {package, from, to} ->
-        query_string =
-          params
-          |> Map.drop(["diff", "diffs"])
-          |> URI.encode_query()
-
-        permanent_redirect(conn, ~p"/diff/#{package}/#{from <> ".." <> to}", query_string)
-
-      nil ->
-        permanent_redirect(conn, "/packages", "")
-    end
-  end
-
-  defp first_comparison(params) do
+  defp extra_query(params) do
     params
-    |> Map.get("diffs", Map.get(params, "diff", []))
-    |> List.wrap()
-    |> Enum.find_value(&parse_comparison/1)
+    |> Map.drop(["diff", "diffs"])
+    |> URI.encode_query()
   end
 
-  defp parse_comparison(comparison) when is_binary(comparison) do
-    case String.split(comparison, ":", parts: 3) do
-      [package, from, to] when package != "" and from != "" and to != "" ->
-        {package, from, to}
-
-      _other ->
-        nil
-    end
-  end
-
-  defp parse_comparison(_comparison), do: nil
+  defp join_query(query, ""), do: query
+  defp join_query(query, extra), do: query <> "&" <> extra
 end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -210,6 +210,8 @@ defmodule HexpmWeb.Router do
       live "/diff/:package/:versions", DiffLive, :show
     end
 
+    get "/diffs", DiffController, :index
+
     get "/preview/:package", PreviewRedirectController, :latest
     get "/preview/:package/show/*filename", PreviewRedirectController, :latest_file
     get "/preview/:package/:version", PreviewRedirectController, :version

--- a/lib/hexpm_web/templates/diff/index.html.heex
+++ b/lib/hexpm_web/templates/diff/index.html.heex
@@ -1,0 +1,46 @@
+<div class="mx-auto flex w-full max-w-3xl flex-col px-4 py-8 sm:px-6 lg:px-8">
+  <h1 class="mb-6 text-h5 font-semibold text-grey-800 dark:text-grey-100">Package Diffs</h1>
+
+  <section class="overflow-hidden rounded-lg border border-grey-200 bg-white dark:border-grey-700 dark:bg-grey-800">
+    <table class="w-full text-sm">
+      <thead>
+        <tr class="border-b border-grey-200 bg-grey-50 text-left text-caption font-semibold uppercase tracking-wider text-grey-500 dark:border-grey-700 dark:bg-grey-900 dark:text-grey-300">
+          <th class="px-6 py-3">Package</th>
+          <th class="px-4 py-3">From</th>
+          <th class="px-4 py-3">To</th>
+          <th class="px-4 py-3"><span class="sr-only">Diff</span></th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-grey-100 dark:divide-grey-700">
+        <tr :if={@diffs == []}>
+          <td colspan="4" class="px-6 py-8 text-center text-grey-400 dark:text-grey-300">
+            No package diffs available.
+          </td>
+        </tr>
+        <tr
+          :for={{package, from, to} <- @diffs}
+          class="transition-colors hover:bg-grey-50 dark:hover:bg-grey-700/40"
+        >
+          <td class="px-6 py-3">
+            <a
+              href={~p"/packages/#{package}/#{to}"}
+              class="font-mono font-semibold text-primary-700 transition-colors hover:text-primary-900 dark:text-primary-400 dark:hover:text-primary-300"
+            >
+              {package}
+            </a>
+          </td>
+          <td class="px-4 py-3 font-mono text-xs text-grey-500 dark:text-grey-300">{from}</td>
+          <td class="px-4 py-3 font-mono text-xs text-grey-500 dark:text-grey-300">{to}</td>
+          <td class="px-4 py-3 text-right">
+            <a
+              href={~p"/diff/#{package}/#{from <> ".." <> to}"}
+              class="inline-flex items-center rounded-md bg-primary-600 px-3 py-1 text-xs font-semibold text-white transition-colors hover:bg-primary-700"
+            >
+              View diff
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+</div>

--- a/lib/hexpm_web/views/diff_view.ex
+++ b/lib/hexpm_web/views/diff_view.ex
@@ -1,0 +1,3 @@
+defmodule HexpmWeb.DiffView do
+  use HexpmWeb, :view
+end

--- a/test/hexpm_web/controllers/diff_controller_test.exs
+++ b/test/hexpm_web/controllers/diff_controller_test.exs
@@ -1,0 +1,32 @@
+defmodule HexpmWeb.DiffControllerTest do
+  use HexpmWeb.ConnCase, async: true
+
+  test "lists all requested comparisons with links to each diff" do
+    conn = get(build_conn(), "/diffs?diffs[]=ecto%3A3.0.0%3A3.1.0&diffs[]=plug%3A1.0.0%3A1.1.0")
+    html = html_response(conn, 200)
+
+    assert html =~ "Package Diffs"
+    assert html =~ "/diff/ecto/3.0.0..3.1.0"
+    assert html =~ "/diff/plug/1.0.0..1.1.0"
+  end
+
+  test "supports the historical diff[] parameter" do
+    conn = get(build_conn(), "/diffs?diff[]=ecto%3A3.0.0%3A3.1.0")
+
+    assert html_response(conn, 200) =~ "/diff/ecto/3.0.0..3.1.0"
+  end
+
+  test "skips malformed comparisons" do
+    conn = get(build_conn(), "/diffs?diffs[]=invalid&diffs[]=ecto%3A3.0.0%3A3.1.0")
+    html = html_response(conn, 200)
+
+    assert html =~ "/diff/ecto/3.0.0..3.1.0"
+    refute html =~ "invalid"
+  end
+
+  test "shows an empty state without comparisons" do
+    conn = get(build_conn(), "/diffs")
+
+    assert html_response(conn, 200) =~ "No package diffs available."
+  end
+end

--- a/test/hexpm_web/controllers/diff_redirect_controller_test.exs
+++ b/test/hexpm_web/controllers/diff_redirect_controller_test.exs
@@ -20,9 +20,17 @@ defmodule HexpmWeb.DiffRedirectControllerTest do
              "http://localhost:5000/diff/ecto/3.0.0..3.1.0"
   end
 
-  test "redirects legacy comparison lists to the first supported comparison" do
+  test "redirects legacy comparison lists to the diffs index with all comparisons" do
     conn =
       request("/diffs?diffs[]=ecto%3A3.0.0%3A3.1.0&diffs[]=plug%3A1.0.0%3A1.1.0&w=1")
+
+    assert redirected_to(conn, 301) ==
+             "http://localhost:5000/diffs?" <>
+               "diffs%5B%5D=ecto%3A3.0.0%3A3.1.0&diffs%5B%5D=plug%3A1.0.0%3A1.1.0&w=1"
+  end
+
+  test "redirects a single legacy comparison straight to its diff" do
+    conn = request("/diffs?diffs[]=ecto%3A3.0.0%3A3.1.0&w=1")
 
     assert redirected_to(conn, 301) ==
              "http://localhost:5000/diff/ecto/3.0.0..3.1.0?w=1"


### PR DESCRIPTION
The diff integration (#1711) dropped the multi-comparison view that `mix hex.outdated` short URLs and legacy `diff.hex.pm/diffs?diffs[]=...` links point at — the redirect kept only the first comparison and silently discarded the rest.

This adds a `/diffs` index page on the main host that accepts the legacy `diffs[]`/`diff[]` parameters and renders all requested comparisons as a list linking to each single-package diff, matching the page the standalone diff app served. The Diff host redirect now preserves all comparisons: multiple go to the new index, a single one still redirects straight to its diff page, and none still falls back to `/packages`. Existing short URLs stored for multi-comparison links resolve to the full list again.

<img width="1456" height="820" alt="diffs-page" src="https://github.com/user-attachments/assets/2ab8a31a-1336-4e54-8d1f-779539538745" />
