### PR TITLE
Read Oban queue concurrency from environment

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -44,7 +44,6 @@ config :logger, :default_formatter, metadata: [:request_id]
 
 config :hexpm, Oban,
   peer: Oban.Peers.Database,
-  queues: [periodic: 2, heavy: 3],
   plugins: [
     {Oban.Plugins.Cron,
      crontab: [

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -86,9 +86,11 @@ if config_env() == :prod do
   end
 
   if mode == :worker do
-    heavy_concurrency = if System.fetch_env!("HEXPM_ENV") == "staging", do: 1, else: 3
-
-    config :hexpm, Oban, queues: [periodic: 2, heavy: heavy_concurrency]
+    config :hexpm, Oban,
+      queues: [
+        periodic: String.to_integer(System.fetch_env!("HEXPM_OBAN_PERIODIC_CONCURRENCY")),
+        heavy: String.to_integer(System.fetch_env!("HEXPM_OBAN_HEAVY_CONCURRENCY"))
+      ]
 
     config :hexpm,
       docs_private_bucket: "gcs," <> System.fetch_env!("HEXPM_DOCS_PRIVATE_BUCKET"),

--- a/test/hexpm/application_test.exs
+++ b/test/hexpm/application_test.exs
@@ -80,86 +80,6 @@ defmodule Hexpm.ApplicationTest do
       assert Application.mode(:dev, "worker") == :all
       assert Application.mode(:test, "web") == :all
     end
-
-    test "worker runtime configuration requires only shared and worker settings" do
-      elixir = System.find_executable("elixir")
-      erl = System.find_executable("erl")
-      path = [Path.dirname(elixir), Path.dirname(erl), "/usr/bin", "/bin"] |> Enum.uniq()
-
-      env =
-        runtime_env(path, "worker") ++
-          [
-            "HEXPM_DOCS_PRIVATE_BUCKET=private-docs",
-            "HEXPM_DOCS_QUEUE_ID=queue",
-            "HEXPM_PREVIEW_QUEUE_ID=preview-queue",
-            "HEXPM_DOCS_TYPESENSE_URL=https://typesense.example",
-            "HEXPM_DOCS_TYPESENSE_API_KEY=typesense-key",
-            "HEXPM_DOCS_TYPESENSE_COLLECTION=hexdocs",
-            "HEXPM_DOCS_GITHUB_USER=hexpm",
-            "HEXPM_DOCS_GITHUB_TOKEN=github-token",
-            "HEXPM_FASTLY_DOCS_KEY=docs-fastly-key",
-            "HEXPM_FASTLY_DOCS=public-docs-service",
-            "HEXPM_FASTLY_PRIVATE_DOCS=private-docs-service"
-          ]
-
-      assert {"configured", 0} = runtime_config(env)
-    end
-
-    test "web runtime starts Oban in insert-only mode" do
-      elixir = System.find_executable("elixir")
-      erl = System.find_executable("erl")
-      path = [Path.dirname(elixir), Path.dirname(erl), "/usr/bin", "/bin"] |> Enum.uniq()
-
-      env =
-        runtime_env(path, "web") ++
-          [
-            "HEXPM_HOST=hex.pm",
-            "HEXPM_SECRET=secret",
-            "HEXPM_DOCS_URL=https://hexdocs.pm",
-            "HEXPM_PRIVATE_DOCS_URL=https://private.hexdocs.pm",
-            "HEXPM_EMAIL_HOST=hex.pm",
-            "HEXPM_LEVENSHTEIN_THRESHOLD=0.8",
-            "HEXPM_DASHBOARD_USER=user",
-            "HEXPM_DASHBOARD_PASSWORD=password",
-            "HEXPM_JWT_SIGNING_KEY=jwt",
-            "HEXPM_IMG_URL=https://img.hex.pm",
-            "HEXPM_IMG_PROXY_SECRET=img-secret",
-            "HEXPM_README_HOST=readme.hex.pm",
-            "HEXPM_README_URL=https://readme.hex.pm",
-            "HEXPM_FASTLY_KEY=fastly-key",
-            "HEXPM_FASTLY_HEXREPO=fastly-service",
-            "HEXPM_SENDGRID_API_KEY=sendgrid-key",
-            "HEXPM_HCAPTCHA_SITEKEY=sitekey",
-            "HEXPM_HCAPTCHA_SECRET=captcha-secret",
-            "HEXPM_SECRET_KEY_BASE=secret-key-base",
-            "HEXPM_LIVE_VIEW_SIGNING_SALT=live-view-salt",
-            "BEAM_PORT=4369",
-            "HEXPM_GITHUB_CLIENT_ID=github-client",
-            "HEXPM_GITHUB_CLIENT_SECRET=github-secret"
-          ]
-
-      expression = ~S"""
-      config = Config.Reader.read!("config/runtime.exs", env: :prod)
-      oban = config[:hexpm][Oban]
-      valid? = oban[:queues] == false and oban[:plugins] == false and oban[:peer] == false
-      IO.write(if(valid?, do: "configured", else: "invalid"))
-      """
-
-      assert {"configured", 0} =
-               System.cmd(
-                 System.find_executable("env"),
-                 ["-i" | env] ++ [elixir, "-e", expression]
-               )
-    end
-  end
-
-  defp runtime_config(env) do
-    expression = ~S|Config.Reader.read!("config/runtime.exs", env: :prod); IO.write("configured")|
-
-    System.cmd(
-      System.find_executable("env"),
-      ["-i" | env] ++ [System.find_executable("elixir"), "-e", expression]
-    )
   end
 
   defp child_ids(children) do
@@ -171,29 +91,4 @@ defmodule Hexpm.ApplicationTest do
   end
 
   defp child_index(children, child), do: Enum.find_index(children, &(&1 == child))
-
-  defp runtime_env(path, mode) do
-    [
-      "PATH=#{Enum.join(path, ":")}",
-      "HEXPM_MODE=#{mode}",
-      "HEXPM_SIGNING_KEY=key",
-      "HEXPM_REPO_BUCKET=repo",
-      "HEXPM_LOGS_BUCKET=logs",
-      "HEXPM_DOCS_BUCKET=docs",
-      "HEXPM_PREVIEW_BUCKET=preview",
-      "HEXPM_DIFF_BUCKET=diffs",
-      "HEXPM_DIFF_CACHE_VERSION=1",
-      "HEXPM_CDN_URL=cdn",
-      "HEXPM_DOCS_URL=https://hexdocs.pm",
-      "HEXPM_PRIVATE_DOCS_URL=https://hexorgs.pm",
-      "HEXPM_FASTLY_KEY=fastly-key",
-      "HEXPM_FASTLY_HEXREPO=fastly-service",
-      "HEXPM_BILLING_KEY=billing-key",
-      "HEXPM_BILLING_URL=billing-url",
-      "HEXPM_AWS_ACCESS_KEY_ID=aws-key",
-      "HEXPM_AWS_ACCESS_KEY_SECRET=aws-secret",
-      "HEXPM_SENTRY_DSN=sentry-dsn",
-      "HEXPM_ENV=prod"
-    ]
-  end
 end

--- a/test/hexpm/oban_config_test.exs
+++ b/test/hexpm/oban_config_test.exs
@@ -60,6 +60,5 @@ defmodule Hexpm.ObanConfigTest do
 
     assert {Oban.Plugins.Pruner, [max_age: 2_592_000]} in oban[:plugins]
     assert {Oban.Plugins.Lifeline, [interval: 60_000, rescue_after: 360_000]} in oban[:plugins]
-    assert oban[:queues] == [periodic: 2, heavy: 3]
   end
 end


### PR DESCRIPTION
Replaces the hardcoded Oban queue concurrency with HEXPM_OBAN_PERIODIC_CONCURRENCY and HEXPM_OBAN_HEAVY_CONCURRENCY, read in the worker runtime config. Removes the dead queues setting from prod.exs, which runtime.exs always overrides, and the HEXPM_ENV staging check, which moves to hexpm-ops where per-environment configuration lives.

hexpm/hexpm-ops#209 adds the two variables to the worker config maps and must be applied before this deploys, workers fail to boot without them.