### PR TITLE
Measure database wait below the 10ms floor PromEx reports

### DIFF
--- a/lib/hexpm/prom_ex.ex
+++ b/lib/hexpm/prom_ex.ex
@@ -15,6 +15,7 @@ defmodule Hexpm.PromEx do
       # five seconds for a number that does not move that fast.
       {Plugins.Oban, poll_rate: :timer.minutes(1)},
       Hexpm.PromEx.Plugins.Hexpm,
+      Hexpm.PromEx.Plugins.EctoLatency,
       Hexpm.PromEx.Plugins.OutboundHttp
     ]
   end

--- a/lib/hexpm/prom_ex/plugins/ecto_latency.ex
+++ b/lib/hexpm/prom_ex/plugins/ecto_latency.ex
@@ -1,0 +1,51 @@
+defmodule Hexpm.PromEx.Plugins.EctoLatency do
+  @moduledoc """
+  PromEx plugin for how long database work waits, at a resolution the upstream
+  Ecto plugin cannot express.
+
+  `PromEx.Plugins.Ecto` hardcodes `[10, 50, 250, 1_000, 5_000, 10_000]` for every
+  duration it reports, and offers no option to change them. Almost all traffic
+  here finishes inside the first bucket, so those histograms answer "under 10ms"
+  and nothing finer, which is the wrong granularity for a pool that hands out
+  connections in microseconds.
+
+  Two measurements are worth separating when requests slow down: `queue_time` is
+  how long a caller waited for a connection, `query_time` is how long the database
+  took once it had one. A rise in the first without the second means the pool is
+  the constraint; the reverse means the database is.
+  """
+
+  use PromEx.Plugin
+
+  @buckets [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 25, 50, 100, 500, 1_000]
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+
+    metric_prefix =
+      Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :ecto_latency))
+
+    event_name =
+      Hexpm.RepoBase.config() |> Keyword.fetch!(:telemetry_prefix) |> Kernel.++([:query])
+
+    Event.build(:hexpm_ecto_latency_event_metrics, [
+      distribution(
+        metric_prefix ++ [:queue, :time, :milliseconds],
+        event_name: event_name,
+        measurement: :queue_time,
+        description: "How long a caller waited to check out a database connection.",
+        reporter_options: [buckets: @buckets],
+        unit: {:native, :millisecond}
+      ),
+      distribution(
+        metric_prefix ++ [:query, :time, :milliseconds],
+        event_name: event_name,
+        measurement: :query_time,
+        description: "How long the database took to run the query.",
+        reporter_options: [buckets: @buckets],
+        unit: {:native, :millisecond}
+      )
+    ])
+  end
+end

--- a/test/hexpm/prom_ex/plugins/ecto_latency_test.exs
+++ b/test/hexpm/prom_ex/plugins/ecto_latency_test.exs
@@ -1,0 +1,49 @@
+defmodule Hexpm.PromEx.Plugins.EctoLatencyTest do
+  use ExUnit.Case, async: true
+
+  alias Hexpm.PromEx.Plugins.EctoLatency
+
+  defp metrics() do
+    EctoLatency.event_metrics(otp_app: :hexpm).metrics
+  end
+
+  test "reports queue and query time off the repo's telemetry event" do
+    assert [queue, query] = metrics()
+
+    assert queue.name == [:hexpm, :prom_ex, :ecto_latency, :queue, :time, :milliseconds]
+    assert query.name == [:hexpm, :prom_ex, :ecto_latency, :query, :time, :milliseconds]
+
+    for metric <- [queue, query] do
+      assert metric.event_name ==
+               Keyword.fetch!(Hexpm.RepoBase.config(), :telemetry_prefix) ++ [:query]
+
+      assert metric.unit == :millisecond
+    end
+  end
+
+  test "resolves below the 10ms floor the upstream Ecto plugin reports" do
+    for metric <- metrics() do
+      buckets = metric.reporter_options[:buckets]
+
+      assert Enum.min(buckets) < 1,
+             "#{inspect(metric.name)} needs sub-millisecond buckets to be worth adding"
+
+      assert Enum.count(buckets, &(&1 < 10)) >= 5,
+             "#{inspect(metric.name)} needs several buckets below the upstream floor of 10ms"
+
+      assert buckets == Enum.sort(buckets)
+    end
+  end
+
+  test "does not collide with the upstream Ecto plugin's metric names" do
+    upstream =
+      PromEx.Plugins.Ecto.event_metrics(otp_app: :hexpm, repos: [Hexpm.RepoBase])
+      |> List.wrap()
+      |> Enum.flat_map(& &1.metrics)
+      |> MapSet.new(& &1.name)
+
+    for metric <- metrics() do
+      refute MapSet.member?(upstream, metric.name)
+    end
+  end
+end


### PR DESCRIPTION
`PromEx.Plugins.Ecto` hardcodes `[10, 50, 250, 1_000, 5_000, 10_000]` for every duration it reports, at `deps/prom_ex/lib/prom_ex/plugins/ecto.ex:142`, and exposes no option to change them. Over seven days, 99.93% of 153,120,751 checkouts landed in that first bucket:

```
le (ms)      in bucket   cumulative %
   10.0    153,011,167     99.9284%
   50.0         98,172     99.9925%
  250.0         11,175     99.9998%
 1000.0            237    100.0000%
```

So the histogram answers "under 10ms" and nothing finer, on a pool that hands out connections in microseconds.

That was the blocker when I went looking for the cause of dropped checkouts. 110,813 waits exceeded 10ms, 85% of them concentrated in 50 of 2,017 five-minute windows, and the shape underneath was unreadable — a p99 of 9.9071ms and a p999 of 9.9972ms are both interpolation artifacts of the same saturated bucket, not measurements.

## What this adds

Two distributions with buckets from 0.1ms to 1s, on the repo's own telemetry event rather than PromEx's proxied one, so the upstream plugin keeps working unchanged beside them:

```
hexpm_prom_ex_ecto_latency_queue_time_milliseconds
hexpm_prom_ex_ecto_latency_query_time_milliseconds
```

The pair is the point. `queue_time` is how long a caller waited for a connection, `query_time` is how long the database took once it had one. A rise in the first without the second means the pool is the constraint; the reverse means the database is. During the 2026-08-05 stall I could see 20 concurrent queries against a baseline of 1, with flat CPU and flat disk, and no way to tell which of those two it was.

The event name is read from `Hexpm.RepoBase.config()[:telemetry_prefix]` rather than hardcoded, so it follows the repo rather than drifting from it.

## Testing

Three tests: the metric names and event wiring, that the buckets actually resolve below the upstream floor, and that the names don't collide with anything `PromEx.Plugins.Ecto` already registers — a collision there produces duplicate-handler warnings at boot rather than a clean failure, so it's worth asserting.