### PR TITLE
Size the Finch connection pool for concurrent GCS uploads

### DIFF
--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -126,7 +126,7 @@ defmodule Hexpm.Application do
   defp common_children do
     [
       Hexpm.RepoBase,
-      {Finch, name: Hexpm.Finch},
+      {Finch, name: Hexpm.Finch, pools: finch_pools()},
       Hexpm.TmpDir,
       {Task.Supervisor, name: Hexpm.Tasks},
       goth_spec(),
@@ -137,6 +137,11 @@ defmodule Hexpm.Application do
   end
 
   defp oban_child, do: {Oban, Application.fetch_env!(:hexpm, Oban)}
+
+  defp finch_pools() do
+    gcs_url = Application.get_env(:hexpm, :gcs_url, "https://storage.googleapis.com")
+    %{gcs_url => [size: 50, count: 2]}
+  end
 
   defp web_children do
     [


### PR DESCRIPTION
Thirteen minutes after the heavy queue concurrency increase deployed, a worker exhausted the default Finch pool during GCS uploads (HEXPM-C6). Heavy jobs upload with Task.async_stream at max_concurrency 10, so ten concurrent heavy jobs demand up to 100 connections to storage.googleapis.com while the default pool holds 50 and requests raise after queuing for 5 seconds. This sizes the GCS pool to 2x50 connections to cover peak demand.

Fixes HEXPM-C6