### PR TITLE
Sort package ids rather than package rows when ordering by downloads

### DIFF
--- a/lib/hexpm/repository/package.ex
+++ b/lib/hexpm/repository/package.ex
@@ -124,15 +124,38 @@ defmodule Hexpm.Repository.Package do
   end
 
   def all(repositories, page, count, search, sort, fields) do
-    from(
-      p in assoc(repositories, :packages),
-      as: :package,
-      preload: :downloads
-    )
-    |> sort(sort)
-    |> Hexpm.Utils.paginate(page, count)
-    |> search(search)
-    |> fields(fields)
+    if view = download_view(sort) do
+      # Ordering by downloads cannot use an index, since the key lives in the
+      # package_downloads view, so the whole matching set is sorted to return one
+      # page of it. Sorting ids and download counts rather than package rows
+      # keeps meta out of the sort: 1.6MB rather than 8.1MB for a repository this
+      # size, which is the difference between a quicksort and a spill to disk.
+      page_ids =
+        from(p in assoc(repositories, :packages), as: :package)
+        |> downloads_join(view)
+        |> select([p, d], %{id: p.id, downloads: d.downloads})
+        |> Hexpm.Utils.paginate(page, count)
+        |> search(search)
+
+      from(
+        p in Package,
+        join: page_id in subquery(page_ids),
+        on: page_id.id == p.id,
+        order_by: [fragment("? DESC NULLS LAST", page_id.downloads)],
+        preload: :downloads
+      )
+      |> fields(fields)
+    else
+      from(
+        p in assoc(repositories, :packages),
+        as: :package,
+        preload: :downloads
+      )
+      |> sort(sort)
+      |> Hexpm.Utils.paginate(page, count)
+      |> search(search)
+      |> fields(fields)
+    end
   end
 
   def dependants(repositories, dependency, page, count, sort, fields) do
@@ -596,24 +619,27 @@ defmodule Hexpm.Repository.Package do
   end
 
   defp sort(query, :total_downloads) do
-    from(
-      p in query,
-      left_join: d in PackageDownload,
-      on: p.id == d.package_id and d.view == "all",
-      order_by: [fragment("? DESC NULLS LAST", d.downloads)]
-    )
+    downloads_join(query, "all")
   end
 
   defp sort(query, :recent_downloads) do
-    from(
-      p in query,
-      left_join: d in PackageDownload,
-      on: p.id == d.package_id and d.view == "recent",
-      order_by: [fragment("? DESC NULLS LAST", d.downloads)]
-    )
+    downloads_join(query, "recent")
   end
 
   defp sort(query, nil) do
     query
   end
+
+  defp downloads_join(query, view) do
+    from(
+      p in query,
+      left_join: d in PackageDownload,
+      on: p.id == d.package_id and d.view == ^view,
+      order_by: [fragment("? DESC NULLS LAST", d.downloads)]
+    )
+  end
+
+  defp download_view(:total_downloads), do: "all"
+  defp download_view(:recent_downloads), do: "recent"
+  defp download_view(_sort), do: nil
 end

--- a/test/hexpm/repository/package_test.exs
+++ b/test/hexpm/repository/package_test.exs
@@ -686,6 +686,50 @@ defmodule Hexpm.Repository.PackageTest do
              |> Enum.map(& &1.id)
   end
 
+  test "sort filtered packages by total downloads, keeping zero-download packages last", %{
+    repository: repository
+  } do
+    other_repository = insert(:repository)
+    top = insert(:package, repository_id: repository.id)
+    middle = insert(:package, repository_id: repository.id)
+    zero = insert(:package, repository_id: repository.id)
+    other_tool = insert(:package, repository_id: repository.id)
+    hidden = insert(:package, repository_id: other_repository.id)
+
+    insert(:release,
+      package: top,
+      meta: build(:release_metadata, build_tools: ["mix"]),
+      daily_downloads: [build(:download, package_id: top.id, downloads: 10)]
+    )
+
+    insert(:release,
+      package: middle,
+      meta: build(:release_metadata, build_tools: ["mix"]),
+      daily_downloads: [build(:download, package_id: middle.id, downloads: 5)]
+    )
+
+    insert(:release, package: zero, meta: build(:release_metadata, build_tools: ["mix"]))
+
+    insert(:release,
+      package: other_tool,
+      meta: build(:release_metadata, build_tools: ["rebar3"]),
+      daily_downloads: [build(:download, package_id: other_tool.id, downloads: 100)]
+    )
+
+    insert(:release,
+      package: hidden,
+      meta: build(:release_metadata, build_tools: ["mix"]),
+      daily_downloads: [build(:download, package_id: hidden.id, downloads: 100)]
+    )
+
+    :ok = Hexpm.Repo.refresh_view(Hexpm.Repository.PackageDownload)
+
+    assert [top.id, middle.id, zero.id] ==
+             Package.all([repository], 1, 10, "build_tool:mix", :total_downloads, nil)
+             |> Repo.all()
+             |> Enum.map(& &1.id)
+  end
+
   test "search packages by total downloads uses download order and repo scoping", %{
     repository: repository
   } do


### PR DESCRIPTION
Ordering by downloads cannot use an index, because the key lives in the `package_downloads` materialized view. So the whole matching set gets sorted to return one page of it, and each of those rows carried the full package including `meta`. 22,525 of them do not fit in `work_mem`.

Every call spilled about 8.1MB. Measured on prod across both views and all four build tools the filter sidebar offers, sorting rows against sorting ids:

| view | tool | current | deferred |
|---|---|---|---|
| all | mix | external merge 4992 + 3144 kB | quicksort 1072 + 561 kB |
| all | rebar3 | external merge 4888 + 3240 kB | quicksort 1073 + 559 kB |
| all | make | external merge 4936 + 3184 kB | quicksort 1073 + 560 kB |
| all | gleam | external merge 5160 + 2968 kB | quicksort 1088 + 545 kB |
| recent | mix | external merge 5160 + 2968 kB | quicksort 1049 + 776 kB |
| recent | rebar3 | external merge 4904 + 3224 kB | quicksort 1055 + 770 kB |
| recent | make | external merge 5056 + 3064 kB | quicksort 1089 + 544 kB |
| recent | gleam | external merge 5152 + 2976 kB | quicksort 1079 + 554 kB |

Spills in eight cases out of eight, spills in none of them after. Execution time moves from 32-72ms to 22-60ms, faster in seven of the eight, but the timings are noisy on a live instance and the memory is the point.

This is the largest remaining source of temp files on the instance: 327 calls in six hours wrote 2.5GB, and it is the query that made me look at `work_mem` in the first place. hexpm/hexpm-ops#240 raises the instance-wide `work_mem` to 16MB, which stops this spilling too, but at 8x the memory per call and only while that setting holds.

`Packages.search/6` already takes an ids-first path through `paginate_by_downloads/5` when there is no search term. This is the same idea for the filtered case, which was the one still sorting wide rows.

## What to check

The left join has to stay, so packages with no `package_downloads` row still sort last instead of dropping out. The new test pins that: it filters by `build_tool:mix` with a downloads sort and asserts a zero-download package comes back last. I checked it discriminates by switching the join to an inner one, which drops that package and fails it.

I also compared the generated SQL against what I measured on prod. Sorts other than downloads are untouched, since their keys are on `packages` itself and they were writing no temp files.

## Two things I considered and did not do

Driving the query from `package_downloads_view_downloads_package_id_idx` in download order and stopping at 100 is much faster when the filter is common (1.17ms for `mix`) and much worse when it is rare (46.6ms for `gleam`, walking 3,936 index entries and probing `releases` for each). That asymmetry is presumably why the existing ids-first path is gated on there being no search term. The deferred fetch behaves the same way whatever the filter matches.

The `gleam` case is still the slowest, at a median 62.7ms over five runs, because the `EXISTS` probe reads every release of every candidate package: 66,855 of its 70,217 buffers.

Correction to what this section said when the PR was opened: I claimed a GIN index on `releases ((meta->'build_tools'))` would address that and that it was unmeasured. The index already exists.

```
CREATE INDEX releases_meta_build_tools_idx ON public.releases USING gin (((meta -> 'build_tools'::text)))
```

The bitmap scan finds all 8,819 `gleam` releases in 7 buffers. The planner does not use it here because the semi join is driven per-package from the download-ordered list, so it probes `releases_package_id_idx` once per candidate. Rephrasing `EXISTS` to `IN` changes nothing: Postgres normalizes both to the same semi join and produces an identical plan.

Forcing it with `WITH ... AS MATERIALIZED` works, and is a trade rather than a win:

| tool | packages | `EXISTS`, as shipped | forced GIN scan |
|---|---|---|---|
| mix | 18,781 | 4,509 bufs, 21.6 ms | 80,233 bufs, 130.8 ms |
| rebar3 | 2,226 | 12,589 bufs, 27.6 ms | 15,339 bufs, 26.3 ms |
| gleam | 1,627 | 70,519 bufs, 62.7 ms | 10,486 bufs, 19.3 ms |
| make | 566 | 37,972 bufs, 41.5 ms | 9,261 bufs, 17.5 ms |

Times are medians of five runs against prod; buffer counts are stable to within 100 across runs, so they are the figure to trust. Summed across the four that is 125,589 buffers against 115,319, so neither shape wins. Forcing the scan costs `mix` 6x the time and 18x the buffers, because the CTE then feeds 22,643 primary key lookups into a nested loop.

The planner cannot pick per-tool: jsonb `?` has no selectivity estimator, so it applies a fixed constant whatever the operand and cannot tell `mix` at 83% of packages from `gleam` at 7%. Which shape is better depends on which filters real traffic uses, and I could not determine that. The request logs record `path=` without the query string.

Worth knowing: `gleam` is worse than `make` despite matching 3x more packages. The `EXISTS` cost is how far down the download-ordered list you walk to find 100 matches, not how many match overall.

