### PR TITLE
Keep OAuth tokens that still have a valid refresh token

### DIFF
--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -82,13 +82,20 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
     Logger.info("[task] Purged #{count} expired device codes")
   end
 
+  # A row has a reachable refresh token iff refresh_jti is set, since that is
+  # what refresh lookups resolve by, and every path that sets it also sets
+  # refresh_token_expires_at. The row is unreachable once both timestamps have
+  # passed, not once the access token alone has.
   defp purge_oauth_tokens(repo, batch_size) do
     count =
       delete_in_batches(
         repo,
         Hexpm.OAuth.Token,
         from(t in Hexpm.OAuth.Token,
-          where: t.expires_at < fragment("NOW()") or not is_nil(t.revoked_at),
+          where:
+            (t.expires_at < fragment("NOW()") and
+               (is_nil(t.refresh_jti) or t.refresh_token_expires_at < fragment("NOW()"))) or
+              not is_nil(t.revoked_at),
           order_by: t.expires_at
         ),
         batch_size

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -162,6 +162,50 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
       assert Repo.get(Hexpm.OAuth.Token, active.id)
     end
 
+    test "keeps expired tokens whose refresh token is still valid" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      token =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "expired-access-jti",
+          refresh_jti: "live-refresh-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at: truncated_seconds_ago(60),
+          refresh_token_expires_at: truncated_seconds_from_now(86400),
+          grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run()
+
+      assert Repo.get(Hexpm.OAuth.Token, token.id)
+    end
+
+    test "deletes tokens whose refresh token has also expired" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      token =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "expired-access-jti",
+          refresh_jti: "expired-refresh-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at: truncated_seconds_ago(86400),
+          refresh_token_expires_at: truncated_seconds_ago(60),
+          grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.OAuth.Token, token.id)
+    end
+
     test "deletes any revoked token" do
       user = insert(:user)
       client = insert(:oauth_client)
@@ -174,6 +218,29 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
           expires_at: truncated_seconds_from_now(86400),
           revoked_at: truncated_seconds_ago(60),
           grant_type: "authorization_code",
+          user_id: user.id,
+          client_id: client.client_id
+        })
+
+      PurgeExpiredRecords.run()
+
+      refute Repo.get(Hexpm.OAuth.Token, revoked.id)
+    end
+
+    test "deletes revoked tokens whose refresh token has not expired" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      revoked =
+        Repo.insert!(%Hexpm.OAuth.Token{
+          jti: "rotated-jti",
+          refresh_jti: "rotated-refresh-jti",
+          token_type: "bearer",
+          scopes: ["api"],
+          expires_at: truncated_seconds_ago(60),
+          refresh_token_expires_at: truncated_seconds_from_now(86400),
+          revoked_at: truncated_seconds_ago(60),
+          grant_type: "refresh_token",
           user_id: user.id,
           client_id: client.client_id
         })


### PR DESCRIPTION
The daily purge deleted `oauth_tokens` rows on `expires_at`, which is the 30 minute access token expiry. The refresh token lives on the same row with its own `refresh_token_expires_at` set to the 30 day session lifetime, so the purge threw away refresh tokens that were still good.

That made every CLI session die at the next 02:00 UTC run: the stored refresh token JWT was still valid, but `refresh_jti` no longer resolved to a row, so the token endpoint returned `invalid_grant` / "Invalid refresh token" and the CLI reported the session as expired. Reported as hexpm/hex#1211.

A row now only goes once the access token has expired and either it has no refresh token at all or the refresh token has expired too. Revoked rows are still purged immediately, which is the rotation loser on every refresh.

Anyone hit by this has to run `mix hex.user auth` once after deploy, their rows are already gone.

Closes hexpm/hex#1211.