### PR TITLE
Give async test waits room for a loaded machine

### DIFF
--- a/test/hexpm/accounts/sso_test.exs
+++ b/test/hexpm/accounts/sso_test.exs
@@ -5,6 +5,10 @@ defmodule Hexpm.Accounts.SSOTest do
   alias Hexpm.Accounts.SSO.{Connection, Features, Identity, OIDC}
   alias Hexpm.Emails.OutboxEntry
 
+  # The tasks below report in only after a few queries on a shared sandbox
+  # connection, which the 100ms default does not cover on a loaded machine.
+  @receive_timeout 10_000
+
   setup :verify_on_exit!
 
   setup do
@@ -159,7 +163,7 @@ defmodule Hexpm.Accounts.SSOTest do
       end)
 
       task = Task.async(fn -> configure_connection(context) end)
-      assert_receive {:discovery_started, task_pid}
+      assert_receive {:discovery_started, task_pid}, @receive_timeout
 
       assert {:ok, _membership} =
                Organizations.change_role(
@@ -214,7 +218,7 @@ defmodule Hexpm.Accounts.SSOTest do
 
       Mox.allow(OIDC.Mock, self(), task.pid)
       send(task.pid, :go)
-      assert_receive {:slow_discovery_started, task_pid}
+      assert_receive {:slow_discovery_started, task_pid}, @receive_timeout
 
       assert {:ok, updated} =
                SSO.configure(
@@ -803,7 +807,7 @@ defmodule Hexpm.Accounts.SSOTest do
         end
 
       for task <- tasks do
-        assert_receive {:ready, pid}
+        assert_receive {:ready, pid}, @receive_timeout
         send(pid, :go)
         _ = task
       end

--- a/test/hexpm/cdn/fastly_test.exs
+++ b/test/hexpm/cdn/fastly_test.exs
@@ -3,7 +3,9 @@ defmodule Hexpm.CDN.FastlyTest do
   import Mox
   alias Hexpm.CDN.Fastly
 
-  @receive_timeout 1_000
+  # The two extra purges come from a supervised task that sleeps between them,
+  # so the wait has to outlast a loaded machine scheduling that task late.
+  @receive_timeout 10_000
 
   describe "purge_key/2" do
     test "calls purge endpoint 3 times after waiting" do

--- a/test/hexpm/emails/outbox_worker_test.exs
+++ b/test/hexpm/emails/outbox_worker_test.exs
@@ -8,6 +8,10 @@ defmodule Hexpm.Emails.OutboxWorkerTest do
   alias Hexpm.Emails
   alias Hexpm.Emails.{Outbox, OutboxEntry, OutboxEnvelope, OutboxReconciler, OutboxWorker}
 
+  # The producers report in from a task that checks out a connection and takes
+  # an advisory lock first, which the 100ms default does not cover.
+  @receive_timeout 10_000
+
   setup do
     mailer_config = Application.fetch_env!(:hexpm, Emails.Mailer)
     on_exit(fn -> Application.put_env(:hexpm, Emails.Mailer, mailer_config) end)
@@ -359,7 +363,7 @@ defmodule Hexpm.Emails.OutboxWorkerTest do
         Ecto.Adapters.SQL.Sandbox.checkin(Hexpm.RepoBase)
       end)
 
-    assert_receive :first_enqueued
+    assert_receive :first_enqueued, @receive_timeout
 
     second =
       Task.async(fn ->
@@ -375,12 +379,12 @@ defmodule Hexpm.Emails.OutboxWorkerTest do
         Ecto.Adapters.SQL.Sandbox.checkin(Hexpm.RepoBase)
       end)
 
-    assert_receive :second_started
+    assert_receive :second_started, @receive_timeout
     refute_receive :second_enqueued, 100
 
     send(first.pid, :release)
     assert :ok = Task.await(first)
-    assert_receive :second_enqueued
+    assert_receive :second_enqueued, @receive_timeout
     assert :ok = Task.await(second)
   end
 

--- a/test/hexpm/http_test.exs
+++ b/test/hexpm/http_test.exs
@@ -4,6 +4,7 @@ defmodule Hexpm.HTTPTest do
   alias Hexpm.HTTP
   alias Plug.Conn
 
+  @receive_timeout 10_000
   @server_step_timeout 10_000
   @server_await_timeout 30_000
 
@@ -83,10 +84,10 @@ defmodule Hexpm.HTTPTest do
         )
       end)
 
-    assert_receive {:pinned_request_received, request_process}, 1_000
-    assert {:error, :timeout} = Task.await(request, 1_000)
+    assert_receive {:pinned_request_received, request_process}, @receive_timeout
+    assert {:error, :timeout} = Task.await(request, @receive_timeout)
     send(request_process, :finish_request)
-    assert_receive :pinned_request_finished, 1_000
+    assert_receive :pinned_request_finished, @receive_timeout
   end
 
   test "get/3 validates the original hostname over a pinned HTTPS connection" do

--- a/test/hexpm/tmp_dir_test.exs
+++ b/test/hexpm/tmp_dir_test.exs
@@ -3,7 +3,9 @@ defmodule Hexpm.TmpDirTest do
 
   import Bitwise
 
-  @receive_timeout 1000
+  # The paths come from a spawned process, which a loaded machine can leave
+  # unscheduled for a while before it reports them.
+  @receive_timeout 10_000
 
   test "tmp_file/1 creates a file" do
     path = Hexpm.TmpDir.tmp_file("test")


### PR DESCRIPTION
CI failed on `Hexpm.CDN.FastlyTest` in #1813 while the sibling workflow run on the same commit passed, so the code was identical and the difference was scheduling.

`Fastly.purge_key/2` does one synchronous post, then hands the remaining two to a supervised task that sleeps 100ms between them. The test waited with a 1000ms `assert_receive`, so it needed the scheduler to run that task within 900ms of the sleep ending. Under eight parallel cases and 2574 tests it did not. The `Mox.UnexpectedCallError` further down that log is a consequence rather than a second problem: the test process had already failed and exited, taking its expectation with it.

`assert_receive` returns as soon as the message lands, so a longer deadline costs nothing on the passing path. It only decides how long a machine is allowed to stall before the suite calls it a failure.

Four other files have the same shape — a fixed deadline racing a spawned process, a supervised task, or a task that checks out a sandbox connection and takes an advisory lock before reporting:

| file | racing | measured work | margin before |
|---|---|---|---|
| `cdn/fastly_test.exs` | supervised task, 100ms sleep | — | 900ms |
| `tmp_dir_test.exs` | spawned process | 2.2–16.6ms | ~983ms |
| `http_test.exs` | task around a 250ms client timeout | ~3ms | ~997ms / ~747ms |
| `emails/outbox_worker_test.exs` | sandbox checkout + advisory lock + inserts | ~4ms | ~96ms (default) |
| `accounts/sso_test.exs` | tasks running queries on the shared sandbox | 4.6–7.7ms | ~93–98ms (default) |

`refute_receive` deadlines are deliberately unchanged. There a longer window only makes the suite slower, and the one in `outbox_worker_test.exs` is asserting something that cannot arrive — the second producer is blocked on an advisory lock the test holds until it sends `:release`.

Also left alone after checking: `plugs/attack_test.exs` (5s headroom against ~8ms of work), `sso_concurrency_test.exs` (already 2–5s against 14ms), `hexdocs/debouncer_test.exs` and the `oidcc_test.exs` telemetry assertions (the message is sent by the test process itself, so there is no race), and `sso/oidcc_test.exs:428` and `syntax_highlight_test.exs:39`, which race in the safe direction — more load makes the timeout assertion more true, not less.

`test/support/concurrency_case.ex` was already at 15_000 with a comment describing this exact failure mode, which is the precedent these follow.

Verified with the full suite at normal concurrency and under `+S 1 --max-cases 16`, plus five consecutive runs of the changed files. No `lib/` changes.