### PR TITLE
Stop Lifeline rescuing jobs that are still running

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -57,5 +57,8 @@ config :hexpm, Oban,
     # Successful jobs are read by nobody and are the bulk of the table, which
     # Oban's queue length metric counts on a timer. Failures are worth keeping.
     {Hexpm.Oban.Pruner, max_age: 3 * 24 * 60 * 60, discarded_max_age: 365 * 24 * 60 * 60},
-    {Oban.Plugins.Lifeline, interval: 60_000, rescue_after: 360_000}
+    # Lifeline rescues on elapsed time alone and does not check whether the job
+    # is still running, so a window shorter than a worker's timeout hands a live
+    # job to a second node and runs it twice. Stats declares an hour.
+    {Oban.Plugins.Lifeline, interval: 60_000, rescue_after: :timer.minutes(90)}
   ]

--- a/test/hexpm/oban_config_test.exs
+++ b/test/hexpm/oban_config_test.exs
@@ -98,6 +98,29 @@ defmodule Hexpm.ObanConfigTest do
              :plugins
            ]
 
-    assert {Oban.Plugins.Lifeline, [interval: 60_000, rescue_after: 360_000]} in oban[:plugins]
+    assert {Oban.Plugins.Lifeline, [interval: 60_000, rescue_after: 5_400_000]} in oban[:plugins]
+  end
+
+  test "orphan rescue waits longer than any worker may legitimately run" do
+    prod = Config.Reader.read!("config/prod.exs", env: :prod)
+
+    assert {Oban.Plugins.Lifeline, lifeline} =
+             Enum.find(prod[:hexpm][Oban][:plugins], &match?({Oban.Plugins.Lifeline, _}, &1))
+
+    workers =
+      :hexpm
+      |> Application.spec(:modules)
+      |> Enum.filter(&(Code.ensure_loaded?(&1) and function_exported?(&1, :__opts__, 0)))
+      |> Enum.map(&{&1, &1.timeout(%Oban.Job{})})
+      |> Enum.filter(&is_integer(elem(&1, 1)))
+
+    assert {Hexpm.ReleaseTasks.Stats, 3_600_000} in workers
+
+    for {worker, timeout} <- workers do
+      assert lifeline[:rescue_after] > timeout,
+             "#{inspect(worker)} may run for #{timeout}ms, but Lifeline returns a job to " <>
+               "available after #{lifeline[:rescue_after]}ms whether or not it is still " <>
+               "running, so it would be picked up a second time mid-flight"
+    end
   end
 end


### PR DESCRIPTION
`Oban.Plugins.Lifeline` moves executing jobs back to available on elapsed time alone. Its own docs are explicit about this: rescuing "is purely based on time, rather than any heuristic about the job's expected execution time or whether the node is still alive", and it "may transition jobs that are genuinely `executing` and cause duplicate execution".

`rescue_after` was 360_000, six minutes. `Hexpm.ReleaseTasks.Stats` declares a timeout of an hour and actually takes 9 to 47 minutes. So every night it got handed to a second producer while the first was still running.

It has been running two or three times a night for at least a week, each run re-reading the full Fastly log set out of the bucket, re-running the delete and insert, and refreshing both materialized views again:

```
2026-08-11  01:13:04  7457534 downloads (783758ms)
2026-08-11  01:18:41  7457534 downloads (734735ms)
2026-08-09  01:16:18  2435993 downloads (578901ms)
2026-08-09  01:22:45  2435993 downloads (544772ms)
2026-08-09  01:26:26  2435993 downloads (1586543ms)
2026-08-08  01:14:29 / 01:27:42 / 01:51:18   7246323 downloads, three times
```

Identical counts, overlapping windows. `oban_jobs` agrees: of the three `Stats` rows still inside the pruner's window, two have `attempt > 1` and the highest attempt is 3.

Uniqueness cannot prevent this. `unique: [period: :infinity, states: :incomplete, fields: [:worker]]` is enforced when a job is inserted, and a rescue does not insert anything, it moves the existing row back to available.

90 minutes clears the longest declared timeout with room to spare. `CheckNames` at 10 minutes and `PurgeExpiredRecords` at 30 were also above the old six-minute window, but neither ever tripped it because both finish in under 5 seconds.

The cost is that a genuinely orphaned job now waits up to 90 minutes instead of 6. That only happens when a node dies without draining, and running the stats job twice is the worse outcome. Per-queue rescue windows would avoid the trade entirely but need `DynamicLifeline` from Oban Pro.

The new test walks every Oban worker that declares an integer timeout and fails if the rescue window is not longer than it, so this cannot drift back. I checked it discriminates by restoring 360_000, which fails it on both `Stats` and `CheckNames`.