### PR TITLE
Keep failed jobs, stop keeping every successful one for a month

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -55,6 +55,8 @@ config :hexpm, Oban,
        {"0 2 * * *", Hexpm.ReleaseTasks.PurgeExpiredRecords}
      ],
      timezone: "Etc/UTC"},
-    {Oban.Plugins.Pruner, max_age: 30 * 24 * 60 * 60},
+    # Successful jobs are read by nobody and are the bulk of the table, which
+    # Oban's queue length metric counts on a timer. Failures are worth keeping.
+    {Hexpm.Oban.Pruner, max_age: 3 * 24 * 60 * 60, discarded_max_age: 365 * 24 * 60 * 60},
     {Oban.Plugins.Lifeline, interval: 60_000, rescue_after: 360_000}
   ]

--- a/lib/hexpm/oban/pruner.ex
+++ b/lib/hexpm/oban/pruner.ex
@@ -1,0 +1,146 @@
+defmodule Hexpm.Oban.Pruner do
+  @moduledoc """
+  Prunes finished Oban jobs, keeping the ones that failed for longer.
+
+  `Oban.Plugins.Pruner` takes one age for every finished state, so keeping a
+  failure around long enough to audit means keeping every successful job for
+  just as long. Successes are the bulk of the table and nobody reads them:
+  hexpm completes around eight thousand jobs a day and discards twenty.
+
+  That matters because Oban's queue length metric counts the whole table on a
+  timer, from every node. Against thirty days of completed jobs that is a
+  sequential scan of a hundred and seventy megabytes, and it was the single
+  largest consumer of database time on the instance.
+  """
+
+  @behaviour Oban.Plugin
+
+  use GenServer
+
+  import Ecto.Query, only: [where: 3, or_where: 3, limit: 2, select: 2, join: 5]
+
+  alias Oban.{Job, Peer, Plugin, Repo, Validation}
+
+  require Logger
+
+  defstruct [
+    :conf,
+    :timer,
+    interval: :timer.seconds(30),
+    limit: 10_000,
+    max_age: :timer.hours(24 * 3) |> div(1000),
+    discarded_max_age: :timer.hours(24 * 365) |> div(1000)
+  ]
+
+  @doc false
+  @spec child_spec(Keyword.t()) :: Supervisor.child_spec()
+  def child_spec(opts), do: super(opts)
+
+  @impl Plugin
+  def start_link(opts) do
+    {name, opts} = Keyword.pop(opts, :name)
+
+    GenServer.start_link(__MODULE__, struct!(__MODULE__, opts), name: name)
+  end
+
+  @impl Plugin
+  def validate(opts) do
+    Validation.validate_schema(opts,
+      conf: :any,
+      name: :any,
+      interval: :pos_integer,
+      limit: :pos_integer,
+      max_age: :pos_integer,
+      discarded_max_age: :pos_integer
+    )
+  end
+
+  @impl Plugin
+  def format_logger_output(_conf, meta), do: Map.take(meta, [:pruned_count])
+
+  @impl GenServer
+  def init(state) do
+    Process.flag(:trap_exit, true)
+
+    :telemetry.execute([:oban, :plugin, :init], %{}, %{conf: state.conf, plugin: __MODULE__})
+
+    {:ok, schedule_prune(state)}
+  end
+
+  @impl GenServer
+  def terminate(_reason, state) do
+    if is_reference(state.timer), do: Process.cancel_timer(state.timer)
+
+    :ok
+  end
+
+  @impl GenServer
+  def handle_info(:prune, %__MODULE__{} = state) do
+    meta = %{conf: state.conf, plugin: __MODULE__}
+
+    :telemetry.span([:oban, :plugin], meta, fn ->
+      case prune(state) do
+        {:ok, extra} when is_map(extra) -> {:ok, Map.merge(meta, extra)}
+        error -> {:error, Map.put(meta, :error, error)}
+      end
+    end)
+
+    {:noreply, schedule_prune(state)}
+  end
+
+  def handle_info(message, state) do
+    Logger.warning("Hexpm.Oban.Pruner received an unexpected message: #{inspect(message)}")
+
+    {:noreply, state}
+  end
+
+  defp schedule_prune(state) do
+    %{state | timer: Process.send_after(self(), :prune, state.interval)}
+  end
+
+  defp prune(state) do
+    if Peer.leader?(state.conf) do
+      Repo.transaction(state.conf, fn -> prune_jobs(state) end, on_exhausted: :log)
+    else
+      {:ok, %{pruned_count: 0, pruned_succeeded: 0, pruned_failed: 0}}
+    end
+  end
+
+  @doc false
+  def prune_jobs(%__MODULE__{} = state) do
+    # Oban ages each state by the column it sets on entering it, and a completed
+    # job's is scheduled_at rather than a completed_at.
+    succeeded =
+      delete(state, state.max_age, fn query, cutoff ->
+        query
+        |> where([j], j.state == "completed" and j.scheduled_at < ^cutoff)
+        |> or_where([j], j.state == "cancelled" and j.cancelled_at < ^cutoff)
+      end)
+
+    failed =
+      delete(state, state.discarded_max_age, fn query, cutoff ->
+        where(query, [j], j.state == "discarded" and j.discarded_at < ^cutoff)
+      end)
+
+    %{pruned_count: succeeded + failed, pruned_succeeded: succeeded, pruned_failed: failed}
+  end
+
+  # Deleting through a limited subquery keeps a backlog from turning into one
+  # statement that runs past the query timeout.
+  defp delete(state, max_age, filter) do
+    cutoff = DateTime.add(DateTime.utc_now(), -max_age)
+
+    subquery =
+      Job
+      |> select([:id])
+      |> filter.(cutoff)
+      |> where([j], not is_nil(j.queue))
+      |> limit(^state.limit)
+
+    query = join(Job, :inner, [j], x in subquery(subquery), on: j.id == x.id)
+
+    {count, _} = Repo.delete_all(state.conf, query)
+
+    count
+  end
+end

--- a/lib/hexpm/prom_ex.ex
+++ b/lib/hexpm/prom_ex.ex
@@ -10,7 +10,10 @@ defmodule Hexpm.PromEx do
       Plugins.Beam,
       {Plugins.Phoenix, router: HexpmWeb.Router, endpoint: HexpmWeb.Endpoint},
       {Plugins.Ecto, repos: [Hexpm.RepoBase]},
-      Plugins.Oban,
+      # Queue lengths come from counting the jobs table, which every node does
+      # on its own timer, so the default five seconds is a scan per node per
+      # five seconds for a number that does not move that fast.
+      {Plugins.Oban, poll_rate: :timer.minutes(1)},
       Hexpm.PromEx.Plugins.Hexpm,
       Hexpm.PromEx.Plugins.OutboundHttp
     ]

--- a/test/hexpm/oban/pruner_test.exs
+++ b/test/hexpm/oban/pruner_test.exs
@@ -1,0 +1,85 @@
+defmodule Hexpm.Oban.PrunerTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.Oban.Pruner
+
+  @day 24 * 60 * 60
+
+  defp job(state, age_in_days) do
+    at = DateTime.add(DateTime.utc_now(), -age_in_days * @day)
+
+    finished =
+      case state do
+        "completed" -> [completed_at: at]
+        "cancelled" -> [cancelled_at: at]
+        "discarded" -> [discarded_at: at]
+        _ -> []
+      end
+
+    Hexpm.Repo.insert!(
+      struct!(
+        Oban.Job,
+        [
+          worker: "Fake",
+          queue: "periodic",
+          args: %{},
+          state: state,
+          inserted_at: at,
+          scheduled_at: at
+        ] ++ finished
+      )
+    )
+  end
+
+  defp prune(opts) do
+    opts
+    |> Keyword.put(:conf, Oban.config(Oban))
+    |> then(&struct!(Pruner, &1))
+    |> Pruner.prune_jobs()
+  end
+
+  defp states() do
+    from(j in Oban.Job, select: {j.state, count(j.id)}, group_by: j.state)
+    |> Hexpm.Repo.all()
+    |> Map.new()
+  end
+
+  describe "prune_jobs/1" do
+    test "keeps failures for longer than successes" do
+      job("completed", 5)
+      job("cancelled", 5)
+      job("discarded", 5)
+      job("completed", 1)
+      job("discarded", 400)
+
+      assert %{pruned_succeeded: 2, pruned_failed: 1} =
+               prune(max_age: 3 * @day, discarded_max_age: 365 * @day)
+
+      # The five day old success and cancellation go, the five day old failure
+      # stays, and only the failure older than a year goes with them.
+      assert states() == %{"completed" => 1, "discarded" => 1}
+    end
+
+    test "leaves jobs that have not finished alone" do
+      for state <- ~w(available scheduled executing retryable), do: job(state, 400)
+
+      prune(max_age: 1, discarded_max_age: 1)
+
+      assert states() == %{
+               "available" => 1,
+               "scheduled" => 1,
+               "executing" => 1,
+               "retryable" => 1
+             }
+    end
+
+    test "deletes no more than the limit in one pass" do
+      for _ <- 1..5, do: job("completed", 5)
+
+      assert %{pruned_count: 2} =
+               prune(max_age: 3 * @day, discarded_max_age: 365 * @day, limit: 2)
+
+      assert states() == %{"completed" => 3}
+    end
+  end
+end

--- a/test/hexpm/oban_config_test.exs
+++ b/test/hexpm/oban_config_test.exs
@@ -69,7 +69,7 @@ defmodule Hexpm.ObanConfigTest do
     end
   end
 
-  test "production schedules periodic work and retains completed jobs for thirty days" do
+  test "production schedules periodic work and keeps failures far longer than successes" do
     prod = Config.Reader.read!("config/prod.exs", env: :prod)
     oban = prod[:hexpm][Oban]
 
@@ -89,7 +89,10 @@ defmodule Hexpm.ObanConfigTest do
              {"0 2 * * *", Hexpm.ReleaseTasks.PurgeExpiredRecords}
            ]
 
-    assert {Oban.Plugins.Pruner, [max_age: 2_592_000]} in oban[:plugins]
+    assert {Hexpm.Oban.Pruner, [max_age: 259_200, discarded_max_age: 31_536_000]} in oban[
+             :plugins
+           ]
+
     assert {Oban.Plugins.Lifeline, [interval: 60_000, rescue_after: 360_000]} in oban[:plugins]
   end
 end


### PR DESCRIPTION
Counting the Oban jobs table is the largest consumer of database time on the instance:

```
Parallel Seq Scan on oban_jobs  (rows=75917, loops=3)
  Buffers: shared hit=13091
Execution Time: 132 ms
```

170,517 calls, 115 ms mean, **5.45 hours**, 12,385 buffers each. PromEx polls queue lengths every five seconds from every node, so roughly 1.5 of those a second, and what it scans is 227,424 completed jobs against 254 discarded.

`Oban.Plugins.Pruner` takes a single `max_age` for every finished state, so keeping a failure around long enough to audit means keeping a month of successes nobody reads. `Hexpm.Oban.Pruner` takes an age per state: three days for `completed` and `cancelled`, a year for `discarded`. hexpm completes around 8,000 jobs a day and discards 20, so that leaves roughly 25,000 rows instead of 227,678 while making failures outlive successes by a factor of 120.

I measured the effect by building a temp table pruned that far back and counting it the same way:

| | rows | size | time | buffers |
|---|---|---|---|---|
| now | 227,678 | 174 MB | 132 ms | 13,091 |
| pruned to 3 days | 8,402 | 4.2 MB | **6.7 ms** | **531** |

The poll rate also goes from 5 seconds to a minute, because queue depth does not move fast enough to justify a table scan per node per five seconds. Between the two this stops being on the list.

Things I ruled out by measuring rather than guessing. Forcing the index-only scan on `oban_jobs_state_queue_priority_scheduled_at_id_index` gives 90 ms but *more* buffers (20,401, with 24,236 heap fetches), so it isn't the fix. And the table is only 8% dead tuples, so this isn't bloat, it's genuinely that much data.

The pruner deletes through a limited subquery the same way Oban's does, so working off the existing 227k backlog happens 10,000 rows at a time rather than in one statement that outruns the query timeout. It ages each state by the column Oban sets on entering it, which for `completed` is `scheduled_at` rather than `completed_at`.

`mix test`: 2,314 tests, 28 properties, 0 failures. Three new ones cover the per-state ages, that unfinished jobs are never touched, and that the limit is respected.