### PR TITLE
Serve fallback preview content without redirecting on dead renders

### DIFF
--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -57,7 +57,7 @@ defmodule HexpmWeb.PreviewLive do
         |> assign_source(repository, package_name, version, source)
 
       socket =
-        if replace_path? do
+        if replace_path? and connected?(socket) do
           push_patch(socket,
             to: files_path(repository, package_name, version, source.filename),
             replace: true
@@ -165,7 +165,7 @@ defmodule HexpmWeb.PreviewLive do
   defp source(repository, package, version, requested_filename, fallback) do
     case Hexpm.Preview.source(repository, package, version, requested_filename) do
       {:ok, source} ->
-        {:ok, source, fallback == "default"}
+        {:ok, source, false}
 
       :error when fallback == "default" ->
         case Hexpm.Preview.source(repository, package, version) do

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -141,16 +141,24 @@ defmodule HexpmWeb.PreviewLiveTest do
              "2.0.0"
            )
 
-    assert {:error, {:live_redirect, %{to: "/packages/versioned_preview/2.0.0/files/README.md"}}} =
-             live(
-               conn,
-               "/packages/versioned_preview/2.0.0/files/lib/shared.ex?fallback=default"
-             )
+    {:ok, direct_view, _html} =
+      live(conn, "/packages/versioned_preview/1.0.0/files/lib/shared.ex?fallback=default")
 
-    {:ok, fallback_view, _html} =
-      live(conn, "/packages/versioned_preview/2.0.0/files/README.md")
+    assert has_element?(direct_view, "h2", "shared.ex")
+
+    conn = get(conn, "/packages/versioned_preview/2.0.0/files/lib/shared.ex?fallback=default")
+
+    assert html_response(conn, 200) =~
+             HexpmWeb.Endpoint.url() <>
+               ~s(/packages/versioned_preview/2.0.0/files/README.md" rel="canonical")
+
+    {:ok, fallback_view, _html} = live(conn)
 
     assert has_element?(fallback_view, "h2", "README.md")
+
+    render_patch(view, "/packages/versioned_preview/2.0.0/files/lib/shared.ex?fallback=default")
+    assert_patch(view, "/packages/versioned_preview/2.0.0/files/README.md")
+    assert has_element?(view, "h2", "README.md")
   end
 
   test "returns 404 when package or file data is missing", %{conn: conn} do


### PR DESCRIPTION
Version-switcher links carry ?fallback=default because the selected file may not exist in the target version. PreviewLive resolved the fallback and then unconditionally push_patched to the canonical path, which turns into a 302 on dead renders: every version switch cost a second full render (3 more GCS round trips) plus an extra HTTP round trip, for crawlers on every hit.

Now the resolved content renders directly with a canonical link tag. The path is only patched on connected mounts, and only when the fallback actually resolved a different file; a direct hit no longer patches at all since the query param is harmless. The common case (file exists in the target version) drops from 3 backend resolutions to 2. When the fallback does kick in, the connected mount still resolves twice (fallback, then canonical after the patch); reusing the file list from assigns would remove that and is left for a follow-up.