### PR TITLE
Use search input type on mobile search inputs

### DIFF
--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -238,7 +238,7 @@ defmodule HexpmWeb.Components.Navbar do
             <input
               id="mobile-search-input"
               name="search"
-              type="text"
+              type="search"
               value={@search}
               autocomplete="off"
               autocapitalize="none"
@@ -289,7 +289,7 @@ defmodule HexpmWeb.Components.Navbar do
               </div>
               <input
                 name="search"
-                type="text"
+                type="search"
                 value={@search}
                 autocomplete="off"
                 autocapitalize="none"


### PR DESCRIPTION
## Summary

Change the input type from `text` to `search` on the mobile search fields.

This prompts mobile browsers to natively render a clear ("X") button inside the search field when text is present, allowing mobile users to quickly clear their query and start over.

This also matches the desktop search form and is the semantic form field type in HTML5.

## Testing

Check on a mobile device/simulator that querying a new package is easier by clicking the standard "x" button to clear the current query before typing the new one, instead of having to deal with text selection or soft keyboard backspace.

### Before

<img width="400" height="132" alt="hex.pm before" src="https://github.com/user-attachments/assets/c1f94e8d-5ae8-47e0-a647-37ec5b4d1b4e" />

### After

<img width="400" height="132" alt="hex.pm after" src="https://github.com/user-attachments/assets/43d59bcd-6e4d-4d2c-8b07-d291bcba675a" />

