### PR TITLE
Stop auditing API key session creation

### DIFF
--- a/lib/hexpm/oauth/tokens.ex
+++ b/lib/hexpm/oauth/tokens.ex
@@ -244,8 +244,7 @@ defmodule Hexpm.OAuth.Tokens do
     # Build flat Multi (no nested transactions, last_use folded into INSERT)
     UserSessions.build_api_key_session_multi(user, organization, client_id, session_expires_at,
       name: Keyword.get(opts, :name),
-      usage_info: Keyword.get(opts, :usage_info),
-      audit: Keyword.fetch!(opts, :audit)
+      usage_info: Keyword.get(opts, :usage_info)
     )
     |> Ecto.Multi.run(:token, fn _repo, %{session: session} ->
       token_changeset

--- a/lib/hexpm/user_sessions.ex
+++ b/lib/hexpm/user_sessions.ex
@@ -131,7 +131,9 @@ defmodule Hexpm.UserSessions do
   - Expire with the access token (short-lived, typically 30 minutes)
   - Can be for users or organizations
   - Organizations have dynamic limits based on seat count: max(5, seat_count)
-  Requires audit data for security logging.
+  - Are not audited, since the client exchanges its key for a token every 30
+    minutes and the key itself is already recorded in `keys` and audited by
+    `key.generate` and `key.remove`
   """
   def create_api_key_session(user, organization, client_id, expires_at, opts) do
     # Calculate session limit: use dynamic limit for orgs, default for users
@@ -160,22 +162,8 @@ defmodule Hexpm.UserSessions do
         expires_at: expires_at
       })
 
-    changeset = UserSession.changeset(%UserSession{}, attrs)
-
-    multi =
-      Ecto.Multi.new()
-      |> Ecto.Multi.insert(:session, changeset)
-      |> Ecto.Multi.run(:preload, fn _repo, %{session: session} ->
-        {:ok, Repo.preload(session, :client)}
-      end)
-      |> audit(Keyword.fetch!(opts, :audit), "session.create", fn %{preload: session} ->
-        session
-      end)
-
-    case Repo.transaction(multi) do
-      {:ok, %{session: session}} -> {:ok, session}
-      {:error, :session, changeset, _} -> {:error, changeset}
-    end
+    UserSession.changeset(%UserSession{}, attrs)
+    |> Repo.insert()
   end
 
   @doc """
@@ -211,7 +199,8 @@ defmodule Hexpm.UserSessions do
   Builds an Ecto.Multi for creating an API key session without executing a transaction.
 
   Similar to `build_oauth_session_multi/3` but supports both users and organizations,
-  and uses the provided `expires_at` directly (API key sessions have shorter lifetimes).
+  uses the provided `expires_at` directly (API key sessions have shorter lifetimes),
+  and does not audit. See `create_api_key_session/5` for why.
 
   Returns the Multi (caller is responsible for executing the transaction).
   """
@@ -229,7 +218,7 @@ defmodule Hexpm.UserSessions do
       name: Keyword.get(opts, :name),
       expires_at: expires_at
     })
-    |> build_session_multi(opts)
+    |> build_session_multi(Keyword.delete(opts, :audit))
   end
 
   defp build_session_multi(attrs, opts) do

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -210,14 +210,6 @@ defmodule HexpmWeb.API.OAuthController do
       # Determine user or organization from the API key
       user_or_org = auth_info.user || auth_info.organization
 
-      # Build audit data with the authenticated user/org
-      audit_data = %{
-        user: user_or_org,
-        auth_credential: auth_info.auth_credential,
-        user_agent: conn.assigns.user_agent,
-        remote_ip: HexpmWeb.RequestHelpers.parse_ip(conn.remote_ip)
-      }
-
       case Tokens.create_session_and_token_for_api_key(
              user_or_org,
              client.client_id,
@@ -225,8 +217,7 @@ defmodule HexpmWeb.API.OAuthController do
              "client_credentials",
              api_key_secret,
              name: safe_param(params, "name"),
-             usage_info: usage_info,
-             audit: audit_data
+             usage_info: usage_info
            ) do
         {:ok, token} ->
           render(conn, :token, token: token)

--- a/priv/repo/migrations/20260806120000_add_audit_logs_action_index.exs
+++ b/priv/repo/migrations/20260806120000_add_audit_logs_action_index.exs
@@ -1,0 +1,28 @@
+defmodule Hexpm.Repo.Migrations.AddAuditLogsActionIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up() do
+    create_if_not_exists(
+      index(
+        :audit_logs,
+        [:action, :inserted_at],
+        name: :audit_logs_action_inserted_at_index,
+        concurrently: true
+      )
+    )
+  end
+
+  def down() do
+    drop_if_exists(
+      index(
+        :audit_logs,
+        [:action, :inserted_at],
+        name: :audit_logs_action_inserted_at_index,
+        concurrently: true
+      )
+    )
+  end
+end

--- a/test/hexpm/user_sessions_test.exs
+++ b/test/hexpm/user_sessions_test.exs
@@ -473,6 +473,73 @@ defmodule Hexpm.UserSessionsTest do
     end
   end
 
+  describe "session.create audit entries" do
+    test "browser sessions are audited" do
+      user = insert(:user)
+
+      {:ok, _session, _token} =
+        UserSessions.create_browser_session(user, name: "Browser", audit: audit_data(user))
+
+      assert [%AuditLog{action: "session.create"}] = AuditLogs.all_by(user)
+    end
+
+    test "OAuth sessions are audited" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+
+      {:ok, _session} =
+        UserSessions.create_oauth_session(user, client.client_id,
+          name: "OAuth",
+          audit: audit_data(user)
+        )
+
+      assert [%AuditLog{action: "session.create"}] = AuditLogs.all_by(user)
+    end
+
+    test "API key sessions are not audited" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+      expires_at = DateTime.add(DateTime.utc_now(), 30 * 60, :second)
+
+      {:ok, _session} =
+        UserSessions.create_api_key_session(user, nil, client.client_id, expires_at,
+          name: "API key",
+          audit: audit_data(user)
+        )
+
+      assert AuditLogs.all_by(user) == []
+    end
+
+    test "API key sessions built as a multi are not audited" do
+      user = insert(:user)
+      client = insert(:oauth_client)
+      expires_at = DateTime.add(DateTime.utc_now(), 30 * 60, :second)
+
+      {:ok, _changes} =
+        UserSessions.build_api_key_session_multi(user, nil, client.client_id, expires_at,
+          name: "API key",
+          audit: audit_data(user)
+        )
+        |> Hexpm.Repo.transaction()
+
+      assert AuditLogs.all_by(user) == []
+    end
+
+    test "organization API key sessions are not audited" do
+      organization = insert(:organization)
+      client = insert(:oauth_client)
+      expires_at = DateTime.add(DateTime.utc_now(), 30 * 60, :second)
+
+      {:ok, _session} =
+        UserSessions.create_api_key_session(nil, organization, client.client_id, expires_at,
+          name: "API key",
+          audit: audit_data(organization.user)
+        )
+
+      assert AuditLogs.all_by(organization) == []
+    end
+  end
+
   describe "session expiration" do
     test "browser sessions are created with 30-day expiration" do
       user = insert(:user)


### PR DESCRIPTION
A client exchanges its API key for a 30-minute access token, so every CI runner pulling private packages writes a `session.create` audit row twice an hour, forever. That is 77% of `audit_logs`: roughly 3.1M of 3.9M rows, and most of the table's 3,830 MB. Organizations only ever get API key sessions, so their entire audit log is this one action — for the largest organization, the most recent 50,000 entries are 100% `session.create`.

That volume is what makes counting an organization's audit log expensive, and it is why `audit_logs` occupies 951 MB of the 2,481 MB buffer pool.

The key itself is already in `keys` and audited by `key.generate` and `key.remove`, and the live session is in `user_sessions` with its `last_use`. The token exchange adds nothing durable.

Browser and OAuth session creation stay audited. Those are a person authenticating, and that history is kept indefinitely.

`build_api_key_session_multi/5` drops `:audit` rather than trusting callers not to pass it, so the guarantee holds structurally rather than by convention — the test for the multi path caught exactly that gap.

`audit_logs_action_inserted_at_index` is here for the backfill below, which would otherwise sequential-scan 400,129 pages per batch.

## Backfill

Run once in a prod iex after deploy. `key_data` is set only when authentication went through an API key, so it selects exactly the client_credentials sessions and leaves browser and device-code logins alone.

```elixir
import Ecto.Query
alias Hexpm.Accounts.AuditLog

batch = 10_000

purge = fn purge, total ->
  ids =
    from(l in AuditLog,
      where: l.action == "session.create" and not is_nil(l.key_data),
      order_by: l.inserted_at,
      select: l.id,
      limit: ^batch
    )

  {count, _} = Hexpm.Repo.delete_all(from(l in AuditLog, where: l.id in subquery(ids)))
  IO.puts("deleted #{total + count}")

  if count < batch do
    total + count
  else
    Process.sleep(500)
    purge.(purge, total + count)
  end
end

purge.(purge, 0)
```

Sampling production, that is about 3,008,200 rows deleted and 19,150 kept (10,800 browser, 8,350 device code), roughly 300 batches.

The heap keeps the dead tuples afterwards, so reclaim with `pg_repack -d hexpm -t audit_logs`.