### PR TITLE
Serialize migrations across pods with an advisory lock

### DIFF
--- a/lib/hexpm/release_tasks.ex
+++ b/lib/hexpm/release_tasks.ex
@@ -123,14 +123,49 @@ defmodule Hexpm.ReleaseTasks do
       app = Keyword.get(repo.config(), :otp_app)
       Logger.info("[task] Running migrations for #{app}")
 
-      case args do
-        ["--step", n] -> migrate(repo, :up, step: String.to_integer(n))
-        ["-n", n] -> migrate(repo, :up, step: String.to_integer(n))
-        ["--to", to] -> migrate(repo, :up, to: to)
-        ["--all"] -> migrate(repo, :up, all: true)
-        [] -> migrate(repo, :up, all: true)
-      end
+      with_migration_lock(repo, fn ->
+        case args do
+          ["--step", n] -> migrate(repo, :up, step: String.to_integer(n))
+          ["-n", n] -> migrate(repo, :up, step: String.to_integer(n))
+          ["--to", to] -> migrate(repo, :up, to: to)
+          ["--all"] -> migrate(repo, :up, all: true)
+          [] -> migrate(repo, :up, all: true)
+        end
+      end)
     end)
+  end
+
+  @doc false
+  # Every app pod runs migrate() at boot, so they race. Ecto's own migration
+  # lock cannot serialize them here: it holds a transaction for the duration,
+  # and CREATE INDEX CONCURRENTLY waits for concurrent transactions to finish,
+  # so the two deadlock. A session level advisory lock on its own connection
+  # holds no transaction, and the lock is released when that connection ends,
+  # including when the pod dies mid-migration.
+  def with_migration_lock(repo, fun) do
+    key = Hexpm.RepoBase.advisory_lock_key(:migrate)
+
+    opts =
+      Keyword.take(repo.config(), [
+        :hostname,
+        :port,
+        :username,
+        :password,
+        :database,
+        :socket_options,
+        :ssl
+      ])
+
+    {:ok, conn} = Postgrex.start_link(opts)
+
+    try do
+      Logger.info("[task] Waiting for migration lock")
+      Postgrex.query!(conn, "SELECT pg_advisory_lock($1)", [key], timeout: :infinity)
+      Logger.info("[task] Acquired migration lock")
+      fun.()
+    after
+      GenServer.stop(conn)
+    end
   end
 
   defp run_rollback(args) do

--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -75,8 +75,11 @@ defmodule Hexpm.RepoBase do
     vulnerability_updater: 2,
     policy: 3,
     diff: 4,
-    email_outbox: 5
+    email_outbox: 5,
+    migrate: 6
   }
+
+  def advisory_lock_key(key), do: Map.fetch!(@advisory_locks, key)
 
   def init(_reason, opts) do
     if url = System.get_env("HEXPM_DATABASE_URL") do

--- a/test/hexpm/release_tasks_test.exs
+++ b/test/hexpm/release_tasks_test.exs
@@ -1,0 +1,69 @@
+defmodule Hexpm.ReleaseTasksTest do
+  use Hexpm.DataCase, async: false
+
+  alias Hexpm.ReleaseTasks
+
+  defp locks_held() do
+    key = Hexpm.RepoBase.advisory_lock_key(:migrate)
+
+    %{rows: [[count]]} =
+      Repo.query!(
+        "SELECT count(*) FROM pg_locks WHERE locktype = 'advisory' AND classid = 0 AND objid = $1",
+        [key]
+      )
+
+    count
+  end
+
+  describe "with_migration_lock/2" do
+    test "holds the lock while the function runs" do
+      assert locks_held() == 0
+
+      ReleaseTasks.with_migration_lock(Hexpm.RepoBase, fn ->
+        assert locks_held() == 1
+      end)
+
+      assert locks_held() == 0
+    end
+
+    test "releases the lock when the function raises" do
+      assert_raise RuntimeError, "boom", fn ->
+        ReleaseTasks.with_migration_lock(Hexpm.RepoBase, fn -> raise "boom" end)
+      end
+
+      assert locks_held() == 0
+    end
+
+    test "returns what the function returned" do
+      assert ReleaseTasks.with_migration_lock(Hexpm.RepoBase, fn -> :migrated end) == :migrated
+    end
+
+    test "a second caller waits for the first to finish" do
+      test = self()
+
+      holder =
+        Task.async(fn ->
+          ReleaseTasks.with_migration_lock(Hexpm.RepoBase, fn ->
+            send(test, :holding)
+            receive do: (:release -> :ok)
+          end)
+        end)
+
+      assert_receive :holding, 10_000
+
+      waiter =
+        Task.async(fn ->
+          ReleaseTasks.with_migration_lock(Hexpm.RepoBase, fn -> send(test, :second_ran) end)
+        end)
+
+      refute_receive :second_ran, 200
+
+      send(holder.pid, :release)
+      Task.await(holder, 10_000)
+
+      assert_receive :second_ran, 10_000
+      Task.await(waiter, 10_000)
+      assert locks_held() == 0
+    end
+  end
+end


### PR DESCRIPTION
Both `hexpm-deployment` and `hexpm-worker-deployment` run `Hexpm.ReleaseTasks.migrate()` before starting the app, so six pods race to migrate on every deploy.

Ecto's own migration lock can't serialize them when a migration uses `CREATE INDEX CONCURRENTLY`. The lock holds a transaction for the duration, and `CONCURRENTLY` waits for concurrent transactions to finish, so the two deadlock. That's why those migrations carry `@disable_migration_lock true` — which then leaves nothing serializing the pods at all.

This is not hypothetical. On the deploy that shipped #1813 and #1814, two pods ran the same `CREATE INDEX CONCURRENTLY` on `downloads` and deadlocked:

```
Process 6742 waits for ShareLock on virtual transaction 138/3299; blocked by process 6998.
Process 6998 waits for ShareUpdateExclusiveLock on relation 16799 of database 16521; blocked by process 6742.
```

Both migrations were recorded in `schema_migrations` while both indexes were left `indisvalid = false`, and `downloads_package_id_day_idx` had already been dropped by the same migration. So the query that runs 31.8M times lost its index entirely:

```
                        buffers    time     scan
before                      560   1.78 ms   Index Scan
after the failed deploy  12,554  110.8 ms   Parallel Seq Scan
after manual rebuild        500   0.79 ms   Index Only Scan
```

Nothing retries, because the migrations are recorded as applied. It took four manual `DROP`/`CREATE INDEX CONCURRENTLY` statements against prod to recover.

## The fix

A session-level advisory lock on its own Postgrex connection, held around the whole migration run. It holds no transaction, so `CONCURRENTLY` is unaffected, and Postgres releases it when the connection ends — including when a pod is killed mid-migration, which a table lock or a lock row would not survive as cleanly.

The connection is built from `repo.config()`, which Ecto has already expanded from `HEXPM_DATABASE_URL` by the time `init/2` has run, so it needs no new configuration.

`migrate: 6` joins the existing `@advisory_locks` map so the key can't collide with the registry, policy, diff or outbox locks.

## What this does not change

`@disable_migration_lock true` stays on migrations using `CONCURRENTLY` — it's still required, it just no longer means "unserialized". `20260421120000_add_package_downloads_browse_index.exs` carries the same attribute and has simply never been unlucky; it's covered by this too.

A Kubernetes Job would also solve it, but deploys go through the separate `hexpm_deploy` service, so that's a change in another repo. This is contained to hexpm and correct regardless of how many pods start or how they're scheduled.

## Testing

Four tests covering hold, release on success, release on raise, and that a second caller blocks until the first finishes. I verified the serialization test is meaningful by stubbing the lock out — it fails with "Unexpectedly received message :second_ran".