### PR TITLE
Redirect when a release does not have the requested file

### DIFF
--- a/lib/hexpm/preview/preview.ex
+++ b/lib/hexpm/preview/preview.ex
@@ -8,10 +8,28 @@ defmodule Hexpm.Preview do
   @max_file_size 100 * 1000
   @readme_filenames ~w(README.md readme.md README.markdown readme.markdown README.txt readme.txt README readme)
 
+  @doc """
+  Reads the file a request asked for.
+
+  Returns `{:missing, filename}` when the release has no such file, naming the
+  file it shows when none is asked for, so a caller can send the request there
+  without reading anything more.
+  """
   def source(repository, package, version, requested_filename \\ nil) do
-    with [_ | _] = files <- Bucket.get_file_list(repository, package, version),
-         filename when is_binary(filename) <- selected_file(files, requested_filename),
-         size when is_integer(size) <- Bucket.file_size(repository, package, version, filename),
+    case Bucket.get_file_list(repository, package, version) do
+      [_ | _] = files ->
+        case selected_file(files, requested_filename) do
+          nil -> {:missing, default_file(files)}
+          filename -> read_source(repository, package, version, files, filename)
+        end
+
+      _ ->
+        :error
+    end
+  end
+
+  defp read_source(repository, package, version, files, filename) do
+    with size when is_integer(size) <- Bucket.file_size(repository, package, version, filename),
          result when is_map(result) <-
            source_result(repository, package, version, filename, size) do
       {:ok, Map.merge(result, %{files: files, filename: filename})}

--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -53,7 +53,7 @@ defmodule HexpmWeb.PreviewLive do
            RepositoryAccess.fetch_package(socket.assigns.current_user, repository, package_name),
          [_ | _] = releases <- Releases.all(package),
          release when not is_nil(release) <- find_release(releases, version),
-         {:ok, source, replace_path?} <-
+         {:ok, source} <-
            source(repository, package_name, version, requested_filename, params["fallback"]) do
       socket =
         socket
@@ -61,19 +61,24 @@ defmodule HexpmWeb.PreviewLive do
         |> assign_package(package, release, releases)
         |> assign_source(repository, package_name, version, source)
 
-      socket =
-        if replace_path? and connected?(socket) do
-          push_patch(socket,
-            to: files_path(repository, package_name, version, source.filename),
-            replace: true
-          )
-        else
-          socket
-        end
-
       {:noreply, socket}
     else
-      _ -> raise NotFoundError
+      # The version picker links the file being read in every release of the
+      # package, so a release that never had that file gets asked for it. The
+      # answer is the file the release does show, at that file's own address:
+      # rendering it here would serve a 200 under a path the release does not
+      # have, and every path it does not have would be a page of its own.
+      {:missing, filename} ->
+        to = files_path(repository, package_name, version, filename)
+
+        if connected?(socket) do
+          {:noreply, push_patch(socket, to: to, replace: true)}
+        else
+          {:noreply, redirect(socket, to: to)}
+        end
+
+      _ ->
+        raise NotFoundError
     end
   end
 
@@ -151,17 +156,9 @@ defmodule HexpmWeb.PreviewLive do
 
   defp source(repository, package, version, requested_filename, fallback) do
     case Hexpm.Preview.source(repository, package, version, requested_filename) do
-      {:ok, source} ->
-        {:ok, source, false}
-
-      :error when fallback == "default" ->
-        case Hexpm.Preview.source(repository, package, version) do
-          {:ok, source} -> {:ok, source, true}
-          :error -> :error
-        end
-
-      :error ->
-        :error
+      {:ok, source} -> {:ok, source}
+      {:missing, filename} when fallback == "default" -> {:missing, filename}
+      _ -> :error
     end
   end
 

--- a/test/hexpm/preview/preview_test.exs
+++ b/test/hexpm/preview/preview_test.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.PreviewTest do
 
   alias Hexpm.Preview
 
-  test "source selects known files and rejects invalid paths" do
+  test "source selects known files and names a default for paths a release does not have" do
     put_release("hexpm", "source_package", "1.0.0", [
       {"mix.exs", "mix"},
       {"README.md", "readme"},
@@ -15,7 +15,13 @@ defmodule Hexpm.PreviewTest do
     assert source.contents == "source"
     assert source.type == :text
 
-    assert Preview.source("hexpm", "source_package", "1.0.0", "../other/file") == :error
+    # A path outside the release is answered from the file list, so nothing is
+    # ever read under the requested name.
+    assert Preview.source("hexpm", "source_package", "1.0.0", "../other/file") ==
+             {:missing, "README.md"}
+
+    assert Preview.source("hexpm", "source_package", "1.0.0", "lib/gone.ex") ==
+             {:missing, "README.md"}
   end
 
   test "source reports binary and oversized files without returning their contents" do

--- a/test/hexpm_web/live/preview_live_test.exs
+++ b/test/hexpm_web/live/preview_live_test.exs
@@ -338,16 +338,29 @@ defmodule HexpmWeb.PreviewLiveTest do
 
     assert has_element?(direct_view, "h2", "shared.ex")
 
-    conn = get(conn, "/packages/versioned_preview/2.0.0/files/lib/shared.ex?fallback=default")
+    # A release without the file sends the request to the file it does show,
+    # rather than answering under a path it does not have.
+    redirected =
+      get(conn, "/packages/versioned_preview/2.0.0/files/lib/shared.ex?fallback=default")
 
-    assert html_response(conn, 200) =~
-             HexpmWeb.Endpoint.url() <>
-               ~s(/packages/versioned_preview/2.0.0/files/README.md" rel="canonical")
+    assert redirected_to(redirected) ==
+             "/packages/versioned_preview/2.0.0/files/README.md"
 
-    {:ok, fallback_view, _html} = live(conn)
+    assert {:error, {:redirect, %{to: "/packages/versioned_preview/2.0.0/files/README.md"}}} =
+             live(conn, "/packages/versioned_preview/2.0.0/files/lib/shared.ex?fallback=default")
 
-    assert has_element?(fallback_view, "h2", "README.md")
+    # Any path the release does not have lands on that same page, so following
+    # the picker never opens a page per path.
+    assert redirected_to(
+             get(conn, "/packages/versioned_preview/2.0.0/files/made/up/path.ex?fallback=default")
+           ) == "/packages/versioned_preview/2.0.0/files/README.md"
 
+    # Without the parameter the path is simply not found.
+    assert_raise HexpmWeb.PreviewLive.NotFoundError, fn ->
+      get(conn, "/packages/versioned_preview/2.0.0/files/made/up/path.ex")
+    end
+
+    # An already connected view patches in place instead of reloading.
     render_patch(view, "/packages/versioned_preview/2.0.0/files/lib/shared.ex?fallback=default")
     assert_patch(view, "/packages/versioned_preview/2.0.0/files/README.md")
     assert has_element?(view, "h2", "README.md")


### PR DESCRIPTION
The version picker on a file preview links the file being read in every release of the package, appending `?fallback=default` so a release that never had that file shows something rather than a 404. It did that by rendering the release's default file under the requested path and answering 200, and only correcting the address once a browser connected the socket.

That made every path a release lacks into a page of its own. `/packages/ash/1.0.0/files/totally/made/up/path.ex?fallback=default` returned 200 with README.md for any string at all, so there were no dead ends to stop on, and ash alone advertises 892 of these from each of its file pages.

Now the request goes to the file the release does show. `Preview.source/4` reads the file list, and when the requested name is not in it, returns `{:missing, filename}` naming the default without reading anything under the requested name. Answering costs one bucket read and a redirect instead of a read, a syntax highlight and a tree build, and every path a release lacks lands on the same page. A view that is already connected still patches in place, so switching versions from a file does not reload.

The redirect is a 302 rather than a 301 because a public release can be replaced within an hour of publishing, and a permanent redirect cached before that would be hard to undo.