### PR TITLE
Enable compression on the LiveView websocket

### DIFF
--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -22,7 +22,7 @@ defmodule HexpmWeb.Endpoint do
     only: HexpmWeb.static_paths()
 
   socket("/live", Phoenix.LiveView.Socket,
-    websocket: [connect_info: [:peer_data, :x_headers, session: @session_options]]
+    websocket: [compress: true, connect_info: [:peer_data, :x_headers, session: @session_options]]
   )
 
   if Code.ensure_loaded?(Tidewave) do


### PR DESCRIPTION
Phoenix defaults to compress: false on websocket transports, so LiveView join replies and diffs cross the wire uncompressed. The files-page join reply for a large package is ~666KB of highlighted HTML and deflates about 16x. Bandit negotiates permessage-deflate when the transport allows it, which this enables.

Regular HTTP responses are already compressed by Bandit's default content-encoding negotiation, so the websocket was the only uncompressed path.

Cost is ~300KB of zlib state per connection (window_bits 15, mem_level 8, context takeover) plus deflate CPU per frame. At our connection counts and payload sizes that trades well, pods sit at ~570Mi of a 2Gi limit.