### PR TITLE
Load the syntax highlighter before a request needs it

### DIFF
--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -133,7 +133,8 @@ defmodule Hexpm.Application do
       goth_spec(),
       setup(),
       HexpmWeb.Telemetry,
-      metrics_server_spec()
+      metrics_server_spec(),
+      {Task, &HexpmWeb.SyntaxHighlight.warm/0}
     ]
     |> Enum.reject(&is_nil/1)
   end

--- a/lib/hexpm_web/syntax_highlight.ex
+++ b/lib/hexpm_web/syntax_highlight.ex
@@ -4,6 +4,20 @@ defmodule HexpmWeb.SyntaxHighlight do
   @timeout 1_000
   @line_pattern ~r/<div class="l-line" data-line="\d+">(.*?)\n?<\/div>/s
 
+  @doc """
+  Loads the highlighter so the first request does not have to.
+
+  The NIF is 143 MB, and the timeout above is sized for highlighting a file, not
+  for opening it. Whichever request arrived first used to pay that load out of
+  its own budget and fall back to unhighlighted source when it ran out.
+  """
+  def warm() do
+    Lumis.highlight!("", formatter: {:html_linked, language: "warm.ex"})
+    :ok
+  rescue
+    error -> Logger.warning("Failed to warm the highlighter: #{Exception.message(error)}")
+  end
+
   def highlight(source, language, label) do
     run(
       fn -> Lumis.highlight!(source, formatter: {:html_linked, language: language}) end,

--- a/test/hexpm/preview/workers_test.exs
+++ b/test/hexpm/preview/workers_test.exs
@@ -240,6 +240,7 @@ defmodule Hexpm.Preview.WorkersTest do
              ["new.txt"]
   end
 
+  @tag :capture_log
   test "upload publishes the file list after all files succeed" do
     package = insert(:package, name: "manifest_preview")
     release = insert(:release, package: package, version: "1.0.0")

--- a/test/hexpm/release_tasks/stats_test.exs
+++ b/test/hexpm/release_tasks/stats_test.exs
@@ -136,6 +136,7 @@ defmodule Hexpm.ReleaseTasks.StatsTest do
              perform_job(Stats, %{"date" => "not-a-date"})
   end
 
+  @tag :capture_log
   test "processing failures propagate for Oban retries and report an error check-in" do
     Store.put(
       :logs_bucket,

--- a/test/hexpm_web/live/diff_live_test.exs
+++ b/test/hexpm_web/live/diff_live_test.exs
@@ -334,6 +334,7 @@ defmodule HexpmWeb.DiffLiveTest do
              )
   end
 
+  @tag :capture_log
   test "storage failures render an error without enqueueing regeneration", %{package: package} do
     original_bucket = Application.fetch_env!(:hexpm, :diff_bucket)
     Application.put_env(:hexpm, :diff_bucket, {Hexpm.Diff.TestStore, "diff_bucket"})
@@ -352,6 +353,7 @@ defmodule HexpmWeb.DiffLiveTest do
              0
   end
 
+  @tag :capture_log
   test "storage exceptions render an error without crashing or enqueueing", %{package: package} do
     original_bucket = Application.fetch_env!(:hexpm, :diff_bucket)
     Application.put_env(:hexpm, :diff_bucket, {Hexpm.Diff.TestStore, "diff_bucket"})

--- a/test/hexpm_web/syntax_highlight_test.exs
+++ b/test/hexpm_web/syntax_highlight_test.exs
@@ -3,6 +3,14 @@ defmodule HexpmWeb.SyntaxHighlightTest do
 
   alias HexpmWeb.SyntaxHighlight
 
+  # Without this the assertions below race the highlighter's first load, and a
+  # loaded machine loses: `highlight/3` gives up after @timeout and answers with
+  # escaped plain source, which looks like a highlighting bug.
+  setup do
+    assert SyntaxHighlight.warm() == :ok
+    :ok
+  end
+
   test "highlights documents and line fragments with Lumis" do
     document = SyntaxHighlight.highlight("value = <script>", "lib/app.ex", "test document")
 


### PR DESCRIPTION
`SyntaxHighlight.run/4` gives Lumis a second and falls back to escaped plain source when it runs out. The NIF is 143 MB, so the first call in a VM pays a dlopen and grammar init out of that budget, and whichever request arrives first is the one that pays.

On CI it lost, on [this run](https://github.com/hexpm/hexpm/actions/runs/30680841110/job/91317387318). The highlight test failed asserting on `class="l-variable"` against a string that is byte-for-byte what `plain_source/1` builds, since Lumis itself always emits `<code class="language-...">`, even for a language it cannot resolve. `config :logger, level: :error` in test dropped the warning that would have said so, so the failure read as a highlighting bug. Same commit passed the `pull_request` run and failed the `push` run, because whether that test draws the cold call depends on the ExUnit seed.

Warming it from the supervision tree fixes the first request after a deploy too, which until now could be served unhighlighted. The task is temporary and rescues, so a highlighter that cannot load still leaves the app starting and every page falling back the way it does today.

Also tags the four tests that deliberately fail, so their crash reports stop landing in the run. Each already asserts the error is handled, and between them they were writing six error lines into every run, two of them full stacktraces inline on a single line.