### PR TITLE
Remove deprecated Docker Compose version

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3'
-
 services:
   db:
     image: postgres:14


### PR DESCRIPTION
For a few years now, Docker Compose has obsoleted the version field in the docker-compose.yaml spec and has been emitting warnings about it.

Since it is ignored anyway, we can safely remove it.

See:

- The spec https://docs.docker.com/reference/compose-file/version-and-name/
- Discussion at https://github.com/docker/compose/issues/11628

## Summary

Starting a development environment with `docker compose up` emits a warning:

```
WARN[0000] .../hexpm/docker-compose.yaml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion
```

## Testing

Remove the version, run `docker compose up -d`, `docker compose down`. Database service is started/stopped with no warnings.