### PR TITLE
Give the sponsors hero a dark-mode text color

### DIFF
--- a/lib/hexpm_web/components/buttons.ex
+++ b/lib/hexpm_web/components/buttons.ex
@@ -256,7 +256,7 @@ defmodule HexpmWeb.Components.Buttons do
 
   # Text link variants
   defp text_link_variant("primary") do
-    "text-blue-600 hover:text-blue-500 focus:ring-blue-500 font-medium"
+    "text-blue-600 hover:text-blue-500 focus:ring-blue-500 font-medium dark:text-blue-300 dark:hover:text-blue-200"
   end
 
   defp text_link_variant("secondary") do

--- a/lib/hexpm_web/templates/page/about.html.heex
+++ b/lib/hexpm_web/templates/page/about.html.heex
@@ -6,7 +6,7 @@
       alt="Hex Logo"
       class="w-12 h-12"
     />
-    <h1 class="text-grey-900 text-4xl font-bold">
+    <h1 class="text-grey-900 dark:text-white text-4xl font-bold">
       About Hex
     </h1>
   </div>

--- a/lib/hexpm_web/templates/page/sponsors.html.heex
+++ b/lib/hexpm_web/templates/page/sponsors.html.heex
@@ -1,10 +1,10 @@
 <%!-- Hero Section with Title --%>
 <div class="flex flex-col items-center justify-center mt-12 mb-16">
-  <h1 class="text-grey-900 text-4xl font-bold">
+  <h1 class="text-grey-900 dark:text-white text-4xl font-bold">
     Sponsors
   </h1>
 
-  <p class="text-grey-600 text-center text-lg mt-3 max-w-4xl mx-auto">
+  <p class="text-grey-600 dark:text-grey-300 text-center text-lg mt-3 max-w-4xl mx-auto">
     The following companies provide resources and services that make running Hex possible.
   </p>
 </div>


### PR DESCRIPTION
The sponsors hero sets `text-grey-900` on the h1 and `text-grey-600` on the subtitle with no dark variants. Under `[data-theme=dark]` the body background is `--color-grey-800` (#0d1829), so the title renders at 1.09:1 contrast and the subtitle at 1.72:1.

This adds the `dark:` variants the pricing hero at `lib/hexpm_web/templates/page/pricing.html.heex:4` already uses. Computed contrast goes to 17.8:1 for the title and 6.95:1 for the subtitle. Light mode is unchanged.

Before:

<img width="1456" height="820" alt="sponsors-dark-before" src="https://github.com/user-attachments/assets/b431c2b0-5464-4fea-86e5-4e989f67f126" />

After:

<img width="1456" height="820" alt="sponsors-dark-after" src="https://github.com/user-attachments/assets/f1a36c2b-db20-4129-9ce8-fb44091b4fb4" />

The about hero had the same missing variant on its h1. `text_link_variant("primary")` in `lib/hexpm_web/components/buttons.ex` had no dark variant either, unlike the secondary and purple variants next to it; its `text-blue-600` renders at 3.33:1 on the grey-950 stats section of the home page and on the grey-800 auth card, and blue-300 takes it to 10.63:1.

<img width="1456" height="820" alt="about-dark-after" src="https://github.com/user-attachments/assets/5292d43a-d81e-4731-aa18-ed0880adae82" />

The sponsor and about panels stay light so the logos keep rendering the way they do today.

A dark-mode contrast sweep over the public pages (home, sponsors, about, pricing, packages, docs, blog, package show, auth) found no other text missing a dark variant. It flagged two things this PR leaves alone, because both are a palette choice rather than a missing variant: the `text-blue-500` links inside the about card sit at 4.14:1 against white in either theme, and muted metadata already on `dark:text-grey-400` (the "Updated 1 week ago" line on /packages, blog bylines) sits at 3.75:1.

Closes https://github.com/hexpm/hexpm/issues/1797.
