### PR TITLE
Refactor theme toggle functionality and remove unused theme menu

### DIFF
--- a/assets/css/tailwind.css
+++ b/assets/css/tailwind.css
@@ -293,17 +293,6 @@ html[data-theme-preference="system"] [data-theme-toggle] [data-theme-icon="syste
   display: inline-flex;
 }
 
-/* Highlight active choice in theme menu */
-[data-theme-menu] [data-theme-choice] {
-  font-weight: normal;
-}
-
-html[data-theme-preference="light"] [data-theme-menu] [data-theme-choice="light"],
-html[data-theme-preference="dark"] [data-theme-menu] [data-theme-choice="dark"],
-html[data-theme-preference="system"] [data-theme-menu] [data-theme-choice="system"] {
-  font-weight: 600;
-}
-
 /* ===== LEGACY UTILITY CLASSES ===== */
 /* Legacy utility classes still referenced by some templates/helpers. */
 

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -46,36 +46,23 @@ function setPreference(preference) {
   applyTheme(resolveTheme());
 }
 
-function closeAllMenus() {
-  document.querySelectorAll("[data-theme-menu]").forEach((menu) => {
-    menu.classList.add("hidden");
-  });
+const PREFERENCE_CYCLE = ["light", "dark", "system"];
+
+function nextPreference(preference) {
+  const index = PREFERENCE_CYCLE.indexOf(preference);
+  return PREFERENCE_CYCLE[(index + 1) % PREFERENCE_CYCLE.length];
 }
 
 export function initializeTheme() {
   applyTheme(resolveTheme());
 
-  // Toggle menu open/closed
+  // Clicking the icon cycles to the next theme
   document.addEventListener("click", (event) => {
     const toggle = event.target.closest("[data-theme-toggle]");
-    if (toggle) {
-      event.preventDefault();
-      const menu = toggle.parentElement.querySelector("[data-theme-menu]");
-      if (menu) menu.classList.toggle("hidden");
-      return;
-    }
+    if (!toggle) return;
 
-    // Handle choice selection
-    const choice = event.target.closest("[data-theme-choice]");
-    if (choice) {
-      event.preventDefault();
-      setPreference(choice.getAttribute("data-theme-choice"));
-      closeAllMenus();
-      return;
-    }
-
-    // Click outside closes menu
-    closeAllMenus();
+    event.preventDefault();
+    setPreference(nextPreference(currentPreference()));
   });
 
   // System theme changes

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,5 +1,11 @@
 const THEME_STORAGE_KEY = "hexpm-theme";
 const THEME_MEDIA_QUERY = "(prefers-color-scheme: dark)";
+const PREFERENCE_CYCLE = ["light", "dark", "system"];
+
+function nextPreference(preference) {
+  const index = PREFERENCE_CYCLE.indexOf(preference);
+  return PREFERENCE_CYCLE[(index + 1) % PREFERENCE_CYCLE.length];
+}
 
 function getStoredPreference() {
   return window.localStorage.getItem(THEME_STORAGE_KEY);
@@ -21,6 +27,12 @@ function currentPreference() {
 
 function syncToggleState(preference) {
   document.documentElement.setAttribute("data-theme-preference", preference);
+
+  const label = `Switch to ${nextPreference(preference)} mode`;
+  document.querySelectorAll("[data-theme-toggle]").forEach((toggle) => {
+    toggle.setAttribute("title", label);
+    toggle.setAttribute("aria-label", label);
+  });
 }
 
 function syncReadmeFrameTheme(theme) {
@@ -44,13 +56,6 @@ function setPreference(preference) {
     window.localStorage.setItem(THEME_STORAGE_KEY, preference);
   }
   applyTheme(resolveTheme());
-}
-
-const PREFERENCE_CYCLE = ["light", "dark", "system"];
-
-function nextPreference(preference) {
-  const index = PREFERENCE_CYCLE.indexOf(preference);
-  return PREFERENCE_CYCLE[(index + 1) % PREFERENCE_CYCLE.length];
 }
 
 export function initializeTheme() {

--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -161,7 +161,7 @@ defmodule HexpmWeb.Components.Navbar do
 
   defp theme_toggle(assigns) do
     ~H"""
-    <div class={["relative flex items-center", @class]}>
+    <div class={["flex items-center", @class]}>
       <button
         type="button"
         data-theme-toggle
@@ -171,7 +171,7 @@ defmodule HexpmWeb.Components.Navbar do
           !@compact && "h-5 w-5"
         ]}
         aria-label="Change theme"
-        aria-haspopup="true"
+        title="Change theme"
       >
         <span class="sr-only">Change color theme</span>
         <span data-theme-icon="light">
@@ -184,33 +184,6 @@ defmodule HexpmWeb.Components.Navbar do
           {icon(:heroicon, "computer-desktop", width: 18, height: 18)}
         </span>
       </button>
-
-      <div
-        data-theme-menu
-        class="hidden absolute right-0 top-full mt-2 w-36 bg-grey-700 border border-grey-600 rounded-lg shadow-lg py-1 z-50"
-      >
-        <button
-          type="button"
-          data-theme-choice="light"
-          class="w-full flex items-center gap-2 px-4 py-2 text-sm text-grey-200 hover:bg-grey-600 transition-colors cursor-pointer"
-        >
-          {icon(:heroicon, "sun", width: 16, height: 16)} Light
-        </button>
-        <button
-          type="button"
-          data-theme-choice="dark"
-          class="w-full flex items-center gap-2 px-4 py-2 text-sm text-grey-200 hover:bg-grey-600 transition-colors cursor-pointer"
-        >
-          {icon(:heroicon, "moon", width: 16, height: 16)} Dark
-        </button>
-        <button
-          type="button"
-          data-theme-choice="system"
-          class="w-full flex items-center gap-2 px-4 py-2 text-sm text-grey-200 hover:bg-grey-600 transition-colors cursor-pointer"
-        >
-          {icon(:heroicon, "computer-desktop", width: 16, height: 16)} System
-        </button>
-      </div>
     </div>
     """
   end

--- a/lib/hexpm_web/components/navbar.ex
+++ b/lib/hexpm_web/components/navbar.ex
@@ -173,7 +173,6 @@ defmodule HexpmWeb.Components.Navbar do
         aria-label="Change theme"
         title="Change theme"
       >
-        <span class="sr-only">Change color theme</span>
         <span data-theme-icon="light">
           {icon(:heroicon, "sun", width: 18, height: 18)}
         </span>


### PR DESCRIPTION
## Summary

Currently, changing the theme requires opening the dropdown menu and then selecting an option. This adds an unnecessary interaction.
This PR allowing users to switch themes directly by clicking the theme icon.

## Testing

N/A

## Screen record:


https://github.com/user-attachments/assets/bc8bcc49-a388-4f31-be78-840d19770ca1

