### PR TITLE
Fix Dependabot Group Typo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
-    mix:
-      actions:
+    groups:
+      mix:
         patterns:
           - "*"


### PR DESCRIPTION
## Summary

Copy Pasted the groups wrong.

## Testing

Merge and see.