### PR TITLE
Cover the downloads package index and drop its unused primary key

### DIFF
--- a/priv/repo/migrations/20260806130000_cover_downloads_package_day_index.exs
+++ b/priv/repo/migrations/20260806130000_cover_downloads_package_day_index.exs
@@ -1,0 +1,36 @@
+defmodule Hexpm.Repo.Migrations.CoverDownloadsPackageDayIndex do
+  use Ecto.Migration
+
+  @disable_ddl_transaction true
+  @disable_migration_lock true
+
+  def up() do
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS downloads_package_id_day_downloads_idx
+    ON downloads (package_id, day) INCLUDE (downloads)
+    """)
+
+    execute("DROP INDEX CONCURRENTLY IF EXISTS downloads_package_id_day_idx")
+
+    # Dropping the constraint is a catalog change, but it still needs ACCESS
+    # EXCLUSIVE and would otherwise queue behind a long read and block writers.
+    execute("SET lock_timeout TO '5s'")
+    execute("ALTER TABLE downloads DROP CONSTRAINT IF EXISTS downloads_pkey")
+    execute("SET lock_timeout TO DEFAULT")
+  end
+
+  def down() do
+    execute("""
+    CREATE INDEX CONCURRENTLY IF NOT EXISTS downloads_package_id_day_idx
+    ON downloads (package_id, day)
+    """)
+
+    execute("DROP INDEX CONCURRENTLY IF EXISTS downloads_package_id_day_downloads_idx")
+
+    execute("""
+    CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS downloads_pkey ON downloads (id)
+    """)
+
+    execute("ALTER TABLE downloads ADD CONSTRAINT downloads_pkey PRIMARY KEY USING INDEX downloads_pkey")
+  end
+end


### PR DESCRIPTION
The package download graph runs 31.8M times at 125 blocks a call, 3.98 billion in total, fifth-largest consumer on the instance. It needs `d0.downloads`, which `downloads_package_id_day_idx` does not carry, so every matching row costs a heap fetch. The daily stats load writes one row per package per day, so a single package's 31 days land in 31 separate regions of the heap:

```
GroupAggregate  (actual time=0.343..1.658 rows=31)
  Buffers: shared hit=560
  ->  Index Scan using downloads_package_id_day_idx on downloads
        Index Cond: ((package_id = 6198) AND (day >= $1))
        rows=506
```

560 buffers for 506 rows. `INCLUDE (downloads)` makes it index-only. The migration replaces the index rather than adding one, so it costs about 200 MB.

`downloads_pkey` is 953 MB and has been scanned zero times since the `pg_stat_statements` reset. Nothing looks a download up by id; the only delete is by `day`. It exists because Ecto puts an id primary key on every schema. I checked `pg_publication` and `pg_replication_slots` — both empty, and `relreplident` is `'d'` — so nothing depends on it as a replica identity. Net is roughly 750 MB smaller.

The column and Ecto's primary key stay, which means a future `Repo.get(Download, id)` would sequential-scan rather than fail loudly. There is no such caller today.

The constraint drop runs under `SET lock_timeout TO '5s'`. It is a catalog change but still takes ACCESS EXCLUSIVE, and would otherwise queue behind a long read and block writers.

Note this needs hexpm-ops#239 to pay off fully. An index-only scan still hits the heap for pages the visibility map does not mark all-visible, and `downloads` sits at 82.7% coverage having never been autovacuumed.