### PR TITLE
Render the file tree as it is opened

### DIFF
--- a/assets/js/hooks/file_finder.js
+++ b/assets/js/hooks/file_finder.js
@@ -105,18 +105,12 @@ export const FileFinder = {
   buildIndex() {
     this.treeVersion = this.el.dataset.treeVersion;
     const payload = this.treeContainer.querySelector("template[data-file-paths]");
-    const paths = payload ? JSON.parse(payload.content.textContent) : [];
+    const encoded = payload ? JSON.parse(payload.content.textContent) : [];
 
-    this.index = paths.map((path) => ({
-      path,
-      lower: path.toLowerCase(),
-      href: this.hrefFor(path),
-    }));
-  },
-
-  hrefFor(path) {
-    const encoded = path.split("/").map(encodeSegment).join("/");
-    return `${this.hrefBase}/${encoded}`;
+    this.index = encoded.map((encodedPath) => {
+      const path = decodePath(encodedPath);
+      return { path, lower: path.toLowerCase(), href: `${this.hrefBase}/${encodedPath}` };
+    });
   },
 
   /**
@@ -337,14 +331,12 @@ export const FileFinder = {
   },
 };
 
-// Phoenix builds paths with URI.char_unreserved?/1, which percent-encodes these
-// five where encodeURIComponent leaves them alone. Matching it keeps one URL per
-// file whether the link came from the server or from here.
-function encodeSegment(segment) {
-  return encodeURIComponent(segment).replace(
-    /[!'()*]/g,
-    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
-  );
+// The payload is encoded the way the router encodes, so links are a string
+// append and only the name has to be recovered. Decoding is the exact inverse of
+// percent-encoding, unlike encoding, where JavaScript and Elixir disagree about
+// which characters are reserved.
+function decodePath(encodedPath) {
+  return encodedPath.split("/").map(decodeURIComponent).join("/");
 }
 
 function fuzzyMatch(file, query) {

--- a/assets/js/hooks/file_finder.js
+++ b/assets/js/hooks/file_finder.js
@@ -95,7 +95,11 @@ export const FileFinder = {
     this.treeContainer = this.treeEl.querySelector("[data-tree-container]");
     this.fileTemplate = this.treeContainer.querySelector("template[data-tree-file]");
     this.dirTemplate = this.treeContainer.querySelector("template[data-tree-dir]");
+    this.moreTemplate = this.treeContainer.querySelector("template[data-tree-more]");
     this.hrefBase = this.el.dataset.fileHrefBase || "";
+    // Page by whatever the server rendered per directory, so a partly rendered
+    // directory continues where it left off instead of overlapping or skipping.
+    this.limit = Number(this.el.dataset.childrenLimit) || RESULT_LIMIT;
   },
 
   buildIndex() {
@@ -117,9 +121,11 @@ export const FileFinder = {
 
   /**
    * Builds the immediate children of an open directory. Names that have
-   * anything below them become directories, the rest become file links.
+   * anything below them become directories, the rest become file links. Only
+   * `limit` are added at a time, with a button for the next page, because a
+   * generated client can hold hundreds of files in one directory.
    */
-  fill(details) {
+  fill(details, ensure) {
     const holder = details.querySelector("[data-children]");
     if (!holder || holder.dataset.filled === "true") return;
 
@@ -143,20 +149,65 @@ export const FileFinder = {
     // put two nodes on the client where the server renders one.
     const files = candidates.filter((file) => !directories.has(file.name));
 
+    // Keyed so a page can be stretched to reach a particular child, which is how
+    // the file on screen gets rendered when it sorts past the first page.
+    const children = [
+      ...[...directories.keys()].sort(compare).map((name) => ({
+        key: directories.get(name),
+        build: () => this.buildDirectory(name, directories.get(name)),
+      })),
+      ...files.sort((a, b) => compare(a.name, b.name)).map((file) => ({
+        key: file.entry.path,
+        build: () => this.buildFile(file.name, file.entry),
+      })),
+    ];
+
     const list = document.createElement("ul");
     list.className = "space-y-0.5";
-
-    const names = [...directories.keys()].sort(compare);
-    for (const name of names) {
-      list.appendChild(this.buildDirectory(name, directories.get(name)));
-    }
-    for (const file of files.sort((a, b) => compare(a.name, b.name))) {
-      list.appendChild(this.buildFile(file.name, file.entry));
-    }
 
     holder.textContent = "";
     holder.appendChild(list);
     holder.dataset.filled = "true";
+
+    this.addPage(list, children, 0, ensure);
+  },
+
+  /**
+   * Appends one page of children, then a button for the next page if any remain.
+   * Runs on past the page boundary when `ensure` sits beyond it.
+   */
+  addPage(list, children, from, ensure) {
+    let to = Math.min(from + this.limit, children.length);
+
+    if (ensure) {
+      const index = children.findIndex((child) => child.key === ensure);
+      if (index >= to) {
+        to = Math.min(children.length, Math.ceil((index + 1) / this.limit) * this.limit);
+      }
+    }
+
+    for (let index = from; index < to; index++) list.appendChild(children[index].build());
+
+    const remaining = children.length - to;
+    if (remaining === 0) return;
+
+    const item = document.createElement("li");
+    const button = this.moreTemplate.content.firstElementChild.cloneNode(true);
+    const next = Math.min(this.limit, remaining);
+    button.querySelector("[data-name]").textContent =
+      `Show ${next} more (${remaining} remaining)`;
+
+    button.addEventListener(
+      "click",
+      () => {
+        item.remove();
+        this.addPage(list, children, to);
+      },
+      { once: true },
+    );
+
+    item.appendChild(button);
+    list.appendChild(item);
   },
 
   buildDirectory(name, path) {
@@ -186,14 +237,17 @@ export const FileFinder = {
     const parts = path.split("/");
     let prefix = "";
 
-    for (const part of parts.slice(0, -1)) {
-      prefix = prefix === "" ? part : `${prefix}/${part}`;
+    for (let level = 0; level < parts.length - 1; level++) {
+      prefix = level === 0 ? parts[0] : `${prefix}/${parts[level]}`;
       const details = this.treeContainer.querySelector(
         `details[data-dir-path="${CSS.escape(prefix)}"]`,
       );
       if (!details) break;
       details.open = true;
-      this.fill(details);
+      // Whatever has to exist for the next lap: the directory below, or the file.
+      const needed =
+        level === parts.length - 2 ? path : parts.slice(0, level + 2).join("/");
+      this.fill(details, needed);
     }
 
     return this.treeContainer.querySelector(`a[data-path="${CSS.escape(path)}"]`);

--- a/assets/js/hooks/file_finder.js
+++ b/assets/js/hooks/file_finder.js
@@ -1,15 +1,19 @@
 /**
  * FileFinder Hook
  *
- * Client-side file navigation for the package file browser. The server
- * renders the full file tree once per version; this hook owns everything
- * that used to be a LiveView round trip:
+ * Client-side file navigation for the package file browser. The server renders
+ * the top level of the tree and the directories leading to the file on screen;
+ * this hook owns everything else:
  *
- * - fuzzy file filtering (sidebar search and modal finder) over the tree's
- *   `a[data-path]` links, rendered from a <template data-finder-item>
- * - the active-file highlight (aria-current) and ancestor <details>
- *   expansion, driven by the root's data-active-path attribute, which the
- *   server updates on patch navigation
+ * - the file index, read from a <template data-file-paths> JSON payload rather
+ *   than from the document, so a directory does not have to be rendered for its
+ *   files to be searchable. 700 paths is around 29KB against roughly 2KB of
+ *   markup per rendered node.
+ * - filling a directory when it is opened, by cloning <template data-tree-file>
+ *   and <template data-tree-dir> so the markup matches what the server renders
+ * - fuzzy file filtering (sidebar search and modal finder)
+ * - the active-file highlight (aria-current) and revealing the file on screen,
+ *   driven by the root's data-active-path attribute
  *
  * The filter mirrors HexpmWeb.Components.FileSelector.filter/2: match by
  * substring or character subsequence, rank exact > prefix > path-segment >
@@ -26,7 +30,6 @@ export const FileFinder = {
     this.modalId = this.el.dataset.modalId;
     this.modalResults = document.getElementById(this.el.dataset.modalResults);
     this.template = this.el.querySelector("template[data-finder-item]");
-    this.treeContainer = this.treeEl.querySelector("[data-tree-container]");
     this.resultsContainer = this.treeEl.querySelector("[data-results-container]");
     this.sidebarList = this.resultsContainer.querySelector("[data-results]");
     this.sidebarEmpty = this.resultsContainer.querySelector("[data-empty]");
@@ -34,6 +37,7 @@ export const FileFinder = {
     this.modalEmpty = this.modalResults.querySelector("[data-empty]");
     this.query = "";
 
+    this.resolveTree();
     this.buildIndex();
     this.applyActive();
     this.renderResults(this.modalList, this.modalEmpty, this.filter(""));
@@ -46,6 +50,12 @@ export const FileFinder = {
       if (this.modalResults.contains(link)) this.closeModal();
       this.setQuery("");
     };
+    // `toggle` does not bubble, so it is captured from the container instead of
+    // bound per <details>, which also covers the ones this hook adds later.
+    this.onToggle = (event) => {
+      const details = event.target;
+      if (details.tagName === "DETAILS" && details.open) this.fill(details);
+    };
 
     this.inputs = [this.sidebarInput, this.modalInput].filter(Boolean);
     this.forms = this.inputs.map((input) => input.closest("form")).filter(Boolean);
@@ -53,13 +63,23 @@ export const FileFinder = {
     this.forms.forEach((form) => form.addEventListener("submit", this.onSubmit));
     this.sidebarList.addEventListener("click", this.onResultsClick);
     this.modalResults.addEventListener("click", this.onResultsClick);
+    this.treeEl.addEventListener("toggle", this.onToggle, true);
   },
 
   updated() {
     if (this.el.dataset.treeVersion !== this.treeVersion) {
+      // A new tree replaces the container, so the cached nodes and the paths
+      // they were built from are both stale.
+      this.resolveTree();
       this.buildIndex();
-      this.filterAndRender();
     }
+
+    // Re-assert view state on every patch, not only when the tree changed. A
+    // patch re-renders the results list from the server, which empties the
+    // injected results and restores their hidden class, while the tree
+    // container is ignored and keeps whatever class the client put on it. Skip
+    // this and a patch during an active search leaves both halves hidden.
+    this.filterAndRender();
     this.applyActive();
   },
 
@@ -68,27 +88,122 @@ export const FileFinder = {
     this.forms.forEach((form) => form.removeEventListener("submit", this.onSubmit));
     this.sidebarList.removeEventListener("click", this.onResultsClick);
     this.modalResults.removeEventListener("click", this.onResultsClick);
+    this.treeEl.removeEventListener("toggle", this.onToggle, true);
+  },
+
+  resolveTree() {
+    this.treeContainer = this.treeEl.querySelector("[data-tree-container]");
+    this.fileTemplate = this.treeContainer.querySelector("template[data-tree-file]");
+    this.dirTemplate = this.treeContainer.querySelector("template[data-tree-dir]");
+    this.hrefBase = this.el.dataset.fileHrefBase || "";
   },
 
   buildIndex() {
     this.treeVersion = this.el.dataset.treeVersion;
-    this.index = Array.from(this.treeContainer.querySelectorAll("a[data-path]")).map((el) => ({
-      el,
-      path: el.dataset.path,
-      lower: el.dataset.path.toLowerCase(),
-      href: el.getAttribute("href"),
+    const payload = this.treeContainer.querySelector("template[data-file-paths]");
+    const paths = payload ? JSON.parse(payload.content.textContent) : [];
+
+    this.index = paths.map((path) => ({
+      path,
+      lower: path.toLowerCase(),
+      href: this.hrefFor(path),
     }));
+  },
+
+  hrefFor(path) {
+    const encoded = path.split("/").map(encodeSegment).join("/");
+    return `${this.hrefBase}/${encoded}`;
+  },
+
+  /**
+   * Builds the immediate children of an open directory. Names that have
+   * anything below them become directories, the rest become file links.
+   */
+  fill(details) {
+    const holder = details.querySelector("[data-children]");
+    if (!holder || holder.dataset.filled === "true") return;
+
+    const parent = details.dataset.dirPath;
+    const prefix = parent === "" ? "" : `${parent}/`;
+    const directories = new Map();
+    const candidates = [];
+
+    for (const entry of this.index) {
+      if (!entry.path.startsWith(prefix)) continue;
+      const rest = entry.path.slice(prefix.length).split("/");
+      if (rest.length === 1) {
+        candidates.push({ name: rest[0], entry });
+      } else if (!directories.has(rest[0])) {
+        directories.set(rest[0], prefix + rest[0]);
+      }
+    }
+
+    // A name with anything below it is a directory, even if a file of the same
+    // name also exists, which is what child_nodes/3 does. Emitting both would
+    // put two nodes on the client where the server renders one.
+    const files = candidates.filter((file) => !directories.has(file.name));
+
+    const list = document.createElement("ul");
+    list.className = "space-y-0.5";
+
+    const names = [...directories.keys()].sort(compare);
+    for (const name of names) {
+      list.appendChild(this.buildDirectory(name, directories.get(name)));
+    }
+    for (const file of files.sort((a, b) => compare(a.name, b.name))) {
+      list.appendChild(this.buildFile(file.name, file.entry));
+    }
+
+    holder.textContent = "";
+    holder.appendChild(list);
+    holder.dataset.filled = "true";
+  },
+
+  buildDirectory(name, path) {
+    const item = document.createElement("li");
+    const node = this.dirTemplate.content.firstElementChild.cloneNode(true);
+    node.dataset.dirPath = path;
+    node.querySelector("summary [data-name]").textContent = name;
+    item.appendChild(node);
+    return item;
+  },
+
+  buildFile(name, entry) {
+    const item = document.createElement("li");
+    const node = this.fileTemplate.content.firstElementChild.cloneNode(true);
+    node.setAttribute("href", entry.href);
+    node.dataset.path = entry.path;
+    node.querySelector("[data-name]").textContent = name;
+    item.appendChild(node);
+    return item;
+  },
+
+  /**
+   * Opens every directory above a path, filling each one as it goes so the next
+   * one down exists to be opened, and returns the file's link if it is there.
+   */
+  reveal(path) {
+    const parts = path.split("/");
+    let prefix = "";
+
+    for (const part of parts.slice(0, -1)) {
+      prefix = prefix === "" ? part : `${prefix}/${part}`;
+      const details = this.treeContainer.querySelector(
+        `details[data-dir-path="${CSS.escape(prefix)}"]`,
+      );
+      if (!details) break;
+      details.open = true;
+      this.fill(details);
+    }
+
+    return this.treeContainer.querySelector(`a[data-path="${CSS.escape(path)}"]`);
   },
 
   applyActive() {
     const active = this.el.dataset.activePath || null;
 
-    for (const entry of this.index) {
-      if (entry.path === active) {
-        entry.el.setAttribute("aria-current", "page");
-      } else {
-        entry.el.removeAttribute("aria-current");
-      }
+    for (const link of this.treeContainer.querySelectorAll("a[data-path][aria-current]")) {
+      link.removeAttribute("aria-current");
     }
 
     for (const list of [this.sidebarList, this.modalList]) {
@@ -101,16 +216,13 @@ export const FileFinder = {
       }
     }
 
-    const entry = this.index.find((item) => item.path === active);
-    if (!entry) return;
+    if (!active) return;
 
-    let parent = entry.el.parentElement;
-    while (parent && parent !== this.treeEl) {
-      if (parent.tagName === "DETAILS") parent.open = true;
-      parent = parent.parentElement;
-    }
+    const link = this.reveal(active);
+    if (!link) return;
 
-    entry.el.scrollIntoView({ block: "nearest" });
+    link.setAttribute("aria-current", "page");
+    link.scrollIntoView({ block: "nearest" });
   },
 
   setQuery(value) {
@@ -170,6 +282,16 @@ export const FileFinder = {
     content?.querySelector('[aria-label="Close modal"]')?.click();
   },
 };
+
+// Phoenix builds paths with URI.char_unreserved?/1, which percent-encodes these
+// five where encodeURIComponent leaves them alone. Matching it keeps one URL per
+// file whether the link came from the server or from here.
+function encodeSegment(segment) {
+  return encodeURIComponent(segment).replace(
+    /[!'()*]/g,
+    (character) => `%${character.charCodeAt(0).toString(16).toUpperCase()}`,
+  );
+}
 
 function fuzzyMatch(file, query) {
   return query === "" || file.includes(query) || subsequence(file, query);

--- a/lib/hexpm/preview/sitemaps.ex
+++ b/lib/hexpm/preview/sitemaps.ex
@@ -1,6 +1,8 @@
 defmodule Hexpm.Preview.Sitemaps do
   require EEx
 
+  # These URLs pin a version, so a file's contents never change once it is
+  # published and there is nothing for a crawler to come back for.
   package_template = ~S"""
   <?xml version="1.0" encoding="utf-8"?>
   <urlset
@@ -11,7 +13,7 @@ defmodule Hexpm.Preview.Sitemaps do
     <url>
       <loc><%= xml_escape(preview_url <> "/packages/" <> encode_path(package) <> "/" <> encode_path(version) <> "/files/" <> encode_path(file)) %></loc>
       <lastmod><%= format_datetime(updated_at) %></lastmod>
-      <changefreq>daily</changefreq>
+      <changefreq>yearly</changefreq>
       <priority>0.8</priority>
     </url>
   <% end %>

--- a/lib/hexpm_web/components/file_selector.ex
+++ b/lib/hexpm_web/components/file_selector.ex
@@ -36,6 +36,10 @@ defmodule HexpmWeb.Components.FileSelector do
     default: nil,
     doc: "path the client appends a file's path to when it builds a tree link"
 
+  attr :children_limit, :integer,
+    default: nil,
+    doc: "how many children the server rendered per directory, so the client pages by the same"
+
   attr :title, :string, required: true
   attr :sidebar_label, :string, required: true
   attr :search_label, :string, required: true
@@ -67,6 +71,7 @@ defmodule HexpmWeb.Components.FileSelector do
       data-tree-version={@client_finder && @tree_version}
       data-tree-id={@client_finder && "#{@id}-tree"}
       data-file-href-base={@client_finder && @file_href_base}
+      data-children-limit={@client_finder && @children_limit}
       data-sidebar-input={@client_finder && @tree_query_id}
       data-modal-input={@client_finder && @finder_query_id}
       data-modal-id={@client_finder && "#{@id}-modal"}

--- a/lib/hexpm_web/components/file_selector.ex
+++ b/lib/hexpm_web/components/file_selector.ex
@@ -31,6 +31,11 @@ defmodule HexpmWeb.Components.FileSelector do
 
   attr :active_path, :string, default: nil
   attr :tree_version, :string, default: nil
+
+  attr :file_href_base, :string,
+    default: nil,
+    doc: "path the client appends a file's path to when it builds a tree link"
+
   attr :title, :string, required: true
   attr :sidebar_label, :string, required: true
   attr :search_label, :string, required: true
@@ -61,6 +66,7 @@ defmodule HexpmWeb.Components.FileSelector do
       data-active-path={@client_finder && @active_path}
       data-tree-version={@client_finder && @tree_version}
       data-tree-id={@client_finder && "#{@id}-tree"}
+      data-file-href-base={@client_finder && @file_href_base}
       data-sidebar-input={@client_finder && @tree_query_id}
       data-modal-input={@client_finder && @finder_query_id}
       data-modal-id={@client_finder && "#{@id}-modal"}
@@ -110,7 +116,17 @@ defmodule HexpmWeb.Components.FileSelector do
           aria-label={@sidebar_label}
         >
           <%= if @client_finder do %>
-            <div data-tree-container>
+            <%!-- The client owns this subtree once it is rendered: it fills in
+                  directories as they are opened and moves the active marker, and
+                  a re-render would throw that away. Keying the id on the tree's
+                  identity gets a fresh one when it changes. The id can contain
+                  slashes and dots, so it is not usable as a CSS selector
+                  unescaped; nothing targets it that way. --%>
+            <div
+              id={"#{@id}-tree-root-#{@tree_version}"}
+              data-tree-container
+              phx-update="ignore"
+            >
               {render_slot(@tree, %{modal_id: "#{@id}-modal"})}
             </div>
             <div data-results-container class="hidden">

--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -357,13 +357,20 @@ defmodule HexpmWeb.PreviewLive do
   Markup the client clones when it fills a directory, and every path in the
   package so it can build those children and run the file finder without the
   tree being in the document.
+
+  Paths go over already encoded, the same way the router encodes them, so the
+  client appends one to the base to get a link and percent-decodes it to get the
+  name back. Sending them raw would mean writing the encoding rule a second time
+  in JavaScript, and the two spellings disagreed on `!'()*` when it was.
   """
   def tree_templates(assigns) do
+    assigns = assign(assigns, :encoded_files, Enum.map(assigns.files, &encode_path/1))
+
     ~H"""
     <template data-tree-file><.tree_file path="" name="" href="#" /></template>
     <template data-tree-dir><.tree_directory path="" name="" /></template>
     <template data-tree-more><.tree_more /></template>
-    <template data-file-paths>{JSON.encode!(@files)}</template>
+    <template data-file-paths>{JSON.encode!(@encoded_files)}</template>
     """
   end
 

--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -113,9 +113,16 @@ defmodule HexpmWeb.PreviewLive do
     {highlighted, message} = render_contents(package, version, source)
     filename = source.filename
 
+    # Opening the path to the file only matters on the render the browser keeps.
+    # Once connected the client owns the tree and discards what is pushed to it,
+    # so a tree that varies per file would be rebuilt, diffed and sent on every
+    # navigation for nothing. Holding it at the top level keeps it identical
+    # across navigations, and change tracking then sends none of it.
+    open_to = if connected?(socket), do: nil, else: filename
+
     assign(socket,
       files: source.files,
-      file_tree: build_file_tree(source.files),
+      file_tree: build_visible_tree(source.files, open_to),
       filename: filename,
       highlighted: highlighted,
       message: message,
@@ -194,30 +201,49 @@ defmodule HexpmWeb.PreviewLive do
     "View #{filename} from #{package} #{version} on Hex."
   end
 
-  defp build_file_tree(files) do
+  # Directories render collapsed, so building the whole tree emits markup nobody
+  # sees. Only the top level and the path to the shown file are built; the client
+  # has every path and fills a directory in when it is opened.
+  defp build_visible_tree(files, filename) do
+    child_nodes(files, "", open_directories(filename))
+  end
+
+  defp open_directories(nil), do: MapSet.new()
+
+  defp open_directories(filename) do
+    filename
+    |> Path.split()
+    |> Enum.drop(-1)
+    |> Enum.scan(&Path.join(&2, &1))
+    |> MapSet.new()
+  end
+
+  defp child_nodes(files, parent, open) do
+    depth = if parent == "", do: 0, else: length(Path.split(parent))
+
     files
-    |> Enum.reduce(%{}, fn file, tree -> insert_file(tree, Path.split(file), file) end)
-    |> tree_nodes("")
-  end
+    |> Enum.group_by(&Enum.at(Path.split(&1), depth))
+    |> Enum.reject(fn {name, _group} -> is_nil(name) end)
+    |> Enum.map(fn {name, group} ->
+      # A name with anything below it is a directory even if a file shares the
+      # name, and a file keeps the path it was stored under rather than one
+      # rebuilt from its segments, which need not join back to the same string.
+      case Enum.split_with(group, &(length(Path.split(&1)) == depth + 1)) do
+        {[file | _], []} ->
+          %{type: :file, name: name, path: file}
 
-  defp insert_file(tree, [name], file), do: Map.put(tree, name, {:file, file})
+        {_files, [_ | _] = descendants} ->
+          path = if parent == "", do: name, else: Path.join(parent, name)
+          open? = MapSet.member?(open, path)
 
-  defp insert_file(tree, [directory | rest], file) do
-    Map.update(tree, directory, {:directory, insert_file(%{}, rest, file)}, fn
-      {:directory, children} -> {:directory, insert_file(children, rest, file)}
-      {:file, _file} -> {:directory, insert_file(%{}, rest, file)}
-    end)
-  end
-
-  defp tree_nodes(tree, parent) do
-    tree
-    |> Enum.map(fn
-      {name, {:file, file}} ->
-        %{type: :file, name: name, path: file}
-
-      {name, {:directory, children}} ->
-        path = if parent == "", do: name, else: Path.join(parent, name)
-        %{type: :directory, name: name, path: path, children: tree_nodes(children, path)}
+          %{
+            type: :directory,
+            name: name,
+            path: path,
+            open?: open?,
+            children: if(open?, do: child_nodes(descendants, path, open), else: [])
+          }
+      end
     end)
     |> Enum.sort_by(fn node -> {if(node.type == :directory, do: 0, else: 1), node.name} end)
   end
@@ -232,36 +258,84 @@ defmodule HexpmWeb.PreviewLive do
     <ul class="space-y-0.5">
       <%= for node <- @nodes do %>
         <li :if={node.type == :directory}>
-          <details>
-            <summary class="flex w-full cursor-pointer list-none items-center gap-1.5 rounded px-2 py-1.5 text-left text-sm font-medium text-grey-700 hover:bg-grey-100 dark:text-grey-200 dark:hover:bg-grey-700/60 [&::-webkit-details-marker]:hidden">
-              {icon(:heroicon, "chevron-right",
-                class: "size-3.5 shrink-0 transition-transform [details[open]>summary_&]:rotate-90"
-              )}
-              {icon(:heroicon, "folder", class: "size-4 shrink-0 text-grey-400")}
-              <span class="truncate">{node.name}</span>
-            </summary>
-            <div class="ml-3 border-l border-grey-200 pl-2 dark:border-grey-700">
-              <.source_tree
-                nodes={node.children}
-                repository={@repository}
-                package_name={@package_name}
-                version={@version}
-              />
-            </div>
-          </details>
+          <.tree_directory path={node.path} name={node.name} open?={node.open?}>
+            <.source_tree
+              nodes={node.children}
+              repository={@repository}
+              package_name={@package_name}
+              version={@version}
+            />
+          </.tree_directory>
         </li>
         <li :if={node.type == :file}>
-          <.link
-            patch={files_path(@repository, @package_name, @version, node.path)}
-            data-path={node.path}
-            class="flex items-center gap-1.5 rounded px-2 py-1.5 font-mono text-xs transition-colors text-grey-600 hover:bg-grey-100 hover:text-grey-900 dark:text-grey-300 dark:hover:bg-grey-700/60 dark:hover:text-white aria-[current=page]:bg-primary-50 aria-[current=page]:font-semibold aria-[current=page]:text-primary-700 dark:aria-[current=page]:bg-grey-700 dark:aria-[current=page]:text-white"
-          >
-            {icon(:heroicon, "document", class: "ml-5 size-3.5 shrink-0 text-grey-400")}
-            <span class="truncate">{node.name}</span>
-          </.link>
+          <.tree_file
+            path={node.path}
+            name={node.name}
+            href={files_path(@repository, @package_name, @version, node.path)}
+          />
         </li>
       <% end %>
     </ul>
+    """
+  end
+
+  attr :path, :string, required: true
+  attr :name, :string, required: true
+  attr :open?, :boolean, default: false
+  slot :inner_block
+
+  def tree_directory(assigns) do
+    ~H"""
+    <details open={@open?} data-dir-path={@path}>
+      <summary class="flex w-full cursor-pointer list-none items-center gap-1.5 rounded px-2 py-1.5 text-left text-sm font-medium text-grey-700 hover:bg-grey-100 dark:text-grey-200 dark:hover:bg-grey-700/60 [&::-webkit-details-marker]:hidden">
+        {icon(:heroicon, "chevron-right",
+          class: "size-3.5 shrink-0 transition-transform [details[open]>summary_&]:rotate-90"
+        )}
+        {icon(:heroicon, "folder", class: "size-4 shrink-0 text-grey-400")}
+        <span data-name class="truncate">{@name}</span>
+      </summary>
+      <div
+        class="ml-3 border-l border-grey-200 pl-2 dark:border-grey-700"
+        data-children
+        data-filled={@open? && "true"}
+      >
+        {render_slot(@inner_block)}
+      </div>
+    </details>
+    """
+  end
+
+  attr :path, :string, required: true
+  attr :name, :string, required: true
+  attr :href, :string, required: true
+
+  def tree_file(assigns) do
+    ~H"""
+    <a
+      href={@href}
+      data-phx-link="patch"
+      data-phx-link-state="push"
+      data-path={@path}
+      class="flex items-center gap-1.5 rounded px-2 py-1.5 font-mono text-xs transition-colors text-grey-600 hover:bg-grey-100 hover:text-grey-900 dark:text-grey-300 dark:hover:bg-grey-700/60 dark:hover:text-white aria-[current=page]:bg-primary-50 aria-[current=page]:font-semibold aria-[current=page]:text-primary-700 dark:aria-[current=page]:bg-grey-700 dark:aria-[current=page]:text-white"
+    >
+      {icon(:heroicon, "document", class: "ml-5 size-3.5 shrink-0 text-grey-400")}
+      <span data-name class="truncate">{@name}</span>
+    </a>
+    """
+  end
+
+  attr :files, :list, required: true
+
+  @doc """
+  Markup the client clones when it fills a directory, and every path in the
+  package so it can build those children and run the file finder without the
+  tree being in the document.
+  """
+  def tree_templates(assigns) do
+    ~H"""
+    <template data-tree-file><.tree_file path="" name="" href="#" /></template>
+    <template data-tree-dir><.tree_directory path="" name="" /></template>
+    <template data-file-paths>{JSON.encode!(@files)}</template>
     """
   end
 end

--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -11,6 +11,15 @@ defmodule HexpmWeb.PreviewLive do
     defexception message: "Package file not found", plug_status: 404
   end
 
+  # Generated clients keep nearly everything in one directory: ory_client has 384
+  # of its 408 files in lib/ory/model, mailslurp 235 of 270. Rendering a whole
+  # directory to show one file in it puts those packages back where they started,
+  # so a directory renders this many children and the client pages through the
+  # rest. The client reads the same number off the DOM.
+  @children_limit 100
+
+  def children_limit, do: @children_limit
+
   @impl true
   def mount(params, _session, socket) do
     {:ok,
@@ -235,17 +244,29 @@ defmodule HexpmWeb.PreviewLive do
         {_files, [_ | _] = descendants} ->
           path = if parent == "", do: name, else: Path.join(parent, name)
           open? = MapSet.member?(open, path)
+          {children, rest} = open_children(descendants, path, open, open?)
 
           %{
             type: :directory,
             name: name,
             path: path,
             open?: open?,
-            children: if(open?, do: child_nodes(descendants, path, open), else: [])
+            children: children,
+            # Only claim the directory is done when every child is on the page.
+            # Otherwise the client rebuilds it and takes over paging.
+            filled?: open? and rest == []
           }
       end
     end)
     |> Enum.sort_by(fn node -> {if(node.type == :directory, do: 0, else: 1), node.name} end)
+  end
+
+  defp open_children(_descendants, _path, _open, false), do: {[], []}
+
+  defp open_children(descendants, path, open, true) do
+    descendants
+    |> child_nodes(path, open)
+    |> Enum.split(@children_limit)
   end
 
   attr :nodes, :list, required: true
@@ -258,7 +279,12 @@ defmodule HexpmWeb.PreviewLive do
     <ul class="space-y-0.5">
       <%= for node <- @nodes do %>
         <li :if={node.type == :directory}>
-          <.tree_directory path={node.path} name={node.name} open?={node.open?}>
+          <.tree_directory
+            path={node.path}
+            name={node.name}
+            open?={node.open?}
+            filled?={node.filled?}
+          >
             <.source_tree
               nodes={node.children}
               repository={@repository}
@@ -282,6 +308,7 @@ defmodule HexpmWeb.PreviewLive do
   attr :path, :string, required: true
   attr :name, :string, required: true
   attr :open?, :boolean, default: false
+  attr :filled?, :boolean, default: false
   slot :inner_block
 
   def tree_directory(assigns) do
@@ -297,7 +324,7 @@ defmodule HexpmWeb.PreviewLive do
       <div
         class="ml-3 border-l border-grey-200 pl-2 dark:border-grey-700"
         data-children
-        data-filled={@open? && "true"}
+        data-filled={@filled? && "true"}
       >
         {render_slot(@inner_block)}
       </div>
@@ -335,7 +362,21 @@ defmodule HexpmWeb.PreviewLive do
     ~H"""
     <template data-tree-file><.tree_file path="" name="" href="#" /></template>
     <template data-tree-dir><.tree_directory path="" name="" /></template>
+    <template data-tree-more><.tree_more /></template>
     <template data-file-paths>{JSON.encode!(@files)}</template>
+    """
+  end
+
+  def tree_more(assigns) do
+    ~H"""
+    <button
+      type="button"
+      data-tree-more-button
+      class="flex w-full items-center gap-1.5 rounded px-2 py-1.5 text-left text-xs font-medium text-primary-700 transition-colors hover:bg-grey-100 dark:text-primary-300 dark:hover:bg-grey-700/60"
+    >
+      {icon(:heroicon, "chevron-down", class: "ml-5 size-3.5 shrink-0")}
+      <span data-name class="truncate"></span>
+    </button>
     """
   end
 end

--- a/lib/hexpm_web/live/preview_live.html.heex
+++ b/lib/hexpm_web/live/preview_live.html.heex
@@ -41,6 +41,7 @@
           active_path={@filename}
           tree_version={"#{@repository}/#{@package_name}/#{@version}"}
           file_href_base={files_path(@repository, @package_name, @version)}
+          children_limit={children_limit()}
           file_count={length(@files)}
           title="Package files"
           sidebar_label="Package files"

--- a/lib/hexpm_web/live/preview_live.html.heex
+++ b/lib/hexpm_web/live/preview_live.html.heex
@@ -39,7 +39,8 @@
           id="preview-files"
           client_finder={true}
           active_path={@filename}
-          tree_version={@version}
+          tree_version={"#{@repository}/#{@package_name}/#{@version}"}
+          file_href_base={files_path(@repository, @package_name, @version)}
           file_count={length(@files)}
           title="Package files"
           sidebar_label="Package files"
@@ -50,6 +51,7 @@
           finder_query_id="preview-file-query"
         >
           <:tree :let={_selector}>
+            <.tree_templates files={@files} />
             <.source_tree
               nodes={@file_tree}
               repository={@repository}

--- a/test/hexpm_web/controllers/sitemap_controller_test.exs
+++ b/test/hexpm_web/controllers/sitemap_controller_test.exs
@@ -76,6 +76,10 @@ defmodule HexpmWeb.SitemapControllerTest do
     assert body =~ "docs/a%20%26%20%23%3C.html"
     refute body =~ "docs/a & #<.html"
     assert get_resp_header(conn, "cache-control") == ["public, max-age=300"]
+
+    # The URLs pin a version, so their contents never change.
+    assert body =~ "<changefreq>yearly</changefreq>"
+    refute body =~ "<changefreq>daily</changefreq>"
   end
 
   test "GET /preview/:package/sitemap.xml returns 404 without Preview files", %{package: package} do

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -14,6 +14,8 @@ defmodule HexpmWeb.PreviewLiveTest do
     inner
   end
 
+  # The payload holds route-ready paths, so it is decoded back to names here to
+  # keep assertions readable.
   defp file_paths(html) do
     html
     |> template_html("file-paths")
@@ -23,6 +25,7 @@ defmodule HexpmWeb.PreviewLiveTest do
     |> String.replace("&gt;", ">")
     |> String.replace("&amp;", "&")
     |> JSON.decode!()
+    |> Enum.map(&URI.decode/1)
   end
 
   test "renders package files inside the package layout", %{conn: conn} do
@@ -111,7 +114,7 @@ defmodule HexpmWeb.PreviewLiveTest do
 
   test "renders only the top level of the tree and every path for the client", %{conn: conn} do
     files =
-      [{"README.md", "readme"}] ++
+      [{"README.md", "readme"}, {"lib/tricky/d'x(1)!.ex", "punctuation"}] ++
         for index <- 1..500 do
           {"lib/generated/deep/file_#{index}.ex", "value = #{index}\n"}
         end
@@ -131,7 +134,13 @@ defmodule HexpmWeb.PreviewLiveTest do
     paths = file_paths(html)
     assert "lib/generated/deep/file_1.ex" in paths
     assert "lib/generated/deep/file_500.ex" in paths
-    assert length(paths) == 501
+    assert length(paths) == 502
+
+    # Encoded by the router's own rule, so a link is the base plus one of these
+    # and the client never spells the encoding out a second time.
+    raw = template_html(html, "file-paths")
+    assert raw =~ "lib/tricky/d%27x%281%29%21.ex"
+    refute raw =~ "d'x(1)!.ex"
 
     # The client clones these, so they carry the attributes it fills in and the
     # ones LiveView needs for patch navigation.

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -7,6 +7,24 @@ defmodule HexpmWeb.PreviewLiveTest do
     %{conn: build_conn()}
   end
 
+  # <template> content is a separate fragment, so selectors do not descend into
+  # it and it has to be read out of the markup.
+  defp template_html(html, name) do
+    [_, inner] = Regex.run(~r|<template data-#{name}[^>]*>(.*?)</template>|s, html)
+    inner
+  end
+
+  defp file_paths(html) do
+    html
+    |> template_html("file-paths")
+    |> String.replace("&quot;", "\"")
+    |> String.replace("&#39;", "'")
+    |> String.replace("&lt;", "<")
+    |> String.replace("&gt;", ">")
+    |> String.replace("&amp;", "&")
+    |> JSON.decode!()
+  end
+
   test "renders package files inside the package layout", %{conn: conn} do
     put_release("live_preview", "1.0.0", [
       {"README.md", "readme"},
@@ -91,7 +109,7 @@ defmodule HexpmWeb.PreviewLiveTest do
     assert html =~ "File is too large to be displayed (0.2 MB)."
   end
 
-  test "renders the full tree with collapsible directories and finder scaffolding", %{conn: conn} do
+  test "renders only the top level of the tree and every path for the client", %{conn: conn} do
     files =
       [{"README.md", "readme"}] ++
         for index <- 1..500 do
@@ -99,35 +117,164 @@ defmodule HexpmWeb.PreviewLiveTest do
         end
 
     put_release("large_manifest", "1.0.0", files)
-    {:ok, view, _html} = live(conn, "/packages/large_manifest/1.0.0/files")
+    {:ok, view, html} = live(conn, "/packages/large_manifest/1.0.0/files")
 
-    assert has_element?(view, "aside details summary", "lib")
-    assert has_element?(view, "aside details details details summary", "deep")
+    assert has_element?(view, ~s(aside details[data-dir-path="lib"] summary), "lib")
 
-    assert has_element?(
-             view,
-             ~s(aside a[href$="file_1.ex"][data-path="lib/generated/deep/file_1.ex"])
-           )
+    # Nothing below the closed directory is rendered, and none of its 500 files
+    # reach the document, but the client still gets every path to search and to
+    # build those children from.
+    refute has_element?(view, ~s(aside details details summary), "generated")
+    refute has_element?(view, ~s(aside a[href$="file_1.ex"]))
+    refute has_element?(view, ~s(aside a[href$="file_500.ex"]))
 
-    assert has_element?(view, ~s(aside a[href$="file_500.ex"]))
+    paths = file_paths(html)
+    assert "lib/generated/deep/file_1.ex" in paths
+    assert "lib/generated/deep/file_500.ex" in paths
+    assert length(paths) == 501
+
+    # The client clones these, so they carry the attributes it fills in and the
+    # ones LiveView needs for patch navigation.
+    file_template = template_html(html, "tree-file")
+    assert file_template =~ ~s(data-phx-link="patch")
+    assert file_template =~ "data-name"
+
+    dir_template = template_html(html, "tree-dir")
+    assert dir_template =~ "<details"
+    assert dir_template =~ "data-children"
+    assert dir_template =~ "data-name"
 
     assert has_element?(view, ~s(template[data-finder-item]))
-    assert has_element?(view, ~s(aside[phx-hook="FileFinder"][data-tree-version="1.0.0"]))
-    refute has_element?(view, ~s(form#preview-tree-search[phx-change]))
-    refute has_element?(view, ~s(form#preview-file-finder[phx-change]))
 
-    view
-    |> element(~s(aside a[href$="file_499.ex"]))
-    |> render_click()
+    # The client keys its cached nodes and index on this, so it has to identify
+    # the tree, not just the version.
+    assert has_element?(
+             view,
+             ~s(aside[phx-hook="FileFinder"][data-tree-version="hexpm/large_manifest/1.0.0"])
+           )
 
-    assert_patch(view, "/packages/large_manifest/1.0.0/files/lib/generated/deep/file_499.ex")
+    # A cloned directory must start closed and unfilled, or every client-built
+    # directory would render pre-expanded and never fill. Matched against the
+    # tag itself because a Tailwind class in the summary contains "open".
+    refute dir_template =~ ~r/<details[^>]*\sopen[\s>]/
+    refute dir_template =~ "data-filled"
 
     assert has_element?(
              view,
-             ~s(aside[data-active-path="lib/generated/deep/file_499.ex"])
+             ~s(aside[data-file-href-base="/packages/large_manifest/1.0.0/files"])
            )
 
-    refute has_element?(view, ~s(aside a[aria-current]))
+    assert has_element?(view, ~s(div[data-tree-container][phx-update="ignore"]))
+    refute has_element?(view, ~s(form#preview-tree-search[phx-change]))
+    refute has_element?(view, ~s(form#preview-file-finder[phx-change]))
+  end
+
+  test "opens the directories leading to the file on screen", %{conn: conn} do
+    put_release("deep_manifest", "1.0.0", [
+      {"README.md", "readme"},
+      {"lib/generated/deep/shown.ex", "shown"},
+      {"lib/generated/deep/sibling.ex", "sibling"},
+      {"lib/other/hidden.ex", "hidden"}
+    ])
+
+    {:ok, view, _html} =
+      live(conn, "/packages/deep_manifest/1.0.0/files/lib/generated/deep/shown.ex")
+
+    for path <- ["lib", "lib/generated", "lib/generated/deep"] do
+      assert has_element?(view, ~s(aside details[data-dir-path="#{path}"][open]))
+    end
+
+    # The file itself and its siblings are rendered, so the sidebar shows where
+    # you are without waiting on the client.
+    assert has_element?(view, ~s(aside a[data-path="lib/generated/deep/shown.ex"]), "shown.ex")
+    assert has_element?(view, ~s(aside a[data-path="lib/generated/deep/sibling.ex"]))
+
+    # Branches the file is not under stay closed.
+    assert has_element?(view, ~s(aside details[data-dir-path="lib/other"]))
+    refute has_element?(view, ~s(aside details[data-dir-path="lib/other"][open]))
+    refute has_element?(view, ~s(aside a[data-path="lib/other/hidden.ex"]))
+  end
+
+  test "marks an open directory filled and leaves a closed one for the client", %{conn: conn} do
+    put_release("filled_manifest", "1.0.0", [
+      {"README.md", "readme"},
+      {"lib/shown.ex", "shown"},
+      {"lib/other/hidden.ex", "hidden"}
+    ])
+
+    {:ok, view, _html} = live(conn, "/packages/filled_manifest/1.0.0/files/lib/shown.ex")
+
+    # data-filled is the whole handshake: set means the server already rendered
+    # the children, absent means the client must build them. Getting it wrong
+    # either double-renders or leaves the directory permanently empty.
+    assert has_element?(
+             view,
+             ~s(details[data-dir-path="lib"] > div[data-children][data-filled="true"])
+           )
+
+    assert has_element?(view, ~s(details[data-dir-path="lib/other"] > div[data-children]))
+
+    refute has_element?(
+             view,
+             ~s(details[data-dir-path="lib/other"] > div[data-filled="true"])
+           )
+  end
+
+  test "a name that is both a file and a directory renders as the directory", %{conn: conn} do
+    # A hex tarball cannot produce this, since the file list comes from a real
+    # unpacked tree. Pinned because the client makes the same choice, and the two
+    # rendering the same name differently would be worse than either choice.
+    put_release("collision_manifest", "1.0.0", [
+      {"README.md", "readme"},
+      {"lib", "a file called lib"},
+      {"lib/inner.ex", "inner"}
+    ])
+
+    {:ok, view, _html} = live(conn, "/packages/collision_manifest/1.0.0/files/lib/inner.ex")
+
+    assert has_element?(view, ~s(aside details[data-dir-path="lib"][open]))
+    assert has_element?(view, ~s(aside a[data-path="lib/inner.ex"]))
+    refute has_element?(view, ~s(aside a[data-path="lib"]))
+  end
+
+  test "survives a file list entry whose segments do not rejoin to it", %{conn: conn} do
+    # Path.safe_relative normalises a trailing slash away, so a tarball cannot
+    # produce this either. It is pinned because grouping by segment index used to
+    # hand Path.join a nil and take the whole LiveView down with a 500.
+    put_release("odd_manifest", "1.0.0", [
+      {"README.md", "readme"},
+      {"lib/dir/", "a directory-shaped entry"},
+      {"lib/dir/inner.ex", "inner"}
+    ])
+
+    {:ok, view, _html} = live(conn, "/packages/odd_manifest/1.0.0/files/lib/dir/inner.ex")
+
+    assert has_element?(view, "h2", "lib/dir/inner.ex")
+    assert has_element?(view, ~s(aside details[data-dir-path="lib/dir"][open]))
+    assert has_element?(view, ~s(aside a[data-path="lib/dir/inner.ex"]))
+  end
+
+  test "leaves the tree alone when patching within a version", %{conn: conn} do
+    put_release("patch_manifest", "1.0.0", [
+      {"README.md", "readme"},
+      {"lib/a/one.ex", "one"},
+      {"lib/b/two.ex", "two"}
+    ])
+
+    {:ok, view, _html} = live(conn, "/packages/patch_manifest/1.0.0/files/lib/a/one.ex")
+    assert has_element?(view, ~s(aside details[data-dir-path="lib/a"][open]))
+
+    render_patch(view, "/packages/patch_manifest/1.0.0/files/lib/b/two.ex")
+
+    # The tree container is phx-update="ignore", so the server does not move the
+    # open branch and does not render the newly shown file. Reconciling that is
+    # the client's job, driven by data-active-path, which does update.
+    assert has_element?(view, ~s(aside[data-active-path="lib/b/two.ex"]))
+    assert has_element?(view, ~s(aside details[data-dir-path="lib/a"][open]))
+    refute has_element?(view, ~s(aside a[data-path="lib/b/two.ex"]))
+
+    # Every path is still in the payload, which is what the client rebuilds from.
+    assert "lib/b/two.ex" in file_paths(render(view))
   end
 
   test "version picker preserves the selected filename", %{conn: conn} do
@@ -202,10 +349,11 @@ defmodule HexpmWeb.PreviewLiveTest do
 
     assert has_element?(view, "h2", "mix.exs")
 
+    assert has_element?(view, ~s(aside details[data-dir-path="lib"] summary), "lib")
+
     assert has_element?(
              view,
-             ~s(a[href="/packages/#{repository.name}/private_live_preview/1.0.0/files/lib/private.ex"]),
-             "private.ex"
+             ~s(aside[data-file-href-base="/packages/#{repository.name}/private_live_preview/1.0.0/files"])
            )
 
     assert has_element?(

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -195,6 +195,30 @@ defmodule HexpmWeb.PreviewLiveTest do
     refute has_element?(view, ~s(aside a[data-path="lib/other/hidden.ex"]))
   end
 
+  test "caps how many children a wide directory renders", %{conn: conn} do
+    limit = HexpmWeb.PreviewLive.children_limit()
+    wide = for index <- 1..(limit * 3), do: {"lib/model/file_#{index}.ex", "v\n"}
+
+    put_release("wide_manifest", "1.0.0", [{"README.md", "readme"} | wide])
+
+    {:ok, view, html} = live(conn, "/packages/wide_manifest/1.0.0/files/lib/model/file_1.ex")
+
+    rendered = length(Regex.scan(~r/data-path="lib\/model\//, hd(String.split(html, "l-line"))))
+    assert rendered == limit
+
+    # Not filled, so the client rebuilds the directory and pages through the rest.
+    refute has_element?(view, ~s(details[data-dir-path="lib/model"] > div[data-filled="true"]))
+
+    # It still has every path to page through, and the control to do it with.
+    assert length(file_paths(html)) == limit * 3 + 1
+    assert template_html(html, "tree-more") =~ "data-tree-more-button"
+
+    assert has_element?(
+             view,
+             ~s(aside[data-children-limit="#{limit}"])
+           )
+  end
+
   test "marks an open directory filled and leaves a closed one for the client", %{conn: conn} do
     put_release("filled_manifest", "1.0.0", [
       {"README.md", "readme"},


### PR DESCRIPTION
Every directory in the preview sidebar renders collapsed, so the markup for a
closed one is never displayed. The server now renders the top level plus the
directories leading to the file on screen, and the client fills a directory in
when it is opened, cloning `<template data-tree-file>` and `<template
data-tree-dir>` so the markup matches what the server emits. `child_nodes/3` only
recurses into open directories, so the nested structure is not built either, not
just not rendered.

This came out of the 07-29 outage: `/packages/*/files/*` was 91% of site traffic
under a scrape and its cost per request is what exhausted the web pods.

## How much it saves

A directory renders at most 100 children and the client pages through the rest, so
the worst case is bounded by that limit rather than by how wide a directory is.
Main renders 1,015,261 bytes for every file in a 707-file package, since its tree
does not depend on which file you asked for:

| package shape | file viewed | page bytes | vs main |
|---|---|---|---|
| 707 files over 99 dirs | root | 111,300 | -89% |
| 707 files over 99 dirs | deep | 284,743 | -72% |
| 705 files in one dir | root | 121,499 | -88% |
| 705 files in one dir | deep | 259,362 | -74% |
| 384 files in one dir (ory_client's shape) | deep | 236,925 | |

The cap exists because without it the shown file's own directory rendered in full,
which undid the change for packages that keep everything in one place. Generated
clients do exactly that, from their sitemaps: `ory_client` has 384 of 408 files in
`lib/ory/model`, `mailslurp` 235 of 270, `dagger` 160 of 197, `grizzly` 155 of 286,
`phoenix_kit` 160 of 690. Four of those were among the scraper's top targets. That
case measured +3% before the cap and -74% after.

Getting below roughly 250KB now means making a node cheaper than about 2KB, which
is the icon sprite and the repeated class strings, and is worth measuring against
`ory_client` rather than a synthetic package.

## Design notes for review

**The finder no longer reads the DOM.** It built its index from `a[data-path]`,
which a partial tree would starve, so it reads a JSON payload of every path. That
is cheaper than walking 707 nodes on mount and means a directory does not have to
be rendered for its files to be searchable.

**`phx-update="ignore"` on the tree container.** The client owns that subtree once
rendered and a re-render would discard filled directories. A welcome side effect:
directories the user opened survive navigation, where before morphdom collapsed
them on every patch. Because the client owns it, the open path is only computed
when `not connected?(socket)`, so the tree is identical across navigations within
a version and change tracking sends none of it. The container id is keyed on
repository/package/version; it contains slashes and dots so it is not usable as an
unescaped CSS selector, and nothing targets it that way.

**Encoding lives in one place.** The path payload is encoded the way the router
encodes, so a client-built link is the base plus one entry and the client only
percent-decodes to recover the name. An earlier revision had the client
percent-encode too, and the two disagreed about `!'()*`, which is the kind of
divergence a test could sample but not prevent.

## Trade-offs

Opening a directory now needs JavaScript, and after a patch the tree does not
contain the active file until the client reconciles it. Pre-PR a hook failure lost
only the highlight; now it leaves the sidebar on the previous file's branch.
LiveView needs JavaScript anyway and the finder was already client-side.

A no-JS visitor gets the top level plus the shown file's chain, and other
directories expand to an empty box. Crawler discovery of nested files now rests on
the per-package sitemap, which public packages have and private repositories do
not.

## Also in here

The preview sitemap's `changefreq` goes from `daily` to `yearly`, since those URLs
pin a version. Google ignores `changefreq`, so this changes no crawl behaviour; the
value was simply wrong.

## Reviewed

Four independent reviews ran over this and their findings are folded in: a blank
sidebar when a patch landed during an active search (the ignore boundary excluded
the results container), a `cssEscape` fallback that could throw on a filename
containing a newline, `hrefFor` under-encoding relative to `~p`, and three latent
defects from rebuilding a path from its segments rather than carrying the stored
one. A pre-existing bug was fixed alongside: the modal finder was empty after any
navigation.

Security was reviewed specifically because filenames in tarballs are
attacker-controlled and this adds sinks. No injection found: `JSON.encode!/1`
escapes none of `< > & " '`, but HEEx does, and `<template>` is not a raw-text
element so its content is tokenised with references decoded. Verified in headless
Chrome that `a</template><script>alert(1)</script>.ex` stays a single text node.

Still missing: there is no JS test setup in this repo, and `fill`, `reveal` and
`hrefFor` are where the correctness now lives.
