### PR TITLE
Raise work_mem for the stats view refreshes

### DIFF
--- a/lib/hexpm/release_tasks/stats.ex
+++ b/lib/hexpm/release_tasks/stats.ex
@@ -82,6 +82,10 @@ defmodule Hexpm.ReleaseTasks.Stats do
               |> Enum.each(&Repo.insert_all(Download, &1))
             end)
 
+            # Scoped to this transaction; the default 4MB makes the view
+            # aggregations over the downloads table spill to disk
+            Repo.query!("SET LOCAL work_mem = '128MB'")
+
             time_log("refresh PackageDownload view", fn ->
               Repo.refresh_view(PackageDownload, timeout: 60_000)
             end)


### PR DESCRIPTION
The nightly stats job refreshes the two download matviews with the instance default work_mem of 4MB (118s + 52s measured in prod). The refresh queries run 2 parallel workers with hash aggregates of 52K-650K groups, so 128MB per node comfortably fits the largest hash table while bounding what the planner can reach for. SET LOCAL scopes the bump to the job's transaction, so the instance-wide setting stays safe for the 400 connection limit.

The refresh cost is dominated by scanning the downloads join rather than spilling, so expect a moderate improvement, not a dramatic one. The per-refresh timeout: 60_000 looks like it should cap these at 60s but doesn't: DBConnection deadlines are per-checkout and a transaction is one long checkout, so per-query timeouts inside it are inert (verified empirically).