### PR TITLE
Vacuum downloads after the nightly stats job writes it

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -40,7 +40,10 @@ config :hexpm,
   pwned_impl: Hexpm.Pwned.Mock,
   http_impl: Hexpm.HTTP.Mock,
   cache_enabled: false,
-  skip_advisory_locks: true
+  skip_advisory_locks: true,
+  # VACUUM cannot run inside the sandbox transaction that wraps each test.
+  # Hexpm.ReleaseTasks.StatsTest covers it unboxed.
+  skip_maintenance_vacuum: true
 
 config :hexpm, HexpmWeb.Endpoint,
   http: [port: 5000],

--- a/lib/hexpm/release_tasks/stats.ex
+++ b/lib/hexpm/release_tasks/stats.ex
@@ -121,6 +121,8 @@ defmodule Hexpm.ReleaseTasks.Stats do
           end,
           timeout: 600_000
         )
+
+        vacuum_downloads()
       end
 
       num
@@ -232,6 +234,24 @@ defmodule Hexpm.ReleaseTasks.Stats do
 
   defp copy(nil), do: nil
   defp copy(binary), do: :binary.copy(binary)
+
+  # Runs outside the transaction above, which VACUUM cannot run inside. This job
+  # is the only writer, so nothing else sets the visibility map bits the day's
+  # new pages need, and nothing else refreshes the day histogram that every read
+  # of this table filters on. Autovacuum does not reach it either: its insert
+  # threshold scales with the table, and this one is 43M rows and growing.
+  @doc false
+  def vacuum_downloads() do
+    if Application.get_env(:hexpm, :skip_maintenance_vacuum, false) do
+      :ok
+    else
+      time_log("vacuum downloads", fn ->
+        Repo.query!("VACUUM (ANALYZE) downloads", [], timeout: 600_000)
+      end)
+
+      :ok
+    end
+  end
 
   defp time_log(action, fun) do
     {time, result} = :timer.tc(fun)

--- a/test/hexpm/release_tasks/stats_test.exs
+++ b/test/hexpm/release_tasks/stats_test.exs
@@ -180,6 +180,27 @@ defmodule Hexpm.ReleaseTasks.StatsTest do
     end)
   end
 
+  describe "vacuum_downloads/0" do
+    # The sandboxed tests above run with skip_maintenance_vacuum on, because
+    # VACUUM cannot run inside the transaction wrapping them. This one goes
+    # unboxed on a real connection so the statement is genuinely issued.
+    test "runs against a real connection" do
+      app_env(:hexpm, :skip_maintenance_vacuum, false)
+
+      task = Hexpm.ConcurrencyCase.unboxed_task(fn -> Stats.vacuum_downloads() end)
+
+      assert Task.await(task, 15_000) == :ok
+    end
+
+    test "issues no statement when disabled" do
+      app_env(:hexpm, :skip_maintenance_vacuum, true)
+
+      queries = capture_queries(fn -> assert Stats.vacuum_downloads() == :ok end)
+
+      refute Enum.any?(queries, &(&1 =~ "VACUUM"))
+    end
+  end
+
   defp read_log(path, replaces) do
     Enum.reduce(replaces, read_fixture(path), fn {key, value}, file ->
       String.replace(file, "{#{key}}", value)


### PR DESCRIPTION
`Hexpm.ReleaseTasks.Stats` is the only writer of `downloads`, and nothing keeps the table maintained afterwards.

Autovacuum doesn't reach it. The insert threshold is `threshold + scale_factor × reltuples`, so even at the 0.02 scale factor from hexpm-ops#239, a 43M row table needs about 864,000 inserts. The job writes 50,708 a night, which is 17 days between passes.

That gap is how `downloads` got to 94.6% of `autovacuum_freeze_max_age` having never been vacuumed at all, sitting at 79% visibility map coverage. A stale map costs a heap fetch per row on an index-only scan — the package download query was reading 500 buffers to return 564 rows where the same plan against a current map reads 10.

## Why nightly is cheap

Vacuum skips pages the visibility map already marks all-visible, so its cost is proportional to what changed, not to the table:

```
rows written per night     50,708
rows per page                 152
pages touched                 334      ≈ 2.6 MB
```

Vacuuming often is what makes it cheap. The 271,775-page scan we were heading for was the price of not doing it.

It also spreads the freeze work, so `relfrozenxid` advances a little each night and the anti-wraparound scan never becomes mandatory.

## Why ANALYZE

Every read of this table filters `day >= max(day) - 30`, and the planner's selectivity estimate for that range depends on the histogram's upper bound. The job appends a new maximum every night and nothing re-analyses. It's already observable: `downloads.day` currently has a histogram max of 2026-08-07 against an actual max of 2026-08-08, one night after I analysed it by hand. Autoanalyse won't fire either — its threshold is `0.1 × 43M`.

`VACUUM` and `ANALYZE` both take `ShareUpdateExclusiveLock`, which doesn't conflict with `SELECT`, `INSERT`, `UPDATE` or `DELETE`, so this blocks no traffic. It does conflict with `CREATE INDEX CONCURRENTLY` on the same table, which is worth knowing if a deploy lands during the 01:00 window.

## Placement and testing

The statement runs after the `Repo.transaction` block at `stats.ex:88`, because `VACUUM` cannot run inside a transaction.

That's also why `skip_maintenance_vacuum` is set in test config — the Ecto sandbox wraps every test in a transaction, so the existing `Stats` tests would fail on it. It follows the `skip_advisory_locks` precedent already in that file. The path that actually issues the statement is covered by an unboxed test on a real connection, and a second test asserts nothing is issued when the flag is on.