### PR TITLE
DO NOT MERGE: Disable user keys with repository permissions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -39,8 +39,6 @@ config :hexpm,
 
 config :hexpm, :features, package_reports: true
 
-config :hexpm, :user_repository_keys_disable_date, ~D[2026-12-31]
-
 config :hexpm, ecto_repos: [Hexpm.RepoBase]
 
 config :hexpm, Oban,

--- a/lib/hexpm/permissions.ex
+++ b/lib/hexpm/permissions.ex
@@ -180,6 +180,11 @@ defmodule Hexpm.Permissions do
     check_access?(normalized_permissions, domain, resource)
   end
 
+  def verify_access?(%Key{user_id: user_id}, domain, _resource)
+      when not is_nil(user_id) and domain in ["repository", "repositories"] do
+    false
+  end
+
   def verify_access?(%Key{} = key, domain, resource) do
     verify_access?(key.permissions, domain, resource)
   end

--- a/lib/hexpm_web/controllers/api/auth_controller.ex
+++ b/lib/hexpm_web/controllers/api/auth_controller.ex
@@ -8,7 +8,7 @@ defmodule HexpmWeb.API.AuthController do
     auth_credential = conn.assigns.auth_credential
     user_or_organization = conn.assigns.current_user || conn.assigns.current_organization
     resource = params["resource"]
-    conn = maybe_warn_user_repository_key(conn, auth_credential, domain)
+    conn = maybe_put_user_repository_key_error(conn, auth_credential, domain)
 
     # Two-level permission check:
     # 1. API-level: Check if the API key/OAuth token has the required scopes/permissions
@@ -39,14 +39,14 @@ defmodule HexpmWeb.API.AuthController do
     end
   end
 
-  defp maybe_warn_user_repository_key(conn, %Key{} = key, domain)
+  defp maybe_put_user_repository_key_error(conn, %Key{} = key, domain)
        when domain in ["repository", "repositories"] do
     if Key.user_repository_key?(key) do
-      put_user_repository_key_warning(conn)
+      put_user_repository_key_error(conn)
     else
       conn
     end
   end
 
-  defp maybe_warn_user_repository_key(conn, _auth_credential, _domain), do: conn
+  defp maybe_put_user_repository_key_error(conn, _auth_credential, _domain), do: conn
 end

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -204,8 +204,8 @@ defmodule HexpmWeb.API.OAuthController do
          :ok <- validate_client_supports_grant(client, "client_credentials"),
          {:ok, api_key_secret} <- validate_api_key_secret(safe_param(params, "client_secret")),
          {:ok, auth_info} <- authenticate_api_key(api_key_secret, conn),
+         :ok <- validate_user_key_repository_scopes(params["scope"], auth_info.auth_credential),
          {:ok, scopes} <- expand_and_validate_scopes(params["scope"], auth_info) do
-      conn = maybe_warn_user_repository_key(conn, auth_info.auth_credential, scopes)
       usage_info = build_usage_info(conn)
 
       # Determine user or organization from the API key
@@ -240,6 +240,14 @@ defmodule HexpmWeb.API.OAuthController do
           )
       end
     else
+      {:error, :user_repository_key} ->
+        conn
+        |> put_user_repository_key_error()
+        |> render_oauth_error(
+          :invalid_scope,
+          "user keys no longer grant repository access, use an organization key"
+        )
+
       {:error, error} when is_atom(error) ->
         render_oauth_error(conn, error, error_description(error))
 
@@ -251,18 +259,21 @@ defmodule HexpmWeb.API.OAuthController do
     end
   end
 
-  defp maybe_warn_user_repository_key(conn, %Key{} = key, scopes) do
+  defp validate_user_key_repository_scopes(scope_string, %Key{user_id: user_id})
+       when not is_nil(user_id) and (is_binary(scope_string) or is_nil(scope_string)) do
     repository_scope? =
-      Enum.any?(scopes, &(&1 == "repositories" or String.starts_with?(&1, "repository:")))
+      (scope_string || "")
+      |> String.split(" ", trim: true)
+      |> Enum.any?(&(&1 == "repositories" or String.starts_with?(&1, "repository:")))
 
-    if repository_scope? and Key.user_repository_key?(key) do
-      put_user_repository_key_warning(conn)
+    if repository_scope? do
+      {:error, :user_repository_key}
     else
-      conn
+      :ok
     end
   end
 
-  defp maybe_warn_user_repository_key(conn, _auth_credential, _scopes), do: conn
+  defp validate_user_key_repository_scopes(_scope_string, _auth_credential), do: :ok
 
   defp validate_client_supports_grant(client, grant_type) do
     if Clients.supports_grant_type?(client, grant_type) do

--- a/lib/hexpm_web/controllers/controller_helpers.ex
+++ b/lib/hexpm_web/controllers/controller_helpers.ex
@@ -23,15 +23,13 @@ defmodule HexpmWeb.ControllerHelpers do
     cache(conn, control, vary)
   end
 
-  def put_user_repository_key_warning(conn) do
-    date = Application.fetch_env!(:hexpm, :user_repository_keys_disable_date)
-
+  def put_user_repository_key_error(conn) do
     message =
-      "User API keys with repository permissions are deprecated and will stop working on " <>
-        "#{date}. Use mix hex.user auth for development or an organization key " <>
-        "(mix hex.organization key ORGANIZATION generate) for CI"
+      "User API keys no longer grant repository access. Use mix hex.user auth for " <>
+        "development or an organization key (mix hex.organization key ORGANIZATION generate) " <>
+        "for CI"
 
-    put_resp_header(conn, "x-hex-message", ~s("#{message}";level=warn))
+    put_resp_header(conn, "x-hex-message", ~s("#{message}";level=fatal))
   end
 
   def permanent_redirect(conn, path, query_string \\ nil) do

--- a/test/hexpm/permissions_test.exs
+++ b/test/hexpm/permissions_test.exs
@@ -224,6 +224,40 @@ defmodule Hexpm.PermissionsTest do
       refute Permissions.verify_access?(key, "repositories", nil)
     end
 
+    test "denies repository access for user-owned keys" do
+      user = insert(:user)
+
+      key =
+        insert(:key, user: user, permissions: [build(:key_permission, domain: "repositories")])
+
+      refute Permissions.verify_access?(key, "repository", "foo")
+      refute Permissions.verify_access?(key, "repositories", nil)
+
+      key =
+        insert(:key,
+          user: user,
+          permissions: [
+            build(:key_permission, domain: "api"),
+            build(:key_permission, domain: "repository", resource: "foo")
+          ]
+        )
+
+      refute Permissions.verify_access?(key, "repository", "foo")
+      assert Permissions.verify_access?(key, "api", "read")
+
+      organization = insert(:organization)
+
+      key =
+        insert(:key,
+          organization: organization,
+          permissions: [
+            build(:key_permission, domain: "repository", resource: organization.name)
+          ]
+        )
+
+      assert Permissions.verify_access?(key, "repository", organization.name)
+    end
+
     test "verifies docs permissions" do
       key = build(:key, permissions: [build(:key_permission, domain: "docs", resource: "foo")])
       refute Permissions.verify_access?(key, "api", "read")

--- a/test/hexpm_web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/auth_controller_test.exs
@@ -147,7 +147,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: owned_org.name)
-      |> response(204)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
@@ -313,22 +313,22 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repositories")
-      |> response(204)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: owned_org.name)
-      |> response(204)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: unowned_org.name)
-      |> response(403)
+      |> response(401)
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: "BADREPO")
-      |> response(403)
+      |> response(401)
     end
 
     test "authenticate docs key", %{user: user, owned_org: owned_org} do
@@ -353,7 +353,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: unowned_org.name)
-      |> response(403)
+      |> response(401)
     end
 
     test "authenticate user repository key without active billing", %{user: user} do
@@ -370,7 +370,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       build_conn()
       |> put_req_header("authorization", key.user_secret)
       |> get("/api/auth", domain: "repository", resource: organization.name)
-      |> response(403)
+      |> response(401)
     end
 
     test "authenticate organization repository key without active billing" do
@@ -389,39 +389,37 @@ defmodule HexpmWeb.API.AuthControllerTest do
       |> response(403)
     end
 
-    test "user repository key warns about deprecation", %{
+    test "user repository key is rejected with fatal message", %{
       user_repo_key: key,
       owned_org: owned_org
     } do
-      date = Application.fetch_env!(:hexpm, :user_repository_keys_disable_date)
-
       conn =
         build_conn()
         |> put_req_header("authorization", key.user_secret)
         |> get("/api/auth", domain: "repository", resource: owned_org.name)
 
-      assert conn.status == 204
+      assert json_response(conn, 401)["message"] == "key not authorized for this action"
 
       assert get_resp_header(conn, "x-hex-message") == [
-               "\"User API keys with repository permissions are deprecated and will stop " <>
-                 "working on #{date}. Use mix hex.user auth for development or an organization " <>
-                 "key (mix hex.organization key ORGANIZATION generate) for CI\";level=warn"
+               "\"User API keys no longer grant repository access. Use mix hex.user auth for " <>
+                 "development or an organization key (mix hex.organization key ORGANIZATION " <>
+                 "generate) for CI\";level=fatal"
              ]
     end
 
-    test "user repositories key warns about deprecation", %{user_all_repos_key: key} do
+    test "user repositories key is rejected with fatal message", %{user_all_repos_key: key} do
       conn =
         build_conn()
         |> put_req_header("authorization", key.user_secret)
         |> get("/api/auth", domain: "repositories")
 
-      assert conn.status == 204
+      assert conn.status == 401
       assert [message] = get_resp_header(conn, "x-hex-message")
-      assert message =~ "User API keys with repository permissions are deprecated"
-      assert message =~ ";level=warn"
+      assert message =~ "User API keys no longer grant repository access"
+      assert message =~ ";level=fatal"
     end
 
-    test "user key does not warn for api domain", %{user_full_key: key} do
+    test "user key with api permission succeeds for api domain", %{user_full_key: key} do
       conn =
         build_conn()
         |> put_req_header("authorization", key.user_secret)
@@ -431,7 +429,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       assert get_resp_header(conn, "x-hex-message") == []
     end
 
-    test "organization repository key does not warn", %{
+    test "organization repository key succeeds without message", %{
       organization_repo_key: key,
       owned_org: owned_org
     } do
@@ -444,7 +442,7 @@ defmodule HexpmWeb.API.AuthControllerTest do
       assert get_resp_header(conn, "x-hex-message") == []
     end
 
-    test "oauth token with repository scope does not warn", %{
+    test "oauth token with repository scope succeeds without message", %{
       user: user,
       owned_org: owned_org
     } do

--- a/test/hexpm_web/controllers/api/oauth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/oauth_controller_test.exs
@@ -866,35 +866,39 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert Hexpm.UserSessions.count_for_user(user) == 5
     end
 
-    test "expands 'repositories' scope for API key with generic repositories permission", %{
-      client: client,
-      user: user
-    } do
+    test "returns error for user key with repositories permission requesting 'repositories' scope",
+         %{
+           client: client,
+           user: user
+         } do
       org = insert(:organization)
       insert(:organization_user, organization: org, user: user)
 
       key =
         insert(:key, user: user, permissions: [build(:key_permission, domain: "repositories")])
 
-      api_key = key.user_secret
-
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
           "client_id" => client.client_id,
-          "client_secret" => api_key,
+          "client_secret" => key.user_secret,
           "scope" => "repositories"
         })
 
-      assert json_response(conn, 200)
-      response = json_response(conn, 200)
-      assert response["access_token"]
-      # Should include all repositories the user has access to
-      scopes = String.split(response["scope"], " ")
-      assert "repository:#{org.name}" in scopes
+      response = json_response(conn, 400)
+      assert response["error"] == "invalid_scope"
+
+      assert response["error_description"] ==
+               "user keys no longer grant repository access, use an organization key"
+
+      assert get_resp_header(conn, "x-hex-message") == [
+               "\"User API keys no longer grant repository access. Use mix hex.user auth for " <>
+                 "development or an organization key (mix hex.organization key ORGANIZATION " <>
+                 "generate) for CI\";level=fatal"
+             ]
     end
 
-    test "expands 'repositories' scope for API key with specific repository permission", %{
+    test "returns error for user key requesting specific 'repository:' scope", %{
       client: client,
       user: user
     } do
@@ -907,100 +911,22 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           permissions: [build(:key_permission, domain: "repository", resource: org.name)]
         )
 
-      api_key = key.user_secret
-
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
           "client_id" => client.client_id,
-          "client_secret" => api_key,
-          "scope" => "repositories"
+          "client_secret" => key.user_secret,
+          "scope" => "repository:#{org.name}"
         })
 
-      assert json_response(conn, 200)
-      response = json_response(conn, 200)
-      assert response["access_token"]
-      assert response["scope"] == "repository:#{org.name}"
+      response = json_response(conn, 400)
+      assert response["error"] == "invalid_scope"
+      assert [message] = get_resp_header(conn, "x-hex-message")
+      assert message =~ "User API keys no longer grant repository access"
+      assert message =~ ";level=fatal"
     end
 
-    test "constrains 'repositories' expansion to API key's specific repository permissions", %{
-      client: client,
-      user: user
-    } do
-      org1 = insert(:organization)
-      org2 = insert(:organization)
-      insert(:organization_user, organization: org1, user: user)
-      insert(:organization_user, organization: org2, user: user)
-
-      # API key only has access to org1, not org2
-      key =
-        insert(:key,
-          user: user,
-          permissions: [build(:key_permission, domain: "repository", resource: org1.name)]
-        )
-
-      api_key = key.user_secret
-
-      # Request "repositories" scope - should only expand to org1, not org2
-      conn =
-        post(build_conn(), ~p"/api/oauth/token", %{
-          "grant_type" => "client_credentials",
-          "client_id" => client.client_id,
-          "client_secret" => api_key,
-          "scope" => "repositories"
-        })
-
-      assert json_response(conn, 200)
-      response = json_response(conn, 200)
-      assert response["access_token"]
-      # Should only expand to org1, not org2
-      assert response["scope"] == "repository:#{org1.name}"
-    end
-
-    test "constrains to multiple specific repositories when key has multiple permissions", %{
-      client: client,
-      user: user
-    } do
-      org1 = insert(:organization)
-      org2 = insert(:organization)
-      org3 = insert(:organization)
-      insert(:organization_user, organization: org1, user: user)
-      insert(:organization_user, organization: org2, user: user)
-      insert(:organization_user, organization: org3, user: user)
-
-      # API key has access to org1 and org2, but not org3
-      key =
-        insert(:key,
-          user: user,
-          permissions: [
-            build(:key_permission, domain: "repository", resource: org1.name),
-            build(:key_permission, domain: "repository", resource: org2.name)
-          ]
-        )
-
-      api_key = key.user_secret
-
-      # Request "repositories" scope - should expand to org1 and org2, not org3
-      conn =
-        post(build_conn(), ~p"/api/oauth/token", %{
-          "grant_type" => "client_credentials",
-          "client_id" => client.client_id,
-          "client_secret" => api_key,
-          "scope" => "repositories"
-        })
-
-      assert json_response(conn, 200)
-      response = json_response(conn, 200)
-      assert response["access_token"]
-      # Should expand to both org1 and org2
-      scopes = String.split(response["scope"], " ")
-      assert "repository:#{org1.name}" in scopes
-      assert "repository:#{org2.name}" in scopes
-      refute "repository:#{org3.name}" in scopes
-      assert length(scopes) == 2
-    end
-
-    test "supports mixed scopes with repositories", %{
+    test "returns error for user key with mixed scopes including repositories", %{
       client: client,
       user: user
     } do
@@ -1016,23 +942,48 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           ]
         )
 
-      api_key = key.user_secret
+      conn =
+        post(build_conn(), ~p"/api/oauth/token", %{
+          "grant_type" => "client_credentials",
+          "client_id" => client.client_id,
+          "client_secret" => key.user_secret,
+          "scope" => "api repositories"
+        })
+
+      response = json_response(conn, 400)
+      assert response["error"] == "invalid_scope"
+      assert [message] = get_resp_header(conn, "x-hex-message")
+      assert message =~ ";level=fatal"
+    end
+
+    test "user key with api and repositories permissions can exchange for 'api' scope", %{
+      client: client,
+      user: user
+    } do
+      org = insert(:organization)
+      insert(:organization_user, organization: org, user: user)
+
+      key =
+        insert(:key,
+          user: user,
+          permissions: [
+            build(:key_permission, domain: "api"),
+            build(:key_permission, domain: "repositories")
+          ]
+        )
 
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
           "client_id" => client.client_id,
-          "client_secret" => api_key,
-          "scope" => "api repositories"
+          "client_secret" => key.user_secret,
+          "scope" => "api"
         })
 
-      assert json_response(conn, 200)
       response = json_response(conn, 200)
       assert response["access_token"]
-      # Should include api scope and all repository scopes
-      scopes = String.split(response["scope"], " ")
-      assert "api" in scopes
-      assert "repository:#{org.name}" in scopes
+      assert response["scope"] == "api"
+      assert get_resp_header(conn, "x-hex-message") == []
     end
 
     test "returns error when api:read key requests 'api' scope (CVE-2026-21621)", %{
@@ -1194,7 +1145,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "api"
     end
 
-    test "succeeds when api-only key requests 'repositories' scope", %{
+    test "returns error when api-only user key requests 'repositories' scope", %{
       user: user,
       client: client
     } do
@@ -1213,7 +1164,10 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           "scope" => "repositories"
         })
 
-      assert json_response(conn, 200)
+      response = json_response(conn, 400)
+      assert response["error"] == "invalid_scope"
+      assert [message] = get_resp_header(conn, "x-hex-message")
+      assert message =~ ";level=fatal"
     end
 
     test "succeeds for organization key requesting 'repositories' scope", %{client: client} do
@@ -1387,36 +1341,7 @@ defmodule HexpmWeb.API.OAuthControllerTest do
       assert response["scope"] == "repository:#{org.name}"
     end
 
-    test "user key with repository permissions warns about deprecation", %{
-      client: client,
-      user: user
-    } do
-      org = insert(:organization)
-      insert(:organization_user, organization: org, user: user)
-
-      key =
-        insert(:key, user: user, permissions: [build(:key_permission, domain: "repositories")])
-
-      date = Application.fetch_env!(:hexpm, :user_repository_keys_disable_date)
-
-      conn =
-        post(build_conn(), ~p"/api/oauth/token", %{
-          "grant_type" => "client_credentials",
-          "client_id" => client.client_id,
-          "client_secret" => key.user_secret,
-          "scope" => "repositories"
-        })
-
-      assert json_response(conn, 200)
-
-      assert get_resp_header(conn, "x-hex-message") == [
-               "\"User API keys with repository permissions are deprecated and will stop " <>
-                 "working on #{date}. Use mix hex.user auth for development or an organization " <>
-                 "key (mix hex.organization key ORGANIZATION generate) for CI\";level=warn"
-             ]
-    end
-
-    test "organization key does not warn about deprecation", %{client: client} do
+    test "organization key exchanges for 'repositories' scope without message", %{client: client} do
       org = insert(:organization)
 
       key =
@@ -1433,20 +1358,25 @@ defmodule HexpmWeb.API.OAuthControllerTest do
           "scope" => "repositories"
         })
 
-      assert json_response(conn, 200)
+      response = json_response(conn, 200)
+      assert response["scope"] == "repository:#{org.name}"
       assert get_resp_header(conn, "x-hex-message") == []
     end
 
-    test "user api key does not warn about deprecation", %{client: client, api_key: api_key} do
+    test "user api key exchanges for 'api' scope without message", %{
+      client: client,
+      api_key: api_key
+    } do
       conn =
         post(build_conn(), ~p"/api/oauth/token", %{
           "grant_type" => "client_credentials",
           "client_id" => client.client_id,
           "client_secret" => api_key,
-          "scope" => "repositories"
+          "scope" => "api"
         })
 
-      assert json_response(conn, 200)
+      response = json_response(conn, 200)
+      assert response["scope"] == "api"
       assert get_resp_header(conn, "x-hex-message") == []
     end
   end


### PR DESCRIPTION
Follow-up to #1747, to be merged 90 days after Hex 2.6 ships (the date announced in the deprecation header). Stacked on that branch so this diff shows only the disable step; it retargets to main automatically when #1747 merges.

User-owned keys no longer grant access to the repository domains. The central permission check rejects them, so GET /api/auth returns 401 for repository domains, and the OAuth client_credentials grant rejects user keys that explicitly request repository scopes with invalid_scope. Both rejections carry a fatal `x-hex-message` header telling the user to switch to `mix hex.user auth` for development or an organization key for CI, so even old clients print an actionable error. User keys keep their api permissions, and organization keys and OAuth tokens (including repository scopes granted through `mix hex.user auth`) are unaffected. The deprecation warning header and the `:user_repository_keys_disable_date` config from #1747 are removed.

Two small behavior notes: an api-only user key that explicitly requests repository scopes used to get a 200 with the scope silently dropped and now gets invalid_scope, and the /api/auth failure status for grandfathered user repository keys shifts from 403 to 401 for the unowned-org and inactive-billing cases since the API-level check now fails first (all hex clients treat 401 and 403 the same on that endpoint). Access tokens minted from user repository keys before deploy stay valid until they expire, which is under an hour.