### PR TITLE
Lower preview and diff rendering cap to 100 KB

### DIFF
--- a/lib/hexpm/diff/generator.ex
+++ b/lib/hexpm/diff/generator.ex
@@ -4,7 +4,7 @@ defmodule Hexpm.Diff.Generator do
   alias Hexpm.Diff.{Cache, Request}
   alias Hexpm.Repository.Assets
 
-  @max_file_size 200 * 1000
+  @max_file_size 100 * 1000
 
   def generate(%Request{} = request) do
     with {:ok, from_path} <- download(request.from_release, request.from_checksum),

--- a/lib/hexpm/preview/preview.ex
+++ b/lib/hexpm/preview/preview.ex
@@ -5,7 +5,7 @@ defmodule Hexpm.Preview do
   alias Hexpm.Repository.{Assets, Releases}
   alias Hexpm.Repository.Sitemaps, as: RepositorySitemaps
 
-  @max_file_size 200 * 1000
+  @max_file_size 100 * 1000
   @readme_filenames ~w(README.md readme.md README.markdown readme.markdown README.txt readme.txt README readme)
 
   def source(repository, package, version, requested_filename \\ nil) do

--- a/lib/hexpm_web/live/diff_component.ex
+++ b/lib/hexpm_web/live/diff_component.ex
@@ -70,7 +70,7 @@ defmodule HexpmWeb.DiffComponent do
       <div class="ghd-file-header ghd-file-header-static">
         <span><span class="ghd-file-status ghd-file-status-unknown">unknown</span>{@file}</span>
       </div>
-      <div class="ghd-diff ghd-diff-error">File is too large to be displayed (200 KB limit).</div>
+      <div class="ghd-diff ghd-diff-error">File is too large to be displayed (100 KB limit).</div>
     </div>
     """
   end

--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule Hexpm.MixProject do
       {:mdex, "~> 0.13"},
       {:mdex_gfm, "~> 0.1"},
       {:lumis, github: "leandrocp/lumis", sparse: "packages/elixir/lumis", override: true},
-      {:rustler, ">= 0.0.0", optional: true},
+      {:rustler, ">= 0.0.0"},
       {:mox, "~> 1.0", only: :test},
       {:nimble_ownership, "~> 1.0"},
       {:oban, "~> 2.23"},

--- a/test/hexpm_web/live/diff_component_test.exs
+++ b/test/hexpm_web/live/diff_component_test.exs
@@ -70,7 +70,7 @@ defmodule HexpmWeb.DiffComponentTest do
     end
 
     oversized = render_component(&DiffComponent.too_large/1, file: "large.bin")
-    assert oversized =~ "File is too large to be displayed (200 KB limit)."
+    assert oversized =~ "File is too large to be displayed (100 KB limit)."
     assert oversized =~ "unknown"
     assert oversized =~ "ghd-file-status-unknown"
     refute oversized =~ "ghd-file-status-too-large"


### PR DESCRIPTION
Lowers the preview and diff rendering cap from 200 KB to 100 KB, and drops the no-op optional flag on the rustler dependency.

The tree-sitter crash band on dense minified input starts at about 144 KB (leandrocp/lumis#1028), so the 200 KB cap from #1724 still allowed inputs that segfault the VM on the released lumis binaries; the web pods have been restarting with exit code 139 several times an hour during scraper bursts on preview pages. #1739 ships the fixed highlighter, and this cap keeps rendering below both the crash band and the performance cliff (highlight cost jumps about 15x past 144 KB even on fixed lumis), so a future lumis regression degrades to slow rendering instead of a crash loop.

The diff generator cap applies at generation time, so previously cached pieces containing 100-200 KB files keep rendering until the diff cache version is bumped. With the fixed highlighter that is a performance concern rather than a crash risk.