### PR TITLE
Disable keyboard auto-capitalization on mobile search inputs

### DIFF
--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -240,6 +240,10 @@ defmodule HexpmWeb.Components.Navbar do
               name="search"
               type="text"
               value={@search}
+              autocomplete="off"
+              autocapitalize="none"
+              autocorrect="off"
+              spellcheck="false"
               placeholder="Find packages..."
               class="w-full bg-grey-800 border border-grey-600 rounded-lg px-3 pl-10 py-[11px] text-white text-base font-medium leading-4 placeholder:text-grey-300 focus:outline-none focus:border-grey-500 focus:shadow-[inset_0px_0px_6px_0px_rgba(255,255,255,0.3)]"
             />
@@ -287,6 +291,10 @@ defmodule HexpmWeb.Components.Navbar do
                 name="search"
                 type="text"
                 value={@search}
+                autocomplete="off"
+                autocapitalize="none"
+                autocorrect="off"
+                spellcheck="false"
                 placeholder="Find packages..."
                 class="w-full bg-grey-800 border border-grey-600 rounded-lg px-3 pl-10 py-[11px] text-white text-base font-medium leading-4 placeholder:text-grey-300 focus:outline-none focus:border-grey-500 focus:shadow-[inset_0px_0px_6px_0px_rgba(255,255,255,0.3)]"
               />


### PR DESCRIPTION
## Summary

Mobile keyboards by default capitalize the first letter of search terms. Since package names on Hex are lowercase, searching starts capitalized, requiring the user to manually switch to lowercase.

Disable autocapitalize, autocorrect, and spellcheck on the mobile search inputs to start the virtual keyboard in lowercase mode and match the desktop search input behavior.

## Testing

Run dev server, test on real mobile device (Chrome on Android), observe that keyboard starts with lowercase input.
