### PR TITLE
Build the mdex_native NIF from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt update && \
     apt install -y --no-install-recommends git build-essential curl ca-certificates && \
     apt clean -y && rm -rf /var/lib/apt/lists/*
 
-# install rust, the lumis NIF is built from source
+# install rust, the lumis and mdex_native NIFs are built from source
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal --default-toolchain stable
 ENV PATH="/root/.cargo/bin:${PATH}"
 
@@ -20,6 +20,10 @@ ENV PATH="/root/.cargo/bin:${PATH}"
 # macros violate strict aliasing, which gcc -O2 miscompiles into heap
 # corruption (tree-sitter/tree-sitter-haskell#144)
 ENV CFLAGS="-fno-strict-aliasing"
+
+# mdex_native links its own copy of the grammars, and its precompiled NIF is
+# built without the flag above
+ENV MDEX_NATIVE_BUILD=1
 
 # prepare build dir
 RUN mkdir /app


### PR DESCRIPTION
The precompiled mdex_native NIF links its own copy of the tree-sitter grammars, built upstream without `-fno-strict-aliasing`. The `CFLAGS` we set in #1749 only reached the lumis NIF, which we build from source, so the README rendering path kept corrupting the glibc heap and aborting the VM.

That's what's been restarting the web pods. Every abort in Cloud Logging is preceded by a 502 on `readme.hex.pm` for a package whose README has a Haskell code fence (`lamblichus/0.1.0`, `type_class/1.2.8`, `doma_type_class/1.2.9-quiet` and `1.2.11-blazing`, `type_class_goo/1.21.1`). GCLB retries the failed GET onto a second pod, which is why the restarts always come in pairs.

Verified by building both images for linux/arm64 and rendering those five READMEs through `HexpmWeb.Readme.Renderer`. Before: `corrupted size vs. prev_size` and exit 133 on the first render. After: 50 renders clean.

The cost is compiling comrak and the grammars instead of downloading them. On a 4 core arm runner `mix deps.compile` goes from 52s to 89s, and only on builds that miss the deps layer cache. Warm builds are unaffected.

This can come out once mdex_native ships a release built against lumis 0.12.1, which carries the real fix (leandrocp/lumis#1086).