### PR TITLE
Ask about advisories for the releases that show them

### DIFF
--- a/lib/hexpm/repository/release.ex
+++ b/lib/hexpm/repository/release.ex
@@ -238,29 +238,23 @@ defmodule Hexpm.Repository.Release do
   defp to_version(version) when is_binary(version), do: Version.parse!(version)
 
   def all(package) do
-    package
-    |> assoc(:releases)
-    |> with_vulnerable()
+    assoc(package, :releases)
   end
 
   def sort(releases) do
     Enum.sort(releases, &(Version.compare(&1.version, &2.version) == :gt))
   end
 
-  def with_vulnerable(query) do
-    from(release in query,
-      as: :release,
-      select_merge: %{
-        vulnerable?:
-          exists(
-            from(saar in "security_advisory_affected_releases",
-              join: a in Hexpm.Security.Advisory,
-              on: a.id == saar.advisory_id,
-              where: saar.release_id == parent_as(:release).id and is_nil(a.withdrawn_at),
-              select: 1
-            )
-          )
-      }
+  @doc """
+  The ids, among the given ones, that a published advisory affects.
+  """
+  def vulnerable_ids(release_ids) do
+    from(saar in "security_advisory_affected_releases",
+      join: a in Hexpm.Security.Advisory,
+      on: a.id == saar.advisory_id,
+      where: saar.release_id in ^release_ids and is_nil(a.withdrawn_at),
+      distinct: true,
+      select: saar.release_id
     )
   end
 

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -11,6 +11,30 @@ defmodule Hexpm.Repository.Releases do
     |> Release.sort()
   end
 
+  @doc """
+  Sets `vulnerable?` on the given releases.
+
+  Only the pages that display the flag call this, and only for the releases they
+  display. Asking per release inside the query that loads them costs an index
+  probe each, which is most of that query's work and answers no for all but one
+  release in a hundred.
+  """
+  def mark_vulnerable([]), do: []
+
+  def mark_vulnerable(releases) do
+    vulnerable =
+      releases
+      |> Enum.map(& &1.id)
+      |> Release.vulnerable_ids()
+      |> Repo.all()
+      |> MapSet.new()
+
+    Enum.map(releases, &%{&1 | vulnerable?: MapSet.member?(vulnerable, &1.id)})
+  end
+
+  def mark_vulnerable_one(nil), do: nil
+  def mark_vulnerable_one(release), do: hd(mark_vulnerable([release]))
+
   def count() do
     Repo.one!(Release.count())
   end

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -115,7 +115,13 @@ defmodule HexpmWeb.PackageController do
       total_count = Enum.count(releases)
       page = Hexpm.Utils.safe_page(page_param, total_count, per_page)
       current_release = current_release(releases)
-      paginated_releases = paginate_list(releases, page, per_page)
+
+      # The versions table marks every vulnerable row, but only the page being
+      # shown, not all of a package's releases.
+      paginated_releases =
+        releases
+        |> paginate_list(page, per_page)
+        |> Releases.mark_vulnerable()
 
       render(
         conn,

--- a/lib/hexpm_web/package_layout_assigns.ex
+++ b/lib/hexpm_web/package_layout_assigns.ex
@@ -92,14 +92,19 @@ defmodule HexpmWeb.PackageLayoutAssigns do
   defp current_user(%Plug.Conn{} = conn), do: conn.assigns.current_user
   defp current_user(user), do: user
 
+  # The layout shows a security banner for the release on screen, so that one
+  # release needs its vulnerable? flag and none of the others do.
   defp resolve_current_release(nil, releases) do
     case Release.latest_version(releases, only_stable: true, unstable_fallback: true) do
       nil -> nil
       release -> Releases.preload(release, [:requirements, :downloads, :publisher])
     end
+    |> Releases.mark_vulnerable_one()
   end
 
-  defp resolve_current_release(release, _releases), do: release
+  defp resolve_current_release(release, _releases) do
+    Releases.mark_vulnerable_one(release)
+  end
 
   defp daily_graph(package_or_release) do
     last_day = Hexpm.Cache.fetch(:last_download_day, &Downloads.last_day/0) || Date.utc_today()

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -64,6 +64,79 @@ defmodule Hexpm.Repository.ReleasesTest do
     end
   end
 
+  describe "mark_vulnerable/1" do
+    setup do
+      package = insert(:package, name: "advised")
+      affected = insert(:release, package: package, version: "1.0.0")
+      unaffected = insert(:release, package: package, version: "1.0.1")
+      withdrawn = insert(:release, package: package, version: "1.0.2")
+
+      # One upsert for both: it treats an advisory missing from the records it
+      # is given as gone from the feed and deletes it.
+      advise(package, [
+        {"GHSA-published", "1.0.0", nil},
+        {"GHSA-withdrawn", "1.0.2", ~U[2024-01-01 00:00:00Z]}
+      ])
+
+      %{package: package, affected: affected, unaffected: unaffected, withdrawn: withdrawn}
+    end
+
+    test "flags the releases a published advisory affects", %{
+      package: package,
+      affected: affected,
+      unaffected: unaffected
+    } do
+      flags = vulnerable_by_id(package)
+
+      assert flags[affected.id]
+      refute flags[unaffected.id]
+    end
+
+    test "leaves a release only a withdrawn advisory affects alone", %{
+      package: package,
+      withdrawn: withdrawn
+    } do
+      refute vulnerable_by_id(package)[withdrawn.id]
+    end
+
+    test "all/1 on its own reports nothing vulnerable", %{
+      package: package,
+      affected: affected
+    } do
+      release = Enum.find(Releases.all(package), &(&1.id == affected.id))
+
+      refute release.vulnerable?
+    end
+  end
+
+  defp vulnerable_by_id(package) do
+    package
+    |> Releases.all()
+    |> Releases.mark_vulnerable()
+    |> Map.new(&{&1.id, &1.vulnerable?})
+  end
+
+  defp advise(package, advisories) do
+    records =
+      Enum.map(advisories, fn {id, version, withdrawn_at} ->
+        %{
+          id: id,
+          summary: "summary",
+          aliases: [],
+          published_at: ~U[2024-01-01 00:00:00Z],
+          modified_at: ~U[2024-01-01 00:00:00Z],
+          withdrawn_at: withdrawn_at,
+          cvss_vector: nil,
+          cvss_score: nil,
+          cvss_rating: nil,
+          references: [],
+          affected: [%{package: package.name, requirements: [], versions: [version]}]
+        }
+      end)
+
+    {:ok, _} = Hexpm.Security.Advisories.upsert(records, %{package.name => package.id})
+  end
+
   describe "latest_version/3" do
     test "prefers stable releases and falls back to prereleases" do
       stable_package = insert(:package, name: "stable_preview")

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -226,6 +226,17 @@ defmodule HexpmWeb.PackageControllerTest do
   end
 
   describe "GET /packages/:name" do
+    test "banners the release on screen when an advisory affects it", %{package1: package1} do
+      advise(package1, "GHSA-current-release", "0.0.2")
+
+      # 0.0.2 is the latest stable, so it is what the package page opens on.
+      assert response(get(build_conn(), "/packages/#{package1.name}"), 200) =~
+               "This version has known vulnerabilities"
+
+      refute response(get(build_conn(), "/packages/#{package1.name}/0.0.1"), 200) =~
+               "This version has known vulnerabilities"
+    end
+
     test "show package", %{package1: package1} do
       conn = get(build_conn(), "/packages/#{package1.name}")
       html = response(conn, 200)
@@ -556,6 +567,16 @@ defmodule HexpmWeb.PackageControllerTest do
       assert response(conn, 404)
     end
 
+    test "marks the versions an advisory affects", %{package1: package1, package2: package2} do
+      advise(package1, "GHSA-versions-page", "0.0.1")
+
+      assert response(get(build_conn(), "/packages/#{package1.name}/versions"), 200) =~
+               "Vulnerable"
+
+      refute response(get(build_conn(), "/packages/#{package2.name}/versions"), 200) =~
+               "Vulnerable"
+    end
+
     test "returns 404 for private package without auth", %{
       package3: package3,
       repository1: repository1
@@ -858,6 +879,24 @@ defmodule HexpmWeb.PackageControllerTest do
   defp escape(html) do
     {:safe, safe} = Phoenix.HTML.html_escape(html)
     IO.iodata_to_binary(safe)
+  end
+
+  defp advise(package, id, version) do
+    record = %{
+      id: id,
+      summary: "summary",
+      aliases: [],
+      published_at: ~U[2024-01-01 00:00:00Z],
+      modified_at: ~U[2024-01-01 00:00:00Z],
+      withdrawn_at: nil,
+      cvss_vector: nil,
+      cvss_score: nil,
+      cvss_rating: nil,
+      references: [],
+      affected: [%{package: package.name, requirements: [], versions: [version]}]
+    }
+
+    {:ok, _} = Hexpm.Security.Advisories.upsert([record], %{package.name => package.id})
   end
 
   defp add_dependant(package, name) do


### PR DESCRIPTION
`Releases.all/1` annotated every release it loaded with `vulnerable?`, and that annotation is a correlated subquery, so loading a package's releases did one index probe per release. It's the heaviest statement in the production database:

| | calls | total | mean | rows/call | blocks/call |
|---|---|---|---|---|---|
| with the annotation | 56.7M | 25.9 h | 1.64 ms | 99.8 | 172.3 |
| the same shape without it | 33.9M | 2.4 h | 0.26 ms | 38.6 | 38.5 |

18% of all execution time since the last stats reset. Not a missing index: `security_advisory_affected_releases_release_id_index` exists and the plan uses it, everything is cached (9.8 billion buffer hits against 20,972 disk reads), and the probe is about as cheap as a probe gets. `EXPLAIN` on a 101-release package puts 41 buffers on fetching the releases and 202 on annotating them.

The flag is read in two places: the versions table marks each vulnerable row, and the package layout banners the one release on screen. Every other caller of `Releases.all/1` — readme, previews, preview_raw, diffs, package reports, the organization dashboard, and six of the seven package controller actions — computed it and threw it away.

So the two callers that show it now ask for it, over the releases they show rather than over all of a package's: a page of a hundred versions, or the single release behind the banner. `Releases.mark_vulnerable/1` is one query with `release_id = ANY($1)` against the same index instead of a probe per row, so the package with 2,921 releases stops doing 2,921 probes to render a page of a hundred.

Almost all of that probing was answering no. 2,994 of 255,417 releases have an advisory against them, and 192 of the 194 advisories are not withdrawn, so the join to `security_advisories` that made it a correlated subquery in the first place was excluding two rows.

I tried keeping it in one query — hashing the whole table once per query, scoping the subquery to the package's release ids, dropping the advisory join — and measured all three against prod. None of them beat the per-row probe on a typical package. The win is in not asking.

`mix test` is green: 2,316 tests, 28 properties, 0 failures. Five new ones cover `mark_vulnerable/1` (a published advisory flags, a withdrawn one does not, `all/1` on its own reports nothing), the versions page rendering the badge for an advised package and not for an unadvised one, and the layout banner appearing for the release on screen but not for an unaffected version.