### PR TITLE
Fix what the removal notices got wrong

### DIFF
--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -55,7 +55,13 @@ defmodule Hexpm.AdminTasks do
   `remove_package/3`, `remove_release/4` and `remove_user/2` take a `:reason`
   and stay silent without one. A reason is either an id from `reasons/1` or
   your own text, and it is resolved before anything is deleted, so a
-  misremembered id fails without touching the database.
+  misremembered id fails without touching the database. `reason: "seo_spam"`
+  is refused too, since a string spelling an id is a quoted atom rather than
+  something somebody wrote.
+
+  The removal itself never depends on the mail. If the notice cannot be sent,
+  because delivery failed or because nobody reachable is left to send it to,
+  that is logged as an error and the removal still reports `:ok`.
   """
 
   use Hexpm.Context
@@ -205,14 +211,29 @@ defmodule Hexpm.AdminTasks do
       iex> AdminTasks.remove_user("spammer", reason: :spam_account)
       :ok
   """
-  @spec remove_user(String.t(), keyword()) :: :ok | {:error, term() | Ecto.Changeset.t()}
+  @spec remove_user(String.t(), keyword()) :: :ok | {:error, term()}
   def remove_user(username, opts \\ []) do
+    deleted_packages? = Keyword.get(opts, :delete_packages, false)
+
     with {:ok, user} <- find_user(username),
          {:ok, reason} <- resolve_reason(:user, opts),
          :ok <- delete_user(user, opts) do
-      notify_removal(reason, user.username, &Emails.account_removed(user, &1))
+      notify_removal(
+        reason,
+        "user #{user.username}",
+        &Emails.account_removed(verified_only(user), deleted_packages?, &1)
+      )
+
       :ok
     end
+  end
+
+  # A removal notice accuses somebody. An unverified address was never proved to
+  # belong to this account, and on an abuse removal it is as likely as not to be
+  # a bystander's, so it gets dropped and notify_removal logs that nobody was
+  # reachable.
+  defp verified_only(user) do
+    %{user | emails: Enum.filter(user.emails, & &1.verified)}
   end
 
   defp delete_user(user, opts) do
@@ -363,7 +384,7 @@ defmodule Hexpm.AdminTasks do
   def remove_package(repo, package_name, opts \\ []) do
     with {:ok, package} <- find_package(repo, package_name),
          {:ok, reason} <- resolve_reason(:package, opts) do
-      owners = owner_recipients(package)
+      owners = reason && removal_recipients(package)
 
       {:ok, {releases, package}} =
         Repo.transaction(fn ->
@@ -383,10 +404,27 @@ defmodule Hexpm.AdminTasks do
   end
 
   # Read before the package goes, otherwise there is nobody left to write to.
-  defp owner_recipients(package) do
-    assoc(package, :owners)
-    |> Repo.all()
-    |> Repo.preload([:emails, organization: [organization_users: [user: :emails]]])
+  defp removal_recipients(package) do
+    case Repo.all(assoc(package, :owners)) do
+      [] ->
+        organization_recipients(package)
+
+      owners ->
+        Repo.preload(owners, [:emails, organization: [organization_users: [user: :emails]]])
+    end
+  end
+
+  # A package published into an organization repository has no package_owners
+  # row at all: access there is decided by membership, and Package.put_first_owner
+  # only writes an owner for repository 1. Without this fallback every removal
+  # in a private repository would notify nobody.
+  defp organization_recipients(%{repository: %Repository{id: 1}}), do: []
+
+  defp organization_recipients(package) do
+    package.repository
+    |> Repo.preload(organization: [organization_users: [user: :emails]])
+    |> Map.fetch!(:organization)
+    |> List.wrap()
   end
 
   defp remove_package_db(package) do
@@ -441,7 +479,7 @@ defmodule Hexpm.AdminTasks do
     with {:ok, package} <- find_package(repo, package_name),
          {:ok, release} <- find_release(package, version),
          {:ok, reason} <- resolve_reason(:release, opts) do
-      owners = owner_recipients(package)
+      owners = reason && removal_recipients(package)
 
       Release.delete(release, force: true)
       |> Repo.delete!()
@@ -450,10 +488,12 @@ defmodule Hexpm.AdminTasks do
       RegistryBuilder.package(package)
       RegistryBuilder.repository(package.repository)
 
+      remaining = Repo.aggregate(assoc(package, :releases), :count)
+
       notify_removal(
         reason,
         "owners of #{package.name}",
-        &Emails.release_removed(owners, package.name, version, &1)
+        &Emails.release_removed(owners, package.name, version, remaining, &1)
       )
 
       :ok
@@ -479,12 +519,21 @@ defmodule Hexpm.AdminTasks do
   end
 
   # A delivery failure is logged and not raised, the deletion already happened
-  # and the caller has no way to undo it.
+  # and the caller has no way to undo it. Having nobody to write to is logged
+  # for the same reason: the removal is done either way, and an admin who asked
+  # for a reason to be sent should not have to infer from a bare :ok that it
+  # never went anywhere.
   defp notify_removal(nil, _description, _build_email), do: :ok
 
   defp notify_removal(reason, description, build_email) do
-    email = build_email.(reason)
-    if email.to != [], do: deliver(email, description)
+    case build_email.(reason) do
+      %{to: []} ->
+        Logger.error("Removed with a reason but found no address for #{description}")
+
+      email ->
+        deliver(email, description)
+    end
+
     :ok
   end
 

--- a/lib/hexpm/admin_tasks/reasons.ex
+++ b/lib/hexpm/admin_tasks/reasons.ex
@@ -43,8 +43,8 @@ defmodule Hexpm.AdminTasks.Reasons do
       id: :typosquatting,
       scopes: [:package, :release, :user],
       text:
-        "The name closely imitated an existing Hex.pm package. Names chosen to " <>
-          "be mistaken for another package are not allowed."
+        "Package names chosen to be mistaken for an existing Hex.pm package are " <>
+          "not allowed."
     },
     %{
       id: :copyright,
@@ -93,17 +93,31 @@ defmodule Hexpm.AdminTasks.Reasons do
     for reason <- @reasons, scope in reason.scopes, do: {reason.id, reason.text}
   end
 
+  def all(scope), do: raise(ArgumentError, bad_scope(scope))
+
   @doc """
   Resolves a `:reason` value to the text that goes in the email.
 
   A string is its own text. An id has to be one the scope allows, and an
   unknown id is an error rather than a silent fallback: the removal tasks
   resolve the reason before they delete anything, so a typo costs nothing.
+
+  Two strings are refused rather than sent. A string that spells a known id
+  is a quoted atom, not a sentence somebody wrote: every other argument to
+  the removal tasks is a string, so `reason: "malware"` is the one mistake
+  the id lookup cannot catch, and it would otherwise be delivered as the
+  entire body of an accusation. A blank string would render a `Reason:`
+  heading with nothing under it.
   """
   @spec fetch(:package | :release | :user, atom() | String.t()) ::
-          {:ok, String.t()} | {:error, {:unknown_reason, term()}}
+          {:ok, String.t()}
+          | {:error, {:unknown_reason, term()} | {:quoted_reason_id, String.t()} | :blank_reason}
   def fetch(scope, text) when scope in @scopes and is_binary(text) do
-    {:ok, text}
+    cond do
+      String.trim(text) == "" -> {:error, :blank_reason}
+      Enum.any?(@reasons, &(Atom.to_string(&1.id) == text)) -> {:error, {:quoted_reason_id, text}}
+      true -> {:ok, text}
+    end
   end
 
   def fetch(scope, id) when scope in @scopes do
@@ -111,5 +125,11 @@ defmodule Hexpm.AdminTasks.Reasons do
       nil -> {:error, {:unknown_reason, id}}
       reason -> {:ok, reason.text}
     end
+  end
+
+  def fetch(scope, _reason), do: raise(ArgumentError, bad_scope(scope))
+
+  defp bad_scope(scope) do
+    "unknown scope #{inspect(scope)}, expected one of #{inspect(@scopes)}"
   end
 end

--- a/lib/hexpm/emails/emails.ex
+++ b/lib/hexpm/emails/emails.ex
@@ -65,11 +65,12 @@ defmodule Hexpm.Emails do
     |> render_body(:account_deleted)
   end
 
-  def account_removed(user, reason) do
+  def account_removed(user, packages_deleted?, reason) do
     base_email()
     |> email_to(user)
     |> subject("Hex.pm - Your account has been removed")
     |> assign(:username, user.username)
+    |> assign(:packages_deleted, packages_deleted?)
     |> assign(:reason, reason)
     |> render_body(:account_removed)
   end
@@ -83,12 +84,13 @@ defmodule Hexpm.Emails do
     |> render_body(:package_removed)
   end
 
-  def release_removed(owners, package, version, reason) do
+  def release_removed(owners, package, version, remaining, reason) do
     base_email()
     |> email_to(owners)
     |> subject("Hex.pm - Package #{package} v#{version} has been removed")
     |> assign(:package, package)
     |> assign(:version, version)
+    |> assign(:remaining, remaining)
     |> assign(:reason, reason)
     |> render_body(:release_removed)
   end
@@ -324,11 +326,11 @@ defmodule Hexpm.Emails do
     [user]
   end
 
-  defp expand_organization(%User{organization: organization}) do
-    organization.organization_users
-    |> Enum.filter(&(&1.role == "admin"))
-    |> Enum.map(&User.email(&1.user, :primary))
-  end
+  # Same rule whichever side the organization arrives from. Filtering to admins
+  # here without the fallback below meant an organization with no admin member
+  # resolved to nobody and the mail was simply not sent.
+  defp expand_organization(%User{organization: organization}),
+    do: expand_organization(organization)
 
   defp expand_organization(%Organization{organization_users: org_users}) do
     admins =

--- a/lib/hexpm_web/templates/email/account_removed.html.eex
+++ b/lib/hexpm_web/templates/email/account_removed.html.eex
@@ -3,7 +3,7 @@
 </h1>
 
 <p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
-  <%= AccountRemoved.message(@username) %>
+  <%= AccountRemoved.message(@username, @packages_deleted) %>
 </p>
 
 <p style="color: #030913; font-size: 16px; line-height: 24px; font-weight: 600; margin: 0 0 8px 0;">

--- a/lib/hexpm_web/templates/email/account_removed.text.eex
+++ b/lib/hexpm_web/templates/email/account_removed.text.eex
@@ -1,6 +1,6 @@
 <%= AccountRemoved.title() %>
 
-<%= AccountRemoved.message(@username) %>
+<%= AccountRemoved.message(@username, @packages_deleted) %>
 
 <%= AccountRemoved.reason_heading() %>
 

--- a/lib/hexpm_web/templates/email/release_removed.html.eex
+++ b/lib/hexpm_web/templates/email/release_removed.html.eex
@@ -3,7 +3,7 @@
 </h1>
 
 <p style="color: #304254; font-size: 16px; line-height: 24px; margin: 0 0 16px 0;">
-  <%= ReleaseRemoved.message(@package, @version) %>
+  <%= ReleaseRemoved.message(@package, @version, @remaining) %>
 </p>
 
 <p style="color: #030913; font-size: 16px; line-height: 24px; font-weight: 600; margin: 0 0 8px 0;">

--- a/lib/hexpm_web/templates/email/release_removed.text.eex
+++ b/lib/hexpm_web/templates/email/release_removed.text.eex
@@ -1,6 +1,6 @@
 <%= ReleaseRemoved.title(@package, @version) %>
 
-<%= ReleaseRemoved.message(@package, @version) %>
+<%= ReleaseRemoved.message(@package, @version, @remaining) %>
 
 <%= ReleaseRemoved.reason_heading() %>
 

--- a/lib/hexpm_web/views/email_view.ex
+++ b/lib/hexpm_web/views/email_view.ex
@@ -106,9 +106,15 @@ defmodule HexpmWeb.EmailView do
       "Your account has been removed"
     end
 
-    def message(username) do
+    def message(username, false) do
       "The Hex.pm account \"#{username}\" has been removed by the Hex.pm team. " <>
         "The username has been retired and cannot be registered again."
+    end
+
+    def message(username, true) do
+      "The Hex.pm account \"#{username}\" has been removed by the Hex.pm team, " <>
+        "along with the packages it was the only owner of. The username has " <>
+        "been retired and cannot be registered again."
     end
   end
 
@@ -372,7 +378,13 @@ defmodule HexpmWeb.EmailView do
       "#{package} v#{version} has been removed"
     end
 
-    def message(package, version) do
+    def message(package, version, 0) do
+      "Version #{version} of the package #{package} has been removed from Hex.pm " <>
+        "by the Hex.pm team. It was the only version, so the package no longer " <>
+        "has any releases."
+    end
+
+    def message(package, version, _remaining) do
       "Version #{version} of the package #{package} has been removed from Hex.pm " <>
         "by the Hex.pm team. Other versions of the package are unaffected."
     end

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -298,6 +298,81 @@ defmodule Hexpm.AdminTasksTest do
       assert Repo.get(User, user_id)
       refute_email_sent()
     end
+
+    test "says the packages went too when delete_packages deleted them" do
+      user = insert(:user)
+      package = insert(:package)
+      insert(:package_owner, package: package, user: user)
+
+      assert :ok =
+               AdminTasks.remove_user(user.username,
+                 delete_packages: true,
+                 reason: :spam_account
+               )
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ "along with the packages it was the only owner of"
+      end)
+    end
+
+    test "does not mention packages when none were deleted" do
+      user = insert(:user)
+
+      assert :ok = AdminTasks.remove_user(user.username, reason: :spam_account)
+
+      assert_email_sent(fn email ->
+        refute email.text_body =~ "along with the packages"
+        assert email.text_body =~ "The username has been retired"
+      end)
+    end
+
+    # An unverified address was never proved to belong to the account, and a
+    # removal notice accuses whoever receives it.
+    test "does not accuse an address the account never verified" do
+      user = insert(:user, emails: [build(:email, verified: false)])
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok = AdminTasks.remove_user(user.username, reason: :malware)
+        end)
+
+      refute Repo.get(User, user.id)
+      assert log =~ "found no address for user #{user.username}"
+      refute_email_sent()
+    end
+  end
+
+  describe "the removal emails themselves" do
+    # The appeal line is the only actionable thing in these emails and nothing
+    # asserted it, so replacing Common.questions_notice/1 or reason_heading/0
+    # with a literal left the whole suite green.
+    test "each one carries the reason, its heading, and how to appeal" do
+      user = build(:user)
+
+      emails = [
+        Hexpm.Emails.package_removed([user], "pkg", "Because of a thing."),
+        Hexpm.Emails.release_removed([user], "pkg", "1.0.0", 2, "Because of a thing."),
+        Hexpm.Emails.account_removed(user, false, "Because of a thing.")
+      ]
+
+      for email <- emails do
+        assert email.text_body =~ "Reason:"
+        assert email.text_body =~ "Because of a thing."
+        assert email.text_body =~ "contact support at support@hex.pm"
+
+        assert email.html_body =~ "Reason:"
+        assert email.html_body =~ "Because of a thing."
+        assert email.html_body =~ "mailto:support@hex.pm"
+      end
+    end
+
+    test "a multi-paragraph reason becomes separate paragraphs in the html" do
+      email = Hexpm.Emails.account_removed(build(:user), false, "First one.\n\nSecond one.")
+
+      assert email.text_body =~ "First one."
+      assert email.text_body =~ "Second one."
+      assert email.html_body =~ ~r/First one\..*<\/p>.*<p[^>]*>\s*Second one\./s
+    end
   end
 
   describe "reasons/1" do
@@ -310,10 +385,24 @@ defmodule Hexpm.AdminTasksTest do
       refute :spam_account in Keyword.keys(AdminTasks.reasons(:package))
     end
 
-    test "every reason has text that stands on its own" do
+    # A lint against future typos, not a check that the wording is any good.
+    test "no reason text is a stub" do
       for scope <- [:package, :release, :user], {id, text} <- AdminTasks.reasons(scope) do
         assert String.length(text) > 20, "#{id} is too short to explain anything"
         assert String.ends_with?(text, "."), "#{id} does not end in a sentence"
+      end
+    end
+
+    test "no reason text names the subject the email already named" do
+      for scope <- [:package, :release, :user], {id, text} <- AdminTasks.reasons(scope) do
+        refute text =~ ~r/\bthis account\b/i, "#{id} names the subject"
+        refute text =~ ~r/\byour (account|package)\b/i, "#{id} names the subject"
+      end
+    end
+
+    test "raises a readable error on an unknown scope" do
+      assert_raise ArgumentError, ~r/unknown scope :packages/, fn ->
+        AdminTasks.reasons(:packages)
       end
     end
   end
@@ -532,6 +621,78 @@ defmodule Hexpm.AdminTasksTest do
 
       assert Repo.get(Package, package_id)
     end
+
+    # Every other argument here is a string, so quoting an id is the natural
+    # slip, and it is the one the id lookup cannot catch.
+    test "rejects a quoted reason id rather than sending it as the text" do
+      package = insert(:package)
+      insert(:package_owner, package: package, user: insert(:user))
+      package_id = package.id
+
+      assert {:error, {:quoted_reason_id, "seo_spam"}} =
+               AdminTasks.remove_package("hexpm", package.name, reason: "seo_spam")
+
+      assert Repo.get(Package, package_id)
+      refute_email_sent()
+    end
+
+    test "rejects a blank reason" do
+      package = insert(:package)
+      package_id = package.id
+
+      assert {:error, :blank_reason} =
+               AdminTasks.remove_package("hexpm", package.name, reason: "   ")
+
+      assert Repo.get(Package, package_id)
+    end
+
+    test "mails the organization when a private package has no owner rows" do
+      organization = insert(:organization)
+      admin = insert(:user)
+      insert(:organization_user, organization: organization, user: admin, role: "admin")
+      repository = insert(:repository, organization: organization)
+      package = insert(:package, repository_id: repository.id, repository: repository)
+
+      assert Repo.all(Ecto.assoc(package, :owners)) == []
+
+      assert :ok =
+               AdminTasks.remove_package(repository.name, package.name, reason: :malware)
+
+      refute Repo.get(Package, package.id)
+
+      assert_email_sent(fn email ->
+        assert email.to == [{"", User.email(admin, :primary)}]
+        assert email.text_body =~ AdminTasks.reasons(:package)[:malware]
+      end)
+    end
+
+    # The admins-only filter had no fallback on this side, so an organization
+    # with no admin member resolved to nobody and the mail was dropped.
+    test "falls back to the members when the organization has no admin" do
+      organization = insert(:organization)
+      member = insert(:user)
+      insert(:organization_user, organization: organization, user: member, role: "write")
+      repository = insert(:repository, organization: organization)
+      package = insert(:package, repository_id: repository.id, repository: repository)
+
+      assert :ok = AdminTasks.remove_package(repository.name, package.name, reason: :malware)
+
+      assert_email_sent(fn email ->
+        assert email.to == [{"", User.email(member, :primary)}]
+      end)
+    end
+
+    test "warns instead of returning a bare :ok when nobody is reachable" do
+      package = insert(:package)
+
+      log =
+        ExUnit.CaptureLog.capture_log(fn ->
+          assert :ok = AdminTasks.remove_package("hexpm", package.name, reason: :seo_spam)
+        end)
+
+      assert log =~ "found no address for owners of #{package.name}"
+      refute_email_sent()
+    end
   end
 
   describe "remove_release/3" do
@@ -606,6 +767,67 @@ defmodule Hexpm.AdminTasksTest do
 
       assert_email_sent(fn email ->
         assert email.text_body =~ AdminTasks.reasons(:release)[:undisclosed_behaviour]
+      end)
+    end
+
+    test "does not claim other versions survive when that was the only one" do
+      package = insert(:package)
+      insert(:release, package: package, version: "1.0.0")
+      owner = insert(:user)
+      insert(:package_owner, package: package, user: owner)
+
+      assert :ok = AdminTasks.remove_release("hexpm", package.name, "1.0.0", reason: :malware)
+
+      assert_email_sent(fn email ->
+        refute email.text_body =~ "Other versions"
+        assert email.text_body =~ "no longer has any releases"
+      end)
+    end
+
+    test "says other versions are unaffected when some remain" do
+      package = insert(:package)
+      insert(:release, package: package, version: "1.0.0")
+      insert(:release, package: package, version: "2.0.0")
+      insert(:package_owner, package: package, user: insert(:user))
+
+      assert :ok = AdminTasks.remove_release("hexpm", package.name, "1.0.0", reason: :malware)
+
+      assert_email_sent(fn email ->
+        assert email.text_body =~ "Other versions of the package are unaffected"
+      end)
+    end
+
+    test "mails every owner, not just the first" do
+      package = insert(:package)
+      insert(:release, package: package, version: "1.0.0")
+      owner = insert(:user)
+      other_owner = insert(:user)
+      insert(:package_owner, package: package, user: owner)
+      insert(:package_owner, package: package, user: other_owner)
+
+      assert :ok = AdminTasks.remove_release("hexpm", package.name, "1.0.0", reason: :malware)
+
+      assert_email_sent(fn email ->
+        assert Enum.sort(Enum.map(email.to, &elem(&1, 1))) ==
+                 Enum.sort([User.email(owner, :primary), User.email(other_owner, :primary)])
+      end)
+
+      refute_email_sent()
+    end
+
+    test "escapes the reason in the html email" do
+      package = insert(:package)
+      insert(:release, package: package, version: "1.0.0")
+      insert(:package_owner, package: package, user: insert(:user))
+
+      assert :ok =
+               AdminTasks.remove_release("hexpm", package.name, "1.0.0",
+                 reason: "<script>alert(1)</script>"
+               )
+
+      assert_email_sent(fn email ->
+        refute email.html_body =~ "<script>"
+        assert email.html_body =~ "&lt;script&gt;"
       end)
     end
 


### PR DESCRIPTION
Follow-up to #1791, which shipped with several holes.

**Packages in organization repositories got no mail, and `remove_package` still returned `:ok`.** `Package.put_first_owner/3` only writes a `PackageOwner` row when `repository.id == 1`; access in an org repo runs through membership instead. So `owner_recipients/1` returned `[]` and the notice went nowhere. Across the entire private-repo surface the feature was a no-op that reported success. It falls back to the organization now, which `email_to/2` already expands to its admins.

**Nothing to send to, and failing to send, both vanished into a bare `:ok`.** Reachable in the documented order: remove the spammer's account, their `package_owners` rows cascade, then `remove_package` on the now-ownerless package silently mails nobody. Both are logged as errors now.

**`reason: "seo_spam"` was delivered verbatim as the entire body of an accusation.** Every other argument to these functions is a string, so quoting an id is the natural slip and the one thing the id lookup can't catch. Refused now, along with a blank reason, which rendered a bold `Reason:` heading with nothing under it.

**Two emails said things that weren't true.** Removing the only release told owners "Other versions of the package are unaffected" when none existed. Removing an account with `delete_packages: true` said nothing about the packages that went with it, sitting next to the self-service mail that promises they survive.

**Unverified addresses were being accused.** `User.email(user, :primary)` ignores `verified`, and signups are unverified until confirmed. Register as `mallory` with `victim@example.com`, never confirm, publish malware, get removed, and `victim@example.com` is told the code was malicious. Unverified addresses are dropped.

**An organization with no admin member got no mail.** `expand_organization/1` filtered to admins on the `%User{}` side with no fallback, while the `%Organization{}` clause below it falls back to all members. One delegates to the other now. This also affects `owner_added`, `owner_removed` and `package_published`.

`:typosquatting` read as the username imitating a package when used on an account, so it names package names in all three scopes now. `Reasons.all/1` and `fetch/2` raise an `ArgumentError` naming the bad scope rather than a `FunctionClauseError` pointing at a private function, since `reasons/1` is how you explore the API from iex.

New tests cover the organization fallback, both no-recipient paths, the quoted and blank reasons, the sole-release wording, the deleted-packages wording, the unverified address, multi-owner release mail, escaping on the release template, and the support/appeal line, which nothing asserted before.

Not covered: the `deliver/2` failure branch. Forcing a delivery failure means swapping the Swoosh adapter through global app config, and `admin_tasks_test.exs` is `async: true` alongside everything else that sends mail.
