### PR TITLE
Let the CDN own the hexdocs canonical URL

### DIFF
--- a/lib/hexpm/hexdocs/file_rewriter.ex
+++ b/lib/hexpm/hexdocs/file_rewriter.ex
@@ -6,8 +6,7 @@ defmodule Hexpm.Hexdocs.FileRewriter do
   ]
   @analytics_addition "<script async defer src=\"https://s.${DOMAIN}/js/script.js\"></script><script>window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};plausible.init({endpoint:\"https://s.${DOMAIN}/api/event\"})</script>"
   @official_domains ~w(hex.pm hexdocs.pm hexorgs.pm elixir-lang.org erlang.org)
-  @canonical_tag_re ~r{<link[^>]*\brel=["']canonical["'][^>]*>}i
-  @hexdocs_link_re ~r{https?://hexdocs\.pm/([a-z][a-z0-9_]*)(?![a-zA-Z0-9_.-])}
+  @canonical_tag_re ~r{<link[^>]*\brel=["']canonical["'][^>]*>\s*}i
   @a_tag_re ~r/<a\s[^>]*href="https?:\/\/[^"]*"[^>]*>/
   @href_re ~r/href="(https?:\/\/[^"]*)"/
 
@@ -15,8 +14,7 @@ defmodule Hexpm.Hexdocs.FileRewriter do
     content
     |> add_elixir_org_link(path)
     |> add_analytics(path)
-    |> remove_noindex(path)
-    |> rewrite_canonical_links(path)
+    |> remove_canonical_links(path)
     |> add_nofollow(path)
   end
 
@@ -27,13 +25,14 @@ defmodule Hexpm.Hexdocs.FileRewriter do
     end)
   end
 
-  defp rewrite_canonical_links(content, path) do
+  # The docs CDN sets `Link: rel="canonical"` on every page it serves, pointing
+  # at the same page under the package's unversioned subdomain. A tag left in
+  # the markup is a second answer to the same question: authors set it to a base
+  # URL of their choosing, so it can name a pinned version, the apex host, or on
+  # private docs a public hexdocs.pm URL the package does not own.
+  defp remove_canonical_links(content, path) do
     if String.ends_with?(path, ".html") do
-      Regex.replace(@canonical_tag_re, content, fn tag ->
-        Regex.replace(@hexdocs_link_re, tag, fn _match, package ->
-          "https://#{Hexpm.Utils.name_to_subdomain(package)}.hexdocs.pm"
-        end)
-      end)
+      Regex.replace(@canonical_tag_re, content, "")
     else
       content
     end
@@ -53,14 +52,6 @@ defmodule Hexpm.Hexdocs.FileRewriter do
         host = Application.fetch_env!(:hexpm, :docs_url) |> URI.parse() |> Map.fetch!(:host)
         String.replace(@analytics_addition, "${DOMAIN}", host) <> match
       end)
-    else
-      content
-    end
-  end
-
-  defp remove_noindex(content, path) do
-    if String.ends_with?(path, ".html") do
-      String.replace(content, ~s|<meta name="robots" content="noindex">|, "")
     else
       content
     end

--- a/lib/hexpm/hexdocs/hexdocs.ex
+++ b/lib/hexpm/hexdocs/hexdocs.ex
@@ -8,6 +8,10 @@ defmodule Hexpm.Hexdocs do
   @special_package_names Map.keys(@special_packages)
   @gcs_put_debounce Application.compile_env!(:hexpm, :hexdocs_gcs_put_debounce)
 
+  # ExDoc marks these `noindex`, so listing them asks a crawler to fetch a page
+  # it has been told not to keep.
+  @noindex_pages ~w(404.html search.html)
+
   def upload(key) do
     {repository, package, version} = key_components!(key)
     start = System.monotonic_time(:millisecond)
@@ -163,7 +167,11 @@ defmodule Hexpm.Hexdocs do
   defp update_index_sitemap(_repository, _key), do: :ok
 
   defp update_package_sitemap("hexpm", _key, package, files) do
-    pages = for path <- files, Path.extname(path) == ".html", do: path
+    pages =
+      for path <- files,
+          Path.extname(path) == ".html",
+          path not in @noindex_pages,
+          do: path
 
     Bucket.upload_package_sitemap(
       package,

--- a/lib/hexpm/hexdocs/package_sitemap.ex
+++ b/lib/hexpm/hexdocs/package_sitemap.ex
@@ -9,7 +9,7 @@ defmodule Hexpm.Hexdocs.PackageSitemap do
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <%= for page <- pages do %>
     <url>
-      <loc><%= Hexpm.Utils.docs_html_url("hexpm", package_name, "/" <> page) %></loc>
+      <loc><%= xml_escape(Hexpm.Utils.docs_html_url("hexpm", package_name, "/" <> encode_path(page))) %></loc>
       <lastmod><%= format_datetime updated_at %></lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>
@@ -22,5 +22,20 @@ defmodule Hexpm.Hexdocs.PackageSitemap do
 
   defp format_datetime(datetime) do
     datetime |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+  end
+
+  # Page names come out of the uploaded tarball, so one `&` in a filename would
+  # otherwise take the whole sitemap down with it.
+  defp encode_path(path) do
+    URI.encode(path, &(&1 == ?/ or URI.char_unreserved?(&1)))
+  end
+
+  defp xml_escape(value) do
+    value
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&apos;")
   end
 end

--- a/lib/hexpm/hexdocs/package_sitemap.ex
+++ b/lib/hexpm/hexdocs/package_sitemap.ex
@@ -9,7 +9,7 @@ defmodule Hexpm.Hexdocs.PackageSitemap do
       xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
   <%= for page <- pages do %>
     <url>
-      <loc><%= Hexpm.Utils.docs_html_apex_url(package_name) <> page %></loc>
+      <loc><%= Hexpm.Utils.docs_html_url("hexpm", package_name, "/" <> page) %></loc>
       <lastmod><%= format_datetime updated_at %></lastmod>
       <changefreq>daily</changefreq>
       <priority>0.8</priority>

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -171,22 +171,18 @@ defmodule Hexpm.Utils do
   @spec docs_html_url(String.t(), String.t(), String.t()) :: String.t()
   def docs_html_url(repository, package, "/" <> _ = path)
       when is_binary(repository) and is_binary(package) do
-    {config, host, path} =
-      if repository == "hexpm" do
-        {:docs_url, name_to_subdomain(package), path}
-      else
-        {:private_docs_url, name_to_subdomain(repository), "/#{package}#{path}"}
-      end
-
-    uri = URI.parse(Application.fetch_env!(:hexpm, config))
-    URI.to_string(%{uri | host: "#{host}.#{uri.host}", path: path})
+    if repository == "hexpm" do
+      public_docs_url(package, path)
+    else
+      uri = URI.parse(Application.fetch_env!(:hexpm, :private_docs_url))
+      host = "#{name_to_subdomain(repository)}.#{uri.host}"
+      URI.to_string(%{uri | host: host, path: "/#{package}#{path}"})
+    end
   end
 
   def docs_html_url(%Repository{id: 1}, package, release) do
-    docs_url = URI.parse(Application.get_env(:hexpm, :docs_url))
-    docs_url = %{docs_url | host: "#{name_to_subdomain(package.name)}.#{docs_url.host}"}
     version = release && "#{release.version}/"
-    "#{docs_url}/#{version}"
+    public_docs_url(package.name, "/#{version}")
   end
 
   def docs_html_url(%Repository{} = repository, package, release) do
@@ -197,15 +193,29 @@ defmodule Hexpm.Utils do
     "#{docs_url}/#{package}/#{version}"
   end
 
+  # A handful of packages predate the subdomain scheme and carry a name the
+  # docs CDN routes somewhere else, `search` to the search backend and the rest
+  # to their own services. The apex serves those packages directly instead of
+  # redirecting, so it is the only address they have.
+  @reserved_docs_subdomains ~w(api assets docs preview search staging stats static)
+
+  defp public_docs_url(package, "/" <> _ = path) do
+    uri = URI.parse(Application.fetch_env!(:hexpm, :docs_url))
+
+    if package in @reserved_docs_subdomains do
+      URI.to_string(%{uri | path: "/#{package}#{path}"})
+    else
+      URI.to_string(%{uri | host: "#{name_to_subdomain(package)}.#{uri.host}", path: path})
+    end
+  end
+
   @doc """
   Apex-form docs URL for a hexpm-repo package: `<docs_url>/<package>/`.
 
-  Used by `docs_sitemap.xml`, which lists per-package sitemap index
-  entries. Sitemap consumers (Googlebot) require all listed URLs to
-  share a common host with the sitemap file, so even after package
-  docs move to `<package>.hexdocs.pm`, the index keeps emitting
-  `hexdocs.pm/<package>/...` and lets the apex 301 deliver the
-  canonical URL to the crawler.
+  Used by `docs_sitemap.xml`, which lists per-package sitemap index entries.
+  Sitemap consumers require the sitemaps an index lists to share its host, and
+  the apex 301 takes the crawler on to `<package>.hexdocs.pm/sitemap.xml`,
+  whose own entries name that subdomain.
   """
   @spec docs_html_apex_url(String.t()) :: String.t()
   def docs_html_apex_url(package_name) do

--- a/test/hexpm/hexdocs/file_rewriter_test.exs
+++ b/test/hexpm/hexdocs/file_rewriter_test.exs
@@ -4,29 +4,38 @@ defmodule Hexpm.Hexdocs.FileRewriterTest do
   alias Hexpm.Hexdocs.FileRewriter
 
   test "adds analytics to HTML and keeps noindex" do
-    rewritten =
-      FileRewriter.run(
-        "search.html",
-        ~s(<html><head><meta name="robots" content="noindex"></head></html>)
-      )
+    for path <- ~w(search.html 404.html api-reference.html) do
+      rewritten =
+        FileRewriter.run(
+          path,
+          ~s(<html><head><meta name="robots" content="noindex"></head></html>)
+        )
 
-    assert rewritten =~ ~s(src="https://s.localhost/js/script.js")
-    assert rewritten =~ ~s(content="noindex")
+      assert rewritten =~ ~s(src="https://s.localhost/js/script.js")
+      assert rewritten =~ ~s(content="noindex")
+    end
   end
 
   test "removes canonical tags whatever the author pointed them at" do
     for input <- [
           ~s|<link rel="canonical" href="https://hexdocs.pm/phoenix_html/1.0.0/Phoenix.HTML.html"/>|,
           ~s|<link rel="canonical" href="http://hexdocs.pm/jason/Jason.html" />|,
-          ~s|<link rel='canonical' href='https://jason.hexdocs.pm/Jason.html'>|
+          ~s|<link rel='canonical' href='https://jason.hexdocs.pm/Jason.html'>|,
+          ~s|<link\n  href="https://hexdocs.pm/jason/Jason.html"\n  rel="canonical">|
         ] do
-      refute FileRewriter.run("index.html", ~s|<body>#{input}</body>|) =~ "canonical"
+      assert FileRewriter.run("index.html", ~s|<body>#{input}<p>Jason</p></body>|) ==
+               "<body><p>Jason</p></body>"
     end
   end
 
-  test "leaves body links to hexdocs alone" do
-    input = ~s|<a href="https://hexdocs.pm/jason/Jason.html">Jason</a>|
-    assert FileRewriter.run("index.html", input) == input
+  test "leaves other link tags and body links alone" do
+    for input <- [
+          ~s|<a href="https://hexdocs.pm/jason/Jason.html">Jason</a>|,
+          ~s|<link rel="stylesheet" href="dist/canonical-ABC123.css"/>|,
+          ~s|<link rel="icon" href="/favicon.ico">|
+        ] do
+      assert FileRewriter.run("index.html", input) == input
+    end
   end
 
   test "adds nofollow only to external links and remains idempotent" do

--- a/test/hexpm/hexdocs/file_rewriter_test.exs
+++ b/test/hexpm/hexdocs/file_rewriter_test.exs
@@ -3,33 +3,30 @@ defmodule Hexpm.Hexdocs.FileRewriterTest do
 
   alias Hexpm.Hexdocs.FileRewriter
 
-  test "adds analytics and removes noindex from HTML" do
+  test "adds analytics to HTML and keeps noindex" do
     rewritten =
       FileRewriter.run(
-        "index.html",
+        "search.html",
         ~s(<html><head><meta name="robots" content="noindex"></head></html>)
       )
 
     assert rewritten =~ ~s(src="https://s.localhost/js/script.js")
-    refute rewritten =~ ~s(content="noindex")
+    assert rewritten =~ ~s(content="noindex")
   end
 
-  test "rewrites canonical package URLs to package subdomains" do
-    input =
-      ~s|<link rel="canonical" href="https://hexdocs.pm/phoenix_html/1.0.0/Phoenix.HTML.html"/>|
-
-    assert FileRewriter.run("index.html", input) ==
-             ~s|<link rel="canonical" href="https://phoenix-html.hexdocs.pm/1.0.0/Phoenix.HTML.html"/>|
-  end
-
-  test "does not rewrite body links, apex files, or existing subdomains" do
+  test "removes canonical tags whatever the author pointed them at" do
     for input <- [
-          ~s|<a href="https://hexdocs.pm/jason/Jason.html">Jason</a>|,
-          ~s|<link rel="canonical" href="https://hexdocs.pm/sitemap.xml"/>|,
-          ~s|<link rel="canonical" href="https://jason.hexdocs.pm/Jason.html"/>|
+          ~s|<link rel="canonical" href="https://hexdocs.pm/phoenix_html/1.0.0/Phoenix.HTML.html"/>|,
+          ~s|<link rel="canonical" href="http://hexdocs.pm/jason/Jason.html" />|,
+          ~s|<link rel='canonical' href='https://jason.hexdocs.pm/Jason.html'>|
         ] do
-      assert FileRewriter.run("index.html", input) == input
+      refute FileRewriter.run("index.html", ~s|<body>#{input}</body>|) =~ "canonical"
     end
+  end
+
+  test "leaves body links to hexdocs alone" do
+    input = ~s|<a href="https://hexdocs.pm/jason/Jason.html">Jason</a>|
+    assert FileRewriter.run("index.html", input) == input
   end
 
   test "adds nofollow only to external links and remains idempotent" do

--- a/test/hexpm/hexdocs/workers_test.exs
+++ b/test/hexpm/hexdocs/workers_test.exs
@@ -104,14 +104,16 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     fallback_key = "docs/#{package.name}-#{fallback.version}.tar.gz"
     removed_key = "docs/#{package.name}-#{removed.version}.tar.gz"
 
-    html = ~s(<html><head><meta name="robots" content="noindex"></head></html>)
+    html =
+      ~s(<html><head><link rel="canonical" href="https://hexdocs.pm/promoted_docs/"></head></html>)
+
     Hexpm.Store.put(:repo_bucket, fallback_key, create_docs_tar([{"index.html", html}]))
     Hexpm.Store.put(:docs_bucket, "#{package.name}/index.html", "removed latest")
 
     assert :ok = perform_job(Workers.Delete, %{key: removed_key})
     promoted = Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html")
     assert promoted =~ "plausible"
-    refute promoted =~ ~s(content="noindex")
+    refute promoted =~ "canonical"
   end
 
   test "deleting latest docs retries when the fallback archive is missing" do
@@ -125,7 +127,7 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     end
   end
 
-  test "sitemap extracts html pages from the archive" do
+  test "sitemap lists indexable html pages at the package subdomain" do
     package = insert(:package, name: "sitemap_docs", docs_updated_at: DateTime.utc_now())
     release = insert(:release, package: package, version: "1.0.0", has_docs: true)
     key = "docs/#{package.name}-#{release.version}.tar.gz"
@@ -133,13 +135,20 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     Hexpm.Store.put(
       :repo_bucket,
       key,
-      create_docs_tar([{"index.html", "docs"}, {"asset.js", "js"}])
+      create_docs_tar([
+        {"index.html", "docs"},
+        {"asset.js", "js"},
+        {"404.html", "missing"},
+        {"search.html", "search"}
+      ])
     )
 
     assert :ok = perform_job(Workers.Sitemap, %{key: key})
     sitemap = Hexpm.Store.get(:docs_bucket, "#{package.name}/sitemap.xml")
-    assert sitemap =~ "#{package.name}/index.html"
+    assert sitemap =~ "http://sitemap-docs.localhost:5002/index.html"
     refute sitemap =~ "asset.js"
+    refute sitemap =~ "404.html"
+    refute sitemap =~ "search.html"
   end
 
   test "malformed archives fail so Oban can retry" do

--- a/test/hexpm/utils_test.exs
+++ b/test/hexpm/utils_test.exs
@@ -159,5 +159,19 @@ defmodule Hexpm.UtilsTest do
       assert Utils.docs_html_url("my_org", "secret", "/1.0.0") ==
                "http://my-org.localhost:5002/secret/1.0.0"
     end
+
+    # The docs CDN routes search.hexdocs.pm to the search backend, so the
+    # package of that name is served from the apex and nowhere else.
+    test "keeps packages named after a reserved subdomain on the apex" do
+      assert Utils.docs_html_url("hexpm", "search", "/Search.html") ==
+               "http://localhost:5002/search/Search.html"
+
+      hexpm = %Hexpm.Repository.Repository{id: 1, name: "hexpm"}
+      package = %Hexpm.Repository.Package{name: "search", repository: hexpm}
+      release = %Hexpm.Repository.Release{version: Version.parse!("0.3.0")}
+
+      assert Utils.docs_html_url(hexpm, package, release) ==
+               "http://localhost:5002/search/0.3.0/"
+    end
   end
 end


### PR DESCRIPTION
Two things emit a canonical for a docs page and they disagree. Fastly sets a `Link` header on every version-pinned path, in apex form, which then 301s to the subdomain. `FileRewriter` rewrote the host of whatever tag ExDoc left in the markup, so pages uploaded since the subdomain launch carry the subdomain form while everything older carries the apex form, some of it over `http`. Only 33 of the 200 most-downloaded packages emit a tag at all, since ExDoc's `:canonical` defaults to none, and the ones that do set it choose different shapes: elixir alone pins `/elixir/1.15/` on 1.15.7 and `/elixir/1.18.4/` on 1.18.4 while sending 1.17.3 and 1.19.1 to `/elixir/`.

Strip the tag instead of rewriting it. The header covers every page ever published with no backfill, and an author's base URL is never the answer we want: it can name a pinned version, the apex host, or on private docs a public hexdocs.pm URL the package does not own.

Stop removing noindex while we're here. ExDoc passes it from exactly two templates, `not_found_template.eex` and `search_template.eex`, plus the author's opt-in `:api_reference_noindex`, so today `swoosh.hexdocs.pm/404.html` is a 200 with no noindex that we also list in the package sitemap. Those two pages are dropped from the sitemap and the rest now point at the subdomain the sitemap is served from, since `hexdocs.pm/<package>/sitemap.xml` redirects there and every URL inside it was cross-host.

Needs hexpm/hexpm-ops#237 for the header to name the subdomain. Deploy this one first: new uploads then carry no tag while the header is still apex-form, which is a weaker signal for a few hours but never a conflicting one.

Docs already published keep whatever tag they have until the package republishes.