### PR TITLE
Tell people why we removed their package or account

### DIFF
--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -40,12 +40,27 @@ defmodule Hexpm.AdminTasks do
       iex> AdminTasks.remove_package("hexpm", "malicious_pkg")
       :ok
 
+      # Remove a package and tell its owners why
+      iex> AdminTasks.reasons(:package) |> Keyword.keys()
+      [:seo_spam, :empty, :name_squatting, ...]
+      iex> AdminTasks.remove_package("hexpm", "seo_pkg", reason: :seo_spam)
+      :ok
+
       # Send an email
       iex> AdminTasks.send_email(["bob@example.com"], "Hex.pm - Subject", "Body")
       {:ok, 1}
+
+  ## Removal emails
+
+  `remove_package/3`, `remove_release/4` and `remove_user/2` take a `:reason`
+  and stay silent without one. A reason is either an id from `reasons/1` or
+  your own text, and it is resolved before anything is deleted, so a
+  misremembered id fails without touching the database.
   """
 
   use Hexpm.Context
+
+  alias Hexpm.AdminTasks.Reasons
 
   require Logger
 
@@ -176,6 +191,8 @@ defmodule Hexpm.AdminTasks do
   - `opts` - Options:
     - `:delete_packages` - When `true`, deletes all packages where the user is
       the sole owner before removing the user (default: `false`)
+    - `:reason` - Emails the user why the account was removed, either a canned
+      id from `reasons(:user)` or your own text. Nothing is sent without it.
 
   ## Examples
 
@@ -184,30 +201,40 @@ defmodule Hexpm.AdminTasks do
 
       iex> AdminTasks.remove_user("spammer", delete_packages: true)
       :ok
+
+      iex> AdminTasks.remove_user("spammer", reason: :spam_account)
+      :ok
   """
-  @spec remove_user(String.t(), keyword()) :: :ok | {:error, atom() | Ecto.Changeset.t()}
+  @spec remove_user(String.t(), keyword()) :: :ok | {:error, term() | Ecto.Changeset.t()}
   def remove_user(username, opts \\ []) do
-    with {:ok, user} <- find_user(username) do
-      if Keyword.get(opts, :delete_packages, false) do
-        Repo.transaction(fn ->
-          deleted = delete_sole_owned_packages(user)
+    with {:ok, user} <- find_user(username),
+         {:ok, reason} <- resolve_reason(:user, opts),
+         :ok <- delete_user(user, opts) do
+      notify_removal(reason, user.username, &Emails.account_removed(user, &1))
+      :ok
+    end
+  end
 
-          case Users.delete(user, audit: AuditLogs.admin(), notify: false) do
-            :ok -> deleted
-            {:error, reason} -> Repo.rollback(reason)
-          end
-        end)
-        |> case do
-          {:ok, deleted} ->
-            Enum.each(deleted, &run_package_removal_side_effects/1)
-            :ok
+  defp delete_user(user, opts) do
+    if Keyword.get(opts, :delete_packages, false) do
+      Repo.transaction(fn ->
+        deleted = delete_sole_owned_packages(user)
 
-          {:error, reason} ->
-            {:error, reason}
+        case Users.delete(user, audit: AuditLogs.admin(), notify: false) do
+          :ok -> deleted
+          {:error, reason} -> Repo.rollback(reason)
         end
-      else
-        Users.delete(user, audit: AuditLogs.admin(), notify: false)
+      end)
+      |> case do
+        {:ok, deleted} ->
+          Enum.each(deleted, &run_package_removal_side_effects/1)
+          :ok
+
+        {:error, reason} ->
+          {:error, reason}
       end
+    else
+      Users.delete(user, audit: AuditLogs.admin(), notify: false)
     end
   end
 
@@ -319,23 +346,47 @@ defmodule Hexpm.AdminTasks do
 
   - `repo` - The repository name (e.g., "hexpm")
   - `package_name` - The name of the package to remove
+  - `opts` - Options:
+    - `:reason` - Emails the owners why the package was removed, either a
+      canned id from `reasons(:package)` or your own text. Nothing is sent
+      without it.
 
   ## Examples
 
       iex> AdminTasks.remove_package("hexpm", "malicious_pkg")
       :ok
+
+      iex> AdminTasks.remove_package("hexpm", "seo_pkg", reason: :seo_spam)
+      :ok
   """
-  @spec remove_package(String.t(), String.t()) :: :ok | {:error, atom()}
-  def remove_package(repo, package_name) do
-    with {:ok, package} <- find_package(repo, package_name) do
+  @spec remove_package(String.t(), String.t(), keyword()) :: :ok | {:error, term()}
+  def remove_package(repo, package_name, opts \\ []) do
+    with {:ok, package} <- find_package(repo, package_name),
+         {:ok, reason} <- resolve_reason(:package, opts) do
+      owners = owner_recipients(package)
+
       {:ok, {releases, package}} =
         Repo.transaction(fn ->
           remove_package_db(package)
         end)
 
       run_package_removal_side_effects({releases, package})
+
+      notify_removal(
+        reason,
+        "owners of #{package.name}",
+        &Emails.package_removed(owners, package.name, &1)
+      )
+
       :ok
     end
+  end
+
+  # Read before the package goes, otherwise there is nobody left to write to.
+  defp owner_recipients(package) do
+    assoc(package, :owners)
+    |> Repo.all()
+    |> Repo.preload([:emails, organization: [organization_users: [user: :emails]]])
   end
 
   defp remove_package_db(package) do
@@ -372,24 +423,69 @@ defmodule Hexpm.AdminTasks do
   - `repo` - The repository name (e.g., "hexpm")
   - `package_name` - The name of the package
   - `version` - The version to remove
+  - `opts` - Options:
+    - `:reason` - Emails the owners why the release was removed, either a
+      canned id from `reasons(:release)` or your own text. Nothing is sent
+      without it.
 
   ## Examples
 
       iex> AdminTasks.remove_release("hexpm", "my_pkg", "1.0.0")
       :ok
+
+      iex> AdminTasks.remove_release("hexpm", "my_pkg", "1.0.0", reason: :undisclosed_behaviour)
+      :ok
   """
-  @spec remove_release(String.t(), String.t(), String.t()) :: :ok | {:error, atom()}
-  def remove_release(repo, package_name, version) do
+  @spec remove_release(String.t(), String.t(), String.t(), keyword()) :: :ok | {:error, term()}
+  def remove_release(repo, package_name, version, opts \\ []) do
     with {:ok, package} <- find_package(repo, package_name),
-         {:ok, release} <- find_release(package, version) do
+         {:ok, release} <- find_release(package, version),
+         {:ok, reason} <- resolve_reason(:release, opts) do
+      owners = owner_recipients(package)
+
       Release.delete(release, force: true)
       |> Repo.delete!()
 
       Assets.revert_release(release)
       RegistryBuilder.package(package)
       RegistryBuilder.repository(package.repository)
+
+      notify_removal(
+        reason,
+        "owners of #{package.name}",
+        &Emails.release_removed(owners, package.name, version, &1)
+      )
+
       :ok
     end
+  end
+
+  @doc """
+  The canned `:reason` values a removal task accepts, as `{id, text}` pairs.
+
+      iex> AdminTasks.reasons(:package) |> Keyword.keys()
+      [:seo_spam, :empty, :name_squatting, :typosquatting, :copyright,
+       :undisclosed_behaviour, :malware, :owner_request, :terms_of_service]
+  """
+  @spec reasons(:package | :release | :user) :: keyword(String.t())
+  defdelegate reasons(scope), to: Reasons, as: :all
+
+  # Resolved before anything is deleted so an unknown id costs nothing.
+  defp resolve_reason(scope, opts) do
+    case Keyword.get(opts, :reason) do
+      nil -> {:ok, nil}
+      reason -> Reasons.fetch(scope, reason)
+    end
+  end
+
+  # A delivery failure is logged and not raised, the deletion already happened
+  # and the caller has no way to undo it.
+  defp notify_removal(nil, _description, _build_email), do: :ok
+
+  defp notify_removal(reason, description, build_email) do
+    email = build_email.(reason)
+    if email.to != [], do: deliver(email, description)
+    :ok
   end
 
   @doc """
@@ -727,18 +823,18 @@ defmodule Hexpm.AdminTasks do
       recipients
       |> List.wrap()
       |> Enum.uniq()
-      |> Enum.count(&deliver_email(&1, subject, body))
+      |> Enum.count(&deliver(Emails.announcement(&1, subject, body), &1))
 
     {:ok, sent}
   end
 
-  defp deliver_email(recipient, subject, body) do
-    case Mailer.deliver(Emails.announcement(recipient, subject, body)) do
+  defp deliver(email, description) do
+    case Mailer.deliver(email) do
       {:ok, _} ->
         true
 
       {:error, reason} ->
-        Logger.error("Could not send email to #{recipient}: #{inspect(reason)}")
+        Logger.error("Could not send email to #{description}: #{inspect(reason)}")
         false
     end
   end

--- a/lib/hexpm/admin_tasks/reasons.ex
+++ b/lib/hexpm/admin_tasks/reasons.ex
@@ -1,0 +1,115 @@
+defmodule Hexpm.AdminTasks.Reasons do
+  @moduledoc """
+  Canned reasons for the `:reason` option on the removal tasks.
+
+  Pass an id to send the matching text, or a string to send that string.
+
+  Each text follows the sentence that already named what was removed, so it
+  states the rule that was broken and never repeats the package name, the
+  version, or the username. A reason lists the scopes it makes sense for:
+  `:empty` explains a package and explains nothing about an account.
+
+      iex> AdminTasks.reasons(:user) |> Keyword.keys()
+      [:seo_spam, :typosquatting, :undisclosed_behaviour, :malware, :spam_account,
+       :owner_request, :terms_of_service]
+  """
+
+  @scopes [:package, :release, :user]
+
+  @reasons [
+    %{
+      id: :seo_spam,
+      scopes: [:package, :release, :user],
+      text:
+        "Hex.pm does not accept packages published to advertise a website. " <>
+          "What was published provided no working software, only links and text " <>
+          "pointing at an unrelated site."
+    },
+    %{
+      id: :empty,
+      scopes: [:package, :release],
+      text:
+        "There was no working software here, only an empty or unfinished " <>
+          "skeleton with nothing implemented behind it."
+    },
+    %{
+      id: :name_squatting,
+      scopes: [:package],
+      text:
+        "The package held a name without providing software. Hex.pm does not " <>
+          "reserve names for projects that have not been published."
+    },
+    %{
+      id: :typosquatting,
+      scopes: [:package, :release, :user],
+      text:
+        "The name closely imitated an existing Hex.pm package. Names chosen to " <>
+          "be mistaken for another package are not allowed."
+    },
+    %{
+      id: :copyright,
+      scopes: [:package, :release],
+      text: "The package redistributed someone else's work without the right to do so."
+    },
+    %{
+      id: :undisclosed_behaviour,
+      scopes: [:package, :release, :user],
+      text:
+        "The code did something it never disclosed, such as reading credentials " <>
+          "or contacting a remote server at build time. Hex.pm removes packages " <>
+          "that hide behaviour from the people installing them."
+    },
+    %{
+      id: :malware,
+      scopes: [:package, :release, :user],
+      text:
+        "The code was malicious and attempted to compromise the machines of " <>
+          "anyone who installed it."
+    },
+    %{
+      id: :spam_account,
+      scopes: [:user],
+      text:
+        "The account was used to publish spam. Every package it published was " <>
+          "advertising or filler rather than working software."
+    },
+    %{
+      id: :owner_request,
+      scopes: [:package, :release, :user],
+      text: "The owner asked us to remove it."
+    },
+    %{
+      id: :terms_of_service,
+      scopes: [:package, :release, :user],
+      text: "This broke the Hex.pm terms of service."
+    }
+  ]
+
+  @doc """
+  Every reason usable for `scope`, as `{id, text}` pairs.
+  """
+  @spec all(:package | :release | :user) :: keyword(String.t())
+  def all(scope) when scope in @scopes do
+    for reason <- @reasons, scope in reason.scopes, do: {reason.id, reason.text}
+  end
+
+  @doc """
+  Resolves a `:reason` value to the text that goes in the email.
+
+  A string is its own text. An id has to be one the scope allows, and an
+  unknown id is an error rather than a silent fallback: the removal tasks
+  resolve the reason before they delete anything, so a typo costs nothing.
+  """
+  @spec fetch(:package | :release | :user, atom() | String.t()) ::
+          {:ok, String.t()} | {:error, {:unknown_reason, term()}}
+  def fetch(scope, text) when scope in @scopes and is_binary(text) do
+    {:ok, text}
+  end
+
+  def fetch(scope, id) when scope in @scopes do
+    case Enum.find(@reasons, &(&1.id == id and scope in &1.scopes)) do
+      nil -> {:error, {:unknown_reason, id}}
+      reason -> {:ok, reason.text}
+    end
+  end
+end

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -65,6 +65,34 @@ defmodule Hexpm.Emails do
     |> render_body(:account_deleted)
   end
 
+  def account_removed(user, reason) do
+    base_email()
+    |> email_to(user)
+    |> subject("Hex.pm - Your account has been removed")
+    |> assign(:username, user.username)
+    |> assign(:reason, reason)
+    |> render_body(:account_removed)
+  end
+
+  def package_removed(owners, package, reason) do
+    base_email()
+    |> email_to(owners)
+    |> subject("Hex.pm - Package #{package} has been removed")
+    |> assign(:package, package)
+    |> assign(:reason, reason)
+    |> render_body(:package_removed)
+  end
+
+  def release_removed(owners, package, version, reason) do
+    base_email()
+    |> email_to(owners)
+    |> subject("Hex.pm - Package #{package} v#{version} has been removed")
+    |> assign(:package, package)
+    |> assign(:version, version)
+    |> assign(:reason, reason)
+    |> render_body(:release_removed)
+  end
+
   def password_changed(user) do
     base_email()
     |> email_to(user)

--- a/lib/hexpm_web/templates/email/account_removed.html.eex
+++ b/lib/hexpm_web/templates/email/account_removed.html.eex
@@ -1,0 +1,21 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  <%= AccountRemoved.title() %>
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= AccountRemoved.message(@username) %>
+</p>
+
+<p style="color: #030913; font-size: 16px; line-height: 24px; font-weight: 600; margin: 0 0 8px 0;">
+  <%= AccountRemoved.reason_heading() %>
+</p>
+
+<%= for paragraph <- AccountRemoved.paragraphs(@reason) do %>
+  <p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+    <%= paragraph %>
+  </p>
+<% end %>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(AccountRemoved.questions_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/account_removed.text.eex
+++ b/lib/hexpm_web/templates/email/account_removed.text.eex
@@ -1,0 +1,9 @@
+<%= AccountRemoved.title() %>
+
+<%= AccountRemoved.message(@username) %>
+
+<%= AccountRemoved.reason_heading() %>
+
+<%= @reason %>
+
+<%= AccountRemoved.questions_notice(:text) %>

--- a/lib/hexpm_web/templates/email/package_removed.html.eex
+++ b/lib/hexpm_web/templates/email/package_removed.html.eex
@@ -1,0 +1,21 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  <%= PackageRemoved.title(@package) %>
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= PackageRemoved.message(@package) %>
+</p>
+
+<p style="color: #030913; font-size: 16px; line-height: 24px; font-weight: 600; margin: 0 0 8px 0;">
+  <%= PackageRemoved.reason_heading() %>
+</p>
+
+<%= for paragraph <- PackageRemoved.paragraphs(@reason) do %>
+  <p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+    <%= paragraph %>
+  </p>
+<% end %>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(PackageRemoved.questions_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/package_removed.text.eex
+++ b/lib/hexpm_web/templates/email/package_removed.text.eex
@@ -1,0 +1,9 @@
+<%= PackageRemoved.title(@package) %>
+
+<%= PackageRemoved.message(@package) %>
+
+<%= PackageRemoved.reason_heading() %>
+
+<%= @reason %>
+
+<%= PackageRemoved.questions_notice(:text) %>

--- a/lib/hexpm_web/templates/email/release_removed.html.eex
+++ b/lib/hexpm_web/templates/email/release_removed.html.eex
@@ -1,0 +1,21 @@
+<h1 style="color: #030913; font-size: 24px; line-height: 32px; font-weight: 600; margin: 0 0 24px 0; text-align: center;">
+  <%= ReleaseRemoved.title(@package, @version) %>
+</h1>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= ReleaseRemoved.message(@package, @version) %>
+</p>
+
+<p style="color: #030913; font-size: 16px; line-height: 24px; font-weight: 600; margin: 0 0 8px 0;">
+  <%= ReleaseRemoved.reason_heading() %>
+</p>
+
+<%= for paragraph <- ReleaseRemoved.paragraphs(@reason) do %>
+  <p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+    <%= paragraph %>
+  </p>
+<% end %>
+
+<p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
+  <%= raw(ReleaseRemoved.questions_notice(:html)) %>
+</p>

--- a/lib/hexpm_web/templates/email/release_removed.text.eex
+++ b/lib/hexpm_web/templates/email/release_removed.text.eex
@@ -1,0 +1,9 @@
+<%= ReleaseRemoved.title(@package, @version) %>
+
+<%= ReleaseRemoved.message(@package, @version) %>
+
+<%= ReleaseRemoved.reason_heading() %>
+
+<%= @reason %>
+
+<%= ReleaseRemoved.questions_notice(:text) %>

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -40,6 +40,19 @@ defmodule HexpmWeb.EmailView do
       "If you have any problems don't hesitate to contact support at #{support_link(format)}."
     end
 
+    def questions_notice(format) do
+      "If you have any questions about why this action was taken, please contact support at #{support_link(format)}."
+    end
+
+    def reason_heading(), do: "Reason:"
+
+    def paragraphs(body) do
+      body
+      |> String.split(~r/\n\s*\n/, trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+    end
+
     # Common labels for build tools
     def for_mix_label(), do: "For mix:"
     def for_rebar3_label(), do: "For rebar3:"
@@ -84,16 +97,26 @@ defmodule HexpmWeb.EmailView do
     end
   end
 
+  defmodule AccountRemoved do
+    defdelegate reason_heading(), to: Common
+    defdelegate questions_notice(format), to: Common
+    defdelegate paragraphs(reason), to: Common
+
+    def title() do
+      "Your account has been removed"
+    end
+
+    def message(username) do
+      "The Hex.pm account \"#{username}\" has been removed by the Hex.pm team. " <>
+        "The username has been retired and cannot be registered again."
+    end
+  end
+
   defmodule Announcement do
+    defdelegate paragraphs(body), to: Common
+
     def title("Hex.pm - " <> title), do: title
     def title(subject), do: subject
-
-    def paragraphs(body) do
-      body
-      |> String.split(~r/\n\s*\n/, trim: true)
-      |> Enum.map(&String.trim/1)
-      |> Enum.reject(&(&1 == ""))
-    end
   end
 
   defmodule BuildTools do
@@ -190,9 +213,7 @@ defmodule HexpmWeb.EmailView do
       "If the link above has expired, you can request a new password reset at #{reset_url}."
     end
 
-    def questions_notice(format) do
-      "If you have any questions about why this action was taken, please contact support at #{Common.support_link(format)}."
-    end
+    defdelegate questions_notice(format), to: Common
 
     defdelegate mix_code(), to: BuildTools, as: :mix_hex_user_auth
     defdelegate rebar_code(), to: BuildTools, as: :rebar3_hex_user_auth
@@ -324,6 +345,36 @@ defmodule HexpmWeb.EmailView do
       # or
       gleam hex retire --package #{package} --version #{version} security --message "Not published by owners"
       """
+    end
+  end
+
+  defmodule PackageRemoved do
+    defdelegate reason_heading(), to: Common
+    defdelegate questions_notice(format), to: Common
+    defdelegate paragraphs(reason), to: Common
+
+    def title(package) do
+      "Package #{package} has been removed"
+    end
+
+    def message(package) do
+      "The package #{package} and all of its releases have been removed from Hex.pm " <>
+        "by the Hex.pm team."
+    end
+  end
+
+  defmodule ReleaseRemoved do
+    defdelegate reason_heading(), to: Common
+    defdelegate questions_notice(format), to: Common
+    defdelegate paragraphs(reason), to: Common
+
+    def title(package, version) do
+      "#{package} v#{version} has been removed"
+    end
+
+    def message(package, version) do
+      "Version #{version} of the package #{package} has been removed from Hex.pm " <>
+        "by the Hex.pm team. Other versions of the package are unaffected."
     end
   end
 

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -227,6 +227,97 @@ defmodule Hexpm.AdminTasksTest do
     end
   end
 
+  describe "remove_user/2 with reason" do
+    test "emails the user why the account was removed" do
+      user = insert(:user)
+      address = User.email(user, :primary)
+
+      assert :ok =
+               AdminTasks.remove_user(user.username,
+                 reason: "The account only published packages advertising an unrelated site."
+               )
+
+      assert_email_sent(fn email ->
+        assert email.to == [{user.username, address}]
+        assert email.subject == "Hex.pm - Your account has been removed"
+        assert email.text_body =~ user.username
+        assert email.text_body =~ "advertising an unrelated site"
+        assert email.html_body =~ "advertising an unrelated site"
+      end)
+    end
+
+    test "escapes the reason in the html email" do
+      user = insert(:user)
+
+      assert :ok = AdminTasks.remove_user(user.username, reason: "<script>alert(1)</script>")
+
+      assert_email_sent(fn email ->
+        refute email.html_body =~ "<script>"
+        assert email.html_body =~ "&lt;script&gt;"
+      end)
+    end
+
+    test "sends one email when sole-owned packages are deleted too" do
+      user = insert(:user)
+      package = insert(:package)
+      insert(:package_owner, package: package, user: user)
+      package_id = package.id
+
+      assert :ok =
+               AdminTasks.remove_user(user.username,
+                 delete_packages: true,
+                 reason: "Bulk spam publishing."
+               )
+
+      refute Repo.get(Package, package_id)
+
+      assert_email_sent(fn email ->
+        assert email.subject == "Hex.pm - Your account has been removed"
+      end)
+
+      refute_email_sent()
+    end
+
+    test "sends the canned text for a reason id" do
+      user = insert(:user)
+
+      assert :ok = AdminTasks.remove_user(user.username, reason: :spam_account)
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ AdminTasks.reasons(:user)[:spam_account]
+      end)
+    end
+
+    test "rejects an unknown reason without deleting the user" do
+      user = insert(:user)
+      user_id = user.id
+
+      assert {:error, {:unknown_reason, :empty}} =
+               AdminTasks.remove_user(user.username, reason: :empty)
+
+      assert Repo.get(User, user_id)
+      refute_email_sent()
+    end
+  end
+
+  describe "reasons/1" do
+    test "lists only the reasons that fit the scope" do
+      assert :name_squatting in Keyword.keys(AdminTasks.reasons(:package))
+      refute :name_squatting in Keyword.keys(AdminTasks.reasons(:release))
+      refute :name_squatting in Keyword.keys(AdminTasks.reasons(:user))
+
+      assert :spam_account in Keyword.keys(AdminTasks.reasons(:user))
+      refute :spam_account in Keyword.keys(AdminTasks.reasons(:package))
+    end
+
+    test "every reason has text that stands on its own" do
+      for scope <- [:package, :release, :user], {id, text} <- AdminTasks.reasons(scope) do
+        assert String.length(text) > 20, "#{id} is too short to explain anything"
+        assert String.ends_with?(text, "."), "#{id} does not end in a sentence"
+      end
+    end
+  end
+
   describe "rename_user/2" do
     test "renames user" do
       user = insert(:user, username: "oldname")
@@ -365,6 +456,82 @@ defmodule Hexpm.AdminTasksTest do
       assert {:error, :package_not_found} =
                AdminTasks.remove_package("hexpm", "nonexistent")
     end
+
+    test "sends no email without a reason" do
+      package = insert(:package)
+      insert(:package_owner, package: package, user: insert(:user))
+
+      assert :ok = AdminTasks.remove_package("hexpm", package.name)
+
+      refute_email_sent()
+    end
+  end
+
+  describe "remove_package/3 with reason" do
+    test "emails every owner why the package was removed" do
+      package = insert(:package)
+      insert(:release, package: package)
+      owner = insert(:user)
+      other_owner = insert(:user)
+      insert(:package_owner, package: package, user: owner)
+      insert(:package_owner, package: package, user: other_owner)
+
+      assert :ok =
+               AdminTasks.remove_package("hexpm", package.name,
+                 reason: "The package contains no usable code."
+               )
+
+      assert_email_sent(fn email ->
+        assert Enum.sort(Enum.map(email.to, &elem(&1, 1))) ==
+                 Enum.sort([User.email(owner, :primary), User.email(other_owner, :primary)])
+
+        assert email.subject == "Hex.pm - Package #{package.name} has been removed"
+        assert email.text_body =~ package.name
+        assert email.text_body =~ "no usable code"
+        assert email.html_body =~ "no usable code"
+      end)
+    end
+
+    test "sends no email when the package has no owners" do
+      package = insert(:package)
+
+      assert :ok = AdminTasks.remove_package("hexpm", package.name, reason: "Spam.")
+
+      refute_email_sent()
+    end
+
+    test "sends the canned text for a reason id" do
+      package = insert(:package)
+      insert(:package_owner, package: package, user: insert(:user))
+
+      assert :ok = AdminTasks.remove_package("hexpm", package.name, reason: :seo_spam)
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ AdminTasks.reasons(:package)[:seo_spam]
+      end)
+    end
+
+    test "rejects an unknown reason without deleting anything" do
+      package = insert(:package)
+      insert(:package_owner, package: package, user: insert(:user))
+      package_id = package.id
+
+      assert {:error, {:unknown_reason, :nonsense}} =
+               AdminTasks.remove_package("hexpm", package.name, reason: :nonsense)
+
+      assert Repo.get(Package, package_id)
+      refute_email_sent()
+    end
+
+    test "rejects a reason that belongs to another scope" do
+      package = insert(:package)
+      package_id = package.id
+
+      assert {:error, {:unknown_reason, :spam_account}} =
+               AdminTasks.remove_package("hexpm", package.name, reason: :spam_account)
+
+      assert Repo.get(Package, package_id)
+    end
   end
 
   describe "remove_release/3" do
@@ -393,6 +560,64 @@ defmodule Hexpm.AdminTasksTest do
 
       assert {:error, :release_not_found} =
                AdminTasks.remove_release("hexpm", package.name, "99.99.99")
+    end
+
+    test "sends no email without a reason" do
+      package = insert(:package)
+      insert(:release, package: package, version: "1.0.0")
+      insert(:package_owner, package: package, user: insert(:user))
+
+      assert :ok = AdminTasks.remove_release("hexpm", package.name, "1.0.0")
+
+      refute_email_sent()
+    end
+  end
+
+  describe "remove_release/4 with reason" do
+    test "emails the owners why the release was removed" do
+      package = insert(:package)
+      insert(:release, package: package, version: "1.0.0")
+      owner = insert(:user)
+      insert(:package_owner, package: package, user: owner)
+
+      assert :ok =
+               AdminTasks.remove_release("hexpm", package.name, "1.0.0",
+                 reason: "The release bundles an undisclosed credential scanner."
+               )
+
+      assert_email_sent(fn email ->
+        assert email.to == [{owner.username, User.email(owner, :primary)}]
+        assert email.subject == "Hex.pm - Package #{package.name} v1.0.0 has been removed"
+        assert email.text_body =~ "1.0.0"
+        assert email.text_body =~ "undisclosed credential scanner"
+        assert email.html_body =~ "undisclosed credential scanner"
+      end)
+    end
+
+    test "sends the canned text for a reason id" do
+      package = insert(:package)
+      insert(:release, package: package, version: "1.0.0")
+      insert(:package_owner, package: package, user: insert(:user))
+
+      assert :ok =
+               AdminTasks.remove_release("hexpm", package.name, "1.0.0",
+                 reason: :undisclosed_behaviour
+               )
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ AdminTasks.reasons(:release)[:undisclosed_behaviour]
+      end)
+    end
+
+    test "rejects an unknown reason without deleting the release" do
+      package = insert(:package)
+      release = insert(:release, package: package, version: "1.0.0")
+      release_id = release.id
+
+      assert {:error, {:unknown_reason, :name_squatting}} =
+               AdminTasks.remove_release("hexpm", package.name, "1.0.0", reason: :name_squatting)
+
+      assert Repo.get(Release, release_id)
     end
   end
 


### PR DESCRIPTION
The removal tasks delete quietly today. `remove_package/3`, `remove_release/4` and `remove_user/2` now take a `:reason` and email it to whoever is affected. Without one they behave exactly as before and send nothing, so nothing existing changes.

```elixir
AdminTasks.remove_package("hexpm", "free_bet_tips", reason: :seo_spam)
AdminTasks.remove_release("hexpm", "slugly", "0.1.0", reason: :undisclosed_behaviour)
AdminTasks.remove_user("qy-upup", delete_packages: true, reason: :spam_account)
AdminTasks.remove_package("hexpm", "odd_one", reason: "Something the list does not cover.")
```

A reason is either an id from `AdminTasks.reasons/1` or your own text. The ten ids cover what the registry sweep actually turns up: `seo_spam`, `empty`, `name_squatting`, `typosquatting`, `copyright`, `undisclosed_behaviour`, `malware`, `spam_account`, `owner_request`, `terms_of_service`. Each declares which scopes it fits, so `reasons(:user)` does not offer `name_squatting` and using it there is an error rather than a nonsense email.

The reason resolves before anything is deleted. A mistyped id returns `{:error, {:unknown_reason, id}}` with the package still there, instead of deleting it and then discovering there is no mail to send.

Reason texts never name the package, version or username, because the sentence above them in the email already did. That is what lets one string serve all three emails:

```
Package free_bet_tips has been removed

The package free_bet_tips and all of its releases have been removed from
Hex.pm by the Hex.pm team.

Reason:

Hex.pm does not accept packages published to advertise a website. What was
published provided no working software, only links and text pointing at an
unrelated site.

If you have any questions about why this action was taken, please contact
support at support@hex.pm.
```

Package and release removals mail the owners, read before the delete because `package_owners` goes with the package. Account removal keeps `notify: false` on `Users.delete` and sends its own mail, so the self-service "packages you published remain available to the community" text does not go out on a removal that just deleted them. One email either way.

A delivery failure is logged rather than raised. The deletion already happened and raising would only make the return value of a destructive call ambiguous.

`questions_notice/1` and `paragraphs/1` moved up into `EmailView.Common` since the three new content modules plus the existing `SecurityPasswordReset` and `Announcement` all want them.