### PR TITLE
DO NOT MERGE: Deprecate user keys with repository permissions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,6 +39,8 @@ config :hexpm,
 
 config :hexpm, :features, package_reports: true
 
+config :hexpm, :user_repository_keys_disable_date, ~D[2026-12-31]
+
 config :hexpm, ecto_repos: [Hexpm.RepoBase]
 
 config :hexpm, Oban,

--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -188,6 +188,12 @@ defmodule Hexpm.Accounts.Key do
     not is_nil(key.revoke_at) and DateTime.compare(key.revoke_at, DateTime.utc_now()) == :lt
   end
 
+  def user_repository_key?(%Key{user_id: nil}), do: false
+
+  def user_repository_key?(%Key{} = key) do
+    Enum.any?(key.permissions, &(&1.domain in ["repository", "repositories"]))
+  end
+
   def associate_owner(nil, _owner), do: nil
   def associate_owner(%Key{} = key, %User{} = user), do: %{key | user: user, organization: nil}
 

--- a/lib/hexpm/accounts/key_permission.ex
+++ b/lib/hexpm/accounts/key_permission.ex
@@ -13,10 +13,26 @@ defmodule Hexpm.Accounts.KeyPermission do
   def changeset(struct, user_or_organization, params) do
     cast(struct, params, ~w(domain resource)a)
     |> validate_inclusion(:domain, Permissions.valid_domains())
+    |> validate_user_key_domain(user_or_organization)
     |> normalize_resource()
     |> validate_resource()
     |> validate_permission(user_or_organization)
   end
+
+  defp validate_user_key_domain(changeset, %User{}) do
+    validate_change(changeset, :domain, fn _, domain ->
+      if domain in ["repository", "repositories"] do
+        [
+          domain:
+            "user keys cannot have repository permissions, generate an organization key instead"
+        ]
+      else
+        []
+      end
+    end)
+  end
+
+  defp validate_user_key_domain(changeset, _user_or_organization), do: changeset
 
   defp validate_resource(changeset) do
     validate_change(changeset, :resource, fn _, resource ->

--- a/lib/hexpm_web/controllers/api/auth_controller.ex
+++ b/lib/hexpm_web/controllers/api/auth_controller.ex
@@ -8,6 +8,7 @@ defmodule HexpmWeb.API.AuthController do
     auth_credential = conn.assigns.auth_credential
     user_or_organization = conn.assigns.current_user || conn.assigns.current_organization
     resource = params["resource"]
+    conn = maybe_warn_user_repository_key(conn, auth_credential, domain)
 
     # Two-level permission check:
     # 1. API-level: Check if the API key/OAuth token has the required scopes/permissions
@@ -37,4 +38,15 @@ defmodule HexpmWeb.API.AuthController do
       error(conn, {:error, :domain})
     end
   end
+
+  defp maybe_warn_user_repository_key(conn, %Key{} = key, domain)
+       when domain in ["repository", "repositories"] do
+    if Key.user_repository_key?(key) do
+      put_user_repository_key_warning(conn)
+    else
+      conn
+    end
+  end
+
+  defp maybe_warn_user_repository_key(conn, _auth_credential, _domain), do: conn
 end

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -205,6 +205,7 @@ defmodule HexpmWeb.API.OAuthController do
          {:ok, api_key_secret} <- validate_api_key_secret(safe_param(params, "client_secret")),
          {:ok, auth_info} <- authenticate_api_key(api_key_secret, conn),
          {:ok, scopes} <- expand_and_validate_scopes(params["scope"], auth_info) do
+      conn = maybe_warn_user_repository_key(conn, auth_info.auth_credential, scopes)
       usage_info = build_usage_info(conn)
 
       # Determine user or organization from the API key
@@ -249,6 +250,19 @@ defmodule HexpmWeb.API.OAuthController do
         render_oauth_error(conn, :invalid_client, error)
     end
   end
+
+  defp maybe_warn_user_repository_key(conn, %Key{} = key, scopes) do
+    repository_scope? =
+      Enum.any?(scopes, &(&1 == "repositories" or String.starts_with?(&1, "repository:")))
+
+    if repository_scope? and Key.user_repository_key?(key) do
+      put_user_repository_key_warning(conn)
+    else
+      conn
+    end
+  end
+
+  defp maybe_warn_user_repository_key(conn, _auth_credential, _scopes), do: conn
 
   defp validate_client_supports_grant(client, grant_type) do
     if Clients.supports_grant_type?(client, grant_type) do

--- a/lib/hexpm_web/controllers/controller_helpers.ex
+++ b/lib/hexpm_web/controllers/controller_helpers.ex
@@ -23,6 +23,17 @@ defmodule HexpmWeb.ControllerHelpers do
     cache(conn, control, vary)
   end
 
+  def put_user_repository_key_warning(conn) do
+    date = Application.fetch_env!(:hexpm, :user_repository_keys_disable_date)
+
+    message =
+      "User API keys with repository permissions are deprecated and will stop working on " <>
+        "#{date}. Use mix hex.user auth for development or an organization key " <>
+        "(mix hex.organization key ORGANIZATION generate) for CI"
+
+    put_resp_header(conn, "x-hex-message", ~s("#{message}";level=warn))
+  end
+
   def permanent_redirect(conn, path, query_string \\ nil) do
     query_string = if is_nil(query_string), do: conn.query_string, else: query_string
     query = if query_string == "", do: "", else: "?#{query_string}"

--- a/lib/hexpm_web/controllers/dashboard/key_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/key_controller.ex
@@ -48,7 +48,6 @@ defmodule HexpmWeb.Dashboard.KeyController do
   defp render_index(conn, changeset \\ changeset(), generated_key \\ nil) do
     user = Hexpm.Repo.preload(conn.assigns.current_user, :owned_packages)
     keys = Keys.all(user)
-    organizations = Organizations.all_by_user(user)
     packages = Enum.filter(user.owned_packages, &HexpmWeb.ViewHelpers.main_repository?/1)
 
     render(
@@ -57,7 +56,6 @@ defmodule HexpmWeb.Dashboard.KeyController do
       title: "Dashboard - User keys",
       container: "container page dashboard",
       keys: keys,
-      organizations: organizations,
       packages: packages,
       delete_key_path: ~p"/dashboard/keys",
       create_key_path: ~p"/dashboard/keys",

--- a/lib/hexpm_web/templates/dashboard/_keys.html.heex
+++ b/lib/hexpm_web/templates/dashboard/_keys.html.heex
@@ -1,7 +1,6 @@
 <%!-- Keys section for organization dashboard --%>
 <.key_management_card
   keys={@keys}
-  organizations={[]}
   packages={[]}
   key_changeset={@key_changeset}
   current_user={@current_user}

--- a/lib/hexpm_web/templates/dashboard/key/components/generate_key_modal.ex
+++ b/lib/hexpm_web/templates/dashboard/key/components/generate_key_modal.ex
@@ -9,7 +9,6 @@ defmodule HexpmWeb.Dashboard.Key.Components.GenerateKeyModal do
   attr :form, :map, required: true
   attr :current_user, :map, required: true
   attr :create_key_path, :string, required: true
-  attr :organizations, :list, required: true
   attr :packages, :list, required: true
   attr :organization, :map, default: nil
 
@@ -123,43 +122,6 @@ defmodule HexpmWeb.Dashboard.Key.Components.GenerateKeyModal do
                   Organization repository
                 </span>
               </label>
-            </div>
-          <% else %>
-            <div
-              class="mb-4"
-              phx-hook="PermissionGroup"
-              id="repositories-permission-group"
-              data-parent="repositories-parent"
-            >
-              <label class="flex items-center mb-2">
-                <input
-                  type="checkbox"
-                  id="repositories-parent"
-                  name="key[permissions][repositories]"
-                  value="on"
-                  class="rounded border-grey-300 text-purple-600 focus:ring-purple-500"
-                />
-                <span class="ml-2 text-sm text-grey-700 dark:text-grey-300 font-medium">
-                  All Repositories
-                </span>
-              </label>
-              <%= if @organizations != [] do %>
-                <div class="ml-6 space-y-2">
-                  <%= for organization <- @organizations do %>
-                    <label class="flex items-center">
-                      <input
-                        type="checkbox"
-                        name={"key[permissions][repository][#{organization.name}]"}
-                        value="on"
-                        class="child-checkbox rounded border-grey-300 text-purple-600 focus:ring-purple-500"
-                      />
-                      <span class="ml-2 text-sm text-grey-700 dark:text-grey-300">
-                        Repository: {organization.name}
-                      </span>
-                    </label>
-                  <% end %>
-                </div>
-              <% end %>
             </div>
           <% end %>
 

--- a/lib/hexpm_web/templates/dashboard/key/components/key_management_card.ex
+++ b/lib/hexpm_web/templates/dashboard/key/components/key_management_card.ex
@@ -21,7 +21,6 @@ defmodule HexpmWeb.Dashboard.Key.Components.KeyManagementCard do
   alias Hexpm.Accounts.KeyPermission
 
   attr :keys, :list, required: true
-  attr :organizations, :list, required: true
   attr :packages, :list, required: true
   attr :key_changeset, :map, required: true
   attr :current_user, :map, required: true
@@ -100,7 +99,6 @@ defmodule HexpmWeb.Dashboard.Key.Components.KeyManagementCard do
       form={@form}
       current_user={@current_user}
       create_key_path={@create_key_path}
-      organizations={@organizations}
       packages={@packages}
       organization={assigns[:organization]}
     />

--- a/lib/hexpm_web/templates/dashboard/key/index.html.heex
+++ b/lib/hexpm_web/templates/dashboard/key/index.html.heex
@@ -10,7 +10,6 @@
       <div class="flex-1 min-w-0">
         <.key_management_card
           keys={@keys}
-          organizations={@organizations}
           packages={@packages}
           key_changeset={@key_changeset}
           current_user={@current_user}

--- a/lib/hexpm_web/templates/dashboard/organization/components/keys_tab.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/keys_tab.ex
@@ -26,7 +26,6 @@ defmodule HexpmWeb.Dashboard.Organization.Components.KeysTab do
       key_changeset={@key_changeset}
       keys={@keys}
       organization={@organization}
-      organizations={[]}
       packages={@packages}
     />
     """

--- a/test/hexpm/accounts/keys_test.exs
+++ b/test/hexpm/accounts/keys_test.exs
@@ -78,6 +78,39 @@ defmodule Hexpm.Accounts.KeysTest do
       assert {:ok, _} = Base.decode16(key.user_secret, case: :lower)
     end
 
+    test "user repository permissions are not allowed", %{user: user, organization: organization} do
+      insert(:organization_user, organization: organization, user: user)
+
+      params = %{
+        "name" => "keyname",
+        "permissions" => [%{"domain" => "repository", "resource" => organization.name}]
+      }
+
+      assert {:error, :key, changeset, _} = Keys.create(user, params, audit: audit_data(user))
+
+      assert errors_on(changeset)[:permissions][:domain] ==
+               "user keys cannot have repository permissions, generate an organization key instead"
+
+      params = %{"name" => "keyname", "permissions" => [%{"domain" => "repositories"}]}
+
+      assert {:error, :key, changeset, _} = Keys.create(user, params, audit: audit_data(user))
+
+      assert errors_on(changeset)[:permissions][:domain] ==
+               "user keys cannot have repository permissions, generate an organization key instead"
+    end
+
+    test "organization repository permissions", %{organization: organization} do
+      params = %{
+        "name" => "keyname",
+        "permissions" => [%{"domain" => "repository", "resource" => organization.name}]
+      }
+
+      assert {:ok, %{key: key}} =
+               Keys.create(organization, params, audit: audit_data(organization))
+
+      assert key.organization_id == organization.id
+    end
+
     test "user package permissions", %{user: user, package: package} do
       params = %{
         "name" => "keyname",

--- a/test/hexpm_web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/auth_controller_test.exs
@@ -388,5 +388,86 @@ defmodule HexpmWeb.API.AuthControllerTest do
       |> get("/api/auth", domain: "repository", resource: organization.name)
       |> response(403)
     end
+
+    test "user repository key warns about deprecation", %{
+      user_repo_key: key,
+      owned_org: owned_org
+    } do
+      date = Application.fetch_env!(:hexpm, :user_repository_keys_disable_date)
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "repository", resource: owned_org.name)
+
+      assert conn.status == 204
+
+      assert get_resp_header(conn, "x-hex-message") == [
+               "\"User API keys with repository permissions are deprecated and will stop " <>
+                 "working on #{date}. Use mix hex.user auth for development or an organization " <>
+                 "key (mix hex.organization key ORGANIZATION generate) for CI\";level=warn"
+             ]
+    end
+
+    test "user repositories key warns about deprecation", %{user_all_repos_key: key} do
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "repositories")
+
+      assert conn.status == 204
+      assert [message] = get_resp_header(conn, "x-hex-message")
+      assert message =~ "User API keys with repository permissions are deprecated"
+      assert message =~ ";level=warn"
+    end
+
+    test "user key does not warn for api domain", %{user_full_key: key} do
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "api")
+
+      assert conn.status == 204
+      assert get_resp_header(conn, "x-hex-message") == []
+    end
+
+    test "organization repository key does not warn", %{
+      organization_repo_key: key,
+      owned_org: owned_org
+    } do
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "repository", resource: owned_org.name)
+
+      assert conn.status == 204
+      assert get_resp_header(conn, "x-hex-message") == []
+    end
+
+    test "oauth token with repository scope does not warn", %{
+      user: user,
+      owned_org: owned_org
+    } do
+      client = insert(:oauth_client)
+      session = insert(:oauth_session, user: user, client_id: client.client_id)
+
+      {:ok, token} =
+        Hexpm.OAuth.Tokens.create_and_insert_for_user(
+          user,
+          client.client_id,
+          ["repositories"],
+          "authorization_code",
+          "test_grant_ref",
+          user_session_id: session.id
+        )
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", "Bearer #{token.access_token}")
+        |> get("/api/auth", domain: "repository", resource: owned_org.name)
+
+      assert conn.status == 204
+      assert get_resp_header(conn, "x-hex-message") == []
+    end
   end
 end

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -154,24 +154,26 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert body["message"] == "missing authentication information"
     end
 
-    test "create repository key", c do
+    test "create user repository key is not allowed", c do
       body = %{
         name: "macbook",
         permissions: [%{domain: "repository", resource: c.organization.name}]
       }
 
-      build_conn()
-      |> put_req_header("content-type", "application/json")
-      |> put_req_header("authorization", basic_auth(c.eric))
-      |> post("/api/keys", body)
-      |> json_response(201)
+      result =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", basic_auth(c.eric))
+        |> post("/api/keys", body)
+        |> json_response(422)
 
-      key = Repo.one!(Key.get(c.eric, "macbook"))
-      repo_name = c.organization.name
-      assert [%KeyPermission{domain: "repository", resource: ^repo_name}] = key.permissions
+      assert result["errors"]["permissions"]["domain"] ==
+               "user keys cannot have repository permissions, generate an organization key instead"
+
+      refute Repo.one(Key.get(c.eric, "macbook"))
     end
 
-    test "create repository key with api key", c do
+    test "create user repository key with api key is not allowed", c do
       key = Key.build(c.eric, %{name: "computer"}) |> Repo.insert!()
 
       body = %{
@@ -183,9 +185,26 @@ defmodule HexpmWeb.API.KeyControllerTest do
       |> put_req_header("content-type", "application/json")
       |> put_req_header("authorization", key.user_secret)
       |> post("/api/keys", body)
+      |> json_response(422)
+
+      refute Repo.one(Key.get(c.eric, "macbook"))
+    end
+
+    test "create organization repository key", c do
+      org_key = Key.build(c.organization, %{name: "computer"}) |> Repo.insert!()
+
+      body = %{
+        name: "macbook",
+        permissions: [%{domain: "repository", resource: c.organization.name}]
+      }
+
+      build_conn()
+      |> put_req_header("content-type", "application/json")
+      |> put_req_header("authorization", org_key.user_secret)
+      |> post("/api/orgs/#{c.organization.name}/keys", body)
       |> json_response(201)
 
-      key = Repo.one!(Key.get(c.eric, "macbook"))
+      key = Repo.one!(Key.get(c.organization, "macbook"))
       repo_name = c.organization.name
       assert [%KeyPermission{domain: "repository", resource: ^repo_name}] = key.permissions
     end
@@ -246,17 +265,20 @@ defmodule HexpmWeb.API.KeyControllerTest do
       refute Repo.one(Key.get(c.eric, "expired"))
     end
 
-    test "create repositories key", c do
+    test "create user repositories key is not allowed", c do
       body = %{name: "macbook", permissions: [%{domain: "repositories"}]}
 
-      build_conn()
-      |> put_req_header("content-type", "application/json")
-      |> put_req_header("authorization", basic_auth(c.eric))
-      |> post("/api/keys", body)
-      |> json_response(201)
+      result =
+        build_conn()
+        |> put_req_header("content-type", "application/json")
+        |> put_req_header("authorization", basic_auth(c.eric))
+        |> post("/api/keys", body)
+        |> json_response(422)
 
-      key = Repo.one!(Key.get(c.eric, "macbook"))
-      assert [%KeyPermission{domain: "repositories", resource: nil}] = key.permissions
+      assert result["errors"]["permissions"]["domain"] ==
+               "user keys cannot have repository permissions, generate an organization key instead"
+
+      refute Repo.one(Key.get(c.eric, "macbook"))
     end
 
     test "create repositories key with resource returns 422", c do

--- a/test/hexpm_web/controllers/api/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/oauth_controller_test.exs
@@ -873,12 +873,8 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       org = insert(:organization)
       insert(:organization_user, organization: org, user: user)
 
-      {:ok, %{key: key}} =
-        Hexpm.Accounts.Keys.create(
-          user,
-          %{name: "repo_key", permissions: [%{domain: "repositories"}]},
-          audit: audit_data(user)
-        )
+      key =
+        insert(:key, user: user, permissions: [build(:key_permission, domain: "repositories")])
 
       api_key = key.user_secret
 
@@ -905,14 +901,10 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       org = insert(:organization)
       insert(:organization_user, organization: org, user: user)
 
-      {:ok, %{key: key}} =
-        Hexpm.Accounts.Keys.create(
-          user,
-          %{
-            name: "specific_repo_key",
-            permissions: [%{domain: "repository", resource: org.name}]
-          },
-          audit: audit_data(user)
+      key =
+        insert(:key,
+          user: user,
+          permissions: [build(:key_permission, domain: "repository", resource: org.name)]
         )
 
       api_key = key.user_secret
@@ -941,14 +933,10 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       insert(:organization_user, organization: org2, user: user)
 
       # API key only has access to org1, not org2
-      {:ok, %{key: key}} =
-        Hexpm.Accounts.Keys.create(
-          user,
-          %{
-            name: "limited_repo_key",
-            permissions: [%{domain: "repository", resource: org1.name}]
-          },
-          audit: audit_data(user)
+      key =
+        insert(:key,
+          user: user,
+          permissions: [build(:key_permission, domain: "repository", resource: org1.name)]
         )
 
       api_key = key.user_secret
@@ -981,17 +969,13 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       insert(:organization_user, organization: org3, user: user)
 
       # API key has access to org1 and org2, but not org3
-      {:ok, %{key: key}} =
-        Hexpm.Accounts.Keys.create(
-          user,
-          %{
-            name: "multi_repo_key",
-            permissions: [
-              %{domain: "repository", resource: org1.name},
-              %{domain: "repository", resource: org2.name}
-            ]
-          },
-          audit: audit_data(user)
+      key =
+        insert(:key,
+          user: user,
+          permissions: [
+            build(:key_permission, domain: "repository", resource: org1.name),
+            build(:key_permission, domain: "repository", resource: org2.name)
+          ]
         )
 
       api_key = key.user_secret
@@ -1023,17 +1007,13 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       org = insert(:organization)
       insert(:organization_user, organization: org, user: user)
 
-      {:ok, %{key: key}} =
-        Hexpm.Accounts.Keys.create(
-          user,
-          %{
-            name: "mixed_key",
-            permissions: [
-              %{domain: "api"},
-              %{domain: "repositories"}
-            ]
-          },
-          audit: audit_data(user)
+      key =
+        insert(:key,
+          user: user,
+          permissions: [
+            build(:key_permission, domain: "api"),
+            build(:key_permission, domain: "repositories")
+          ]
         )
 
       api_key = key.user_secret
@@ -1405,6 +1385,69 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       response = json_response(conn, 200)
       assert response["access_token"]
       assert response["scope"] == "repository:#{org.name}"
+    end
+
+    test "user key with repository permissions warns about deprecation", %{
+      client: client,
+      user: user
+    } do
+      org = insert(:organization)
+      insert(:organization_user, organization: org, user: user)
+
+      key =
+        insert(:key, user: user, permissions: [build(:key_permission, domain: "repositories")])
+
+      date = Application.fetch_env!(:hexpm, :user_repository_keys_disable_date)
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => key.user_secret,
+          "scope" => "repositories"
+        })
+
+      assert json_response(conn, 200)
+
+      assert get_resp_header(conn, "x-hex-message") == [
+               "\"User API keys with repository permissions are deprecated and will stop " <>
+                 "working on #{date}. Use mix hex.user auth for development or an organization " <>
+                 "key (mix hex.organization key ORGANIZATION generate) for CI\";level=warn"
+             ]
+    end
+
+    test "organization key does not warn about deprecation", %{client: client} do
+      org = insert(:organization)
+
+      key =
+        insert(:key,
+          organization: org,
+          permissions: [build(:key_permission, domain: "repository", resource: org.name)]
+        )
+
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => key.user_secret,
+          "scope" => "repositories"
+        })
+
+      assert json_response(conn, 200)
+      assert get_resp_header(conn, "x-hex-message") == []
+    end
+
+    test "user api key does not warn about deprecation", %{client: client, api_key: api_key} do
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => api_key,
+          "scope" => "repositories"
+        })
+
+      assert json_response(conn, 200)
+      assert get_resp_header(conn, "x-hex-message") == []
     end
   end
 

--- a/test/hexpm_web/controllers/dashboard/key_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/key_controller_test.exs
@@ -57,6 +57,18 @@ defmodule HexpmWeb.Dashboard.KeyControllerTest do
       assert_email_sent(Hexpm.Emails.api_key_created(user, key))
     end
 
+    test "cannot generate key with repository permissions", c do
+      conn =
+        build_conn()
+        |> test_login(c.user)
+        |> post("/dashboard/keys", %{
+          key: %{name: "repo-key", expires_in: "30", permissions: %{"repositories" => "on"}}
+        })
+
+      assert response(conn, 400)
+      refute Hexpm.Repo.one(Hexpm.Accounts.Key.get(c.user, "repo-key"))
+    end
+
     test "shows validation errors when name is missing", c do
       conn =
         build_conn()


### PR DESCRIPTION
Ships with Hex 2.6. Machine access to repositories should go through organization keys, which org admins can see, count devices on, and revoke, and human development access through `mix hex.user auth`. User-owned keys with repository permissions bypass both, they're invisible to org admins and don't hold a billing seat.

Creating a user-owned key with a `repository` or `repositories` permission is now rejected in the key permission changeset, which covers the API and the dashboard, and the repository permission checkboxes are removed from the user key generation modal (organization key generation is unchanged). The current hex CLI can't create user keys at all anymore, so this only affects old clients: pre-2.4 `mix hex.user auth` created a `<hostname>-repositories` user key and the old `mix hex.organization auth` without `--key` created a `repository:<org>` user key. Both now get a validation error telling them to use an organization key.

Existing user repository keys keep working, but GET /api/auth and the OAuth api_key grant now attach an `x-hex-message` warning header (all hex clients print it) saying the key stops working on the date in `:user_repository_keys_disable_date`. That config is set to a placeholder and must be updated to release + 90 days when 2.6 ships. #1748 disables the remaining keys after that date.

Conflicts trivially with #1746 in auth_controller.ex, whichever merges second needs a small rebase.