### PR TITLE
Hide mobile soft keyboard on search form submission

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -64,6 +64,11 @@ let liveSocket = new LiveSocket("/live", Socket, {
 liveSocket.connect();
 initializeTheme();
 
+// Blur the active element on demand
+window.addEventListener("blur-active", () => {
+  document.activeElement?.blur();
+});
+
 // Focus username, 2FA or search field
 if (document.getElementById("username")) {
   document.getElementById("username").focus();

--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -227,7 +227,7 @@ defmodule HexpmWeb.Components.Navbar do
           role="search"
           action={~p"/packages"}
           class="flex-1"
-          phx-submit={@live_search && "search_submit"}
+          phx-submit={@live_search && search_submit()}
           phx-hook={@live_search && "FormSync"}
           data-sync-to={@live_search && "mobile-menu-search-form"}
         >
@@ -274,7 +274,7 @@ defmodule HexpmWeb.Components.Navbar do
             role="search"
             action={~p"/packages"}
             class="flex-1"
-            phx-submit={@live_search && "search_submit"}
+            phx-submit={@live_search && search_submit()}
             phx-hook={@live_search && "FormSync"}
             data-sync-to={@live_search && "mobile-search-bar-form"}
             phx-auto-recover={if @live_search, do: "ignore"}
@@ -455,6 +455,11 @@ defmodule HexpmWeb.Components.Navbar do
     |> JS.show(to: "#menu-open-icon")
     |> JS.hide(to: "#menu-close-icon")
     |> JS.focus(to: "#mobile-search-input")
+  end
+
+  defp search_submit do
+    JS.dispatch("blur-active")
+    |> JS.push("search_submit")
   end
 
   @doc """


### PR DESCRIPTION
## Summary

When submitting the package search form on mobile, the virtual keyboard briefly dismissed then reappeared, obscuring the new search results.

This occurs because Phoenix LiveView's form submission pipeline unconditionally captures the active element before pushing the event to the server, and restores focus to it once the patch roundtrip completes.

To resolve this UX issue, we dispatch a client-side `"blur-active"` custom event to blur the focused input. Crucially, the JS commands must be chained with `JS.dispatch("blur-active")` preceding `JS.push("search_submit")`. This ensures the input is synchronously blurred and `document.activeElement` is reset to `document.body` before LiveView captures and stores the focus for subsequent restoration.

## Testing

Run dev server, test on real mobile device (Chrome on Android), observe that after submitting the form the keyboard doesn't reappear, making the search results immediately visible on screen.