### PR TITLE
Count OAuth signups

### DIFF
--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -750,6 +750,7 @@ defmodule Hexpm.Accounts.Users do
           |> Mailer.deliver!()
         end
 
+        :telemetry.execute([:hexpm, :accounts, :user_created], %{count: 1}, %{})
         {:ok, user}
 
       {:error, :user, changeset, _} ->

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -140,6 +140,24 @@ defmodule Hexpm.Accounts.UsersTest do
 
       refute Users.get(username)
     end
+
+    test "counts the new account" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:hexpm, :accounts, :user_created]])
+
+      {:ok, _user} =
+        Users.add_from_oauth_with_provider(
+          Hexpm.Fake.sequence(:username),
+          Hexpm.Fake.sequence(:full_name),
+          Hexpm.Fake.sequence(:email),
+          "github",
+          "12345",
+          audit: %{user: nil, user_agent: "TEST", remote_ip: "127.0.0.1", auth_credential: nil}
+        )
+
+      assert_received {[:hexpm, :accounts, :user_created], ^ref, %{count: 1}, %{}}
+
+      :telemetry.detach(ref)
+    end
   end
 
   test "new users default to optional email preferences" do


### PR DESCRIPTION
The `New users` panels on the Activity dashboard undercount: `add_from_oauth_with_provider/6` never emitted the event, only `add/2` did, so every account created through GitHub was invisible to them.

Of the 66 rows added to `users` in the last week, 40 were GitHub signups, 24 came through the password form and 2 are organization accounts.