### PR TITLE
Preserve Bluesky DID handles

### DIFF
--- a/lib/hexpm/accounts/user_handles.ex
+++ b/lib/hexpm/accounts/user_handles.ex
@@ -64,6 +64,7 @@ defmodule Hexpm.Accounts.UserHandles do
     unuri(handle, "x.com", "/")
   end
 
+  def handle(:bluesky, "did:" <> _ = handle), do: handle
   def handle(:bluesky, handle), do: unuri(handle, "bsky.app", "/profile/")
   def handle(:github, handle), do: unuri(handle, "github.com", "/")
   def handle(:elixirforum, handle), do: unuri(handle, "elixirforum.com", "/u/")

--- a/test/hexpm/accounts/user_handles_test.exs
+++ b/test/hexpm/accounts/user_handles_test.exs
@@ -82,6 +82,15 @@ defmodule Hexpm.Accounts.UserHandlesTest do
                ]
     end
 
+    test "Bluesky handles with DIDs" do
+      for did <- ["did:plc:z72i7hdynmk6r22z27h6tvur", "did:web:example.com"] do
+        user = build(:user, handles: build(:user_handles, bluesky: did))
+
+        assert UserHandles.render(user) ==
+                 [{"Bluesky", did, "https://bsky.app/profile/#{did}"}]
+      end
+    end
+
     test "handles with legacy twitter.com URLs" do
       user =
         build(:user,


### PR DESCRIPTION
Preserve Bluesky decentralized identifiers when rendering account social links. URI parsing treats `did` as a scheme, so the previous normalization dropped the prefix and generated invalid `bsky.app/profile/...` URLs.

Add regression coverage for both `did:plc` and `did:web` profile identifiers.

Closes #1776
