### PR TITLE
Bump Elixir to 1.20 and Erlang OTP to 29

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,8 +17,8 @@ jobs:
     name: Format
     runs-on: ubuntu-24.04
     env:
-      otp: 28.5
-      elixir: 1.19.5
+      otp: 29.0
+      elixir: 1.20.3
 
     services:
       postgres:
@@ -66,8 +66,8 @@ jobs:
     name: Test Hexpm
     runs-on: ubuntu-24.04
     env:
-      otp: 28.5
-      elixir: 1.19.5
+      otp: 29.0
+      elixir: 1.20.3
 
     services:
       postgres:
@@ -128,20 +128,20 @@ jobs:
       matrix:
         include:
           - hex-version: main
-            otp: 28.5
-            elixir: 1.19.5
+            otp: 29.0
+            elixir: 1.20.3
           - hex-version: v2.5
-            otp: 28.5
-            elixir: 1.19.5
+            otp: 29.0
+            elixir: 1.20.3
           - hex-version: v2.4
-            otp: 28.5
-            elixir: 1.19.5
+            otp: 29.0
+            elixir: 1.20.3
           - hex-version: v2.3
-            otp: 28.5
-            elixir: 1.19.5
+            otp: 29.0
+            elixir: 1.20.3
           - hex-version: v2.2
-            otp: 27.3
-            elixir: 1.19.5
+            otp: 29.0
+            elixir: 1.20.3
 
     env:
       HEXPM_PATH: ..

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG ELIXIR_VERSION=1.19.5
-ARG ERLANG_VERSION=28.5.0.4
-ARG DEBIAN_VERSION=trixie-20260713-slim
+ARG ELIXIR_VERSION=1.20.3
+ARG ERLANG_VERSION=29.0.5
+ARG DEBIAN_VERSION=trixie-20260803-slim
 
 FROM hexpm/elixir:${ELIXIR_VERSION}-erlang-${ERLANG_VERSION}-debian-${DEBIAN_VERSION} AS build
 
@@ -59,7 +59,7 @@ RUN mix compile
 
 # build release
 COPY rel rel
-RUN mix do sentry.package_source_code, release
+RUN mix do sentry.package_source_code + release
 
 # prepare release image
 FROM debian:${DEBIAN_VERSION} AS app

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ docker-compose up -d db
 Now you are fine to create the `hexpm_dev` database and run the ecto migrations:
 
 ```shell
-mix do ecto.create, ecto.migrate
+mix do ecto.create + ecto.migrate
 ```
 
 ### Sample Data

--- a/lib/hexpm/accounts/auth.ex
+++ b/lib/hexpm/accounts/auth.ex
@@ -120,7 +120,7 @@ defmodule Hexpm.Accounts.Auth do
   defp load_entity(:user, username), do: load_user_from_username(username)
   defp load_entity(:organization, org_name), do: load_organization_from_name(org_name)
 
-  defp validate_entity_auth(%User{} = user), do: user && not User.organization?(user)
+  defp validate_entity_auth(%User{} = user), do: not User.organization?(user)
   defp validate_entity_auth(%Organization{} = _organization), do: true
 
   defp build_auth_result(%User{} = user, oauth_token) do

--- a/lib/hexpm/accounts/key_permission.ex
+++ b/lib/hexpm/accounts/key_permission.ex
@@ -3,7 +3,7 @@ defmodule Hexpm.Accounts.KeyPermission do
 
   alias Hexpm.Permissions
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
 
   embedded_schema do
     field :domain, :string

--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Accounts.UserHandles do
   use Hexpm.Schema
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
 
   embedded_schema do
     field :twitter, :string

--- a/lib/hexpm/diff/generator.ex
+++ b/lib/hexpm/diff/generator.ex
@@ -187,8 +187,8 @@ defmodule Hexpm.Diff.Generator do
 
     left_stat.size == right_stat.size and
       left
-      |> File.stream!([], 64 * 1024)
-      |> Stream.zip(File.stream!(right, [], 64 * 1024))
+      |> File.stream!(64 * 1024, [])
+      |> Stream.zip(File.stream!(right, 64 * 1024, []))
       |> Enum.all?(fn {left_chunk, right_chunk} -> left_chunk == right_chunk end)
   end
 

--- a/lib/hexpm/permissions.ex
+++ b/lib/hexpm/permissions.ex
@@ -352,8 +352,6 @@ defmodule Hexpm.Permissions do
     resource.repository.name == organization and resource.name == package
   end
 
-  defp match_package_resource?(_permission_resource, _resource), do: false
-
   @doc """
   Verifies if a user or organization has access to a specific domain and resource.
 

--- a/lib/hexpm/repository/assets.ex
+++ b/lib/hexpm/repository/assets.ex
@@ -57,7 +57,7 @@ defmodule Hexpm.Repository.Assets do
   def file_checksum(path) do
     hash =
       path
-      |> File.stream!([], 64 * 1024)
+      |> File.stream!(64 * 1024, [])
       |> Enum.reduce(:crypto.hash_init(:sha256), &:crypto.hash_update(&2, &1))
 
     :crypto.hash_final(hash)

--- a/lib/hexpm/repository/download.ex
+++ b/lib/hexpm/repository/download.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Repository.Download do
   use Hexpm.Schema
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
 
   schema "downloads" do
     belongs_to :package, Package

--- a/lib/hexpm/repository/package_download.ex
+++ b/lib/hexpm/repository/package_download.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Repository.PackageDownload do
   use Hexpm.Schema
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
   @primary_key false
 
   schema "package_downloads" do

--- a/lib/hexpm/repository/package_metadata.ex
+++ b/lib/hexpm/repository/package_metadata.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Repository.PackageMetadata do
   use Hexpm.Schema
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
 
   embedded_schema do
     field :description, :string

--- a/lib/hexpm/repository/policies.ex
+++ b/lib/hexpm/repository/policies.ex
@@ -92,7 +92,6 @@ defmodule Hexpm.Repository.Policies do
   defp override_row?(override) when is_map(override), do: Map.has_key?(override, "package")
   defp override_row?(_override), do: false
 
-  defp submitted_repositories(nil), do: []
   defp submitted_repositories(list) when is_list(list), do: list
 
   defp submitted_repositories(map) when is_map(map) do

--- a/lib/hexpm/repository/registry_builder.ex
+++ b/lib/hexpm/repository/registry_builder.ex
@@ -1,6 +1,5 @@
 defmodule Hexpm.Repository.RegistryBuilder do
   import Ecto.Query, only: [from: 2]
-  require Hexpm.Repo
   require Logger
   alias Hexpm.Repository.{Package, Release, Repository, Requirement, Storage}
   alias Hexpm.Repo

--- a/lib/hexpm/repository/release_download.ex
+++ b/lib/hexpm/repository/release_download.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Repository.ReleaseDownload do
   use Hexpm.Schema
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
   @primary_key false
 
   schema "release_downloads" do

--- a/lib/hexpm/repository/release_metadata.ex
+++ b/lib/hexpm/repository/release_metadata.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Repository.ReleaseMetadata do
   use Hexpm.Schema
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
 
   embedded_schema do
     field :app, :string

--- a/lib/hexpm/repository/release_retirement.ex
+++ b/lib/hexpm/repository/release_retirement.ex
@@ -1,7 +1,7 @@
 defmodule Hexpm.Repository.ReleaseRetirement do
   use Hexpm.Schema
 
-  @derive HexpmWeb.Stale
+  @derive {HexpmWeb.Stale, last_modified: nil}
 
   embedded_schema do
     field :reason, :string

--- a/lib/hexpm/repository/requirement.ex
+++ b/lib/hexpm/repository/requirement.ex
@@ -1,7 +1,5 @@
 defmodule Hexpm.Repository.Requirement do
   use Hexpm.Schema
-  require Logger
-
   @derive {HexpmWeb.Stale, last_modified: nil}
 
   schema "requirements" do

--- a/lib/hexpm/security/advisories.ex
+++ b/lib/hexpm/security/advisories.ex
@@ -3,8 +3,6 @@ defmodule Hexpm.Security.Advisories do
 
   import Ecto.Query
 
-  require Logger
-
   alias Hexpm.Repository.Package
   alias Hexpm.Repository.RegistryBuilder
   alias Hexpm.Security.Advisory

--- a/lib/hexpm/short_urls/short_url.ex
+++ b/lib/hexpm/short_urls/short_url.ex
@@ -57,10 +57,13 @@ defmodule Hexpm.ShortURLs.ShortURL do
       url.scheme not in ["http", "https"] ->
         [url: "must use http or https scheme"]
 
+      url.host in [nil, ""] ->
+        [url: "must include a host"]
+
       url.host == "hex.pm" or String.ends_with?(url.host, [".hex.pm"]) ->
         []
 
-      String.ends_with?(url.host || "", [".hexdocs.pm", ".hexorgs.pm"]) ->
+      String.ends_with?(url.host, [".hexdocs.pm", ".hexorgs.pm"]) ->
         []
 
       url.host in ["hexdocs.pm", "staging.hex.pm"] and url.path in [nil, "/"] ->

--- a/lib/hexpm/store/gcs.ex
+++ b/lib/hexpm/store/gcs.ex
@@ -1,7 +1,5 @@
 defmodule Hexpm.Store.GCS do
   import SweetXml, only: [sigil_x: 2]
-  require Logger
-
   @behaviour Hexpm.Store.Behaviour
 
   @default_gs_xml_url "https://storage.googleapis.com"

--- a/lib/hexpm/utils.ex
+++ b/lib/hexpm/utils.ex
@@ -7,7 +7,6 @@ defmodule Hexpm.Utils do
 
   import Ecto.Query, only: [from: 2]
   alias Hexpm.Repository.{Package, Release, Repository}
-  require Logger
 
   def secure_check(left, right) do
     if byte_size(left) == byte_size(right) do

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -681,9 +681,6 @@ defmodule HexpmWeb.Components.PackageLayout do
   defp dependencies_tab_path(%{package: package}),
     do: ViewHelpers.path_for_dependencies(package)
 
-  defp files_path(%{current_release: nil, package: package}),
-    do: ViewHelpers.path_for_package(package)
-
   defp files_path(%{package: package, current_release: release, source_filename: filename})
        when is_binary(filename),
        do: source_path(package, release, filename)

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -300,10 +300,8 @@ defmodule HexpmWeb.API.OAuthController do
     end)
   end
 
-  defp error_description(:unauthorized_client), do: "Client not authorized for this grant type"
   defp error_description(:invalid_request), do: "Missing or invalid client_secret"
   defp error_description(:invalid_client), do: "Invalid API key"
-  defp error_description(_), do: "An error occurred"
 
   defp revoke_token(%{"token" => token_value, "client_id" => client_id})
        when is_binary(token_value) and is_binary(client_id) do

--- a/lib/hexpm_web/templates/dashboard/organization/components/billing_subscription.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/billing_subscription.ex
@@ -208,7 +208,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.BillingSubscription do
               type="button"
               variant="danger-outline"
               size="sm"
-              disabled={!@subscription || @subscription["cancel_at_period_end"]}
+              disabled={@subscription["cancel_at_period_end"]}
               phx-click={show_modal("cancel-billing-modal")}
             >
               Cancel subscription

--- a/test/hexpm/short_urls/short_url_test.exs
+++ b/test/hexpm/short_urls/short_url_test.exs
@@ -67,6 +67,11 @@ defmodule Hexpm.ShortURLs.ShortURLTest do
       assert %{valid?: false} = ShortURL.changeset(%{url: "data://hex.pm/foo"})
     end
 
+    test "rejects URLs without a host" do
+      assert %{valid?: false, errors: errors} = ShortURL.changeset(%{url: "https:/packages/ecto"})
+      assert errors == [url: {"must include a host", []}]
+    end
+
     test "where host is not on hex.pm" do
       assert %{valid?: false, errors: errors} =
                ShortURL.changeset(%{url: "https://supersimple.org?spoof=hex.pm"})

--- a/test/hexpm_web/stale_test.exs
+++ b/test/hexpm_web/stale_test.exs
@@ -1,0 +1,31 @@
+defmodule HexpmWeb.StaleTest do
+  use ExUnit.Case, async: true
+
+  alias Hexpm.Accounts.{KeyPermission, UserHandles}
+
+  alias Hexpm.Repository.{
+    Download,
+    PackageDownload,
+    PackageMetadata,
+    ReleaseDownload,
+    ReleaseMetadata,
+    ReleaseRetirement
+  }
+
+  test "timestamp-less schemas use the minimum last-modified time" do
+    schemas = [
+      %UserHandles{},
+      %KeyPermission{},
+      %Download{},
+      %PackageDownload{},
+      %PackageMetadata{},
+      %ReleaseDownload{},
+      %ReleaseMetadata{},
+      %ReleaseRetirement{}
+    ]
+
+    for schema <- schemas do
+      assert HexpmWeb.Stale.last_modified(schema) == [~N[0000-01-01 00:00:00], []]
+    end
+  end
+end


### PR DESCRIPTION
Updates CI and the production Docker image to Elixir 1.20.3 and Erlang/OTP 29.0.5. The Dockerfile uses the Debian Trixie image returned by Bob for that runtime pair, and the Hex integration matrix runs each maintained Hex branch on the new versions.

Fixes the application warnings and deprecations exposed by Elixir 1.20. Dead clauses and unused `require`s are removed, timestamp-less schemas no longer raise from their `Stale` implementations, hostless short URLs return a changeset error, and file streaming and `mix do` calls use the current argument and separator forms.
