### PR TITLE
Update Hex versions tested in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,16 +123,16 @@ jobs:
           - hex-version: main
             otp: 28.5
             elixir: 1.19.5
+          - hex-version: v2.5
+            otp: 28.5
+            elixir: 1.19.5
+          - hex-version: v2.4
+            otp: 28.5
+            elixir: 1.19.5
           - hex-version: v2.3
             otp: 28.5
             elixir: 1.19.5
           - hex-version: v2.2
-            otp: 27.3
-            elixir: 1.19.5
-          - hex-version: v2.1
-            otp: 27.3
-            elixir: 1.19.5
-          - hex-version: v2.0
             otp: 27.3
             elixir: 1.19.5
 


### PR DESCRIPTION
Adds Hex v2.4 and v2.5 to the integration test matrix and drops v2.0 and v2.1. The new entries run on OTP 28.5 / Elixir 1.19.5, same as main and v2.3. A v2.5 maintenance branch was created in hexpm/hex at the v2.5.1 tag so the matrix can track it like the other release branches.