### PR TITLE
Optimize dependency compilation

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,19 @@
 source_env_if_exists .local/envrc
+
+# Compile dependencies across multiple OS processes
+# https://mix.hexdocs.pm/Mix.Tasks.Deps.Compile.html#module-compiling-dependencies-across-multiple-os-processes
+if [ -z "$MIX_OS_DEPS_COMPILE_PARTITION_COUNT" ]; then
+  if command -v nproc >/dev/null 2>&1; then
+    CORES=$(nproc)
+  elif command -v sysctl >/dev/null 2>&1; then
+    CORES=$(sysctl -n hw.ncpu)
+  else
+    CORES=2
+  fi
+  PARTITIONS=$(( CORES / 2 ))
+  [ "$PARTITIONS" -lt 1 ] && PARTITIONS=1
+  # On a 10-core machine, increasing the partition count past 4 gradually
+  # degrades performance, so we limit it to 4.
+  [ "$PARTITIONS" -gt 4 ] && PARTITIONS=4
+  export MIX_OS_DEPS_COMPILE_PARTITION_COUNT=$PARTITIONS
+fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,13 @@ on: [push, pull_request]
 permissions:
   contents: read
 
+env:
+  # Compile dependencies across multiple OS processes
+  # https://mix.hexdocs.pm/Mix.Tasks.Deps.Compile.html#module-compiling-dependencies-across-multiple-os-processes
+  # Standard GitHub-hosted Linux runners have 4 cores, so we use 2 partitions (cores / 2).
+  # https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories
+  MIX_OS_DEPS_COMPILE_PARTITION_COUNT: 2
+
 jobs:
   format:
     name: Format

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,15 @@ ENV MIX_ENV=prod
 COPY mix.exs mix.lock ./
 COPY config config
 RUN mix deps.get
-RUN mix deps.compile
+# Compiling dependencies across multiple OS processes
+# https://mix.hexdocs.pm/Mix.Tasks.Deps.Compile.html#module-compiling-dependencies-across-multiple-os-processes
+RUN <<EOF
+  CORES=$(nproc 2>/dev/null || echo 2)
+  PARTITIONS=$(( CORES / 2 ))
+  [ "$PARTITIONS" -lt 1 ] && PARTITIONS=1
+  [ "$PARTITIONS" -gt 4 ] && PARTITIONS=4
+  MIX_OS_DEPS_COMPILE_PARTITION_COUNT=$PARTITIONS mix deps.compile
+EOF
 
 # build project and assets
 COPY priv priv


### PR DESCRIPTION
Configure `MIX_OS_DEPS_COMPILE_PARTITION_COUNT` to build Elixir dependencies concurrently across multiple operating system processes.

Benchmark runs including the `:lumis` Rust dependency show up to a 46.3% build time reduction (from 36.5s down to 19.6s) on a 10-core machine. Since compile times degrade past 4 partitions due to resource contention, we clamp the count to a maximum of 4.

Changes made:
- `.envrc`: Dynamically compute partition count based on host cores (cores / 2, clamped to [1, 4]) to optimize native developer setups.
- `Dockerfile`: Inline dynamic core-based computation during the build stage (cores / 2, clamped to [1, 4]) to speed up release compilation.
- `.github/workflows/main.yml`: Configure to 2 partitions globally for CI, aligning with the cores / 2 sizing rule for standard 4-CPU runners.

References:
- https://mix.hexdocs.pm/Mix.Tasks.Deps.Compile.html#module-compiling-dependencies-across-multiple-os-processes
- https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

## Summary

 Dependency Compilation Performance (Clean Build Cache, Apple M4)

| Run Type / Configuration | Compile Time (seconds) | Speedup (%) |
| :--- | :---: | :---: |
| **Default (Sequential / Standard)** | **36.54s** | Baseline (0.0%) |
| **Partition Count: 2** | **22.87s** | +37.4% speedup |
| **Partition Count: 4** (Optimal) | **19.64s** | **+46.3% speedup** |
| **Partition Count: 8** | **21.50s** | +41.1% speedup |
| **Partition Count: 10** | **22.54s** | +38.3% speedup |

* **Optimal partition count:** `4` partitions is the sweet spot. It reduces compile times from **36.54s** to **19.64s** (a **46.3% time saving**).
* **Diminishing returns:** Increasing partitions beyond 4 (e.g. to 8 or 10) introduces resource contention and slows down the build, which is why we clamp the dynamic calculations to a maximum of 4 partitions.

## Testing

Benchmarked multiple `MIX_OS_DEPS_COMPILE_PARTITION_COUNT` values, confirming the anecdotal `CORES / 2` formula seen in the [official Elixir blog post for the v1.19 release](https://elixir-lang.org/blog/2025/10/16/elixir-v1-19-0-released/#:~:text=Empirical%20testing%20shows%20that%20setting%20it%20to%20half%20of%20the%20number%20of%20cores%20on%20your%20machine%20is%20enough%20to%20maximize%20resource%20usage).
