### PR TITLE
Cleanup component global attribute `:include`

### DIFF
--- a/lib/hexpm_web/components/buttons.ex
+++ b/lib/hexpm_web/components/buttons.ex
@@ -23,14 +23,9 @@ defmodule HexpmWeb.Components.Buttons do
   attr :full_width, :boolean, default: false
   attr :loading, :boolean, default: false
 
-  # Global attributes:
-  # - phx-click, phx-target, phx-value-id: LiveView event handling
+  # In addition to standard global attributes:
   # - form: Associate button with a form element
-  # - data-input-id: Legacy jQuery integration for package pages
-  # - id: Required for phx-hook elements and form submissions
-  attr :rest, :global,
-    include:
-      ~w(phx-click phx-target phx-value-id form data-input-id id phx-hook data-copy-target data-print-target data-download-target data-confirm data-target)
+  attr :rest, :global, include: ~w(form)
 
   attr :size, :string, default: "md", values: ["sm", "md", "lg"]
   attr :type, :string, default: "button", values: ["button", "submit", "reset"]
@@ -198,7 +193,7 @@ defmodule HexpmWeb.Components.Buttons do
   attr :size, :integer, default: 16
   attr :type, :string, default: "button", values: ["button", "submit", "reset"]
   attr :variant, :string, default: "default", values: ["default", "danger", "primary"]
-  attr :rest, :global, include: ~w(phx-click phx-target phx-value-id id aria-label)
+  attr :rest, :global
 
   def icon_button(assigns) do
     ~H"""

--- a/lib/hexpm_web/components/form.ex
+++ b/lib/hexpm_web/components/form.ex
@@ -60,7 +60,7 @@ defmodule HexpmWeb.Components.Form do
   attr :for, :any, default: %{}
   attr :method, :string, default: "post"
   attr :as, :atom, default: nil
-  attr :rest, :global, include: ~w(id class phx-hook)
+  attr :rest, :global
   slot :inner_block, required: true
 
   def sudo_form(assigns) do

--- a/lib/hexpm_web/components/input.ex
+++ b/lib/hexpm_web/components/input.ex
@@ -228,7 +228,7 @@ defmodule HexpmWeb.Components.Input do
   attr :options, :list, required: true, doc: "List of {label, value} tuples for select options"
   attr :prompt, :string, default: nil, doc: "Optional prompt text for the first option"
   attr :required, :boolean, default: false
-  attr :rest, :global, include: ~w(disabled multiple phx-hook)
+  attr :rest, :global, include: ~w(disabled multiple)
 
   attr :show_errors, :boolean,
     default: nil,

--- a/lib/hexpm_web/templates/dashboard/organization/components/billing_info_forms.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/billing_info_forms.ex
@@ -142,7 +142,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingInfoForms do
 
   attr :active, :boolean, default: false
   attr :id, :string, required: true
-  attr :rest, :global, include: ~w(phx-click)
+  attr :rest, :global
   slot :inner_block, required: true
 
   defp billing_tab_btn(assigns) do

--- a/lib/hexpm_web/templates/dashboard/policy/components/policy_edit.ex
+++ b/lib/hexpm_web/templates/dashboard/policy/components/policy_edit.ex
@@ -886,7 +886,7 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
   attr :label, :string, required: true
   attr :icon, :string, required: true
   attr :variant, :string, default: "neutral", values: ~w(neutral danger)
-  attr :rest, :global, include: ~w(phx-click phx-hook data-target)
+  attr :rest, :global
 
   defp header_action(assigns) do
     ~H"""


### PR DESCRIPTION
The `:global` attribute type natively includes:
- All standard HTML5 global attributes (such as `id`, `class`, `style`, etc.)
- All prefixed attributes starting with `phx-`, `aria-`, and `data-`

Explicitly listing these in the `:include` list is redundant. This change cleans up the attributes definitions to only specify custom, non-global attributes (such as `form`, `disabled`, and `multiple`) where required by the underlying HTML tags.

References:
- https://phoenix-live-view.hexdocs.pm/1.2.7/Phoenix.Component.html#module-global-attributes
- https://github.com/phoenixframework/phoenix_live_view/blob/v1.2.7/lib/phoenix_component/declarative.ex#L16-L120