### PR TITLE
Poll for the migration lock instead of blocking on it

### DIFF
--- a/lib/hexpm/release_tasks.ex
+++ b/lib/hexpm/release_tasks.ex
@@ -135,13 +135,21 @@ defmodule Hexpm.ReleaseTasks do
     end)
   end
 
+  @migration_lock_poll_interval 1_000
+
   @doc false
   # Every app pod runs migrate() at boot, so they race. Ecto's own migration
   # lock cannot serialize them here: it holds a transaction for the duration,
   # and CREATE INDEX CONCURRENTLY waits for concurrent transactions to finish,
   # so the two deadlock. A session level advisory lock on its own connection
-  # holds no transaction, and the lock is released when that connection ends,
-  # including when the pod dies mid-migration.
+  # holds no transaction once acquired, and the lock is released when that
+  # connection ends, including when the pod dies mid-migration.
+  #
+  # Waiting for the lock must not hold a transaction either. A blocking
+  # pg_advisory_lock() call is a running statement with a snapshot for as long
+  # as it waits, and the holder's CREATE INDEX CONCURRENTLY waits for every
+  # older snapshot to go away, so the two would deadlock through the app.
+  # Polling pg_try_advisory_lock() leaves the connection idle between attempts.
   def with_migration_lock(repo, fun) do
     key = Hexpm.RepoBase.advisory_lock_key(:migrate)
 
@@ -160,11 +168,20 @@ defmodule Hexpm.ReleaseTasks do
 
     try do
       Logger.info("[task] Waiting for migration lock")
-      Postgrex.query!(conn, "SELECT pg_advisory_lock($1)", [key], timeout: :infinity)
+      acquire_migration_lock(conn, key)
       Logger.info("[task] Acquired migration lock")
       fun.()
     after
       GenServer.stop(conn)
+    end
+  end
+
+  defp acquire_migration_lock(conn, key) do
+    %{rows: [[locked?]]} = Postgrex.query!(conn, "SELECT pg_try_advisory_lock($1)", [key])
+
+    unless locked? do
+      Process.sleep(@migration_lock_poll_interval)
+      acquire_migration_lock(conn, key)
     end
   end
 

--- a/test/hexpm/release_tasks_test.exs
+++ b/test/hexpm/release_tasks_test.exs
@@ -15,6 +15,59 @@ defmodule Hexpm.ReleaseTasksTest do
     count
   end
 
+  defp lock_connections() do
+    Repo.query!("SELECT pg_stat_clear_snapshot()", [])
+
+    %{rows: [[count]]} =
+      Repo.query!(
+        """
+        SELECT count(*) FROM pg_stat_activity
+        WHERE datname = current_database()
+          AND pid <> pg_backend_pid()
+          AND query LIKE '%advisory_lock($1)'
+        """,
+        []
+      )
+
+    count
+  end
+
+  defp wait_until(fun, attempts \\ 100) do
+    cond do
+      fun.() ->
+        :ok
+
+      attempts == 0 ->
+        flunk("condition not met")
+
+      true ->
+        Process.sleep(50)
+        wait_until(fun, attempts - 1)
+    end
+  end
+
+  defp create_index_concurrently() do
+    opts =
+      Keyword.take(Hexpm.RepoBase.config(), [:hostname, :port, :username, :password, :database])
+
+    {:ok, conn} = Postgrex.start_link(opts)
+
+    try do
+      Postgrex.query!(conn, "DROP TABLE IF EXISTS migration_lock_test", [])
+      Postgrex.query!(conn, "CREATE TABLE migration_lock_test (id integer)", [])
+
+      Postgrex.query!(
+        conn,
+        "CREATE INDEX CONCURRENTLY migration_lock_test_id_index ON migration_lock_test (id)",
+        []
+      )
+
+      Postgrex.query!(conn, "DROP TABLE migration_lock_test", [])
+    after
+      GenServer.stop(conn)
+    end
+  end
+
   describe "with_migration_lock/2" do
     test "holds the lock while the function runs" do
       assert locks_held() == 0
@@ -62,6 +115,33 @@ defmodule Hexpm.ReleaseTasksTest do
       Task.await(holder, 10_000)
 
       assert_receive :second_ran, 10_000
+      Task.await(waiter, 10_000)
+      assert locks_held() == 0
+    end
+
+    test "a waiting caller does not block CREATE INDEX CONCURRENTLY in the holder" do
+      test = self()
+
+      holder =
+        Task.async(fn ->
+          ReleaseTasks.with_migration_lock(Hexpm.RepoBase, fn ->
+            send(test, :holding)
+            receive do: (:create_index -> :ok)
+            create_index_concurrently()
+          end)
+        end)
+
+      assert_receive :holding, 10_000
+
+      waiter =
+        Task.async(fn ->
+          ReleaseTasks.with_migration_lock(Hexpm.RepoBase, fn -> :ok end)
+        end)
+
+      wait_until(fn -> lock_connections() == 2 end)
+
+      send(holder.pid, :create_index)
+      Task.await(holder, 10_000)
       Task.await(waiter, 10_000)
       assert locks_held() == 0
     end


### PR DESCRIPTION
`with_migration_lock/2` waited with `SELECT pg_advisory_lock($1)`. That call is a running statement for as long as another pod holds the lock, and a running statement holds a snapshot. `CREATE INDEX CONCURRENTLY` in the pod that holds the lock waits for every older snapshot to end before it can finish, so the holder waited on the waiter and the waiter waited on the holder. Postgres doesn't report it as a deadlock because the holder's lock connection is idle and not waiting on anything itself.

This happened on the 2026-08-15 prod deploy: `hexpm-deployment` and `hexpm-worker-deployment` both started `migrate` at 15:55:33 UTC, the web pod took the lock, and its `CREATE INDEX CONCURRENTLY` on `releases` (migration `20260814120200`) sat in `WaitForOlderSnapshots` for 19 minutes on the worker's `pg_advisory_lock` backend (`pg_locks`: the index build waited for `ShareLock` on the waiter's virtualxid, the waiter waited for the advisory lock). Cancelling that backend let the migration finish, and the replacement worker pod then blocked `20260814120300` the same way until its backend was cancelled too.

This changes the wait to poll `pg_try_advisory_lock($1)` with a 1s sleep between attempts. Each poll is a millisecond-long statement and the connection is idle between them, so it holds no snapshot while waiting. The lock stays session level on its own connection and is still released when the connection ends, including when a pod dies mid-migration.

The new test has a holder run `CREATE INDEX CONCURRENTLY` while a second caller waits for the lock. Against the blocking implementation the holder times out (verified locally); with the poll it completes.
