### PR TITLE
Replace the removed mix hex.user key commands in the docs

### DIFF
--- a/lib/hexpm_web/templates/docs/permissions.html.md
+++ b/lib/hexpm_web/templates/docs/permissions.html.md
@@ -138,14 +138,7 @@ Always grant the minimum permissions needed for the task:
 Before using `api` or `api:write` scopes, enable 2FA on your account for added security.
 
 #### 3. Use Resource-Specific Scopes
-When possible, use package-specific or repository-specific scopes instead of broad permissions:
-```bash
-# Instead of:
-$ mix hex.user key generate --key-name ci --permission api:write
-
-# Consider:
-$ mix hex.user key generate --key-name ci --permission package:myorg/myapp
-```
+When possible, use package-specific or repository-specific scopes instead of broad permissions. A key that manages one package needs `package:{org}/{name}` rather than `api:write`. Grant it by checking that package under "Packages" when you generate the key.
 
 #### 4. Rotate API Keys Regularly
 Regularly revoke old API keys and generate new ones, especially for CI/CD pipelines.
@@ -167,28 +160,23 @@ This allows you to revoke access for a specific purpose without affecting others
 
 #### Generate a New Key
 
-```bash
-# Interactive key generation (prompts for permissions)
-$ mix hex.user key generate
+Keys are generated on the [keys page](/dashboard/keys) of your dashboard:
 
-# Generate key with specific permissions
-$ mix hex.user key generate --key-name publish-ci --permission api:write
+1. Select "Generate New Key".
+2. Enter a key name, such as `publish-ci`.
+3. Choose an expiration.
+4. Under "Key permissions", check the scopes to grant. "Read" and "Write" sit beneath "API", private repositories beneath "All Repositories", and single packages beneath "Packages".
+5. Select "Generate Key".
 
-# Generate key for specific package
-$ mix hex.user key generate --key-name myapp-ci --permission package:myorg/myapp
-```
+The key is shown once, when you generate it.
 
 #### List Existing Keys
 
-```bash
-$ mix hex.user key list
-```
+The keys page lists every key on your account with its name, permissions, expiration, and last use.
 
 #### Revoke a Key
 
-```bash
-$ mix hex.user key revoke key-name
-```
+Select the revoke action in the key's row on the keys page.
 
 #### For Organization Keys
 
@@ -246,34 +234,28 @@ The `repositories` scope grants access to ALL private repositories you belong to
 
 #### Scenario 1: CI/CD Publishing Public Packages
 **Recommended Scopes:** `api:write`
-```bash
-$ mix hex.user key generate --key-name github-ci --permission api:write
-```
+
+Check "Write" beneath "API".
 
 #### Scenario 2: CI/CD Publishing to Private Repository
 **Recommended Scopes:** `api:write` (publishing) + `repositories` (fetching private dependencies)
-```bash
-# The CI needs to both fetch private deps and publish
-$ mix hex.user key generate --key-name github-ci --permission api:write,repositories
-```
+
+Check "Write" beneath "API", and check "All Repositories".
 
 #### Scenario 3: Development Machine Fetching Private Packages
 **Recommended Scopes:** `repositories` only
-```bash
-$ mix hex.user key generate --key-name laptop --permission repositories
-```
+
+Check "All Repositories", or a single organization beneath it.
 
 #### Scenario 4: Read-Only Monitoring Tool
 **Recommended Scopes:** `api:read`
-```bash
-$ mix hex.user key generate --key-name monitoring --permission api:read
-```
+
+Check "Read" beneath "API".
 
 #### Scenario 5: Single Package Management
 **Recommended Scopes:** `package:org/name`
-```bash
-$ mix hex.user key generate --key-name myapp-deploy --permission package:myorg/myapp
-```
+
+Check the package beneath "Packages".
 
 ---
 

--- a/lib/hexpm_web/templates/docs/publish.html.md
+++ b/lib/hexpm_web/templates/docs/publish.html.md
@@ -163,15 +163,15 @@ When running the command to publish a package, Hex will create a tar file of all
 
 ### Publishing from CI
 
-You can automate publishing packages from tools such as CI. You need a key with permissions to publish packages:
+You can automate publishing packages from tools such as CI. You need a key with permissions to publish packages. Generate one on the [keys page](/dashboard/keys) of your dashboard:
 
-```nohighlight
-$ mix hex.user key generate --key-name publish-ci --permission api:write
-Username:
-Account password:
-Generating key...
-f48ac236bca15c3271e077c15c5320c4
-```
+1. Select "Generate New Key".
+2. Enter a key name, such as `publish-ci`.
+3. Choose an expiration.
+4. Under "Key permissions", check "Write" beneath "API".
+5. Select "Generate Key".
+
+The key is shown once, when you generate it.
 
 If you are publishing a package for your organization it is recommended to use a key for the organization instead of a personal key:
 


### PR DESCRIPTION
Closes #1787.

Hex 2.4.0 removed the `key` subcommand from `mix hex.user`. The publishing and permissions pages still instruct readers to run it, so the documented way to get a key for CI fails on every current client:

```
$ mix hex.user key generate --key-name publish-ci --permission api:write
** (Mix) Could not invoke task "hex.user": 2 errors found!
--key-name : Unknown option
--permission : Unknown option
```

This replaces those thirteen command blocks with the flow on `/dashboard/keys`, which is where a user key is now created, listed, and revoked.

Every quoted label comes from `generate_key_modal.ex` and `key_management_card.ex`: "Generate New Key", "Key name", "Expiration", "Key permissions", "API" with "Read" and "Write", "All Repositories", "Packages", and "Generate Key". The keys table columns named under "List Existing Keys" are the ones the card renders.

### Left alone

- The `mix hex.organization key ORG generate|list|revoke` blocks. That task still exists on 2.5.1 and parses the documented `--key-name` and `--permission` flags.
- The `Local password:` line in the organization sample output. Checking it needs an organization, so I have no evidence either way.
- `blog/003-hex-v018-released.html.md`, which names the old command in a 2015 announcement.
- `rebar3_publish.html.md`, which shows `rebar3 hex user register` prompting for a password. That is a separate client and I gathered no evidence about it.

The permissions page uses Title Case headings and bold run-in labels, and the publish page uses sentence case. Both are unchanged here. The diff removes commands and adds prose, and reformats nothing.
