### PR TITLE
Move file browser interactions to the client and disallow diff crawling

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -25,6 +25,7 @@ import { PolicyDirtyState } from "./hooks/policy_dirty_state";
 import LineHighlight from "./hooks/line_highlight";
 import { InfiniteScroll } from "./hooks/diff";
 import { FormSync } from "./hooks/form_sync";
+import { FileFinder } from "./hooks/file_finder";
 
 let csrfToken = document
   .querySelector("meta[name='csrf-token']")
@@ -53,6 +54,7 @@ let Hooks = {
   LineHighlight,
   InfiniteScroll,
   FormSync,
+  FileFinder,
 };
 let liveSocket = new LiveSocket("/live", Socket, {
   params: { _csrf_token: csrfToken },

--- a/assets/js/hooks/file_finder.js
+++ b/assets/js/hooks/file_finder.js
@@ -1,0 +1,200 @@
+/**
+ * FileFinder Hook
+ *
+ * Client-side file navigation for the package file browser. The server
+ * renders the full file tree once per version; this hook owns everything
+ * that used to be a LiveView round trip:
+ *
+ * - fuzzy file filtering (sidebar search and modal finder) over the tree's
+ *   `a[data-path]` links, rendered from a <template data-finder-item>
+ * - the active-file highlight (aria-current) and ancestor <details>
+ *   expansion, driven by the root's data-active-path attribute, which the
+ *   server updates on patch navigation
+ *
+ * The filter mirrors HexpmWeb.Components.FileSelector.filter/2: match by
+ * substring or character subsequence, rank exact > prefix > path-segment >
+ * substring > subsequence, capped at 100 results.
+ */
+
+const RESULT_LIMIT = 100;
+
+export const FileFinder = {
+  mounted() {
+    this.treeEl = document.getElementById(this.el.dataset.treeId);
+    this.sidebarInput = document.getElementById(this.el.dataset.sidebarInput);
+    this.modalInput = document.getElementById(this.el.dataset.modalInput);
+    this.modalId = this.el.dataset.modalId;
+    this.modalResults = document.getElementById(this.el.dataset.modalResults);
+    this.template = this.el.querySelector("template[data-finder-item]");
+    this.treeContainer = this.treeEl.querySelector("[data-tree-container]");
+    this.resultsContainer = this.treeEl.querySelector("[data-results-container]");
+    this.sidebarList = this.resultsContainer.querySelector("[data-results]");
+    this.sidebarEmpty = this.resultsContainer.querySelector("[data-empty]");
+    this.modalList = this.modalResults.querySelector("[data-results]");
+    this.modalEmpty = this.modalResults.querySelector("[data-empty]");
+    this.query = "";
+
+    this.buildIndex();
+    this.applyActive();
+    this.renderResults(this.modalList, this.modalEmpty, this.filter(""));
+
+    this.onInput = (event) => this.setQuery(event.target.value);
+    this.onSubmit = (event) => event.preventDefault();
+    this.onResultsClick = (event) => {
+      const link = event.target.closest("a[data-path]");
+      if (!link) return;
+      if (this.modalResults.contains(link)) this.closeModal();
+      this.setQuery("");
+    };
+
+    this.inputs = [this.sidebarInput, this.modalInput].filter(Boolean);
+    this.forms = this.inputs.map((input) => input.closest("form")).filter(Boolean);
+    this.inputs.forEach((input) => input.addEventListener("input", this.onInput));
+    this.forms.forEach((form) => form.addEventListener("submit", this.onSubmit));
+    this.sidebarList.addEventListener("click", this.onResultsClick);
+    this.modalResults.addEventListener("click", this.onResultsClick);
+  },
+
+  updated() {
+    if (this.el.dataset.treeVersion !== this.treeVersion) {
+      this.buildIndex();
+      this.filterAndRender();
+    }
+    this.applyActive();
+  },
+
+  destroyed() {
+    this.inputs.forEach((input) => input.removeEventListener("input", this.onInput));
+    this.forms.forEach((form) => form.removeEventListener("submit", this.onSubmit));
+    this.sidebarList.removeEventListener("click", this.onResultsClick);
+    this.modalResults.removeEventListener("click", this.onResultsClick);
+  },
+
+  buildIndex() {
+    this.treeVersion = this.el.dataset.treeVersion;
+    this.index = Array.from(this.treeContainer.querySelectorAll("a[data-path]")).map((el) => ({
+      el,
+      path: el.dataset.path,
+      lower: el.dataset.path.toLowerCase(),
+      href: el.getAttribute("href"),
+    }));
+  },
+
+  applyActive() {
+    const active = this.el.dataset.activePath || null;
+
+    for (const entry of this.index) {
+      if (entry.path === active) {
+        entry.el.setAttribute("aria-current", "page");
+      } else {
+        entry.el.removeAttribute("aria-current");
+      }
+    }
+
+    for (const list of [this.sidebarList, this.modalList]) {
+      for (const link of list.querySelectorAll("a[data-path]")) {
+        if (link.dataset.path === active) {
+          link.setAttribute("aria-current", "page");
+        } else {
+          link.removeAttribute("aria-current");
+        }
+      }
+    }
+
+    const entry = this.index.find((item) => item.path === active);
+    if (!entry) return;
+
+    let parent = entry.el.parentElement;
+    while (parent && parent !== this.treeEl) {
+      if (parent.tagName === "DETAILS") parent.open = true;
+      parent = parent.parentElement;
+    }
+
+    entry.el.scrollIntoView({ block: "nearest" });
+  },
+
+  setQuery(value) {
+    this.query = value;
+    this.inputs.forEach((input) => {
+      if (input.value !== value) input.value = value;
+    });
+    this.filterAndRender();
+  },
+
+  filterAndRender() {
+    const query = this.query.trim().toLowerCase();
+    const matches = this.filter(query);
+
+    this.renderResults(this.modalList, this.modalEmpty, matches);
+
+    if (query === "") {
+      this.treeContainer.classList.remove("hidden");
+      this.resultsContainer.classList.add("hidden");
+    } else {
+      this.treeContainer.classList.add("hidden");
+      this.resultsContainer.classList.remove("hidden");
+      this.renderResults(this.sidebarList, this.sidebarEmpty, matches);
+    }
+  },
+
+  filter(query) {
+    return this.index
+      .filter((entry) => fuzzyMatch(entry.lower, query))
+      .map((entry) => [score(entry.lower, query), entry])
+      .sort(([scoreA, a], [scoreB, b]) => scoreA - scoreB || compare(a.lower, b.lower))
+      .slice(0, RESULT_LIMIT)
+      .map(([, entry]) => entry);
+  },
+
+  renderResults(list, empty, matches) {
+    const active = this.el.dataset.activePath || null;
+    const fragment = document.createDocumentFragment();
+
+    for (const entry of matches) {
+      const item = this.template.content.firstElementChild.cloneNode(true);
+      const link = item.querySelector("a");
+      link.setAttribute("href", entry.href);
+      link.dataset.path = entry.path;
+      if (entry.path === active) link.setAttribute("aria-current", "page");
+      link.querySelector("[data-name]").textContent = entry.path;
+      fragment.appendChild(item);
+    }
+
+    list.textContent = "";
+    list.appendChild(fragment);
+    empty.classList.toggle("hidden", matches.length !== 0);
+  },
+
+  closeModal() {
+    const content = document.getElementById(`${this.modalId}-content`);
+    content?.querySelector('[aria-label="Close modal"]')?.click();
+  },
+};
+
+function fuzzyMatch(file, query) {
+  return query === "" || file.includes(query) || subsequence(file, query);
+}
+
+function subsequence(file, query) {
+  const characters = Array.from(query);
+  let position = 0;
+  for (const character of file) {
+    if (character === characters[position]) position += 1;
+    if (position === characters.length) return true;
+  }
+  return characters.length === 0;
+}
+
+function score(file, query) {
+  if (query === "" || file === query) return 0;
+  if (file.startsWith(query)) return 1;
+  if (file.includes(`/${query}`)) return 2;
+  if (file.includes(query)) return 3;
+  return 4;
+}
+
+function compare(a, b) {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}

--- a/lib/hexpm_web/components/file_selector.ex
+++ b/lib/hexpm_web/components/file_selector.ex
@@ -20,10 +20,17 @@ defmodule HexpmWeb.Components.FileSelector do
   end
 
   attr :id, :string, required: true
-  attr :query, :string, required: true
+  attr :query, :string, default: ""
   attr :file_count, :integer, required: true
   attr :total_file_count, :integer, default: nil
   attr :filter_event, :string, default: "filter_files"
+
+  attr :client_finder, :boolean,
+    default: false,
+    doc: "filter and render results on the client from the tree's data-path links"
+
+  attr :active_path, :string, default: nil
+  attr :tree_version, :string, default: nil
   attr :title, :string, required: true
   attr :sidebar_label, :string, required: true
   attr :search_label, :string, required: true
@@ -35,7 +42,7 @@ defmodule HexpmWeb.Components.FileSelector do
   attr :finder_query_id, :string, default: nil
 
   slot :tree
-  slot :results, required: true
+  slot :results
 
   def file_selector(assigns) do
     assigns =
@@ -47,10 +54,34 @@ defmodule HexpmWeb.Components.FileSelector do
       )
 
     ~H"""
-    <aside class="hidden min-w-0 lg:block">
+    <aside
+      id={"#{@id}-selector"}
+      class="hidden min-w-0 lg:block"
+      phx-hook={@client_finder && "FileFinder"}
+      data-active-path={@client_finder && @active_path}
+      data-tree-version={@client_finder && @tree_version}
+      data-tree-id={@client_finder && "#{@id}-tree"}
+      data-sidebar-input={@client_finder && @tree_query_id}
+      data-modal-input={@client_finder && @finder_query_id}
+      data-modal-id={@client_finder && "#{@id}-modal"}
+      data-modal-results={@client_finder && "#{@id}-results"}
+    >
+      <template :if={@client_finder} data-finder-item>
+        <li>
+          <a
+            href="#"
+            data-phx-link="patch"
+            data-phx-link-state="push"
+            class="flex w-full items-center gap-2 rounded px-2 py-2 text-left font-mono text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:ring-offset-1 text-grey-600 hover:bg-grey-100 hover:text-grey-900 dark:text-grey-300 dark:hover:bg-grey-700/60 dark:hover:text-white aria-[current=page]:bg-primary-50 aria-[current=page]:font-semibold aria-[current=page]:text-primary-700 dark:aria-[current=page]:bg-grey-700 dark:aria-[current=page]:text-white"
+          >
+            {icon(:heroicon, "document", class: "size-3.5 shrink-0 text-grey-400")}
+            <span data-name class="truncate"></span>
+          </a>
+        </li>
+      </template>
       <div class="sticky top-4 overflow-hidden rounded-lg border border-grey-200 bg-white dark:border-grey-700 dark:bg-grey-800">
         <div class="border-b border-grey-200 p-3 dark:border-grey-700">
-          <form id={@tree_form_id} phx-change={@filter_event}>
+          <form id={@tree_form_id} phx-change={!@client_finder && @filter_event}>
             <label for={@tree_query_id} class="sr-only">{@search_label}</label>
             <div class="relative">
               {icon(:heroicon, "magnifying-glass",
@@ -78,18 +109,33 @@ defmodule HexpmWeb.Components.FileSelector do
           class="max-h-[70vh] overflow-auto p-2"
           aria-label={@sidebar_label}
         >
-          <div :if={@query == "" && @tree != []}>
-            {render_slot(@tree, %{modal_id: "#{@id}-modal"})}
-          </div>
-          <div :if={@query != "" || @tree == []}>
-            {render_slot(@results, %{close_modal?: false, modal_id: "#{@id}-modal"})}
-          </div>
+          <%= if @client_finder do %>
+            <div data-tree-container>
+              {render_slot(@tree, %{modal_id: "#{@id}-modal"})}
+            </div>
+            <div data-results-container class="hidden">
+              <ul data-results class="space-y-1"></ul>
+              <p
+                data-empty
+                class="hidden px-2 py-8 text-center text-sm text-grey-500 dark:text-grey-300"
+              >
+                No matching files
+              </p>
+            </div>
+          <% else %>
+            <div :if={@query == "" && @tree != []}>
+              {render_slot(@tree, %{modal_id: "#{@id}-modal"})}
+            </div>
+            <div :if={@query != "" || @tree == []}>
+              {render_slot(@results, %{close_modal?: false, modal_id: "#{@id}-modal"})}
+            </div>
+          <% end %>
         </nav>
       </div>
     </aside>
 
     <.modal id={"#{@id}-modal"} title={@title} max_width="3xl">
-      <form id={@finder_form_id} phx-change={@filter_event} class="mb-3">
+      <form id={@finder_form_id} phx-change={!@client_finder && @filter_event} class="mb-3">
         <label for={@finder_query_id} class="sr-only">{@search_label}</label>
         <div class="relative">
           {icon(:heroicon, "magnifying-glass",
@@ -113,7 +159,14 @@ defmodule HexpmWeb.Components.FileSelector do
         class="max-h-[60vh] overflow-auto"
         aria-label={@search_label}
       >
-        {render_slot(@results, %{close_modal?: true, modal_id: "#{@id}-modal"})}
+        <%= if @client_finder do %>
+          <ul data-results class="space-y-1"></ul>
+          <p data-empty class="hidden px-2 py-8 text-center text-sm text-grey-500 dark:text-grey-300">
+            No matching files
+          </p>
+        <% else %>
+          {render_slot(@results, %{close_modal?: true, modal_id: "#{@id}-modal"})}
+        <% end %>
       </nav>
     </.modal>
     """

--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -4,7 +4,6 @@ defmodule HexpmWeb.PreviewLive do
   import HexpmWeb.Components.PackageLayout
 
   alias Hexpm.Repository.Releases
-  alias HexpmWeb.Components.FileSelector
   alias HexpmWeb.PackageLayoutAssigns
   alias HexpmWeb.RepositoryAccess
 
@@ -22,10 +21,7 @@ defmodule HexpmWeb.PreviewLive do
        version: nil,
        files: [],
        file_tree: [],
-       expanded_paths: MapSet.new(),
        filename: nil,
-       filtered_files: [],
-       query: "",
        highlighted: nil,
        message: nil,
        raw_url: nil,
@@ -70,26 +66,6 @@ defmodule HexpmWeb.PreviewLive do
     else
       _ -> raise NotFoundError
     end
-  end
-
-  @impl true
-  def handle_event("filter_files", %{"query" => query}, socket) do
-    {:noreply,
-     assign(socket,
-       query: query,
-       filtered_files: FileSelector.filter(socket.assigns.files, query)
-     )}
-  end
-
-  def handle_event("toggle_directory", %{"path" => path}, socket) do
-    expanded_paths =
-      if MapSet.member?(socket.assigns.expanded_paths, path) do
-        MapSet.delete(socket.assigns.expanded_paths, path)
-      else
-        MapSet.put(socket.assigns.expanded_paths, path)
-      end
-
-    {:noreply, assign(socket, expanded_paths: expanded_paths)}
   end
 
   def files_path("hexpm", package, version) do
@@ -137,15 +113,10 @@ defmodule HexpmWeb.PreviewLive do
     {highlighted, message} = render_contents(package, version, source)
     filename = source.filename
 
-    expanded_paths = MapSet.union(socket.assigns.expanded_paths, parent_paths(filename))
-
     assign(socket,
       files: source.files,
       file_tree: build_file_tree(source.files),
-      expanded_paths: expanded_paths,
       filename: filename,
-      filtered_files: FileSelector.filter(source.files, ""),
-      query: "",
       highlighted: highlighted,
       message: message,
       raw_url: raw_url(repository, package, version, filename),
@@ -229,14 +200,6 @@ defmodule HexpmWeb.PreviewLive do
     |> tree_nodes("")
   end
 
-  defp parent_paths(filename) do
-    filename
-    |> Path.split()
-    |> Enum.drop(-1)
-    |> Enum.scan(&Path.join(&2, &1))
-    |> MapSet.new()
-  end
-
   defp insert_file(tree, [name], file), do: Map.put(tree, name, {:file, file})
 
   defp insert_file(tree, [directory | rest], file) do
@@ -260,60 +223,38 @@ defmodule HexpmWeb.PreviewLive do
   end
 
   attr :nodes, :list, required: true
-  attr :filename, :string, required: true
   attr :repository, :string, required: true
   attr :package_name, :string, required: true
   attr :version, :string, required: true
-  attr :expanded_paths, :any, required: true
-  attr :close_modal?, :boolean, default: false
-  attr :modal_id, :string, default: nil
 
   def source_tree(assigns) do
     ~H"""
     <ul class="space-y-0.5">
       <%= for node <- @nodes do %>
         <li :if={node.type == :directory}>
-          <% expanded? = MapSet.member?(@expanded_paths, node.path) %>
-          <button
-            type="button"
-            phx-click="toggle_directory"
-            phx-value-path={node.path}
-            aria-expanded={expanded?}
-            class="flex w-full cursor-pointer items-center gap-1.5 rounded px-2 py-1.5 text-left text-sm font-medium text-grey-700 hover:bg-grey-100 dark:text-grey-200 dark:hover:bg-grey-700/60"
-          >
-            {icon(:heroicon, "chevron-right",
-              class:
-                "size-3.5 shrink-0 transition-transform" <>
-                  if(expanded?, do: " rotate-90", else: "")
-            )}
-            {icon(:heroicon, "folder", class: "size-4 shrink-0 text-grey-400")}
-            <span class="truncate">{node.name}</span>
-          </button>
-          <div :if={expanded?} class="ml-3 border-l border-grey-200 pl-2 dark:border-grey-700">
-            <.source_tree
-              nodes={node.children}
-              filename={@filename}
-              repository={@repository}
-              package_name={@package_name}
-              version={@version}
-              expanded_paths={@expanded_paths}
-              close_modal?={@close_modal?}
-              modal_id={@modal_id}
-            />
-          </div>
+          <details>
+            <summary class="flex w-full cursor-pointer list-none items-center gap-1.5 rounded px-2 py-1.5 text-left text-sm font-medium text-grey-700 hover:bg-grey-100 dark:text-grey-200 dark:hover:bg-grey-700/60 [&::-webkit-details-marker]:hidden">
+              {icon(:heroicon, "chevron-right",
+                class: "size-3.5 shrink-0 transition-transform [details[open]>summary_&]:rotate-90"
+              )}
+              {icon(:heroicon, "folder", class: "size-4 shrink-0 text-grey-400")}
+              <span class="truncate">{node.name}</span>
+            </summary>
+            <div class="ml-3 border-l border-grey-200 pl-2 dark:border-grey-700">
+              <.source_tree
+                nodes={node.children}
+                repository={@repository}
+                package_name={@package_name}
+                version={@version}
+              />
+            </div>
+          </details>
         </li>
         <li :if={node.type == :file}>
           <.link
             patch={files_path(@repository, @package_name, @version, node.path)}
-            phx-click={if @close_modal?, do: hide_modal(@modal_id)}
-            aria-current={if node.path == @filename, do: "page"}
-            class={[
-              "flex items-center gap-1.5 rounded px-2 py-1.5 font-mono text-xs transition-colors",
-              node.path == @filename &&
-                "bg-primary-50 font-semibold text-primary-700 dark:bg-grey-700 dark:text-white",
-              node.path != @filename &&
-                "text-grey-600 hover:bg-grey-100 hover:text-grey-900 dark:text-grey-300 dark:hover:bg-grey-700/60 dark:hover:text-white"
-            ]}
+            data-path={node.path}
+            class="flex items-center gap-1.5 rounded px-2 py-1.5 font-mono text-xs transition-colors text-grey-600 hover:bg-grey-100 hover:text-grey-900 dark:text-grey-300 dark:hover:bg-grey-700/60 dark:hover:text-white aria-[current=page]:bg-primary-50 aria-[current=page]:font-semibold aria-[current=page]:text-primary-700 dark:aria-[current=page]:bg-grey-700 dark:aria-[current=page]:text-white"
           >
             {icon(:heroicon, "document", class: "ml-5 size-3.5 shrink-0 text-grey-400")}
             <span class="truncate">{node.name}</span>
@@ -321,35 +262,6 @@ defmodule HexpmWeb.PreviewLive do
         </li>
       <% end %>
     </ul>
-    """
-  end
-
-  attr :files, :list, required: true
-  attr :filename, :string, required: true
-  attr :repository, :string, required: true
-  attr :package_name, :string, required: true
-  attr :version, :string, required: true
-  attr :close_modal?, :boolean, default: false
-  attr :modal_id, :string, default: nil
-
-  def source_results(assigns) do
-    ~H"""
-    <HexpmWeb.Components.FileSelector.file_results
-      items={@files}
-      selected={&(&1 == @filename)}
-    >
-      <:item :let={result}>
-        <.link
-          patch={files_path(@repository, @package_name, @version, result.item)}
-          phx-click={if @close_modal?, do: hide_modal(@modal_id)}
-          aria-current={if result.item == @filename, do: "page"}
-          class={result.class}
-        >
-          {icon(:heroicon, "document", class: "size-3.5 shrink-0 text-grey-400")}
-          <span class="truncate">{result.item}</span>
-        </.link>
-      </:item>
-    </HexpmWeb.Components.FileSelector.file_results>
     """
   end
 end

--- a/lib/hexpm_web/live/preview_live.html.heex
+++ b/lib/hexpm_web/live/preview_live.html.heex
@@ -37,7 +37,9 @@
       <div class="grid min-w-0 items-start gap-4 lg:grid-cols-[16rem_minmax(0,1fr)]">
         <HexpmWeb.Components.FileSelector.file_selector
           id="preview-files"
-          query={@query}
+          client_finder={true}
+          active_path={@filename}
+          tree_version={@version}
           file_count={length(@files)}
           title="Package files"
           sidebar_label="Package files"
@@ -47,34 +49,14 @@
           finder_form_id="preview-file-finder"
           finder_query_id="preview-file-query"
         >
-          <:tree :let={selector}>
+          <:tree :let={_selector}>
             <.source_tree
               nodes={@file_tree}
-              filename={@filename}
               repository={@repository}
               package_name={@package_name}
               version={@version}
-              expanded_paths={@expanded_paths}
-              modal_id={selector.modal_id}
             />
           </:tree>
-          <:results :let={selector}>
-            <.source_results
-              files={@filtered_files}
-              filename={@filename}
-              repository={@repository}
-              package_name={@package_name}
-              version={@version}
-              close_modal?={selector.close_modal?}
-              modal_id={selector.modal_id}
-            />
-            <p
-              :if={@filtered_files == []}
-              class="px-2 py-8 text-center text-sm text-grey-500 dark:text-grey-300"
-            >
-              No matching files
-            </p>
-          </:results>
         </HexpmWeb.Components.FileSelector.file_selector>
 
         <section class="min-w-0 overflow-hidden rounded-lg border border-grey-200 bg-white dark:border-grey-700 dark:bg-grey-800">

--- a/priv/static/robots.txt
+++ b/priv/static/robots.txt
@@ -1,7 +1,6 @@
 # See http://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
-#
-# To ban all spiders from the entire site uncomment the next two lines:
-# User-agent: *
-# Disallow: /
+
+User-agent: *
+Disallow: /diff/
 
 Sitemap: https://hex.pm/sitemap.xml

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -21,7 +21,13 @@ defmodule HexpmWeb.PreviewLiveTest do
     assert html =~ "LineHighlight"
     assert html =~ "l-line"
     assert page_title(view) == "lib/live_preview.ex - live_preview 1.0.0 | Hex"
-    assert has_element?(view, ~s(a[aria-current="page"]), "live_preview.ex")
+    assert has_element?(view, ~s(a[data-path="lib/live_preview.ex"]), "live_preview.ex")
+
+    assert has_element?(
+             view,
+             ~s(aside[phx-hook="FileFinder"][data-active-path="lib/live_preview.ex"])
+           )
+
     assert has_element?(view, "h2", "lib/live_preview.ex")
     assert has_element?(view, ~s(button.lg\\:hidden), "Find file")
     refute has_element?(view, ~s(button.lg\\:inline-flex))
@@ -85,7 +91,7 @@ defmodule HexpmWeb.PreviewLiveTest do
     assert html =~ "File is too large to be displayed (0.2 MB)."
   end
 
-  test "searches a manifest containing hundreds of files", %{conn: conn} do
+  test "renders the full tree with collapsible directories and finder scaffolding", %{conn: conn} do
     files =
       [{"README.md", "readme"}] ++
         for index <- 1..500 do
@@ -95,27 +101,33 @@ defmodule HexpmWeb.PreviewLiveTest do
     put_release("large_manifest", "1.0.0", files)
     {:ok, view, _html} = live(conn, "/packages/large_manifest/1.0.0/files")
 
-    assert has_element?(view, ~s(button[phx-value-path="lib"]))
-    refute has_element?(view, ~s(aside a[href$="file_1.ex"]))
-
-    view |> element(~s(button[phx-value-path="lib"])) |> render_click()
-    assert has_element?(view, ~s(button[phx-value-path="lib/generated"]))
-    refute has_element?(view, ~s(aside a[href$="file_1.ex"]))
-
-    view |> element(~s(button[phx-value-path="lib/generated"])) |> render_click()
-    view |> element(~s(button[phx-value-path="lib/generated/deep"])) |> render_click()
-    assert has_element?(view, ~s(aside a[href$="file_1.ex"]))
-
-    view
-    |> element("#preview-tree-search")
-    |> render_change(%{"query" => "deep499"})
+    assert has_element?(view, "aside details summary", "lib")
+    assert has_element?(view, "aside details details details summary", "deep")
 
     assert has_element?(
              view,
-             ~s(a[href="/packages/large_manifest/1.0.0/files/lib/generated/deep/file_499.ex"])
+             ~s(aside a[href$="file_1.ex"][data-path="lib/generated/deep/file_1.ex"])
            )
 
-    refute has_element?(view, ~s(a[href$="file_498.ex"]), "file_498.ex")
+    assert has_element?(view, ~s(aside a[href$="file_500.ex"]))
+
+    assert has_element?(view, ~s(template[data-finder-item]))
+    assert has_element?(view, ~s(aside[phx-hook="FileFinder"][data-tree-version="1.0.0"]))
+    refute has_element?(view, ~s(form#preview-tree-search[phx-change]))
+    refute has_element?(view, ~s(form#preview-file-finder[phx-change]))
+
+    view
+    |> element(~s(aside a[href$="file_499.ex"]))
+    |> render_click()
+
+    assert_patch(view, "/packages/large_manifest/1.0.0/files/lib/generated/deep/file_499.ex")
+
+    assert has_element?(
+             view,
+             ~s(aside[data-active-path="lib/generated/deep/file_499.ex"])
+           )
+
+    refute has_element?(view, ~s(aside a[aria-current]))
   end
 
   test "version picker preserves the selected filename", %{conn: conn} do


### PR DESCRIPTION
Package file pages are ~20 req/s of mostly crawler traffic and 68% of all request time on the web tier, and diffs went from robots-banned on the standalone diff.hex.pm to fully crawlable after the consolidation, now triggering 12-15k git-diff generation jobs a day. This takes two bites out of that.

The file tree no longer bakes selection and expansion state into its markup, so it renders once per version and a file navigation diffs down to the code block plus one attribute instead of re-sending the whole tree. Directories are native details/summary elements, so expanding one costs no server round trip and works without JS. Selection styling keys off aria-current, set by the new FileFinder hook from a data-active-path attribute the server updates on navigation. The fuzzy finder (sidebar and modal) filters the tree's data-path links client-side with the same match and ranking semantics as FileSelector.filter/2, rendering results from a server-rendered template, so finder keystrokes no longer hit the server at all. The filter_files and toggle_directory events and their assigns are deleted from PreviewLive. The diff page keeps the server-driven finder since its file list grows as pieces load.

robots.txt restores the Disallow: /diff/ rule that diff.hex.pm always had; it was lost in the consolidation.

One trade: the dead render now ships the whole tree collapsed instead of only the expanded directories, roughly 60KB gzipped for a 3k-file package, and crawlers see every file link without executing JS. If that ever bites, the follow-up is a file-count cap that falls back to finder-only.

Verified in the browser against dev: initial load highlights the active file and opens its ancestors, tree clicks patch and move the highlight, sidebar search and the modal finder filter as you type, result clicks navigate, reset the query, and close the modal.