### PR TITLE
Fix dual search field on mobile

### DIFF
--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -249,7 +249,7 @@ defmodule HexpmWeb.Components.Navbar do
           type="button"
           phx-click={show_modal("search-cheatsheet")}
           aria-label="Search filter cheatsheet"
-          class="px-2 py-1 text-grey-200 hover:text-white border border-grey-600 rounded text-sm cursor-pointer"
+          class="flex items-center justify-center w-[43px] self-stretch shrink-0 text-grey-200 hover:text-white border border-grey-600 rounded-lg text-sm font-medium cursor-pointer"
         >
           ?
         </button>
@@ -448,6 +448,9 @@ defmodule HexpmWeb.Components.Navbar do
         {"transition-all ease-in duration-150 transform", "opacity-100 translate-y-0",
          "opacity-0 -translate-y-2"}
     )
+    |> JS.hide(to: "#navbar-mobile")
+    |> JS.show(to: "#menu-open-icon")
+    |> JS.hide(to: "#menu-close-icon")
     |> JS.focus(to: "#mobile-search-input")
   end
 
@@ -490,6 +493,7 @@ defmodule HexpmWeb.Components.Navbar do
     )
     |> JS.toggle(to: "#menu-open-icon")
     |> JS.toggle(to: "#menu-close-icon")
+    |> JS.hide(to: "#mobile-search-bar")
   end
 
   @doc """


### PR DESCRIPTION
Clicking both the search icon and the hamburger menu icon on mobile would show two search fields on screen at once, which is a confusing UX.

This adds JS commands to only show one search field at a time. And, because the two fields also had slightly different styling, we also update the styling to match, reducing layout shifts when toggling between them.

## Before

<img width="452" height="424" alt="image" src="https://github.com/user-attachments/assets/0749db66-fdd3-4c19-946a-7c0044782a04" />

## After (side-by-side for CSS comparison)

<img width="400" height="389" alt="127 0 0 1_4000_packages_sort=updated_at search=nerves" src="https://github.com/user-attachments/assets/812fcd0f-35cb-4b35-a1de-13de1ec57cc7" />

## After (only one visible at a time, reduced layout shift)

<img width="400" height="132" alt="127 0 0 1_4000_packages_sort=updated_at search=nerves (1)" src="https://github.com/user-attachments/assets/6e7cdc54-9b9c-44c0-acb9-c3fd6cd40b5c" />
<img width="400" height="330" alt="127 0 0 1_4000_packages_sort=updated_at search=nerves (2)" src="https://github.com/user-attachments/assets/bfb344c7-fd70-409d-99cd-031016430093" />

---

_Related to https://github.com/hexpm/hexpm/pull/1697#issuecomment-5022056561_