### PR TITLE
Group Dependabot Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,9 +7,9 @@ updates:
     cooldown:
       default-days: 7
     groups:
-      codeql:
+      actions:
         patterns:
-          - "github/codeql-action*"
+          - "*"
 
   - package-ecosystem: "mix"
     directory: "/"
@@ -17,3 +17,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    mix:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

Reduce Weekly Noise by Dependabot Updates

Downside: If there's a single dependency that does not work, it will fail the whole group. => Manual Action needed.

## Testing

We'll see it next week.
