### PR TITLE
Return key owner from GET /api/auth

### DIFF
--- a/lib/hexpm_web/controllers/api/auth_controller.ex
+++ b/lib/hexpm_web/controllers/api/auth_controller.ex
@@ -22,11 +22,11 @@ defmodule HexpmWeb.API.AuthController do
       # 2. User-level: Check if the authenticated user/organization actually owns/has access to the resource
       case Hexpm.Permissions.verify_user_access(user_or_organization, domain, resource) do
         {:ok, nil} ->
-          send_resp(conn, 204, "")
+          success(conn)
 
         {:ok, repository} ->
           case organization_billing_active(repository, user_or_organization) do
-            :ok -> send_resp(conn, 204, "")
+            :ok -> success(conn)
             error -> error(conn, error)
           end
 
@@ -35,6 +35,13 @@ defmodule HexpmWeb.API.AuthController do
       end
     else
       error(conn, {:error, :domain})
+    end
+  end
+
+  defp success(conn) do
+    case conn.assigns.auth_credential do
+      %Key{} = key -> render(conn, :show, key: key)
+      _ -> send_resp(conn, 204, "")
     end
   end
 end

--- a/lib/hexpm_web/views/api/auth_view.ex
+++ b/lib/hexpm_web/views/api/auth_view.ex
@@ -1,0 +1,20 @@
+defmodule HexpmWeb.API.AuthView do
+  use HexpmWeb, :view
+
+  def render("show." <> _, %{key: key}) do
+    %{
+      key: %{
+        name: key.name,
+        owner: render_owner(key)
+      }
+    }
+  end
+
+  defp render_owner(%Key{organization: %Organization{} = organization}) do
+    %{type: "organization", name: organization.name}
+  end
+
+  defp render_owner(%Key{user: %User{} = user}) do
+    %{type: "user", name: user.username}
+  end
+end

--- a/test/hexpm_web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/auth_controller_test.exs
@@ -131,7 +131,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api")
-      |> response(204)
+      |> response(200)
     end
 
     test "authenticate full user key", %{
@@ -142,12 +142,12 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: owned_org.name)
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -173,12 +173,12 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: owned_org.name)
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -200,17 +200,17 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "read")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "write")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -222,22 +222,75 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "read")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "write")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: "myrepo")
       |> response(401)
+    end
+
+    test "authenticate user key returns key owner", %{user_api_key: key, user: user} do
+      body =
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "api")
+        |> json_response(200)
+
+      assert body == %{
+               "key" => %{
+                 "name" => key.name,
+                 "owner" => %{"type" => "user", "name" => user.username}
+               }
+             }
+    end
+
+    test "authenticate organization key returns key owner", %{
+      organization_api_key: key,
+      owned_org: owned_org
+    } do
+      body =
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "api")
+        |> json_response(200)
+
+      assert body == %{
+               "key" => %{
+                 "name" => key.name,
+                 "owner" => %{"type" => "organization", "name" => owned_org.name}
+               }
+             }
+    end
+
+    test "authenticate oauth token returns no content", %{user: user} do
+      client = insert(:oauth_client)
+      oauth_session = insert(:oauth_session, user: user, client_id: client.client_id)
+
+      {:ok, oauth_token} =
+        Hexpm.OAuth.Tokens.create_and_insert_for_user(
+          user,
+          client.client_id,
+          ["api:read"],
+          "authorization_code",
+          "test_grant_ref",
+          user_session_id: oauth_session.id
+        )
+
+      build_conn()
+      |> put_req_header("authorization", "Bearer #{oauth_token.access_token}")
+      |> get("/api/auth", domain: "api")
+      |> response(204)
     end
 
     test "authenticate user read api key", %{user: user} do
@@ -247,7 +300,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "read")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -262,7 +315,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "write")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -277,7 +330,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "read")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -292,7 +345,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "api", resource: "write")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -313,12 +366,12 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repositories")
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: owned_org.name)
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -338,7 +391,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "docs", resource: owned_org.name)
-      |> response(204)
+      |> response(200)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)

--- a/test/hexpm_web/read_only_mode_test.exs
+++ b/test/hexpm_web/read_only_mode_test.exs
@@ -10,7 +10,7 @@ defmodule HexpmWeb.ReadOnlyModeTest do
     build_conn()
     |> put_req_header("authorization", key.user_secret)
     |> get("/api/auth", domain: "api")
-    |> response(204)
+    |> response(200)
   after
     Application.put_env(:hexpm, :read_only_mode, false)
   end


### PR DESCRIPTION
When a request to GET /api/auth is authenticated with an API key, respond with 200 and a body describing the key, its name and its owner (user or organization), instead of a bare 204. Other authentication methods keep the 204.

The hex client needs this to tell organization-owned keys from user-owned keys when verifying a key in `mix hex.organization auth ORG --key KEY`: the stored-key deprecation warning in Hex 2.5 tells users to authenticate with an organization key, but the client can't tell it apart from a user key once stored, so the warning keeps firing for people who followed the instructions. Client side: hexpm/hex#1207.

Safe for existing clients: mix hex (back to at least v0.20), hex_core, and rebar3_hex all treat any 2xx from this endpoint as success and ignore the body.