### PR TITLE
Load organization audit logs only on the audit logs tab

### DIFF
--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -975,10 +975,6 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       Hexpm.Billing.get(organization.name, script_nonce: conn.assigns[:script_src_nonce])
 
     keys = Keys.all(organization)
-    per_page = opts[:per_page] || 30
-    page = opts[:page] || 1
-    audit_logs = opts[:audit_logs] || AuditLogs.all_by(organization, page, per_page)
-    audit_logs_total_count = opts[:audit_logs_total_count] || AuditLogs.count_by(organization)
     delete_key_path = ~p"/dashboard/orgs/#{organization}/keys"
     create_key_path = ~p"/dashboard/orgs/#{organization}/keys"
     packages = organization_packages(organization)
@@ -1000,10 +996,6 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
         organization: organization,
         repository: organization.repository,
         keys: keys,
-        audit_logs: audit_logs,
-        audit_logs_total_count: audit_logs_total_count,
-        page: page,
-        per_page: per_page,
         audit_logs_path_fn: &~p"/dashboard/orgs/#{organization}/audit-logs?#{&1}",
         params: opts[:params],
         errors: opts[:errors],
@@ -1024,11 +1016,28 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
         policy_rev: policy_rev,
         sso_org_session: current_org_session(conn, organization)
       ] ++
+        audit_log_assigns(organization, opts[:tab], opts) ++
         sso_assigns(organization, opts[:tab]) ++
         member_assigns(organization, opts[:tab], opts)
 
     assigns = Keyword.merge(assigns, customer_assigns(customer, organization))
     render(conn, "index.html", assigns)
+  end
+
+  defp audit_log_assigns(organization, :audit_logs, opts) do
+    per_page = opts[:per_page] || 30
+    page = opts[:page] || 1
+
+    [
+      audit_logs: opts[:audit_logs] || AuditLogs.all_by(organization, page, per_page),
+      audit_logs_total_count: opts[:audit_logs_total_count] || AuditLogs.count_by(organization),
+      page: page,
+      per_page: per_page
+    ]
+  end
+
+  defp audit_log_assigns(_organization, _tab, _opts) do
+    [audit_logs: [], audit_logs_total_count: 0, page: 1, per_page: 30]
   end
 
   defp policy_assigns(organization, :policies, nil, _policy) do

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -20,6 +20,36 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
     end)
   end
 
+  defp capture_audit_log_reads(fun) do
+    test = self()
+    handler = {__MODULE__, System.unique_integer()}
+
+    :telemetry.attach(
+      handler,
+      [:hexpm, :repo_base, :query],
+      fn _event, _measurements, %{query: query}, _config ->
+        if query =~ ~s(FROM "audit_logs"), do: send(test, {handler, query})
+      end,
+      nil
+    )
+
+    try do
+      fun.()
+    after
+      :telemetry.detach(handler)
+    end
+
+    collect_messages(handler, [])
+  end
+
+  defp collect_messages(handler, acc) do
+    receive do
+      {^handler, query} -> collect_messages(handler, [query | acc])
+    after
+      0 -> Enum.reverse(acc)
+    end
+  end
+
   defp active_org_tab(html) do
     {:ok, document} = Floki.parse_document(html)
 
@@ -310,6 +340,31 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
         |> get("/dashboard/orgs/#{organization.name}/audit-logs")
 
       assert response(conn, 200) =~ "Recent Activities"
+    end
+
+    test "queries audit_logs only on the audit logs tab", %{
+      user: user,
+      organization: organization
+    } do
+      insert(:organization_user, organization: organization, user: user)
+      mock_customer(organization)
+
+      audit_logs_tab =
+        capture_audit_log_reads(fn ->
+          build_conn()
+          |> test_login(user)
+          |> get("/dashboard/orgs/#{organization.name}/audit-logs")
+        end)
+
+      profile_tab =
+        capture_audit_log_reads(fn ->
+          build_conn()
+          |> test_login(user)
+          |> get("/dashboard/orgs/#{organization.name}")
+        end)
+
+      assert audit_logs_tab != []
+      assert profile_tab == []
     end
   end
 


### PR DESCRIPTION
`render_index/3` fetched the audit log page and its total count for every organization dashboard tab, but `index.html.heex` reads those assigns only inside the `:audit_logs` branch. Ten of the eleven call sites paid for a count they never rendered.

For the largest organization that count is an index-only scan over 460,796 entries:

```
Aggregate  (actual time=8265.753..8265.754 rows=1)
  Buffers: shared hit=116072 read=16617
  I/O Timings: read=7852.090
  ->  Index Only Scan using audit_logs_organization_id_inserted_at_index
        Heap Fetches: 104015
```

8.3 seconds and 132,689 buffer accesses, running on the billing, keys, members, packages, policies, SSO and danger zone tabs. The 104,015 heap fetches also evict the rest of the buffer pool, which is part of why `audit_logs` holds 951 MB of it.

`audit_log_assigns/3` dispatches on the tab the way `policy_assigns/4`, `sso_assigns/2` and `member_assigns/3` already do in the same module. The test attaches an Ecto telemetry handler and asserts zero `FROM "audit_logs"` reads on the profile tab and at least one on the audit logs tab.