### PR TITLE
Remove obscured live package filtering on mobile

### DIFF
--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -227,7 +227,6 @@ defmodule HexpmWeb.Components.Navbar do
           role="search"
           action={~p"/packages"}
           class="flex-1"
-          phx-change={if @live_search, do: "search_change"}
           phx-submit={@live_search && "search_submit"}
           phx-hook={@live_search && "FormSync"}
           data-sync-to={@live_search && "mobile-menu-search-form"}
@@ -241,7 +240,6 @@ defmodule HexpmWeb.Components.Navbar do
               name="search"
               type="text"
               value={@search}
-              phx-debounce={if @live_search, do: "300"}
               placeholder="Find packages..."
               class="w-full bg-grey-800 border border-grey-600 rounded-lg px-3 pl-10 py-[11px] text-white text-base font-medium leading-4 placeholder:text-grey-300 focus:outline-none focus:border-grey-500 focus:shadow-[inset_0px_0px_6px_0px_rgba(255,255,255,0.3)]"
             />
@@ -276,7 +274,6 @@ defmodule HexpmWeb.Components.Navbar do
             role="search"
             action={~p"/packages"}
             class="flex-1"
-            phx-change={if @live_search, do: "search_change"}
             phx-submit={@live_search && "search_submit"}
             phx-hook={@live_search && "FormSync"}
             data-sync-to={@live_search && "mobile-search-bar-form"}
@@ -290,7 +287,6 @@ defmodule HexpmWeb.Components.Navbar do
                 name="search"
                 type="text"
                 value={@search}
-                phx-debounce={if @live_search, do: "300"}
                 placeholder="Find packages..."
                 class="w-full bg-grey-800 border border-grey-600 rounded-lg px-3 pl-10 py-[11px] text-white text-base font-medium leading-4 placeholder:text-grey-300 focus:outline-none focus:border-grey-500 focus:shadow-[inset_0px_0px_6px_0px_rgba(255,255,255,0.3)]"
               />

--- a/lib/hexpm_web/live/package_live/index.ex
+++ b/lib/hexpm_web/live/package_live/index.ex
@@ -381,21 +381,6 @@ defmodule HexpmWeb.PackageLive.Index do
   end
 
   @impl true
-  def handle_event("search_change", %{"search" => search}, socket) do
-    search = nil_if_empty(search)
-
-    if search == socket.assigns.search do
-      {:noreply, socket}
-    else
-      url_params =
-        %{sort: socket.assigns.sort, search: search}
-        |> Enum.reject(fn {_k, v} -> is_nil(v) end)
-
-      {:noreply, push_patch(socket, to: ~p"/packages?#{url_params}")}
-    end
-  end
-
-  @impl true
   def handle_event("search_submit", %{"search" => search}, socket) do
     search = nil_if_empty(search)
 

--- a/test/hexpm_web/live/package_live/index_test.exs
+++ b/test/hexpm_web/live/package_live/index_test.exs
@@ -234,17 +234,5 @@ defmodule HexpmWeb.PackageLive.IndexTest do
 
       refute_patched(view)
     end
-
-    test "does not reset page when search change event is triggered with the same search term", %{
-      conn: conn
-    } do
-      {:ok, view, _html} = live(conn, ~p"/packages?page=2&search=phoenix_test_pkg")
-
-      view
-      |> form("#mobile-search-bar-form", %{"search" => "phoenix_test_pkg"})
-      |> render_change()
-
-      refute_patched(view)
-    end
   end
 end


### PR DESCRIPTION
On mobile devices, typing in the search input triggered real-time package filtering on every debounced keystroke. However, physical mobile keyboards obscure the main content area, rendering the real-time feedback useless while sending unnecessary queries.

Mobile search now relies exclusively on explicit form submission.

## Summary

Closes #1699.

## Testing

Manually verified that search still works after explicit form submission.