### PR TITLE
Sort user-facing collections by name

### DIFF
--- a/lib/hexpm/accounts/key.ex
+++ b/lib/hexpm/accounts/key.ex
@@ -63,7 +63,8 @@ defmodule Hexpm.Accounts.Key do
     from(
       k in assoc(user_or_organization, :keys),
       where: not query_revoked(k),
-      where: k.public
+      where: k.public,
+      order_by: k.name
     )
   end
 

--- a/lib/hexpm/accounts/organizations.ex
+++ b/lib/hexpm/accounts/organizations.ex
@@ -5,7 +5,17 @@ defmodule Hexpm.Accounts.Organizations do
   alias Hexpm.Repository.OrgNamesPublisher
 
   def all_by_user(user, preload \\ []) do
-    Repo.all(assoc(user, :organizations))
+    from(organization in assoc(user, :organizations), order_by: organization.name)
+    |> Repo.all()
+    |> Repo.preload(preload)
+  end
+
+  def all_members(organization, preload \\ []) do
+    from(organization_user in assoc(organization, :organization_users),
+      join: user in assoc(organization_user, :user),
+      order_by: user.username
+    )
+    |> Repo.all()
     |> Repo.preload(preload)
   end
 

--- a/lib/hexpm/accounts/users.ex
+++ b/lib/hexpm/accounts/users.ex
@@ -64,7 +64,7 @@ defmodule Hexpm.Accounts.Users do
   def get_maybe_unverified_email(_, _), do: nil
 
   def all_organizations(%User{organizations: organizations}) when is_list(organizations) do
-    [Organization.hexpm() | organizations]
+    [Organization.hexpm() | Enum.sort_by(organizations, & &1.name)]
   end
 
   def all_organizations(nil) do

--- a/lib/hexpm/repository/owners.ex
+++ b/lib/hexpm/repository/owners.ex
@@ -4,7 +4,10 @@ defmodule Hexpm.Repository.Owners do
   alias Hexpm.Accounts.OptionalEmails
 
   def all(package, preload \\ []) do
-    assoc(package, :package_owners)
+    from(owner in assoc(package, :package_owners),
+      join: user in assoc(owner, :user),
+      order_by: user.username
+    )
     |> Repo.all()
     |> Repo.preload(preload)
   end

--- a/lib/hexpm_web/controllers/api/organization_controller.ex
+++ b/lib/hexpm_web/controllers/api/organization_controller.ex
@@ -21,8 +21,9 @@ defmodule HexpmWeb.API.OrganizationController do
 
   def index(conn, _params) do
     organizations =
-      all_organizations_by_user(conn.assigns.current_user) ++
-        current_organization(conn.assigns.current_organization)
+      (all_organizations_by_user(conn.assigns.current_user) ++
+         current_organization(conn.assigns.current_organization))
+      |> Enum.sort_by(& &1.name)
 
     conn
     |> api_cache(:private)

--- a/lib/hexpm_web/controllers/api/organization_user_controller.ex
+++ b/lib/hexpm_web/controllers/api/organization_user_controller.ex
@@ -18,11 +18,12 @@ defmodule HexpmWeb.API.OrganizationUserController do
        when action in [:create, :update, :delete]
 
   def index(conn, %{"organization" => name}) do
-    organization = Organizations.get(name, users: :emails)
+    organization = Organizations.get(name)
+    organization_users = Organizations.all_members(organization, user: :emails)
 
     conn
     |> api_cache(:private)
-    |> render(:index, organization_users: organization.organization_users)
+    |> render(:index, organization_users: organization_users)
   end
 
   def show(conn, %{"organization" => name, "name" => username}) do

--- a/lib/hexpm_web/controllers/api/repository_controller.ex
+++ b/lib/hexpm_web/controllers/api/repository_controller.ex
@@ -13,9 +13,12 @@ defmodule HexpmWeb.API.RepositoryController do
 
   def index(conn, _params) do
     repositories =
-      Repositories.all_public() ++
-        all_by_user(conn.assigns.current_user) ++
-        all_by_organization(conn.assigns.current_organization)
+      (Repositories.all_public() ++
+         all_by_user(conn.assigns.current_user) ++
+         all_by_organization(conn.assigns.current_organization))
+      |> Enum.sort_by(fn repository ->
+        if repository.id == 1, do: {0, nil}, else: {1, repository.name}
+      end)
 
     when_stale(conn, repositories, [modified: false], fn conn ->
       conn

--- a/lib/hexpm_web/controllers/dashboard/key_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/key_controller.ex
@@ -49,7 +49,11 @@ defmodule HexpmWeb.Dashboard.KeyController do
     user = Hexpm.Repo.preload(conn.assigns.current_user, :owned_packages)
     keys = Keys.all(user)
     organizations = Organizations.all_by_user(user)
-    packages = Enum.filter(user.owned_packages, &HexpmWeb.ViewHelpers.main_repository?/1)
+
+    packages =
+      user.owned_packages
+      |> Enum.filter(&HexpmWeb.ViewHelpers.main_repository?/1)
+      |> Enum.sort_by(& &1.name)
 
     render(
       conn,

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -940,7 +940,7 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
   defp packages_assign(_organization, _tab), do: []
 
   defp organization_packages(%{repository: %{packages: packages}}) when is_list(packages) do
-    packages
+    Enum.sort_by(packages, & &1.name)
   end
 
   defp organization_packages(_), do: []
@@ -1188,13 +1188,16 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
     organization =
       Organizations.get(organization, [
         :user,
-        :organization_users,
         user: :emails,
-        users: :emails,
         repository: [packages: :repository]
       ])
 
     if organization do
+      organization = %{
+        organization
+        | organization_users: Organizations.all_members(organization, user: :emails)
+      }
+
       if repo_user = Enum.find(organization.organization_users, &(&1.user_id == user.id)) do
         if repo_user.role in Organization.role_or_higher(role) do
           fun.(organization)

--- a/lib/hexpm_web/views/api/user_view.ex
+++ b/lib/hexpm_web/views/api/user_view.ex
@@ -83,7 +83,9 @@ defmodule HexpmWeb.API.UserView do
   defp repository_sort(%Package{repository: %Repository{name: name}}), do: name
 
   defp organizations(user) do
-    Enum.map(user.organization_users, fn ru ->
+    user.organization_users
+    |> Enum.sort_by(& &1.organization.name)
+    |> Enum.map(fn ru ->
       %{
         name: ru.organization.name,
         role: ru.role

--- a/lib/hexpm_web/views/api/user_view.ex
+++ b/lib/hexpm_web/views/api/user_view.ex
@@ -83,9 +83,7 @@ defmodule HexpmWeb.API.UserView do
   defp repository_sort(%Package{repository: %Repository{name: name}}), do: name
 
   defp organizations(user) do
-    user.organization_users
-    |> Enum.sort_by(& &1.organization.name)
-    |> Enum.map(fn ru ->
+    Enum.map(user.organization_users, fn ru ->
       %{
         name: ru.organization.name,
         role: ru.role

--- a/test/hexpm/accounts/users_test.exs
+++ b/test/hexpm/accounts/users_test.exs
@@ -6,6 +6,24 @@ defmodule Hexpm.Accounts.UsersTest do
   alias Hexpm.Accounts.{AuditLog, OptionalEmails, User, Users, UserProviders}
   alias Hexpm.Emails.OutboxEntry
 
+  describe "all_organizations/1" do
+    test "keeps the public organization first and sorts the rest by name" do
+      user =
+        build(:user,
+          organizations: [
+            build(:organization, name: "zulu_org"),
+            build(:organization, name: "alpha_org")
+          ]
+        )
+
+      assert Enum.map(Users.all_organizations(user), & &1.name) == [
+               "hexpm",
+               "alpha_org",
+               "zulu_org"
+             ]
+    end
+  end
+
   describe "add_from_oauth_with_provider/6" do
     test "creates user and provider atomically" do
       username = Hexpm.Fake.sequence(:username)

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -34,7 +34,6 @@ defmodule HexpmWeb.API.KeyControllerTest do
         |> put_req_header("authorization", key.user_secret)
         |> get("/api/keys")
         |> json_response(200)
-        |> Enum.sort_by(fn %{"name" => name} -> name end)
 
       assert length(body) == 2
       [a, b] = body

--- a/test/hexpm_web/controllers/api/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_controller_test.exs
@@ -41,6 +41,22 @@ defmodule HexpmWeb.API.OrganizationControllerTest do
       assert [org] = json_response(conn, 200)
       assert org["name"] == organization.name
     end
+
+    test "sorts organizations by name", %{user1: user1} do
+      zulu = insert(:organization, name: "zulu_org")
+      alpha = insert(:organization, name: "alpha_org")
+      insert(:organization_user, organization: zulu, user: user1)
+      insert(:organization_user, organization: alpha, user: user1)
+
+      names =
+        build_conn()
+        |> put_req_header("authorization", key_for(user1))
+        |> get("/api/orgs")
+        |> json_response(200)
+        |> Enum.map(& &1["name"])
+
+      assert names == ["alpha_org", "zulu_org"]
+    end
   end
 
   describe "GET /api/orgs/:name" do

--- a/test/hexpm_web/controllers/api/organization_user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_user_controller_test.exs
@@ -45,6 +45,28 @@ defmodule HexpmWeb.API.OrganizationUserControllerTest do
       assert user["username"] == user1.username
       assert user["role"] == "read"
     end
+
+    test "sorts organization members by username", %{
+      user1: user1,
+      organization: organization
+    } do
+      zulu = insert(:user, username: "zulu_member")
+      alpha = insert(:user, username: "alpha_member")
+      insert(:organization_user, organization: organization, user: user1)
+      insert(:organization_user, organization: organization, user: zulu)
+      insert(:organization_user, organization: organization, user: alpha)
+
+      usernames =
+        build_conn()
+        |> put_req_header("authorization", key_for(user1))
+        |> get("/api/orgs/#{organization.name}/members")
+        |> json_response(200)
+        |> Enum.map(& &1["username"])
+
+      assert usernames == Enum.sort(usernames)
+      assert "alpha_member" in usernames
+      assert "zulu_member" in usernames
+    end
   end
 
   describe "POST /api/orgs/:organization/members" do

--- a/test/hexpm_web/controllers/api/owner_controller_test.exs
+++ b/test/hexpm_web/controllers/api/owner_controller_test.exs
@@ -6,8 +6,8 @@ defmodule HexpmWeb.API.OwnerControllerTest do
   alias Hexpm.Repository.{Owners, PackageOwner}
 
   setup do
-    user1 = insert(:user)
-    user2 = insert(:user)
+    user1 = insert(:user, username: "zulu_owner")
+    user2 = insert(:user, username: "alpha_owner")
     repository = insert(:repository)
     package = insert(:package, package_owners: [build(:package_owner, user: user1)])
 
@@ -43,8 +43,8 @@ defmodule HexpmWeb.API.OwnerControllerTest do
         |> get("/api/packages/#{package.name}/owners")
 
       [first, second] = json_response(conn, 200)
-      assert first["username"] in [user1.username, user2.username]
-      assert second["username"] in [user1.username, user2.username]
+      assert first["username"] == user2.username
+      assert second["username"] == user1.username
     end
   end
 

--- a/test/hexpm_web/controllers/api/repository_controller_test.exs
+++ b/test/hexpm_web/controllers/api/repository_controller_test.exs
@@ -36,6 +36,29 @@ defmodule HexpmWeb.API.RepositoryControllerTest do
 
       assert length(result) == 2
     end
+
+    test "sorts organization repositories by name after the public repository", %{
+      repo_user: repo_user
+    } do
+      zulu_organization = insert(:organization, name: "zulu_repo")
+      alpha_organization = insert(:organization, name: "alpha_repo")
+      insert(:repository, name: "zulu_repo", organization: zulu_organization)
+      insert(:repository, name: "alpha_repo", organization: alpha_organization)
+      insert(:organization_user, user: repo_user, organization: zulu_organization)
+      insert(:organization_user, user: repo_user, organization: alpha_organization)
+
+      names =
+        build_conn()
+        |> put_req_header("authorization", key_for(repo_user))
+        |> get("/api/repos")
+        |> json_response(200)
+        |> Enum.map(& &1["name"])
+
+      assert hd(names) == "hexpm"
+      assert names == ["hexpm" | Enum.sort(tl(names))]
+      assert "alpha_repo" in names
+      assert "zulu_repo" in names
+    end
   end
 
   describe "GET /api/repos/:repository" do

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -124,23 +124,6 @@ defmodule HexpmWeb.API.UserControllerTest do
       |> json_response(401)
     end
 
-    test "sorts organizations by name" do
-      user = insert(:user)
-      zulu = insert(:organization, name: "zulu_org")
-      alpha = insert(:organization, name: "alpha_org")
-      insert(:organization_user, organization: zulu, user: user)
-      insert(:organization_user, organization: alpha, user: user)
-
-      organizations =
-        build_conn()
-        |> put_req_header("authorization", key_for(user))
-        |> get("/api/users/me")
-        |> json_response(200)
-        |> Map.fetch!("organizations")
-
-      assert Enum.map(organizations, & &1["name"]) == ["alpha_org", "zulu_org"]
-    end
-
     test "return 404 for organization keys" do
       organization = insert(:organization)
 

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -124,6 +124,23 @@ defmodule HexpmWeb.API.UserControllerTest do
       |> json_response(401)
     end
 
+    test "sorts organizations by name" do
+      user = insert(:user)
+      zulu = insert(:organization, name: "zulu_org")
+      alpha = insert(:organization, name: "alpha_org")
+      insert(:organization_user, organization: zulu, user: user)
+      insert(:organization_user, organization: alpha, user: user)
+
+      organizations =
+        build_conn()
+        |> put_req_header("authorization", key_for(user))
+        |> get("/api/users/me")
+        |> json_response(200)
+        |> Map.fetch!("organizations")
+
+      assert Enum.map(organizations, & &1["name"]) == ["alpha_org", "zulu_org"]
+    end
+
     test "return 404 for organization keys" do
       organization = insert(:organization)
 

--- a/test/hexpm_web/controllers/dashboard/key_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/key_controller_test.exs
@@ -31,6 +31,63 @@ defmodule HexpmWeb.Dashboard.KeyControllerTest do
       conn = get(build_conn(), "/dashboard/keys")
       assert redirected_to(conn) == "/login?return=%2Fdashboard%2Fkeys"
     end
+
+    test "sorts keys, organizations, and packages by name", c do
+      zulu_organization = insert(:organization, name: "zulu_org")
+      alpha_organization = insert(:organization, name: "alpha_org")
+
+      insert(:organization_user, organization: zulu_organization, user: c.user)
+      insert(:organization_user, organization: alpha_organization, user: c.user)
+
+      insert(:package,
+        name: "zulu_package",
+        package_owners: [build(:package_owner, user: c.user)]
+      )
+
+      insert(:package,
+        name: "alpha_package",
+        package_owners: [build(:package_owner, user: c.user)]
+      )
+
+      insert(:key, user: c.user, name: "zulu_key")
+      insert(:key, user: c.user, name: "alpha_key")
+
+      document =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/keys")
+        |> html_response(200)
+        |> Floki.parse_document!()
+
+      key_names =
+        document
+        |> Floki.find("table tbody tr td:first-child span")
+        |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+
+      organization_inputs =
+        document
+        |> Floki.find(
+          ~s(#repositories-permission-group input[name^="key[permissions][repository]"])
+        )
+        |> Enum.map(&(Floki.attribute(&1, "name") |> List.first()))
+
+      package_inputs =
+        document
+        |> Floki.find(~s(#generate-key-modal input[name^="key[permissions][package]"]))
+        |> Enum.map(&(Floki.attribute(&1, "name") |> List.first()))
+
+      assert key_names == ["alpha_key", "zulu_key"]
+
+      assert organization_inputs == [
+               "key[permissions][repository][alpha_org]",
+               "key[permissions][repository][zulu_org]"
+             ]
+
+      assert package_inputs == [
+               "key[permissions][package][alpha_package]",
+               "key[permissions][package][zulu_package]"
+             ]
+    end
   end
 
   describe "POST /dashboard/keys" do

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -191,6 +191,31 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
 
       assert response(conn, 404)
     end
+
+    test "sorts members by username", %{user: user, organization: organization} do
+      insert(:organization_user, organization: organization, user: user, role: "admin")
+      zulu = insert(:user, username: "zulu_member")
+      alpha = insert(:user, username: "alpha_member")
+      insert(:organization_user, organization: organization, user: zulu)
+      insert(:organization_user, organization: organization, user: alpha)
+      mock_customer(organization)
+
+      document =
+        build_conn()
+        |> test_login(user)
+        |> get("/dashboard/orgs/#{organization.name}/members")
+        |> html_response(200)
+        |> Floki.parse_document!()
+
+      usernames =
+        document
+        |> Floki.find(~s(form[id^="change-role-form-"] input[name="organization_user[username]"]))
+        |> Enum.map(&(Floki.attribute(&1, "value") |> List.first()))
+
+      assert usernames == Enum.sort(usernames)
+      assert "alpha_member" in usernames
+      assert "zulu_member" in usernames
+    end
   end
 
   describe "GET /dashboard/orgs/:dashboard_org/keys" do
@@ -238,6 +263,27 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
         |> get("/dashboard/orgs/#{organization.name}/keys")
 
       assert response(conn, 200) =~ "mykey"
+    end
+
+    test "sorts package permissions by package name", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "write")
+      insert(:package, name: "zulu_package", repository_id: c.repository.id)
+      insert(:package, name: "alpha_package", repository_id: c.repository.id)
+      mock_customer(c.organization)
+
+      package_inputs =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/orgs/#{c.organization.name}/keys")
+        |> html_response(200)
+        |> Floki.parse_document!()
+        |> Floki.find(~s(#generate-key-modal input[name^="key[permissions][package]"]))
+        |> Enum.map(&(Floki.attribute(&1, "name") |> List.first()))
+
+      assert package_inputs == [
+               "key[permissions][package][#{c.organization.name}/alpha_package]",
+               "key[permissions][package][#{c.organization.name}/zulu_package]"
+             ]
     end
 
     test "shows incomplete subscription status", %{user: user, organization: organization} do
@@ -1725,6 +1771,24 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
         |> get("/dashboard/orgs/#{c.organization.name}/packages")
 
       assert response(conn, 200) =~ "4 321"
+    end
+
+    test "sorts packages by name", c do
+      insert(:organization_user, organization: c.organization, user: c.user, role: "read")
+      insert(:package, name: "zulu_package", repository_id: c.repository.id)
+      insert(:package, name: "alpha_package", repository_id: c.repository.id)
+      mock_customer(c.organization)
+
+      package_names =
+        build_conn()
+        |> test_login(c.user)
+        |> get("/dashboard/orgs/#{c.organization.name}/packages")
+        |> html_response(200)
+        |> Floki.parse_document!()
+        |> Floki.find("table tbody tr td:first-child span.font-medium")
+        |> Enum.map(&(&1 |> Floki.text() |> String.trim()))
+
+      assert package_names == ["alpha_package", "zulu_package"]
     end
 
     test "returns 404 for non-members", c do


### PR DESCRIPTION
Several user-facing association queries relied on unspecified database row order. Sort those collections at their query or presentation boundaries so API key forms list organizations and packages alphabetically and related dashboard and API lists stay deterministic.

This also covers keys, repositories, organization members, package owners, organization packages, and the organization list returned for the current user. Chronological, ranked, semantic-version, and user-authored collections keep their existing order.
