### PR TITLE
Move plug sessions to encrypted cookies with a DB transition store

### DIFF
--- a/lib/hexpm_web/controllers/auth_controller.ex
+++ b/lib/hexpm_web/controllers/auth_controller.ex
@@ -145,6 +145,7 @@ defmodule HexpmWeb.AuthController do
        ) do
     conn
     |> put_session("pending_oauth", %{
+      at: NaiveDateTime.utc_now() |> NaiveDateTime.to_iso8601(),
       provider: provider,
       provider_uid: provider_uid,
       provider_email: provider_email,
@@ -155,7 +156,7 @@ defmodule HexpmWeb.AuthController do
   end
 
   def show_username_form(conn, _params) do
-    case get_session(conn, "pending_oauth") do
+    case fetch_pending_oauth(conn) do
       nil ->
         conn
         |> put_flash(:error, "Session expired. Please try signing up again.")
@@ -174,7 +175,7 @@ defmodule HexpmWeb.AuthController do
   end
 
   def complete_signup(conn, %{"user" => %{"username" => username}}) do
-    case get_session(conn, "pending_oauth") do
+    case fetch_pending_oauth(conn) do
       nil ->
         conn
         |> put_flash(:error, "Session expired. Please try signing up again.")
@@ -182,6 +183,16 @@ defmodule HexpmWeb.AuthController do
 
       oauth_data ->
         create_user_from_oauth(conn, oauth_data, username)
+    end
+  end
+
+  defp fetch_pending_oauth(conn) do
+    case get_session(conn, "pending_oauth") do
+      %{"at" => at} = oauth_data ->
+        if HexpmWeb.Session.TTL.within?(at, minute: 30), do: oauth_data
+
+      _ ->
+        nil
     end
   end
 

--- a/lib/hexpm_web/controllers/controller_helpers.ex
+++ b/lib/hexpm_web/controllers/controller_helpers.ex
@@ -389,6 +389,7 @@ defmodule HexpmWeb.ControllerHelpers do
     |> configure_session(renew: true)
     |> put_session("tfa_user_id", %{
       "uid" => user.id,
+      "at" => NaiveDateTime.utc_now() |> NaiveDateTime.to_iso8601(),
       "return" => return,
       "session_token" => Base.encode64(session_token)
     })

--- a/lib/hexpm_web/controllers/tfa_auth_controller.ex
+++ b/lib/hexpm_web/controllers/tfa_auth_controller.ex
@@ -75,11 +75,15 @@ defmodule HexpmWeb.TFAAuthController do
 
   defp authenticate(conn, _opts) do
     case get_session(conn, "tfa_user_id") do
-      nil ->
-        conn |> redirect(to: "/") |> halt()
+      %{"at" => at} ->
+        if HexpmWeb.Session.TTL.within?(at, minute: 15) do
+          conn
+        else
+          conn |> delete_session("tfa_user_id") |> redirect(to: "/") |> halt()
+        end
 
       _ ->
-        conn
+        conn |> redirect(to: "/") |> halt()
     end
   end
 end

--- a/lib/hexpm_web/controllers/tfa_recovery_controller.ex
+++ b/lib/hexpm_web/controllers/tfa_recovery_controller.ex
@@ -41,11 +41,15 @@ defmodule HexpmWeb.TFARecoveryController do
 
   defp authenticate(conn, _opts) do
     case get_session(conn, "tfa_user_id") do
-      nil ->
-        conn |> redirect(to: "/") |> halt()
+      %{"at" => at} ->
+        if HexpmWeb.Session.TTL.within?(at, minute: 15) do
+          conn
+        else
+          conn |> delete_session("tfa_user_id") |> redirect(to: "/") |> halt()
+        end
 
       _ ->
-        conn
+        conn |> redirect(to: "/") |> halt()
     end
   end
 

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -6,7 +6,9 @@ defmodule HexpmWeb.Endpoint do
 
   @session_options [
     signing_salt: "NOcCmerj",
-    store: HexpmWeb.Session,
+    encryption_salt: "Zb5cCLE7",
+    store: HexpmWeb.Session.Transition,
+    serializer: HexpmWeb.Session.JSON,
     key: "_hexpm_key",
     max_age: 60 * 60 * 24 * 30
   ]

--- a/lib/hexpm_web/plugs.ex
+++ b/lib/hexpm_web/plugs.ex
@@ -6,6 +6,14 @@ defmodule HexpmWeb.Plugs do
   alias Hexpm.UserSessions
   alias HexpmWeb.ControllerHelpers
 
+  def migrate_session(conn, _opts) do
+    if get_session(conn, HexpmWeb.Session.Transition.legacy_marker()) do
+      delete_session(conn, HexpmWeb.Session.Transition.legacy_marker())
+    else
+      conn
+    end
+  end
+
   # Max filesize: 20MB
   # Min upload speed: ~10kb/s
   # Read 100kb every 10s

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -8,6 +8,7 @@ defmodule HexpmWeb.Router do
   pipeline :browser do
     plug :accepts, ["html"]
     plug :fetch_session
+    plug :migrate_session
     plug :fetch_flash
     plug :put_root_layout, {HexpmWeb.LayoutView, :root}
     plug :put_layout, {HexpmWeb.LayoutView, :app}
@@ -72,6 +73,7 @@ defmodule HexpmWeb.Router do
   pipeline :browser_api do
     plug :accepts, ["json"]
     plug :fetch_session
+    plug :migrate_session
     plug :protect_from_forgery
     plug :put_secure_browser_headers
     plug :user_agent, required: false

--- a/lib/hexpm_web/session/json.ex
+++ b/lib/hexpm_web/session/json.ex
@@ -4,14 +4,13 @@ defmodule HexpmWeb.Session.JSON do
   # JSON-representable values survive a roundtrip.
 
   def encode(term) do
-    case Jason.encode(term) do
-      {:ok, binary} -> {:ok, binary}
-      {:error, _} -> :error
-    end
+    {:ok, Elixir.JSON.encode!(term)}
+  rescue
+    _ -> :error
   end
 
   def decode(binary) do
-    case Jason.decode(binary) do
+    case Elixir.JSON.decode(binary) do
       {:ok, term} -> {:ok, term}
       {:error, _} -> :error
     end

--- a/lib/hexpm_web/session/json.ex
+++ b/lib/hexpm_web/session/json.ex
@@ -1,0 +1,19 @@
+defmodule HexpmWeb.Session.JSON do
+  # Session cookie serializer with the same semantics as the legacy
+  # database store's jsonb column: atom keys become strings and only
+  # JSON-representable values survive a roundtrip.
+
+  def encode(term) do
+    case Jason.encode(term) do
+      {:ok, binary} -> {:ok, binary}
+      {:error, _} -> :error
+    end
+  end
+
+  def decode(binary) do
+    case Jason.decode(binary) do
+      {:ok, term} -> {:ok, term}
+      {:error, _} -> :error
+    end
+  end
+end

--- a/lib/hexpm_web/session/transition.ex
+++ b/lib/hexpm_web/session/transition.ex
@@ -1,0 +1,47 @@
+defmodule HexpmWeb.Session.Transition do
+  alias Plug.Session.COOKIE
+
+  @behaviour Plug.Session.Store
+
+  # Session store that reads both encrypted cookie sessions and legacy
+  # database-backed sessions (HexpmWeb.Session), but only ever writes
+  # cookies. Legacy sessions are marked so MigrateSession can rewrite them
+  # on their first request. Once the legacy cookies have aged out the
+  # database fallback, the sessions table, and the purge job step can go.
+
+  @legacy_marker "__legacy__"
+
+  def legacy_marker(), do: @legacy_marker
+
+  def init(opts) do
+    COOKIE.init(opts)
+  end
+
+  def get(conn, cookie, opts) do
+    case COOKIE.get(conn, cookie, opts) do
+      {_sid, data} when data != %{} ->
+        {nil, data}
+
+      _ ->
+        case HexpmWeb.Session.get(conn, cookie, :ok) do
+          {nil, _data} ->
+            {nil, %{}}
+
+          {legacy_sid, data} ->
+            {{:legacy, legacy_sid}, Map.put(data, @legacy_marker, true)}
+        end
+    end
+  end
+
+  def put(conn, _sid, data, opts) do
+    COOKIE.put(conn, nil, Map.delete(data, @legacy_marker), opts)
+  end
+
+  def delete(conn, {:legacy, legacy_sid}, _opts) do
+    HexpmWeb.Session.delete(conn, legacy_sid, :ok)
+  end
+
+  def delete(_conn, _sid, _opts) do
+    :ok
+  end
+end

--- a/lib/hexpm_web/session/ttl.ex
+++ b/lib/hexpm_web/session/ttl.ex
@@ -1,0 +1,18 @@
+defmodule HexpmWeb.Session.TTL do
+  # Session flow state (TFA login, pending OAuth signup) lives in the
+  # cookie until cookie expiry, so replay protection has to come from
+  # timestamps embedded in the values themselves.
+
+  def within?(iso8601, duration) when is_binary(iso8601) do
+    case NaiveDateTime.from_iso8601(iso8601) do
+      {:ok, at} ->
+        expires_at = NaiveDateTime.shift(at, duration)
+        NaiveDateTime.compare(NaiveDateTime.utc_now(), expires_at) == :lt
+
+      _ ->
+        false
+    end
+  end
+
+  def within?(_at, _duration), do: false
+end

--- a/test/hexpm_web/controllers/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/auth_controller_test.exs
@@ -226,6 +226,18 @@ defmodule HexpmWeb.AuthControllerTest do
   end
 
   describe "GET /auth/complete-signup - Username selection form" do
+    test "redirects to signup when pending oauth is stale" do
+      stale =
+        NaiveDateTime.utc_now() |> NaiveDateTime.shift(minute: -31) |> NaiveDateTime.to_iso8601()
+
+      conn =
+        build_conn()
+        |> Plug.Test.init_test_session(%{"pending_oauth" => %{"at" => stale}})
+        |> get("/auth/complete-signup")
+
+      assert redirected_to(conn) == "/signup"
+    end
+
     test "shows form with suggested username" do
       email = Hexpm.Fake.sequence(:email)
       username = Hexpm.Fake.sequence(:username)
@@ -236,6 +248,7 @@ defmodule HexpmWeb.AuthControllerTest do
         build_conn()
         |> Plug.Test.init_test_session(%{
           "pending_oauth" => %{
+            "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
             "provider" => "github",
             "provider_uid" => "12345",
             "provider_email" => email,
@@ -271,6 +284,7 @@ defmodule HexpmWeb.AuthControllerTest do
         build_conn()
         |> Plug.Test.init_test_session(%{
           "pending_oauth" => %{
+            "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
             "provider" => "github",
             "provider_uid" => "12345",
             "provider_email" => email,
@@ -316,6 +330,7 @@ defmodule HexpmWeb.AuthControllerTest do
         build_conn()
         |> Plug.Test.init_test_session(%{
           "pending_oauth" => %{
+            "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
             "provider" => "github",
             "provider_uid" => "12345",
             "provider_email" => email,
@@ -348,6 +363,7 @@ defmodule HexpmWeb.AuthControllerTest do
         build_conn()
         |> Plug.Test.init_test_session(%{
           "pending_oauth" => %{
+            "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
             "provider" => "github",
             "provider_uid" => "12345",
             "provider_email" => email,
@@ -374,6 +390,7 @@ defmodule HexpmWeb.AuthControllerTest do
         build_conn()
         |> Plug.Test.init_test_session(%{
           "pending_oauth" => %{
+            "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
             "provider" => "github",
             "provider_uid" => "12345",
             "provider_email" => email,

--- a/test/hexpm_web/controllers/login_controller_test.exs
+++ b/test/hexpm_web/controllers/login_controller_test.exs
@@ -17,7 +17,7 @@ defmodule HexpmWeb.LoginControllerTest do
     assert redirected_to(conn) == "/users/#{c.user.username}"
 
     assert get_session(conn, "session_token")
-    refute last_session().data["user_id"]
+    refute get_session(conn, "user_id")
   end
 
   @tag :focus

--- a/test/hexpm_web/controllers/tfa_auth_controller_test.exs
+++ b/test/hexpm_web/controllers/tfa_auth_controller_test.exs
@@ -10,7 +10,10 @@ defmodule HexpmWeb.TFAAuthControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", c.user.id)
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> get("/tfa")
 
       result = response(conn, 200)
@@ -25,6 +28,19 @@ defmodule HexpmWeb.TFAAuthControllerTest do
 
       assert redirected_to(conn) == "/"
     end
+
+    test "redirects to homepage if the tfa session is stale", c do
+      stale =
+        NaiveDateTime.utc_now() |> NaiveDateTime.shift(minute: -16) |> NaiveDateTime.to_iso8601()
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> put_session("tfa_user_id", %{"uid" => c.user.id, "at" => stale})
+        |> get("/tfa")
+
+      assert redirected_to(conn) == "/"
+    end
   end
 
   describe "post /tfa" do
@@ -32,7 +48,11 @@ defmodule HexpmWeb.TFAAuthControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "/"})
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "/",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> post("/tfa", %{"code" => "000000"})
 
       assert response(conn, 200) =~
@@ -45,7 +65,11 @@ defmodule HexpmWeb.TFAAuthControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "/"})
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "/",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> post("/tfa", %{"code" => token})
 
       assert redirected_to(conn) == "/"
@@ -59,6 +83,7 @@ defmodule HexpmWeb.TFAAuthControllerTest do
         |> test_login(c.user)
         |> put_session("tfa_user_id", %{
           "uid" => c.user.id,
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
           "return" => "https%3A%2F%2Fhex.pm%2Foauth%2Fauthorize%3Fclient_id%3Dabc"
         })
         |> post("/tfa", %{"code" => token})
@@ -72,7 +97,11 @@ defmodule HexpmWeb.TFAAuthControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "//evil.com"})
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "//evil.com",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> post("/tfa", %{"code" => token})
 
       assert redirected_to(conn) == "/users/#{c.user.username}"
@@ -81,7 +110,11 @@ defmodule HexpmWeb.TFAAuthControllerTest do
     test "redirects to login after too many failed attempts", c do
       PlugAttack.Storage.Ets.clean(HexpmWeb.Plugs.Attack.Storage)
 
-      session_data = %{"uid" => c.user.id, "return" => "/"}
+      session_data = %{
+        "uid" => c.user.id,
+        "return" => "/",
+        "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+      }
 
       # Exhaust rate limit using the throttle function directly (this is the real test)
       Enum.each(1..5, fn _ ->

--- a/test/hexpm_web/controllers/tfa_recovery_controller_test.exs
+++ b/test/hexpm_web/controllers/tfa_recovery_controller_test.exs
@@ -10,11 +10,28 @@ defmodule HexpmWeb.TFARecoveryControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "/"})
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "/",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> get("/tfa/recovery")
 
       result = response(conn, 200)
       assert result =~ "Recovery code"
+    end
+
+    test "redirects to homepage if the tfa session is stale", c do
+      stale =
+        NaiveDateTime.utc_now() |> NaiveDateTime.shift(minute: -16) |> NaiveDateTime.to_iso8601()
+
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> put_session("tfa_user_id", %{"uid" => c.user.id, "at" => stale})
+        |> get("/tfa/recovery")
+
+      assert redirected_to(conn) == "/"
     end
   end
 
@@ -23,7 +40,11 @@ defmodule HexpmWeb.TFARecoveryControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "/"})
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "/",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> post("/tfa/recovery", %{"code" => "0000"})
 
       assert response(conn, 200) =~
@@ -34,7 +55,11 @@ defmodule HexpmWeb.TFARecoveryControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "/"})
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "/",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> post("/tfa/recovery", %{"code" => "1234-1234-1234-1234"})
 
       assert redirected_to(conn) == "/"
@@ -46,7 +71,8 @@ defmodule HexpmWeb.TFARecoveryControllerTest do
         |> test_login(c.user)
         |> put_session("tfa_user_id", %{
           "uid" => c.user.id,
-          "return" => "https://example.com"
+          "return" => "https://example.com",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
         })
         |> post("/tfa/recovery", %{"code" => "1234-1234-1234-1234"})
 
@@ -57,7 +83,11 @@ defmodule HexpmWeb.TFARecoveryControllerTest do
       conn =
         build_conn()
         |> test_login(c.user)
-        |> put_session("tfa_user_id", %{"uid" => c.user.id, "return" => "//example.com"})
+        |> put_session("tfa_user_id", %{
+          "uid" => c.user.id,
+          "return" => "//example.com",
+          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
+        })
         |> post("/tfa/recovery", %{"code" => "1234-1234-1234-1234"})
 
       assert redirected_to(conn) == "/users/#{c.user.username}"

--- a/test/hexpm_web/session/json_test.exs
+++ b/test/hexpm_web/session/json_test.exs
@@ -1,0 +1,15 @@
+defmodule HexpmWeb.Session.JSONTest do
+  use ExUnit.Case, async: true
+
+  alias HexpmWeb.Session.JSON, as: SessionJSON
+
+  test "round trips JSON-compatible session data" do
+    assert {:ok, encoded} = SessionJSON.encode(%{foo: "bar"})
+    assert {:ok, %{"foo" => "bar"}} = SessionJSON.decode(encoded)
+  end
+
+  test "rejects values that cannot be encoded or decoded" do
+    assert :error = SessionJSON.encode(self())
+    assert :error = SessionJSON.decode("not-json")
+  end
+end

--- a/test/hexpm_web/session/transition_test.exs
+++ b/test/hexpm_web/session/transition_test.exs
@@ -1,0 +1,50 @@
+defmodule HexpmWeb.Session.TransitionTest do
+  use HexpmWeb.ConnCase, async: false
+
+  alias Hexpm.{PlugSession, Repo}
+
+  test "anonymous page views do not write session rows" do
+    conn = get(build_conn(), "/")
+
+    assert conn.status == 200
+    assert Repo.aggregate(PlugSession, :count) == 0
+    assert %{value: _} = conn.resp_cookies["_hexpm_key"]
+  end
+
+  test "legacy database session is read and rewritten as a cookie session" do
+    session =
+      Repo.insert!(%PlugSession{token: :crypto.strong_rand_bytes(32), data: %{"foo" => "bar"}})
+
+    legacy_cookie = "#{session.id}++#{Base.url_encode64(session.token)}"
+
+    conn =
+      build_conn()
+      |> put_req_cookie("_hexpm_key", legacy_cookie)
+      |> get("/")
+
+    assert get_session(conn, "foo") == "bar"
+    refute get_session(conn, HexpmWeb.Session.Transition.legacy_marker())
+
+    assert %{value: new_cookie} = conn.resp_cookies["_hexpm_key"]
+    refute new_cookie == legacy_cookie
+
+    Repo.delete!(session)
+
+    conn =
+      build_conn()
+      |> put_req_cookie("_hexpm_key", new_cookie)
+      |> get("/")
+
+    assert get_session(conn, "foo") == "bar"
+  end
+
+  test "invalid cookies start a fresh session" do
+    conn =
+      build_conn()
+      |> put_req_cookie("_hexpm_key", "42++notvalidbase64")
+      |> get("/")
+
+    assert conn.status == 200
+    refute get_session(conn, "foo")
+  end
+end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -83,13 +83,6 @@ defmodule HexpmWeb.ConnCase do
     }
   end
 
-  def last_session() do
-    import Ecto.Query
-
-    from(s in Hexpm.PlugSession, order_by: [desc: s.id], limit: 1)
-    |> Hexpm.Repo.one()
-  end
-
   def json_post(conn, path, params) do
     conn
     |> Plug.Conn.put_req_header("content-type", "application/json")


### PR DESCRIPTION
The DB-backed plug session INSERTs a row for every anonymous page view because the CSRF token has to persist for LiveView, making sessions 62% of all write statements on the instance, plus the nightly purge (329K rows last night) and the autovacuum churn that follows it.

Real authentication lives in user_sessions and is validated per request, so revocation semantics don't change: revoking a user_session row still logs that browser out on its next request regardless of cookie contents. The cookie store is encrypted since the session carries session_token, generated_key secrets, and the TFA setup secret. It uses a JSON serializer to keep the legacy jsonb semantics: atom keys are written and string keys are read, which pending_oauth depends on.

The transition store reads legacy id++token cookies from the sessions table and marks them; the migrate_session plug forces a write so active legacy sessions rewrite as cookies on their first request. Once legacy cookies age out (30d max_age), a follow-up removes the fallback, the sessions table, the PlugSession schema, and the purge step.

Flow state now outlives DB row deletion, and the encrypted cookie itself has no server-side expiry (Plug.Session.COOKIE is ageless; max_age only limits the browser), so tfa_user_id and pending_oauth carry embedded timestamps checked with 15/30 minute TTLs in both TFA controllers. Sudo and device verification already had them.