### PR TITLE
Use Elixir standard library JSON

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('mix.lock', 'config/config.exs') }}
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile
@@ -90,7 +90,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-elixir-${{ env.elixir }}-otp-${{ env.otp }}-${{ hashFiles('mix.lock', 'config/config.exs') }}
 
       - name: Install dependencies
         run: mix do deps.get + deps.compile
@@ -156,7 +156,7 @@ jobs:
           path: |
             deps
             _build
-          key: ${{ runner.os }}-elixir-${{ matrix.elixir }}-otp-${{ matrix.otp }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-elixir-${{ matrix.elixir }}-otp-${{ matrix.otp }}-${{ hashFiles('mix.lock', 'config/config.exs') }}
 
       - name: Install hexpm dependencies
         run: |

--- a/config/config.exs
+++ b/config/config.exs
@@ -47,10 +47,14 @@ config :hexpm, Oban,
   shutdown_grace_period: 300_000
 
 config :ex_aws,
-  json_codec: Jason,
+  json_codec: JSON,
   http_client: ExAws.Request.Req
 
-config :sentry, client: Hexpm.SentryClient
+config :sentry,
+  client: Hexpm.SentryClient,
+  json_library: JSON
+
+config :postgrex, :json_library, JSON
 
 config :bcrypt_elixir, log_rounds: 4
 
@@ -72,6 +76,7 @@ config :hexpm, Hexpm.RepoBase,
 
 config :swoosh, :api_client, Swoosh.ApiClient.Finch
 config :swoosh, :finch_name, Hexpm.Finch
+config :swoosh, :json_library, JSON
 
 config :hexpm, Hexpm.Emails.Mailer, adapter: Swoosh.Adapters.Sendgrid
 
@@ -86,9 +91,9 @@ config :phoenix, :generators,
 config :phoenix, :format_encoders,
   elixir: HexpmWeb.ElixirFormat,
   erlang: HexpmWeb.ErlangFormat,
-  json: Jason
+  json: JSON
 
-config :phoenix, :json_library, Jason
+config :phoenix, :json_library, JSON
 
 config :mime,
   types: %{

--- a/lib/hexpm/accounts/recovery_code.ex
+++ b/lib/hexpm/accounts/recovery_code.ex
@@ -3,7 +3,7 @@ defmodule Hexpm.Accounts.RecoveryCode do
 
   alias Hexpm.Accounts.RecoveryCode
 
-  @derive {Jason.Encoder, only: []}
+  @derive {JSON.Encoder, only: []}
 
   @rand_bytes 10
   @part_size 4

--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -168,7 +168,7 @@ defmodule Hexpm.Application do
       credentials =
         "HEXPM_GCP_CREDENTIALS"
         |> System.fetch_env!()
-        |> Jason.decode!()
+        |> JSON.decode!()
 
       options = [scope: "https://www.googleapis.com/auth/devstorage.read_write"]
       {Goth, name: Hexpm.Goth, source: {:service_account, credentials, options}}

--- a/lib/hexpm/billing/hexpm.ex
+++ b/lib/hexpm/billing/hexpm.ex
@@ -106,7 +106,7 @@ defmodule Hexpm.Billing.Hexpm do
 
   defp post(url, body) do
     url = Application.get_env(:hexpm, :billing_url) <> url
-    body = Jason.encode!(body)
+    body = JSON.encode!(body)
 
     headers = [
       {"authorization", auth()},
@@ -119,7 +119,7 @@ defmodule Hexpm.Billing.Hexpm do
 
   defp patch(url, body) do
     url = Application.get_env(:hexpm, :billing_url) <> url
-    body = Jason.encode!(body)
+    body = JSON.encode!(body)
 
     headers = [
       {"authorization", auth()},

--- a/lib/hexpm/diff/cache.ex
+++ b/lib/hexpm/diff/cache.ex
@@ -25,14 +25,14 @@ defmodule Hexpm.Diff.Cache do
 
   def put_piece!(%Request{} = request, index, data) do
     key = diff_key(request, request.canonical_hash, index)
-    put!(key, Jason.encode!(data))
+    put!(key, JSON.encode!(data))
     %Piece{id: "diff-#{index}", key: key}
   end
 
   def put_metadata!(%Request{} = request, metadata) do
     request
     |> metadata_key(request.canonical_hash)
-    |> put!(Jason.encode!(metadata))
+    |> put!(JSON.encode!(metadata))
   end
 
   def metadata_key(%Request{} = request, hash) do
@@ -81,7 +81,7 @@ defmodule Hexpm.Diff.Cache do
   end
 
   defp decode_metadata(body) do
-    with {:ok, metadata} <- Jason.decode(body),
+    with {:ok, metadata} <- JSON.decode(body),
          {:ok, total_diffs} <- non_negative_integer(metadata["total_diffs"]),
          {:ok, total_additions} <- non_negative_integer(metadata["total_additions"]),
          {:ok, total_deletions} <- non_negative_integer(metadata["total_deletions"]),
@@ -101,7 +101,7 @@ defmodule Hexpm.Diff.Cache do
   end
 
   defp decode_piece(body) do
-    case Jason.decode(body) do
+    case JSON.decode(body) do
       {:ok, %{"type" => "too_large", "file" => file}} when is_binary(file) ->
         {:ok, {:too_large, file}}
 

--- a/lib/hexpm/ecto/version.ex
+++ b/lib/hexpm/ecto/version.ex
@@ -30,6 +30,6 @@ defmodule Hexpm.Version do
   def equal?(left, right), do: Version.compare(left, right) == :eq
 end
 
-defimpl Jason.Encoder, for: Version do
-  def encode(version, _), do: ~s("#{version}")
+defimpl JSON.Encoder, for: Version do
+  def encode(version, encoder), do: encoder.(to_string(version), encoder)
 end

--- a/lib/hexpm/ecto/version_requirement.ex
+++ b/lib/hexpm/ecto/version_requirement.ex
@@ -28,6 +28,6 @@ defmodule Hexpm.VersionRequirement do
   def embed_as(_format), do: :self
 end
 
-defimpl Jason.Encoder, for: Version.Requirement do
-  def encode(version_requirement, _), do: ~s("#{version_requirement}")
+defimpl JSON.Encoder, for: Version.Requirement do
+  def encode(version_requirement, encoder), do: encoder.(to_string(version_requirement), encoder)
 end

--- a/lib/hexpm/hexdocs/bucket.ex
+++ b/lib/hexpm/hexdocs/bucket.ex
@@ -87,9 +87,9 @@ defmodule Hexpm.Hexdocs.Bucket do
 
     data = [
       "var versionNodes = ",
-      Jason.encode_to_iodata!(versions),
+      JSON.encode_to_iodata!(versions),
       ";\n",
-      if(search, do: ["var searchNodes = ", Jason.encode_to_iodata!(search), ";"], else: [])
+      if(search, do: ["var searchNodes = ", JSON.encode_to_iodata!(search), ";"], else: [])
     ]
 
     path = repository_path(repository, Path.join(package, "docs_config.js"))

--- a/lib/hexpm/hexdocs/queue.ex
+++ b/lib/hexpm/hexdocs/queue.ex
@@ -26,7 +26,7 @@ defmodule Hexpm.Hexdocs.Queue do
 
   @impl Broadway
   def handle_message(_processor, %Broadway.Message{} = message, _context) do
-    with {:ok, data} <- Jason.decode(message.data),
+    with {:ok, data} <- JSON.decode(message.data),
          {:ok, jobs} <- jobs_for(data),
          {:ok, _inserted} <- insert_jobs(jobs) do
       message

--- a/lib/hexpm/hexdocs/search.ex
+++ b/lib/hexpm/hexdocs/search.ex
@@ -20,7 +20,7 @@ defmodule Hexpm.Hexdocs.Search do
     search_data =
       case search_data_js do
         "searchData=" <> json ->
-          case Jason.decode(json) do
+          case JSON.decode(json) do
             {:ok, data} ->
               data
 

--- a/lib/hexpm/hexdocs/search/typesense.ex
+++ b/lib/hexpm/hexdocs/search/typesense.ex
@@ -14,7 +14,7 @@ defmodule Hexpm.Hexdocs.Search.Typesense do
           |> Map.update("doc", "", &(&1 || ""))
           |> Map.put("package", full_package)
           |> Map.put("proglang", proglang)
-          |> Jason.encode!()
+          |> JSON.encode!()
 
         [json, ?\n]
       end)
@@ -31,7 +31,7 @@ defmodule Hexpm.Hexdocs.Search.Typesense do
         |> String.split("\n", trim: true)
         |> Enum.zip(search_items)
         |> Enum.each(fn {response, item} ->
-          case Jason.decode!(response) do
+          case JSON.decode!(response) do
             %{"success" => true} ->
               :ok
 

--- a/lib/hexpm/hexdocs/source_repo/github.ex
+++ b/lib/hexpm/hexdocs/source_repo/github.ex
@@ -35,6 +35,6 @@ defmodule Hexpm.Hexdocs.SourceRepo.GitHub do
     end
   end
 
-  defp decode(body) when is_binary(body), do: Jason.decode!(body)
+  defp decode(body) when is_binary(body), do: JSON.decode!(body)
   defp decode(body), do: body
 end

--- a/lib/hexpm/http.ex
+++ b/lib/hexpm/http.ex
@@ -78,14 +78,14 @@ defmodule Hexpm.HTTP do
   defp encode_params(body, headers) when is_map(body) do
     case List.keyfind(headers, "content-type", 0) do
       {_, "application/x-www-form-urlencoded"} -> URI.encode_query(body)
-      {_, "application/json"} -> Jason.encode!(body)
+      {_, "application/json"} -> JSON.encode!(body)
       nil -> body
     end
   end
 
   defp decode_body(body, headers) do
     case List.keyfind(headers, "content-type", 0) do
-      {_, "application/json" <> _} -> Jason.decode!(body)
+      {_, "application/json" <> _} -> JSON.decode!(body)
       _ -> body
     end
   end

--- a/lib/hexpm/preview/bucket.ex
+++ b/lib/hexpm/preview/bucket.ex
@@ -38,7 +38,7 @@ defmodule Hexpm.Preview.Bucket do
     Hexpm.Store.put(
       :preview_bucket,
       file_list_key(repository, package, version),
-      Jason.encode!(file_paths),
+      JSON.encode!(file_paths),
       put_opts(repository, package, version)
     )
 
@@ -59,7 +59,7 @@ defmodule Hexpm.Preview.Bucket do
   def get_file_list(repository, package, version) do
     case Hexpm.Store.get(:preview_bucket, file_list_key(repository, package, version)) do
       nil -> nil
-      json -> json |> Jason.decode!() |> Enum.uniq()
+      json -> json |> JSON.decode!() |> Enum.uniq()
     end
   end
 

--- a/lib/hexpm/preview/queue.ex
+++ b/lib/hexpm/preview/queue.ex
@@ -26,7 +26,7 @@ defmodule Hexpm.Preview.Queue do
 
   @impl Broadway
   def handle_message(_processor, %Broadway.Message{} = message, _context) do
-    with {:ok, data} <- Jason.decode(message.data),
+    with {:ok, data} <- JSON.decode(message.data),
          {:ok, jobs} <- jobs_for(data, message.metadata[:message_id]),
          {:ok, _inserted} <- insert_jobs(jobs) do
       message

--- a/lib/hexpm/security/updater.ex
+++ b/lib/hexpm/security/updater.ex
@@ -45,7 +45,7 @@ defmodule Hexpm.Security.Updater do
   def process_advisories(body) do
     records =
       body
-      |> Enum.map(fn {_filename, content} -> Jason.decode!(content) end)
+      |> Enum.map(fn {_filename, content} -> JSON.decode!(content) end)
       |> Enum.map(&parse_advisory/1)
       |> Enum.reject(&is_nil/1)
 

--- a/lib/hexpm_web/controllers/dashboard/billing_proxy_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/billing_proxy_controller.ex
@@ -14,7 +14,7 @@ defmodule HexpmWeb.Dashboard.BillingProxyController do
       billing_key = Application.get_env(:hexpm, :billing_key)
       url = billing_url <> "/" <> Enum.join(path, "/")
 
-      body = Jason.encode!(conn.body_params)
+      body = JSON.encode!(conn.body_params)
 
       headers = [
         {"authorization", billing_key},
@@ -31,7 +31,7 @@ defmodule HexpmWeb.Dashboard.BillingProxyController do
         {:error, reason} ->
           conn
           |> put_resp_content_type("application/json")
-          |> send_resp(502, Jason.encode!(%{"errors" => inspect(reason)}))
+          |> send_resp(502, JSON.encode!(%{"errors" => inspect(reason)}))
       end
     end)
   end
@@ -39,11 +39,11 @@ defmodule HexpmWeb.Dashboard.BillingProxyController do
   def proxy(conn, _params) do
     conn
     |> put_resp_content_type("application/json")
-    |> send_resp(404, Jason.encode!(%{"errors" => "Not found"}))
+    |> send_resp(404, JSON.encode!(%{"errors" => "Not found"}))
   end
 
   defp encode_body(body) when is_binary(body), do: body
-  defp encode_body(body), do: Jason.encode!(body)
+  defp encode_body(body), do: JSON.encode!(body)
 
   defp access_organization(conn, organization, role, fun) do
     user = conn.assigns.current_user
@@ -59,12 +59,12 @@ defmodule HexpmWeb.Dashboard.BillingProxyController do
       else
         conn
         |> put_resp_content_type("application/json")
-        |> send_resp(403, Jason.encode!(%{"errors" => "Forbidden"}))
+        |> send_resp(403, JSON.encode!(%{"errors" => "Forbidden"}))
       end
     else
       conn
       |> put_resp_content_type("application/json")
-      |> send_resp(404, Jason.encode!(%{"errors" => "Not found"}))
+      |> send_resp(404, JSON.encode!(%{"errors" => "Not found"}))
     end
   end
 end

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -423,12 +423,12 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
         {:ok, _} ->
           conn
           |> put_resp_header("content-type", "application/json")
-          |> send_resp(200, Jason.encode!(%{}))
+          |> send_resp(200, JSON.encode!(%{}))
 
         {:error, reason} ->
           conn
           |> put_resp_header("content-type", "application/json")
-          |> send_resp(422, Jason.encode!(reason))
+          |> send_resp(422, JSON.encode!(reason))
       end
     end)
   end
@@ -578,7 +578,7 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
               |> put_resp_content_type("application/json")
               |> send_resp(
                 402,
-                Jason.encode!(%{
+                JSON.encode!(%{
                   requires_action: true,
                   client_secret: body["client_secret"],
                   invoice_id: body["invoice_id"],

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -51,7 +51,7 @@ defmodule HexpmWeb.Endpoint do
   plug Plug.Parsers,
     parsers: [:urlencoded, :json, HexpmWeb.PlugParser],
     pass: ["*/*"],
-    json_decoder: Jason
+    json_decoder: JSON
 
   plug Sentry.PlugContext
   plug Plug.MethodOverride

--- a/lib/hexpm_web/templates/readme/no_readme.html.heex
+++ b/lib/hexpm_web/templates/readme/no_readme.html.heex
@@ -3,7 +3,7 @@
   <head><meta charset="utf-8" /></head>
   <body>
     <script nonce={@script_src_nonce}>
-      var origins = <%= raw(Jason.encode!(@parent_origins)) %>;
+      var origins = <%= raw(JSON.encode!(@parent_origins)) %>;
       origins.forEach(function(o) {
         window.parent.postMessage({type: 'readme-not-found'}, o);
       });

--- a/lib/hexpm_web/templates/readme/show.html.heex
+++ b/lib/hexpm_web/templates/readme/show.html.heex
@@ -22,7 +22,7 @@
     </article>
     <script nonce={@script_src_nonce}>
       document.addEventListener('DOMContentLoaded', function() {
-        var origins = <%= raw(Jason.encode!(@parent_origins)) %>;
+        var origins = <%= raw(JSON.encode!(@parent_origins)) %>;
         function isAllowedOrigin(origin) {
           return origins[0] === "*" || origins.indexOf(origin) >= 0;
         }

--- a/mix.exs
+++ b/mix.exs
@@ -53,7 +53,6 @@ defmodule Hexpm.MixProject do
       {:floki, "~> 0.37"},
       {:goth, "~> 1.4"},
       {:hex_core, "~> 0.18", hex_core_opts()},
-      {:jason, "~> 1.0"},
       {:joken, "~> 2.6"},
       {:lasso, "~> 0.1.4", only: :test},
       {:libcluster, "~> 3.0"},

--- a/test/hexpm/diff_test.exs
+++ b/test/hexpm/diff_test.exs
@@ -38,14 +38,14 @@ defmodule Hexpm.DiffTest do
     Hexpm.Store.put(
       :diff_bucket,
       Cache.metadata_key(request, request.legacy_hash),
-      Jason.encode!(legacy_metadata),
+      JSON.encode!(legacy_metadata),
       []
     )
 
     Hexpm.Store.put(
       :diff_bucket,
       Cache.diff_key(request, request.legacy_hash, 0),
-      Jason.encode!(legacy_piece),
+      JSON.encode!(legacy_piece),
       []
     )
 
@@ -58,7 +58,7 @@ defmodule Hexpm.DiffTest do
     Hexpm.Store.put(
       :diff_bucket,
       Cache.metadata_key(request, request.canonical_hash),
-      Jason.encode!(canonical_metadata),
+      JSON.encode!(canonical_metadata),
       []
     )
 
@@ -113,7 +113,7 @@ defmodule Hexpm.DiffTest do
     args = Request.to_args(request)
     assert args.repository == repository.name
 
-    args = args |> Jason.encode!() |> Jason.decode!()
+    args = args |> JSON.encode!() |> JSON.decode!()
     assert {:ok, rebuilt} = Request.from_args(args)
     assert rebuilt.repository == repository.name
     assert rebuilt.canonical_hash == request.canonical_hash
@@ -305,7 +305,7 @@ defmodule Hexpm.DiffTest do
     Hexpm.Store.put(
       :diff_bucket,
       Cache.metadata_key(request, request.canonical_hash),
-      Jason.encode!(%{total_diffs: -1}),
+      JSON.encode!(%{total_diffs: -1}),
       []
     )
 
@@ -319,7 +319,7 @@ defmodule Hexpm.DiffTest do
     })
 
     [piece] = elem(Hexpm.Diff.fetch(request), 2)
-    Hexpm.Store.put(:diff_bucket, piece.key, Jason.encode!(%{unexpected: true}), [])
+    Hexpm.Store.put(:diff_bucket, piece.key, JSON.encode!(%{unexpected: true}), [])
     assert {:error, :invalid_piece} = Hexpm.Diff.fetch_piece(piece)
   end
 end

--- a/test/hexpm/hexdocs/queue_test.exs
+++ b/test/hexpm/hexdocs/queue_test.exs
@@ -57,7 +57,7 @@ defmodule Hexpm.Hexdocs.QueueTest do
 
   defp handle(data) do
     message = %Broadway.Message{
-      data: Jason.encode!(data),
+      data: JSON.encode!(data),
       acknowledger: {Broadway.NoopAcknowledger, nil, nil}
     }
 

--- a/test/hexpm/hexdocs/search_test.exs
+++ b/test/hexpm/hexdocs/search_test.exs
@@ -5,7 +5,7 @@ defmodule Hexpm.Hexdocs.SearchTest do
 
   test "extracts explicit search language and items" do
     items = [%{"type" => "module", "title" => "Example", "ref" => "Example.html"}]
-    data = "searchData=" <> Jason.encode!(%{"proglang" => "gleam", "items" => items})
+    data = "searchData=" <> JSON.encode!(%{"proglang" => "gleam", "items" => items})
 
     assert Search.find_search_items("package", "1.0.0", [{"search_data-package.js", data}]) ==
              {"gleam", items}
@@ -44,12 +44,12 @@ defmodule Hexpm.Hexdocs.SearchTest do
       Search.find_search_items(
         "package",
         "1.0.0",
-        [{"search_data-package.js", "searchData=" <> Jason.encode!(%{})}]
+        [{"search_data-package.js", "searchData=" <> JSON.encode!(%{})}]
       )
     end
   end
 
   defp search_file(items) do
-    [{"search_data-package.js", "searchData=" <> Jason.encode!(%{"items" => items})}]
+    [{"search_data-package.js", "searchData=" <> JSON.encode!(%{"items" => items})}]
   end
 end

--- a/test/hexpm/hexdocs/search_typesense_test.exs
+++ b/test/hexpm/hexdocs/search_typesense_test.exs
@@ -42,7 +42,7 @@ defmodule Hexpm.Hexdocs.Search.TypesenseTest do
                body
                |> IO.iodata_to_binary()
                |> String.split("\n", trim: true)
-               |> Enum.map(&Jason.decode!/1)
+               |> Enum.map(&JSON.decode!/1)
 
       assert document == %{
                "type" => "module",

--- a/test/hexpm/http_test.exs
+++ b/test/hexpm/http_test.exs
@@ -141,7 +141,7 @@ defmodule Hexpm.HTTPTest do
   test "post/3 encode json", %{lasso: lasso} do
     Lasso.expect_once(lasso, "POST", "/post", fn conn ->
       {:ok, reqbody, conn} = Conn.read_body(conn)
-      assert Jason.decode(reqbody) == {:ok, %{"key" => "value"}}
+      assert JSON.decode(reqbody) == {:ok, %{"key" => "value"}}
       Conn.resp(conn, 200, "respbody")
     end)
 
@@ -170,7 +170,7 @@ defmodule Hexpm.HTTPTest do
     Lasso.expect_once(lasso, "GET", "/get", fn conn ->
       conn
       |> Conn.put_resp_header("content-type", "application/json")
-      |> Conn.resp(200, Jason.encode!(%{"key" => "value"}))
+      |> Conn.resp(200, JSON.encode!(%{"key" => "value"}))
     end)
 
     assert {:ok, 200, _headers, %{"key" => "value"}} = HTTP.get(lasso_url(lasso, "/get"), [])

--- a/test/hexpm/preview/preview_test.exs
+++ b/test/hexpm/preview/preview_test.exs
@@ -38,7 +38,7 @@ defmodule Hexpm.PreviewTest do
     Hexpm.Store.put(
       :preview_bucket,
       "file_lists/incomplete-1.0.0.json",
-      Jason.encode!(["README.md"])
+      JSON.encode!(["README.md"])
     )
 
     assert Preview.source("hexpm", "incomplete", "1.0.0") == :error
@@ -127,7 +127,7 @@ defmodule Hexpm.PreviewTest do
     Hexpm.Store.put(
       :preview_bucket,
       "#{prefix}file_lists/#{package}-#{version}.json",
-      Jason.encode!(filenames)
+      JSON.encode!(filenames)
     )
 
     for {filename, contents} <- files do

--- a/test/hexpm/preview/queue_test.exs
+++ b/test/hexpm/preview/queue_test.exs
@@ -126,14 +126,14 @@ defmodule Hexpm.Preview.QueueTest do
   end
 
   test "fails malformed JSON and unsupported messages" do
-    assert %{status: {:failed, %Jason.DecodeError{}}} = handle_raw("not-json")
+    assert %{status: {:failed, {:invalid_byte, 1, ?o}}} = handle_raw("not-json")
     assert %{status: {:failed, {:unsupported_preview_message, %{}}}} = handle(%{})
 
     assert %{status: {:failed, {:unsupported_preview_message, _message}}} =
              handle(%{"preview:sitemap" => "tarballs/demo-1.0.0.tar"})
   end
 
-  defp handle(data), do: data |> Jason.encode!() |> handle_raw()
+  defp handle(data), do: data |> JSON.encode!() |> handle_raw()
 
   defp handle_raw(data) do
     message = %Broadway.Message{

--- a/test/hexpm/preview/workers_test.exs
+++ b/test/hexpm/preview/workers_test.exs
@@ -84,9 +84,7 @@ defmodule Hexpm.Preview.WorkersTest do
     assert :ok = perform_job(Workers.Upload, %{key: key})
     assert :ok = perform_job(Workers.Upload, %{key: key})
 
-    assert Jason.decode!(
-             Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")
-           ) ==
+    assert JSON.decode!(Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")) ==
              ["lib/foo.ex"]
 
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/lib/foo.ex") =~
@@ -132,7 +130,7 @@ defmodule Hexpm.Preview.WorkersTest do
 
     prefix = "repos/#{repository.name}/"
 
-    assert Jason.decode!(
+    assert JSON.decode!(
              Hexpm.Store.get(:preview_bucket, "#{prefix}file_lists/#{package.name}-1.0.0.json")
            ) == ["README.md"]
 
@@ -193,9 +191,8 @@ defmodule Hexpm.Preview.WorkersTest do
 
     assert :ok = perform_job(Workers.Upload, %{key: key})
 
-    assert Jason.decode!(
-             Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")
-           ) == ["dot.txt", "safe.txt"]
+    assert JSON.decode!(Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")) ==
+             ["dot.txt", "safe.txt"]
   end
 
   test "CDN failures retry cleanly" do
@@ -239,9 +236,7 @@ defmodule Hexpm.Preview.WorkersTest do
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/old.txt") == nil
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/new.txt") == "new"
 
-    assert Jason.decode!(
-             Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")
-           ) ==
+    assert JSON.decode!(Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")) ==
              ["new.txt"]
   end
 
@@ -253,7 +248,7 @@ defmodule Hexpm.Preview.WorkersTest do
     Hexpm.Store.put(
       :preview_bucket,
       "file_lists/#{package.name}-1.0.0.json",
-      Jason.encode!(["old.txt"])
+      JSON.encode!(["old.txt"])
     )
 
     put_tarball(key, package.name, to_string(release.version), [{"fail.txt", "failure"}])
@@ -271,9 +266,7 @@ defmodule Hexpm.Preview.WorkersTest do
       Process.flag(:trap_exit, trap_exit?)
     end
 
-    assert Jason.decode!(
-             Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")
-           ) ==
+    assert JSON.decode!(Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")) ==
              ["old.txt"]
   end
 
@@ -378,9 +371,7 @@ defmodule Hexpm.Preview.WorkersTest do
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/old.txt") == nil
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/new.txt") == "new"
 
-    assert Jason.decode!(
-             Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")
-           ) ==
+    assert JSON.decode!(Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")) ==
              ["new.txt"]
 
     assert Hexpm.Store.get(:preview_bucket, "latest_versions/#{package.name}") == "2.0.0"

--- a/test/hexpm/security/updater_test.exs
+++ b/test/hexpm/security/updater_test.exs
@@ -48,7 +48,7 @@ defmodule Hexpm.Security.UpdaterTest do
   defp zip_body(advisories) do
     files =
       Enum.map(advisories, fn advisory ->
-        {String.to_charlist("#{advisory["id"]}.json"), Jason.encode!(advisory)}
+        {String.to_charlist("#{advisory["id"]}.json"), JSON.encode!(advisory)}
       end)
 
     {:ok, {_, zip}} = :zip.create(~c"all.zip", files, [:memory])

--- a/test/hexpm_web/captcha_test.exs
+++ b/test/hexpm_web/captcha_test.exs
@@ -6,8 +6,8 @@ defmodule HexpmWeb.CaptchaTest do
 
   setup :verify_on_exit!
 
-  @failure Jason.decode!(~s/{"success":false,"error-codes":["invalid-input-response"]}/)
-  @success Jason.decode!(~s/{"success":true}/)
+  @failure JSON.decode!(~s/{"success":false,"error-codes":["invalid-input-response"]}/)
+  @success JSON.decode!(~s/{"success":true}/)
 
   test "returns false for non-success response" do
     expect(

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -286,7 +286,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
         |> delete("/api/keys")
 
       assert conn.status == 200
-      body = Jason.decode!(conn.resp_body)
+      body = JSON.decode!(conn.resp_body)
       assert body["name"] == key_a.name
       assert body["revoke_at"]
       assert body["updated_at"]
@@ -319,7 +319,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
         |> get("/api/keys")
 
       assert conn.status == 401
-      body = Jason.decode!(conn.resp_body)
+      body = JSON.decode!(conn.resp_body)
       assert %{"message" => "API key revoked", "status" => 401} == body
     end
 
@@ -348,7 +348,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
         |> get("/api/keys/macbook")
 
       assert conn.status == 200
-      body = Jason.decode!(conn.resp_body)
+      body = JSON.decode!(conn.resp_body)
       assert body["name"] == "macbook"
       assert body["secret"] == nil
       assert body["url"] =~ "/api/keys/macbook"
@@ -374,7 +374,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
         |> delete("/api/keys/computer")
 
       assert conn.status == 200
-      body = Jason.decode!(conn.resp_body)
+      body = JSON.decode!(conn.resp_body)
       assert body["name"] == "computer"
       assert body["revoke_at"]
       assert body["updated_at"]
@@ -401,7 +401,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
         |> delete("/api/keys/current")
 
       assert conn.status == 200
-      body = Jason.decode!(conn.resp_body)
+      body = JSON.decode!(conn.resp_body)
       assert body["name"] == "current"
       assert body["revoke_at"]
       assert body["updated_at"]
@@ -423,7 +423,7 @@ defmodule HexpmWeb.API.KeyControllerTest do
         |> get("/api/keys")
 
       assert conn.status == 401
-      body = Jason.decode!(conn.resp_body)
+      body = JSON.decode!(conn.resp_body)
       assert %{"message" => "API key revoked", "status" => 401} == body
     end
   end

--- a/test/hexpm_web/controllers/error_page_test.exs
+++ b/test/hexpm_web/controllers/error_page_test.exs
@@ -54,7 +54,7 @@ defmodule HexpmWeb.ErrorPageTest do
       |> get("/nothing-here")
       |> response(404)
 
-    assert Jason.decode!(body) == %{"message" => "Page not found", "status" => 404}
+    assert JSON.decode!(body) == %{"message" => "Page not found", "status" => 404}
     refute body =~ ~s(<nav id="main-navbar")
     refute body =~ ~s(<!DOCTYPE html>)
   end

--- a/test/hexpm_web/controllers/preview_image_controller_test.exs
+++ b/test/hexpm_web/controllers/preview_image_controller_test.exs
@@ -17,7 +17,7 @@ defmodule HexpmWeb.PreviewImageControllerTest do
     Hexpm.Store.put(
       :preview_bucket,
       "#{prefix}file_lists/#{package.name}-1.0.0.json",
-      Jason.encode!(Enum.map(files, &elem(&1, 0)))
+      JSON.encode!(Enum.map(files, &elem(&1, 0)))
     )
 
     for {filename, contents} <- files do

--- a/test/hexpm_web/controllers/preview_raw_controller_test.exs
+++ b/test/hexpm_web/controllers/preview_raw_controller_test.exs
@@ -19,7 +19,7 @@ defmodule HexpmWeb.PreviewRawControllerTest do
     Hexpm.Store.put(
       :preview_bucket,
       "#{prefix}file_lists/#{package.name}-1.0.0.json",
-      Jason.encode!(Enum.map(files, &elem(&1, 0)))
+      JSON.encode!(Enum.map(files, &elem(&1, 0)))
     )
 
     for {filename, contents} <- files do

--- a/test/hexpm_web/controllers/readme_controller_test.exs
+++ b/test/hexpm_web/controllers/readme_controller_test.exs
@@ -18,7 +18,7 @@ defmodule HexpmWeb.ReadmeControllerTest do
     Hexpm.Store.put(
       :preview_bucket,
       "file_lists/#{package_name}-#{version}.json",
-      Jason.encode!([filename])
+      JSON.encode!([filename])
     )
 
     Hexpm.Store.put(:preview_bucket, "files/#{package_name}/#{version}/#{filename}", content)
@@ -28,7 +28,7 @@ defmodule HexpmWeb.ReadmeControllerTest do
     Hexpm.Store.put(
       :preview_bucket,
       "file_lists/#{package_name}-#{version}.json",
-      Jason.encode!(files)
+      JSON.encode!(files)
     )
   end
 
@@ -47,7 +47,7 @@ defmodule HexpmWeb.ReadmeControllerTest do
       Hexpm.Store.put(
         :preview_bucket,
         "repos/#{repository.name}/file_lists/#{package.name}-1.0.0.json",
-        Jason.encode!(["README.md"])
+        JSON.encode!(["README.md"])
       )
 
       Hexpm.Store.put(

--- a/test/hexpm_web/controllers/sitemap_controller_test.exs
+++ b/test/hexpm_web/controllers/sitemap_controller_test.exs
@@ -62,7 +62,7 @@ defmodule HexpmWeb.SitemapControllerTest do
     Hexpm.Store.put(
       :preview_bucket,
       "file_lists/#{package.name}-0.1.0.json",
-      Jason.encode!(["README.md", "docs/a & #<.html"])
+      JSON.encode!(["README.md", "docs/a & #<.html"])
     )
 
     conn =

--- a/test/hexpm_web/plugs/attack_test.exs
+++ b/test/hexpm_web/plugs/attack_test.exs
@@ -99,7 +99,7 @@ defmodule HexpmWeb.Plugs.AttackTest do
       assert conn.status == 429
 
       assert conn.resp_body ==
-               Jason.encode!(%{status: 429, message: "API rate limit exceeded for IP 1.1.1.1"})
+               JSON.encode!(%{status: 429, message: "API rate limit exceeded for IP 1.1.1.1"})
     end
 
     test "halts requests when user limit is exceeded", %{user: user} do
@@ -115,7 +115,7 @@ defmodule HexpmWeb.Plugs.AttackTest do
       assert conn.status == 429
 
       assert conn.resp_body ==
-               Jason.encode!(%{
+               JSON.encode!(%{
                  status: 429,
                  message: "API rate limit exceeded for user #{user.id}"
                })
@@ -167,7 +167,7 @@ defmodule HexpmWeb.Plugs.AttackTest do
 
       conn = request_ip({10, 1, 1, 1})
       assert conn.status == 403
-      assert conn.resp_body == Jason.encode!(%{status: 403, message: "Blocked"})
+      assert conn.resp_body == JSON.encode!(%{status: 403, message: "Blocked"})
     end
 
     test "halts requests from IPs that are blocked outside of /api" do
@@ -176,7 +176,7 @@ defmodule HexpmWeb.Plugs.AttackTest do
 
       conn = %{request_ip({10, 1, 1, 1}) | request_path: "/"}
       assert conn.status == 403
-      assert conn.resp_body == Jason.encode!(%{status: 403, message: "Blocked"})
+      assert conn.resp_body == JSON.encode!(%{status: 403, message: "Blocked"})
     end
 
     test "halts requests from IP masks that are blocked" do
@@ -185,15 +185,15 @@ defmodule HexpmWeb.Plugs.AttackTest do
 
       conn = request_ip({10, 1, 1, 1})
       assert conn.status == 403
-      assert conn.resp_body == Jason.encode!(%{status: 403, message: "Blocked"})
+      assert conn.resp_body == JSON.encode!(%{status: 403, message: "Blocked"})
 
       conn = request_ip({10, 1, 1, 127})
       assert conn.status == 403
-      assert conn.resp_body == Jason.encode!(%{status: 403, message: "Blocked"})
+      assert conn.resp_body == JSON.encode!(%{status: 403, message: "Blocked"})
 
       conn = request_ip({10, 1, 1, 255})
       assert conn.status == 403
-      assert conn.resp_body == Jason.encode!(%{status: 403, message: "Blocked"})
+      assert conn.resp_body == JSON.encode!(%{status: 403, message: "Blocked"})
 
       conn = request_ip({10, 1, 2, 0})
       assert conn.status == 200
@@ -208,7 +208,7 @@ defmodule HexpmWeb.Plugs.AttackTest do
 
       conn = request_ip({20, 2, 2, 2})
       assert conn.status == 403
-      assert conn.resp_body == Jason.encode!(%{status: 403, message: "Blocked"})
+      assert conn.resp_body == JSON.encode!(%{status: 403, message: "Blocked"})
 
       Hexpm.Repo.delete!(blocked_address)
       Hexpm.BlockAddress.reload()

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -93,7 +93,7 @@ defmodule HexpmWeb.ConnCase do
   def json_post(conn, path, params) do
     conn
     |> Plug.Conn.put_req_header("content-type", "application/json")
-    |> Phoenix.ConnTest.dispatch(HexpmWeb.Endpoint, :post, path, Jason.encode!(params))
+    |> Phoenix.ConnTest.dispatch(HexpmWeb.Endpoint, :post, path, JSON.encode!(params))
   end
 
   def mock_captcha_success(_context \\ %{}) do


### PR DESCRIPTION
Use Elixir's built-in `JSON` module throughout Hexpm's application code, framework and service configuration, and tests. Remove the direct Jason dependency; Jason remains transitively resolved for dependencies that still require it.