### PR TITLE
Fix removing packages from policy overrides

### DIFF
--- a/assets/js/hooks/override_list.js
+++ b/assets/js/hooks/override_list.js
@@ -47,6 +47,7 @@ export const OverrideList = {
         .forEach((input) => {
           clearTimeout(input.suggestionTimer);
           input.setAttribute("aria-expanded", "false");
+          input.removeAttribute("aria-activedescendant");
           input.dataset.activeSuggestion = "-1";
           input.dataset.suggestionToken = "";
         });
@@ -102,6 +103,7 @@ export const OverrideList = {
 
             clearTimeout(input.suggestionTimer);
             input.setAttribute("aria-expanded", "false");
+            input.removeAttribute("aria-activedescendant");
             input.dataset.activeSuggestion = "-1";
             input.dataset.suggestionToken = "";
           });
@@ -124,12 +126,16 @@ export const OverrideList = {
       menu.replaceChildren();
       input.dataset.activeSuggestion = "-1";
       input.setAttribute("aria-expanded", items.length > 0 ? "true" : "false");
+      input.removeAttribute("aria-activedescendant");
       menu.hidden = items.length === 0;
 
       items.slice(0, suggestionLimit).forEach((item, index) => {
         const value = kind === "package" ? item.name : item.version;
         const button = document.createElement("button");
         button.type = "button";
+        button.id = `${menu.id}-option-${index}`;
+        button.setAttribute("role", "option");
+        button.setAttribute("aria-selected", "false");
         button.dataset.suggestionKind = kind;
         button.dataset.suggestionValue = value;
         button.dataset.suggestionIndex = String(index);
@@ -212,8 +218,11 @@ export const OverrideList = {
       const index = (nextIndex + buttons.length) % buttons.length;
       input.dataset.activeSuggestion = String(index);
       buttons.forEach((button, buttonIndex) => {
-        button.dataset.active = buttonIndex === index ? "true" : "false";
+        const active = buttonIndex === index;
+        button.dataset.active = active ? "true" : "false";
+        button.setAttribute("aria-selected", active ? "true" : "false");
       });
+      input.setAttribute("aria-activedescendant", buttons[index].id);
       buttons[index].scrollIntoView({ block: "nearest" });
     };
 
@@ -287,9 +296,22 @@ export const OverrideList = {
       const remove = event.target.closest("[data-override-remove]");
       if (!remove) return;
       const row = remove.closest("[data-override-row]");
-      if (row) row.remove();
+
+      // The button being clicked goes away with the row, so hand focus to the
+      // next remove button, or to the add button once the list is empty.
+      const nextFocus =
+        row?.nextElementSibling?.querySelector("[data-override-remove]") ||
+        row?.previousElementSibling?.querySelector("[data-override-remove]") ||
+        addButton;
+
+      if (row) {
+        closeSuggestions(row);
+        row.remove();
+      }
+
       refreshEmpty();
       notifyFormChanged();
+      nextFocus?.focus();
     };
 
     const onInput = (event) => {

--- a/lib/hexpm/repository/policies.ex
+++ b/lib/hexpm/repository/policies.ex
@@ -57,8 +57,11 @@ defmodule Hexpm.Repository.Policies do
   defp put_repositories(params, org_name, existing) do
     source =
       case params["repositories"] do
-        nil -> Enum.map(existing, &tab_to_params/1)
-        repositories -> submitted_repositories(repositories)
+        nil ->
+          Enum.map(existing, &tab_to_params/1)
+
+        repositories ->
+          repositories |> submitted_repositories() |> Enum.map(&put_overrides/1)
       end
 
     by_repository = Map.new(source, &{&1["repository"], &1})
@@ -70,6 +73,24 @@ defmodule Hexpm.Repository.Policies do
 
     Map.put(params, "repositories", repositories)
   end
+
+  defp put_overrides(repository) do
+    Map.put(repository, "overrides", submitted_overrides(repository["overrides"]))
+  end
+
+  # A submitted tab carries its whole override list, and `cast_embed` reads a
+  # missing key as unchanged, so no key at all means every row was removed.
+  # Every rendered row submits its package, so an entry holding nothing but an
+  # id is the leftover of a row the page removed and drops out with it.
+  defp submitted_overrides(nil), do: []
+
+  defp submitted_overrides(list) when is_list(list), do: Enum.filter(list, &override_row?/1)
+
+  defp submitted_overrides(map) when is_map(map),
+    do: Map.filter(map, fn {_index, override} -> override_row?(override) end)
+
+  defp override_row?(override) when is_map(override), do: Map.has_key?(override, "package")
+  defp override_row?(_override), do: false
 
   defp submitted_repositories(nil), do: []
   defp submitted_repositories(list) when is_list(list), do: list

--- a/lib/hexpm_web/templates/dashboard/policy/components/policy_edit.ex
+++ b/lib/hexpm_web/templates/dashboard/policy/components/policy_edit.ex
@@ -517,6 +517,7 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       |> assign(:cooldown_id, Form.input_id(assigns.form, :cooldown))
       |> assign(:cooldown_name, Form.input_name(assigns.form, :cooldown))
       |> assign(:cooldown_value, Form.input_value(assigns.form, :cooldown))
+      |> assign(:cooldown_errors, field_errors(assigns.form, :cooldown))
 
     ~H"""
     <.rule_block
@@ -527,23 +528,27 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       description="Hold back releases until they reach a minimum age."
       enabled?={present?(@cooldown_value)}
     >
-      <div class="grid gap-2 sm:flex sm:flex-wrap sm:items-center">
-        <input
-          type="text"
-          id={@cooldown_id}
-          name={@cooldown_name}
-          value={@cooldown_value}
-          placeholder="14d"
-          class={[
-            "h-9 px-3 border rounded text-sm font-mono w-28",
-            "bg-white dark:bg-grey-800 text-grey-900 dark:text-grey-100",
-            "border-grey-200 focus:border-primary-600 focus:ring-primary-600 dark:border-grey-600",
-            "focus:outline-none focus:ring-1"
-          ]}
-        />
-        <span class="text-xs leading-5 text-grey-500 dark:text-grey-300">
-          days (<code class="font-mono">d</code>) · weeks (<code class="font-mono">w</code>) · months (<code class="font-mono">mo</code>)
-        </span>
+      <div class="w-full">
+        <div class="grid gap-2 sm:flex sm:flex-wrap sm:items-center">
+          <input
+            type="text"
+            id={@cooldown_id}
+            name={@cooldown_name}
+            value={@cooldown_value}
+            placeholder="14d"
+            aria-invalid={@cooldown_errors != [] && "true"}
+            class={[
+              "h-9 px-3 border rounded text-sm font-mono w-28",
+              "bg-white dark:bg-grey-800 text-grey-900 dark:text-grey-100",
+              "focus:outline-none focus:ring-1",
+              input_border_class(@cooldown_errors)
+            ]}
+          />
+          <span class="text-xs leading-5 text-grey-500 dark:text-grey-300">
+            days (<code class="font-mono">d</code>) · weeks (<code class="font-mono">w</code>) · months (<code class="font-mono">mo</code>)
+          </span>
+        </div>
+        <.errors errors={@cooldown_errors} />
       </div>
     </.rule_block>
     """
@@ -557,6 +562,7 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       |> assign(:advisory_id, Form.input_id(assigns.form, :advisory_min_severity))
       |> assign(:advisory_name, Form.input_name(assigns.form, :advisory_min_severity))
       |> assign(:advisory_value, Form.input_value(assigns.form, :advisory_min_severity))
+      |> assign(:advisory_errors, field_errors(assigns.form, :advisory_min_severity))
 
     ~H"""
     <.rule_block
@@ -567,13 +573,17 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       description="Block any release with an advisory at or above the selected severity."
       enabled?={!is_nil(@advisory_value)}
     >
-      <div class="grid gap-2 text-sm text-grey-500 dark:text-grey-300 sm:flex sm:flex-wrap sm:items-center">
-        <span>Block releases with an advisory of</span>
-        <.severity_select
-          id={@advisory_id}
-          name={@advisory_name}
-          value={@advisory_value}
-        />
+      <div class="w-full">
+        <div class="grid gap-2 text-sm text-grey-500 dark:text-grey-300 sm:flex sm:flex-wrap sm:items-center">
+          <span>Block releases with an advisory of</span>
+          <.severity_select
+            id={@advisory_id}
+            name={@advisory_name}
+            value={@advisory_value}
+            errors={@advisory_errors}
+          />
+        </div>
+        <.errors errors={@advisory_errors} />
       </div>
     </.rule_block>
     """
@@ -582,6 +592,7 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
   attr :id, :string, required: true
   attr :name, :string, required: true
   attr :value, :any, required: true
+  attr :errors, :list, default: []
 
   defp severity_select(assigns) do
     assigns =
@@ -599,11 +610,12 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
         id={@id}
         name={@name}
         data-severity-control
+        aria-invalid={@errors != [] && "true"}
         class={[
           "h-8 w-full sm:w-36 pl-6 pr-7 rounded-md border text-sm font-medium appearance-none",
           "bg-white dark:bg-grey-800 text-grey-900 dark:text-grey-100",
-          "border-grey-200 focus:border-primary-600 focus:ring-primary-600 dark:border-grey-600",
-          "focus:outline-none focus:ring-1"
+          "focus:outline-none focus:ring-1",
+          input_border_class(@errors)
         ]}
       >
         <option value="" selected={@value_string == ""}>Severity</option>
@@ -629,6 +641,7 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       assigns
       |> assign(:retirement_name, Form.input_name(assigns.form, :retirement_reasons))
       |> assign(:selected, selected_retirement_reasons(assigns.form))
+      |> assign(:retirement_errors, field_errors(assigns.form, :retirement_reasons))
 
     ~H"""
     <.rule_block
@@ -641,14 +654,17 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       disabled_text="Retired releases are allowed"
     >
       <input type="hidden" name={@retirement_name <> "[]"} value="" />
-      <div class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
-        <.retirement_checkbox
-          :for={{label, value, _subtitle} <- retirement_reason_options()}
-          name={@retirement_name <> "[]"}
-          label={label}
-          value={value}
-          active?={value in @selected}
-        />
+      <div class="w-full">
+        <div class="grid grid-cols-2 gap-2 sm:flex sm:flex-wrap">
+          <.retirement_checkbox
+            :for={{label, value, _subtitle} <- retirement_reason_options()}
+            name={@retirement_name <> "[]"}
+            label={label}
+            value={value}
+            active?={value in @selected}
+          />
+        </div>
+        <.errors errors={@retirement_errors} />
       </div>
     </.rule_block>
     """
@@ -664,6 +680,7 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       |> assign(:overrides, rendered_overrides(assigns.form))
       |> assign(:override_name, Form.input_name(assigns.form, :overrides))
       |> assign(:override_id, Form.input_id(assigns.form, :overrides))
+      |> assign(:override_errors, field_errors(assigns.form, :overrides))
 
     assigns =
       assigns
@@ -714,6 +731,8 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
           </span>
         </div>
 
+        <.errors errors={@override_errors} />
+
         <div data-override-rows class="space-y-2">
           <%!-- The row renders the embed id itself. `inputs_for` would render a
                 second one outside the row, which removing the row leaves behind. --%>
@@ -723,8 +742,10 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
               action_value={to_string(Form.input_value(of, :action) || "allow")}
               package_name={Form.input_name(of, :package)}
               package_value={Form.input_value(of, :package)}
+              package_errors={field_errors(of, :package)}
               requirement_name={Form.input_name(of, :requirement)}
               requirement_value={Form.input_value(of, :requirement)}
+              requirement_errors={field_errors(of, :requirement)}
               id_name={Form.input_name(of, :id)}
               id_value={Form.input_value(of, :id)}
             />
@@ -767,13 +788,19 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
   attr :action_value, :string, required: true
   attr :package_name, :string, required: true
   attr :package_value, :any, required: true
+  attr :package_errors, :list, default: []
   attr :requirement_name, :string, required: true
   attr :requirement_value, :any, required: true
+  attr :requirement_errors, :list, default: []
   attr :id_name, :any, required: true
   attr :id_value, :any, required: true
 
   defp override_row(assigns) do
-    assigns = assign(assigns, :tone_class, override_row_tone(assigns.action_value))
+    assigns =
+      assigns
+      |> assign(:tone_class, override_row_tone(assigns.action_value))
+      |> assign(:package_menu_id, assigns.package_name <> "-suggestions")
+      |> assign(:requirement_menu_id, assigns.requirement_name <> "-suggestions")
 
     ~H"""
     <div
@@ -809,14 +836,25 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
           role="combobox"
           aria-autocomplete="list"
           aria-expanded="false"
-          class="w-full px-3 py-2 border rounded text-sm font-mono bg-white dark:bg-grey-800 text-grey-900 dark:text-grey-100 border-grey-200 dark:border-grey-600 focus:outline-none focus:ring-1 focus:border-primary-600 focus:ring-primary-600"
+          aria-controls={@package_menu_id}
+          aria-invalid={@package_errors != [] && "true"}
+          class={[
+            "w-full px-3 py-2 border rounded text-sm font-mono",
+            "bg-white dark:bg-grey-800 text-grey-900 dark:text-grey-100",
+            "focus:outline-none focus:ring-1",
+            input_border_class(@package_errors)
+          ]}
         />
         <div
+          id={@package_menu_id}
           data-override-suggestions="package"
+          role="listbox"
+          aria-label="Package suggestions"
           class="absolute inset-x-0 top-full z-50 mt-1 max-h-56 overflow-y-auto rounded-md border border-grey-200 dark:border-grey-600 bg-white dark:bg-grey-800 shadow-lg"
           hidden
         >
         </div>
+        <.errors errors={@package_errors} />
       </div>
       <div class="relative min-w-0 sm:flex-1 sm:min-w-[10rem]">
         <input
@@ -832,14 +870,25 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
           role="combobox"
           aria-autocomplete="list"
           aria-expanded="false"
-          class="w-full px-3 py-2 border rounded text-sm font-mono bg-white dark:bg-grey-800 text-grey-900 dark:text-grey-100 border-grey-200 dark:border-grey-600 focus:outline-none focus:ring-1 focus:border-primary-600 focus:ring-primary-600"
+          aria-controls={@requirement_menu_id}
+          aria-invalid={@requirement_errors != [] && "true"}
+          class={[
+            "w-full px-3 py-2 border rounded text-sm font-mono",
+            "bg-white dark:bg-grey-800 text-grey-900 dark:text-grey-100",
+            "focus:outline-none focus:ring-1",
+            input_border_class(@requirement_errors)
+          ]}
         />
         <div
+          id={@requirement_menu_id}
           data-override-suggestions="version"
+          role="listbox"
+          aria-label="Version suggestions"
           class="absolute inset-x-0 top-full z-50 mt-1 max-h-56 overflow-y-auto rounded-md border border-grey-200 dark:border-grey-600 bg-white dark:bg-grey-800 shadow-lg"
           hidden
         >
         </div>
+        <.errors errors={@requirement_errors} />
       </div>
       <button
         type="button"
@@ -867,6 +916,12 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
 
   defp override_row_tone("deny"), do: "border-l-red-500"
   defp override_row_tone(_), do: "border-l-green-500"
+
+  defp input_border_class([]),
+    do: "border-grey-200 focus:border-primary-600 focus:ring-primary-600 dark:border-grey-600"
+
+  defp input_border_class(_errors),
+    do: "border-red-300 focus:border-red-600 focus:ring-red-600 dark:border-red-700"
 
   attr :value, :string, required: true
   attr :label, :string, required: true

--- a/lib/hexpm_web/templates/dashboard/policy/components/policy_edit.ex
+++ b/lib/hexpm_web/templates/dashboard/policy/components/policy_edit.ex
@@ -137,7 +137,8 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       <h3 class="sr-only">Repository rules</h3>
       <div id="repo-config" phx-hook="PrivateRepoTabs" class="space-y-4">
         <.repo_tabs repositories={@repositories} private?={@private?} />
-        <%= inputs_for @form, :repositories, fn rf -> %>
+        <%!-- The panel renders the embed id itself, see `repo_hidden_fields/1`. --%>
+        <%= inputs_for @form, :repositories, [skip_hidden: true], fn rf -> %>
           <.repo_panel
             form={rf}
             index={repo_index(rf)}
@@ -660,7 +661,7 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
   defp overrides_card(assigns) do
     assigns =
       assigns
-      |> assign(:overrides, Form.input_value(assigns.form, :overrides) || [])
+      |> assign(:overrides, rendered_overrides(assigns.form))
       |> assign(:override_name, Form.input_name(assigns.form, :overrides))
       |> assign(:override_id, Form.input_id(assigns.form, :overrides))
 
@@ -714,7 +715,9 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
         </div>
 
         <div data-override-rows class="space-y-2">
-          <%= inputs_for @form, :overrides, fn of -> %>
+          <%!-- The row renders the embed id itself. `inputs_for` would render a
+                second one outside the row, which removing the row leaves behind. --%>
+          <%= inputs_for @form, :overrides, [skip_hidden: true], fn of -> %>
             <.override_row
               action_name={Form.input_name(of, :action)}
               action_value={to_string(Form.input_value(of, :action) || "allow")}
@@ -848,6 +851,18 @@ defmodule HexpmWeb.Dashboard.Policy.Components.PolicyEdit do
       </button>
     </div>
     """
+  end
+
+  # `inputs_for` skips embeds the changeset marks for replacement, so the empty
+  # state has to count the same rows the form renders.
+  defp rendered_overrides(form) do
+    case Form.input_value(form, :overrides) do
+      list when is_list(list) ->
+        Enum.reject(list, &match?(%Ecto.Changeset{action: :replace}, &1))
+
+      _ ->
+        []
+    end
   end
 
   defp override_row_tone("deny"), do: "border-l-red-500"

--- a/test/hexpm/repository/policies_test.exs
+++ b/test/hexpm/repository/policies_test.exs
@@ -101,6 +101,90 @@ defmodule Hexpm.Repository.PoliciesTest do
       assert tab(updated, "hexpm").cooldown == "14d"
     end
 
+    test "clears the overrides of a submitted tab that has none",
+         %{organization: org, audit_data: audit_data} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "pol1",
+            "visibility" => "public",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "overrides" => [%{"action" => "deny", "package" => "badlib"}]
+              },
+              %{
+                "repository" => org.name,
+                "overrides" => [%{"action" => "allow", "package" => "internal"}]
+              }
+            ]
+          },
+          audit: audit_data
+        )
+
+      org_tab = tab(policy, org.name)
+
+      params = %{
+        "repositories" => [
+          %{"id" => tab(policy, "hexpm").id, "repository" => "hexpm", "cooldown" => "7d"},
+          %{
+            "id" => org_tab.id,
+            "repository" => org.name,
+            "overrides" => [
+              %{"id" => hd(org_tab.overrides).id, "action" => "allow", "package" => "internal"}
+            ]
+          }
+        ]
+      }
+
+      assert {:ok, %{policy: updated}} = Policies.update(policy, params, audit: audit_data)
+
+      assert tab(updated, "hexpm").overrides == []
+      assert Enum.map(tab(updated, org.name).overrides, & &1.package) == ["internal"]
+    end
+
+    test "clears the overrides of every submitted tab in one save",
+         %{organization: org, audit_data: audit_data} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "pol1",
+            "visibility" => "private",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "overrides" => [%{"action" => "deny", "package" => "badlib"}]
+              },
+              %{
+                "repository" => org.name,
+                "overrides" => [%{"action" => "allow", "package" => "internal"}]
+              }
+            ]
+          },
+          audit: audit_data
+        )
+
+      params = %{
+        "repositories" =>
+          Enum.map(policy.repositories, fn tab ->
+            %{"id" => tab.id, "repository" => tab.repository, "cooldown" => "3d"}
+          end)
+      }
+
+      assert {:ok, %{policy: updated}} = Policies.update(policy, params, audit: audit_data)
+
+      assert Enum.map(updated.repositories, & &1.overrides) == [[], []]
+      assert Enum.map(updated.repositories, & &1.cooldown) == ["3d", "3d"]
+
+      audit_log =
+        Hexpm.Repo.all(Hexpm.Accounts.AuditLog)
+        |> Enum.find(&(&1.action == "policy.update"))
+
+      assert Enum.map(audit_log.params["repositories"], & &1["overrides"]) == [[], []]
+    end
+
     test "writes a policy.update audit log entry",
          %{organization: org, audit_data: audit_data} do
       {:ok, %{policy: policy}} =

--- a/test/hexpm/repository/policy_builder_test.exs
+++ b/test/hexpm/repository/policy_builder_test.exs
@@ -135,6 +135,26 @@ defmodule Hexpm.Repository.PolicyBuilderTest do
                :hex_registry.unpack_policy(stored, org.name, "strict-prod", public_key)
     end
 
+    test "republishes a tab without the overrides an update removed",
+         %{organization: org, policy: policy, audit_data: audit_data} do
+      params = %{
+        "repositories" =>
+          Enum.map(policy.repositories, fn tab ->
+            %{"id" => tab.id, "repository" => tab.repository}
+          end)
+      }
+
+      {:ok, _} = Policies.update(policy, params, audit: audit_data)
+
+      stored = Hexpm.Store.get(:repo_bucket, "repos/#{org.name}/policies/strict-prod", [])
+      public_key = Application.fetch_env!(:hexpm, :public_key)
+
+      assert {:ok, %{repositories: repositories}} =
+               :hex_registry.unpack_policy(stored, org.name, "strict-prod", public_key)
+
+      assert Enum.find(repositories, &(&1.repository == "hexpm")).overrides == []
+    end
+
     test "acquires and releases the advisory lock cleanly",
          %{organization: org, policy: policy} do
       previous = Application.get_env(:hexpm, :skip_advisory_locks, false)

--- a/test/hexpm_web/controllers/dashboard/organization_controller_policy_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_policy_test.exs
@@ -135,6 +135,205 @@ defmodule HexpmWeb.Dashboard.OrganizationController.PolicyTest do
       assert Enum.any?(updated.repositories, &(&1.repository == org.name))
     end
 
+    test "removes an override that the form no longer submits",
+         %{user: user, organization: org} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "polone",
+            "visibility" => "public",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "overrides" => [
+                  %{"action" => "allow", "package" => "first"},
+                  %{"action" => "deny", "package" => "removed"},
+                  %{"action" => "deny", "package" => "last"}
+                ]
+              }
+            ]
+          },
+          audit: audit_data(user)
+        )
+
+      kept =
+        policy.repositories
+        |> Enum.find(&(&1.repository == "hexpm"))
+        |> Map.fetch!(:overrides)
+        |> Map.new(&{&1.package, &1.id})
+
+      conn = build_conn() |> test_login(user)
+
+      # The removed row leaves a gap in the submitted indexes, as it does in the
+      # browser.
+      overrides = %{
+        "0" => %{
+          "id" => kept["first"],
+          "action" => "allow",
+          "package" => "first",
+          "requirement" => ""
+        },
+        "2" => %{
+          "id" => kept["last"],
+          "action" => "deny",
+          "package" => "last",
+          "requirement" => ""
+        }
+      }
+
+      params = %{
+        "policy" => %{
+          "visibility" => "public",
+          "repositories" => repository_params(policy, "hexpm", %{"overrides" => overrides})
+        }
+      }
+
+      conn = post(conn, "/dashboard/orgs/#{org.name}/policies/#{policy.name}", params)
+
+      assert redirected_to(conn) =~ "/dashboard/orgs/#{org.name}/policies/polone"
+
+      hexpm = Enum.find(Policies.get(org, "polone").repositories, &(&1.repository == "hexpm"))
+      assert Enum.map(hexpm.overrides, & &1.package) == ["first", "last"]
+    end
+
+    test "removes an override whose row submitted nothing but its id",
+         %{user: user, organization: org} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "polone",
+            "visibility" => "public",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "overrides" => [
+                  %{"action" => "allow", "package" => "first"},
+                  %{"action" => "deny", "package" => "removed"},
+                  %{"action" => "deny", "package" => "last"}
+                ]
+              }
+            ]
+          },
+          audit: audit_data(user)
+        )
+
+      ids =
+        policy.repositories
+        |> Enum.find(&(&1.repository == "hexpm"))
+        |> Map.fetch!(:overrides)
+        |> Map.new(&{&1.package, &1.id})
+
+      conn = build_conn() |> test_login(user)
+
+      # A page rendered before the id input moved into the row posts this for
+      # the removed override.
+      overrides = %{
+        "0" => %{
+          "id" => ids["first"],
+          "action" => "allow",
+          "package" => "first",
+          "requirement" => ""
+        },
+        "1" => %{"id" => ids["removed"]},
+        "2" => %{
+          "id" => ids["last"],
+          "action" => "deny",
+          "package" => "last",
+          "requirement" => ""
+        }
+      }
+
+      params = %{
+        "policy" => %{
+          "visibility" => "public",
+          "repositories" => repository_params(policy, "hexpm", %{"overrides" => overrides})
+        }
+      }
+
+      conn = post(conn, "/dashboard/orgs/#{org.name}/policies/#{policy.name}", params)
+
+      assert redirected_to(conn) =~ "/dashboard/orgs/#{org.name}/policies/polone"
+
+      hexpm = Enum.find(Policies.get(org, "polone").repositories, &(&1.repository == "hexpm"))
+      assert Enum.map(hexpm.overrides, & &1.package) == ["first", "last"]
+    end
+
+    test "removes the last override when the form submits no override rows",
+         %{user: user, organization: org} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "polone",
+            "visibility" => "public",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "cooldown" => "14d",
+                "overrides" => [%{"action" => "deny", "package" => "removed"}]
+              }
+            ]
+          },
+          audit: audit_data(user)
+        )
+
+      conn = build_conn() |> test_login(user)
+
+      params = %{
+        "policy" => %{
+          "visibility" => "public",
+          "repositories" => repository_params(policy, "hexpm", %{"cooldown" => "14d"})
+        }
+      }
+
+      conn = post(conn, "/dashboard/orgs/#{org.name}/policies/#{policy.name}", params)
+
+      assert redirected_to(conn) =~ "/dashboard/orgs/#{org.name}/policies/polone"
+
+      hexpm = Enum.find(Policies.get(org, "polone").repositories, &(&1.repository == "hexpm"))
+      assert hexpm.cooldown == "14d"
+      assert hexpm.overrides == []
+    end
+
+    test "re-renders a cleared tab as empty when the save fails validation",
+         %{user: user, organization: org} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "polone",
+            "visibility" => "public",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "overrides" => [%{"action" => "deny", "package" => "removedpkg"}]
+              }
+            ]
+          },
+          audit: audit_data(user)
+        )
+
+      conn = build_conn() |> test_login(user)
+
+      params = %{
+        "policy" => %{
+          "visibility" => "public",
+          "repositories" => repository_params(policy, "hexpm", %{"cooldown" => "notaduration"})
+        }
+      }
+
+      conn = post(conn, "/dashboard/orgs/#{org.name}/policies/#{policy.name}", params)
+
+      response = html_response(conn, 400)
+      refute response =~ "removedpkg"
+
+      {:ok, document} = Floki.parse_document(response)
+      [empty | _] = Floki.find(document, "[data-override-empty]")
+      refute Floki.attribute([empty], "class") |> List.first() =~ "hidden"
+    end
+
     test "ignores an attempt to rename the policy", %{user: user, organization: org} do
       {:ok, %{policy: policy}} =
         Policies.create(org, %{"name" => "polone", "visibility" => "public"},
@@ -157,6 +356,13 @@ defmodule HexpmWeb.Dashboard.OrganizationController.PolicyTest do
       assert Policies.get(org, "polone")
       refute Policies.get(org, "renamed")
     end
+  end
+
+  defp override_id_inputs(document, selector) do
+    document
+    |> Floki.find(selector)
+    |> Floki.attribute("name")
+    |> Enum.filter(&String.match?(&1, ~r/\[overrides\]\[\d+\]\[id\]$/))
   end
 
   # Builds the nested repositories params the edit form submits: every existing
@@ -222,6 +428,49 @@ defmodule HexpmWeb.Dashboard.OrganizationController.PolicyTest do
       assert response =~ "You need the admin role to edit this policy"
       refute response =~ "Save policy"
       refute response =~ "delete-policy-header-btn"
+    end
+
+    test "renders every override input inside its row", %{user: user, organization: org} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "strict-prod",
+            "visibility" => "public",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "overrides" => [
+                  %{"action" => "deny", "package" => "badlib"},
+                  %{"action" => "allow", "package" => "goodlib"}
+                ]
+              }
+            ]
+          },
+          audit: audit_data(user)
+        )
+
+      conn = build_conn() |> test_login(user)
+      conn = get(conn, "/dashboard/orgs/#{org.name}/policies/#{policy.name}")
+
+      {:ok, document} = Floki.parse_document(html_response(conn, 200))
+
+      # An input rendered outside the row survives the row being removed and
+      # keeps the override alive on the next save.
+      assert override_id_inputs(document, "input") ==
+               override_id_inputs(document, "[data-override-row] input")
+
+      assert length(override_id_inputs(document, "input")) == 2
+
+      # The repository tabs keep theirs, which is what matches a submitted tab
+      # to the stored one.
+      tab_ids =
+        document
+        |> Floki.find("input")
+        |> Floki.attribute("name")
+        |> Enum.filter(&String.match?(&1, ~r/^policy\[repositories\]\[\d+\]\[id\]$/))
+
+      assert length(tab_ids) == 2
     end
 
     test "renders existing restrictions and overrides", %{user: user, organization: org} do

--- a/test/hexpm_web/controllers/dashboard/organization_controller_policy_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_policy_test.exs
@@ -334,6 +334,49 @@ defmodule HexpmWeb.Dashboard.OrganizationController.PolicyTest do
       refute Floki.attribute([empty], "class") |> List.first() =~ "hidden"
     end
 
+    test "renders the errors of a rejected save", %{user: user, organization: org} do
+      {:ok, %{policy: policy}} =
+        Policies.create(org, %{"name" => "polone", "visibility" => "public"},
+          audit: audit_data(user)
+        )
+
+      conn = build_conn() |> test_login(user)
+
+      for {tab_attrs, message} <- [
+            {%{"cooldown" => "notaduration"}, "is invalid"},
+            {%{"overrides" => %{"0" => %{"action" => "deny", "package" => "Bad Name"}}},
+             "has invalid format"},
+            {%{
+               "overrides" => %{
+                 "0" => %{"action" => "deny", "package" => "ecto", "requirement" => "nope"}
+               }
+             }, "is invalid"},
+            {%{"overrides" => %{"0" => %{"action" => "deny", "package" => ""}}},
+             "can&#39;t be blank"},
+            {%{
+               "overrides" => %{
+                 "0" => %{"action" => "deny", "package" => "ecto"},
+                 "1" => %{"action" => "allow", "package" => "ecto"}
+               }
+             }, "list the same package more than once"}
+          ] do
+        params = %{
+          "policy" => %{
+            "visibility" => "public",
+            "repositories" => repository_params(policy, "hexpm", tab_attrs)
+          }
+        }
+
+        conn = post(conn, "/dashboard/orgs/#{org.name}/policies/#{policy.name}", params)
+
+        response = html_response(conn, 400)
+        assert response =~ message
+
+        {:ok, document} = Floki.parse_document(response)
+        assert [_ | _] = Floki.find(document, "p.text-small.text-red-600")
+      end
+    end
+
     test "ignores an attempt to rename the policy", %{user: user, organization: org} do
       {:ok, %{policy: policy}} =
         Policies.create(org, %{"name" => "polone", "visibility" => "public"},
@@ -471,6 +514,49 @@ defmodule HexpmWeb.Dashboard.OrganizationController.PolicyTest do
         |> Enum.filter(&String.match?(&1, ~r/^policy\[repositories\]\[\d+\]\[id\]$/))
 
       assert length(tab_ids) == 2
+    end
+
+    test "points each suggestions combobox at its own listbox",
+         %{user: user, organization: org} do
+      {:ok, %{policy: policy}} =
+        Policies.create(
+          org,
+          %{
+            "name" => "strict-prod",
+            "visibility" => "public",
+            "repositories" => [
+              %{
+                "repository" => "hexpm",
+                "overrides" => [%{"action" => "deny", "package" => "badlib"}]
+              }
+            ]
+          },
+          audit: audit_data(user)
+        )
+
+      conn = build_conn() |> test_login(user)
+      conn = get(conn, "/dashboard/orgs/#{org.name}/policies/#{policy.name}")
+
+      {:ok, document} = Floki.parse_document(html_response(conn, 200))
+
+      for {input_selector, menu_selector} <- [
+            {"input[data-override-package]", ~s([data-override-suggestions="package"])},
+            {"input[data-override-requirement]", ~s([data-override-suggestions="version"])}
+          ] do
+        controls =
+          document
+          |> Floki.find("[data-override-row] " <> input_selector)
+          |> Floki.attribute("aria-controls")
+
+        menus = document |> Floki.find("[data-override-row] " <> menu_selector)
+        ids = Floki.attribute(menus, "id")
+
+        # One rendered row plus the blank row each tab keeps in its template.
+        assert length(ids) == 3
+        assert controls == ids
+        assert ids == Enum.uniq(ids)
+        assert Floki.attribute(menus, "role") == ["listbox", "listbox", "listbox"]
+      end
     end
 
     test "renders existing restrictions and overrides", %{user: user, organization: org} do


### PR DESCRIPTION
`inputs_for` renders the embed id outside the callback's markup, so every override row had a second hidden id input sitting outside `[data-override-row]`. Removing the row left that input behind, the submitted params still carried an id-only entry for the override, and `cast_embed` matched it by id and wrote the stored override back. With `skip_hidden: true` the row is the only place the id is rendered, so removing the row removes all of its inputs. The repository tabs render their own id the same way, so they skip the automatic one too.

A page rendered before this change still posts the id-only entry, so `put_repositories/3` drops submitted override entries that carry no package. That also covers the last row of a tab being removed, where the params carry no `overrides` key at all and `cast_embed` reads a missing key as unchanged. A tab that is not submitted keeps its overrides, which is what preserves the org tab when only the description changes.

A tab that submits no rows now renders as empty rather than hiding its empty state: `inputs_for` skips embeds marked for replacement and the empty state has to count the same rows.

Confirmed against a local server in the browser, before and after: removing the only override of a tab and removing one of three both persist now, and the flash no longer reports an update that did not happen.

Fixes #1798


---

The second commit closes three things the review of this page turned up, all of which predate the fix above.

A rejected save re-rendered the form with no explanation, because the only errors rendered were the policy's visibility and description. An unparsable cooldown, a package name that fails the format check, a bad version requirement, a blank package, or the same package listed twice all came back as a silent 400 with the values still in the fields. Every restriction and override input now renders its own errors and marks itself `aria-invalid`.

Removing an override row destroyed the focused button and dropped focus to the document body, so a keyboard user restarted from the top of the page. Focus now moves to the next row's remove button, or to Add override once the list is empty.

The suggestions popup announced itself as a combobox without being one: the menu had no id and no role, the input had no `aria-controls`, the options had no role, and moving the highlight never set `aria-activedescendant`. All four are wired up now.
