### PR TITLE
Look up users by the column that has an index

### DIFF
--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -156,30 +156,40 @@ defmodule Hexpm.Accounts.User do
   defp email(email), do: email.email
 
   def get(username_or_email, preload \\ []) do
+    if email?(username_or_email) do
+      from(
+        u in Hexpm.Accounts.User,
+        join: e in assoc(u, :emails),
+        where: e.email == ^username_or_email and e.verified,
+        preload: ^preload
+      )
+    else
+      by_username(username_or_email, preload)
+    end
+  end
+
+  def public_get(username_or_email, preload \\ []) do
+    if email?(username_or_email) do
+      from(
+        u in Hexpm.Accounts.User,
+        join: e in assoc(u, :emails),
+        where: e.email == ^username_or_email and e.verified and e.public,
+        preload: ^preload
+      )
+    else
+      by_username(username_or_email, preload)
+    end
+  end
+
+  defp by_username(username, preload) do
     from(
       u in Hexpm.Accounts.User,
-      where:
-        u.username == ^username_or_email or
-          ^username_or_email in fragment(
-            "SELECT emails.email FROM emails WHERE emails.user_id = ? and emails.verified",
-            u.id
-          ),
+      where: u.username == ^username,
       preload: ^preload
     )
   end
 
-  def public_get(username_or_email, preload \\ []) do
-    from(
-      u in Hexpm.Accounts.User,
-      where:
-        u.username == ^username_or_email or
-          ^username_or_email in fragment(
-            "SELECT emails.email FROM emails WHERE emails.user_id = ? and emails.verified and emails.public",
-            u.id
-          ),
-      preload: ^preload
-    )
-  end
+  defp email?(username_or_email), do: String.contains?(username_or_email, "@")
 
   def get_by_role(role, preload \\ []) do
     from(

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -224,6 +224,70 @@ defmodule Hexpm.Accounts.UsersTest do
     end
   end
 
+  describe "get/2 and public_get/2" do
+    test "looks up by username" do
+      user = insert(:user)
+
+      assert Users.get(user.username).id == user.id
+      assert Users.public_get(user.username).id == user.id
+    end
+
+    test "username lookup is case-insensitive" do
+      user = insert(:user)
+
+      assert Users.get(String.upcase(user.username)).id == user.id
+      assert Users.public_get(String.upcase(user.username)).id == user.id
+    end
+
+    test "looks up by verified email" do
+      user = insert(:user, emails: [build(:email, verified: true, public: true)])
+      [email] = user.emails
+
+      assert Users.get(email.email).id == user.id
+      assert Users.public_get(email.email).id == user.id
+    end
+
+    test "email lookup is case-insensitive" do
+      user = insert(:user, emails: [build(:email, verified: true, public: true)])
+      [email] = user.emails
+
+      assert Users.get(String.upcase(email.email)).id == user.id
+      assert Users.public_get(String.upcase(email.email)).id == user.id
+    end
+
+    test "ignores unverified emails" do
+      user = insert(:user, emails: [build(:email, verified: false, public: true)])
+      [email] = user.emails
+
+      refute Users.get(email.email)
+      refute Users.public_get(email.email)
+    end
+
+    test "public_get/2 ignores non-public emails, get/2 does not" do
+      user = insert(:user, emails: [build(:email, verified: true, public: false)])
+      [email] = user.emails
+
+      assert Users.get(email.email).id == user.id
+      refute Users.public_get(email.email)
+    end
+
+    test "returns nil for an unknown username or email" do
+      refute Users.get("nosuchuser")
+      refute Users.public_get("nosuchuser")
+      refute Users.get("nosuch@example.com")
+      refute Users.public_get("nosuch@example.com")
+    end
+
+    test "preloads are applied for both lookup paths" do
+      user = insert(:user, emails: [build(:email, verified: true, public: true)])
+      [email] = user.emails
+
+      assert %Ecto.Association.NotLoaded{} = Users.get(user.username).emails
+      assert [_] = Users.get(user.username, [:emails]).emails
+      assert [_] = Users.get(email.email, [:emails]).emails
+    end
+  end
+
   describe "delete/2" do
     test "purges every SSO notification scoped to the deleted account" do
       user = insert(:user)


### PR DESCRIPTION
`User.get/2` and `User.public_get/2` matched a username or an email with an OR whose right side was a correlated subquery over `emails`. Postgres cannot build a BitmapOr across an index scan and a SubPlan, so it sequential-scanned `users` and ran the subquery once per row:

```
Seq Scan on users u0  (actual time=30.963..43.470 rows=1)
  Filter: ((username = 'ericmj'::citext) OR (SubPlan 1))
  Rows Removed by Filter: 18598
  Buffers: shared hit=56597
  SubPlan 1
    ->  Index Scan using emails_user_id_case_idx1 on emails
          (loops=18598)
          Buffers: shared hit=55568
```

56,597 buffer accesses to return one row, and it gets worse with every signup. In production `public_get/2` accounts for 12.7 billion buffer accesses from 225,709 calls, 11.9% of every block access in the database and the largest single consumer. `get/2` has the same defect at 55,080 blocks per call, just 7,492 calls.

Both branches already have the index they need and neither was used: `users_username_idx` on username, and `emails_email_key` on `(email) WHERE verified = true`. The query never looked an email up by address, it looked emails up by `user_id` for every user in the table.

A username cannot contain `@` (`@username_regex` is `^[a-z0-9_\-\.]+$`, and no username in production contains one) and an email must, so the input decides the lookup. Each branch is a single index scan and the plan drops to 16 buffers.

One behaviour change: previously, if the input matched a username on one user and a public verified email on another, the query returned two rows and `Repo.one` raised `Ecto.MultipleResultsError`. That state is now unreachable.