### PR TITLE
Return the ETag from store writes and the last response from HTTP.retry

### DIFF
--- a/lib/hexpm/diff/cache.ex
+++ b/lib/hexpm/diff/cache.ex
@@ -127,8 +127,6 @@ defmodule Hexpm.Diff.Cache do
 
   defp put!(key, body) do
     case Hexpm.Store.put(:diff_bucket, key, body, @put_options) do
-      :ok -> :ok
-      true -> :ok
       {:ok, _result} -> :ok
       result -> raise "failed to store diff object #{key}: #{inspect(result)}"
     end

--- a/lib/hexpm/http.ex
+++ b/lib/hexpm/http.ex
@@ -338,6 +338,13 @@ defmodule Hexpm.HTTP do
     {:error, reason}
   end
 
+  @doc """
+  Calls `fun` until it returns a response whose status is not in `:statuses`
+  or the attempts run out, sleeping `:base_delay` times 3^n between tries.
+  Transport errors are retried too. Once the attempts are used up the last
+  result is returned as is: the response, so the caller sees the status and
+  body it failed on, or the transport error.
+  """
   def retry(fun, name, opts \\ []) do
     attempts = Keyword.get(opts, :attempts, Keyword.get(opts, :max_attempts, @default_attempts))
     base_delay = Keyword.get(opts, :base_delay, @default_base_delay)
@@ -349,20 +356,20 @@ defmodule Hexpm.HTTP do
     case fun.() do
       {:ok, status, _headers, _body} = result ->
         if retryable_status?(status, statuses) do
-          do_retry(fun, name, attempts, base_delay, statuses, times, "status #{status}")
+          do_retry(fun, name, attempts, base_delay, statuses, times, "status #{status}", result)
         else
           result
         end
 
-      {:error, reason} ->
-        do_retry(fun, name, attempts, base_delay, statuses, times, reason)
+      {:error, reason} = result ->
+        do_retry(fun, name, attempts, base_delay, statuses, times, reason, result)
 
       result ->
         result
     end
   end
 
-  defp do_retry(fun, name, attempts, base_delay, statuses, times, reason) do
+  defp do_retry(fun, name, attempts, base_delay, statuses, times, reason, result) do
     Logger.warning("#{name} API ERROR: #{inspect(reason)}")
 
     if times + 1 < attempts do
@@ -370,7 +377,7 @@ defmodule Hexpm.HTTP do
       if sleep > 0, do: Process.sleep(sleep)
       retry(fun, name, attempts, base_delay, statuses, times + 1)
     else
-      {:error, reason}
+      result
     end
   end
 

--- a/lib/hexpm/repository/storage.ex
+++ b/lib/hexpm/repository/storage.ex
@@ -21,9 +21,9 @@ defmodule Hexpm.Repository.Storage do
   @doc """
   Writes `contents` to `key` in the repo bucket along with the standard
   surrogate-key/surrogate-control metadata and the supplied
-  `cache_control` value.
+  `cache_control` value. Returns the object's ETag as the store reports it.
   """
-  @spec put_object(String.t(), iodata(), [String.t()], String.t()) :: term()
+  @spec put_object(String.t(), iodata(), [String.t()], String.t()) :: String.t()
   def put_object(key, contents, surrogate_keys, cache_control) do
     meta = [
       {"surrogate-key", Enum.join(surrogate_keys, " ")},
@@ -31,7 +31,8 @@ defmodule Hexpm.Repository.Storage do
     ]
 
     opts = [cache_control: cache_control, meta: meta]
-    Hexpm.Store.put(:repo_bucket, key, contents, opts)
+    {:ok, %{etag: etag}} = Hexpm.Store.put(:repo_bucket, key, contents, opts)
+    etag
   end
 
   @doc """

--- a/lib/hexpm/store/behaviour.ex
+++ b/lib/hexpm/store/behaviour.ex
@@ -4,13 +4,19 @@ defmodule Hexpm.Store.Behaviour do
   @type key :: String.t()
   @type body :: binary
   @type opts :: Keyword.t()
+  @typedoc """
+  The written object's ETag: what S3 and GCS returned for the write, and
+  for the local and memory stores a quoted MD5 of the body, the value S3
+  gives a single-part upload.
+  """
+  @type etag :: String.t()
 
   @callback list(bucket, prefix) :: [key]
   @callback get(bucket, key, opts) :: body | nil
   @callback size(bucket, key) :: non_neg_integer() | nil
   @callback get_to_file(bucket, key, Path.t(), opts) :: :ok | nil
-  @callback put(bucket, key, body, opts) :: term
-  @callback put_file(bucket, key, Path.t(), opts) :: term
+  @callback put(bucket, key, body, opts) :: {:ok, %{etag: etag}}
+  @callback put_file(bucket, key, Path.t(), opts) :: {:ok, %{etag: etag}}
   @callback delete(bucket, key) :: term
   @callback delete_many(bucket, [key]) :: :ok
 end

--- a/lib/hexpm/store/gcs.ex
+++ b/lib/hexpm/store/gcs.ex
@@ -59,9 +59,9 @@ defmodule Hexpm.Store.GCS do
     url = url(bucket, key)
     headers = filter_nil_values(headers)
 
-    {:ok, 200, _headers, _body} = retry(url, fn -> fun.(url, headers) end)
+    {:ok, 200, response_headers, _body} = retry(url, fn -> fun.(url, headers) end)
 
-    :ok
+    {:ok, %{etag: header!(response_headers, "etag")}}
   end
 
   def delete_many(bucket, keys) do
@@ -120,10 +120,12 @@ defmodule Hexpm.Store.GCS do
     Enum.reject(keyword, fn {_key, value} -> is_nil(value) end)
   end
 
-  defp content_length!(headers) do
-    case Enum.find(headers, fn {key, _value} -> String.downcase(key) == "content-length" end) do
-      {_key, value} -> String.to_integer(value)
-      nil -> raise "GCS response is missing content-length"
+  defp content_length!(headers), do: headers |> header!("content-length") |> String.to_integer()
+
+  defp header!(headers, name) do
+    case Enum.find(headers, fn {key, _value} -> String.downcase(key) == name end) do
+      {_key, value} -> value
+      nil -> raise "GCS response is missing #{name}"
     end
   end
 

--- a/lib/hexpm/store/local.ex
+++ b/lib/hexpm/store/local.ex
@@ -49,12 +49,21 @@ defmodule Hexpm.Store.Local do
     path = safe_path!(bucket, key)
     File.mkdir_p!(Path.dirname(path))
     File.write!(path, blob)
+    {:ok, %{etag: quote_etag(:crypto.hash(:md5, blob))}}
   end
 
   def put_file(bucket, key, source_path, _opts) do
     path = safe_path!(bucket, key)
     File.mkdir_p!(Path.dirname(path))
     File.cp!(source_path, path)
+
+    hash =
+      path
+      |> File.stream!(65_536)
+      |> Enum.reduce(:crypto.hash_init(:md5), &:crypto.hash_update(&2, &1))
+      |> :crypto.hash_final()
+
+    {:ok, %{etag: quote_etag(hash)}}
   end
 
   def delete(bucket, key) do
@@ -80,4 +89,6 @@ defmodule Hexpm.Store.Local do
     Application.get_env(:hexpm, :local_store_dir) ||
       Path.join(Application.fetch_env!(:hexpm, :tmp_dir), "store")
   end
+
+  defp quote_etag(hash), do: ~s("#{Base.encode16(hash, case: :lower)}")
 end

--- a/lib/hexpm/store/memory.ex
+++ b/lib/hexpm/store/memory.ex
@@ -57,6 +57,7 @@ defmodule Hexpm.Store.Memory do
   def put(bucket, key, body, _opts) do
     owner = owner_pid()
     :ets.insert(@table, {{owner, bucket, key}, body})
+    {:ok, %{etag: ~s("#{Base.encode16(:crypto.hash(:md5, body), case: :lower)}")}}
   end
 
   def put_file(bucket, key, path, opts) do

--- a/lib/hexpm/store/s3.ex
+++ b/lib/hexpm/store/s3.ex
@@ -22,7 +22,7 @@ defmodule Hexpm.Store.S3 do
     S3.head_object(bucket(bucket), key)
     |> ExAws.request(region: region(bucket))
     |> case do
-      {:ok, %{headers: headers}} -> content_length!(headers)
+      {:ok, %{headers: headers}} -> headers |> header!("content-length") |> String.to_integer()
       {:error, {:http_error, 404, _}} -> nil
     end
   end
@@ -44,15 +44,21 @@ defmodule Hexpm.Store.S3 do
   end
 
   def put(bucket, key, blob, opts) do
-    S3.put_object(bucket(bucket), key, blob, opts)
-    |> ExAws.request!(region: region(bucket))
+    %{headers: headers} =
+      S3.put_object(bucket(bucket), key, blob, opts)
+      |> ExAws.request!(region: region(bucket))
+
+    {:ok, %{etag: header!(headers, "etag")}}
   end
 
   def put_file(bucket, key, path, opts) do
-    path
-    |> S3.Upload.stream_file()
-    |> S3.upload(bucket(bucket), key, opts)
-    |> ExAws.request!(region: region(bucket))
+    %{body: %{etag: etag}} =
+      path
+      |> S3.Upload.stream_file()
+      |> S3.upload(bucket(bucket), key, opts)
+      |> ExAws.request!(region: region(bucket))
+
+    {:ok, %{etag: etag}}
   end
 
   def delete(bucket, key) do
@@ -70,21 +76,17 @@ defmodule Hexpm.Store.S3 do
     end)
   end
 
+  defp header!(headers, name) do
+    Enum.find_value(headers, fn {key, value} ->
+      if String.downcase(key) == name, do: List.wrap(value) |> hd()
+    end) || raise "S3 response is missing #{name}"
+  end
+
   defp bucket(binary) when is_binary(binary) do
     Enum.at(String.split(binary, ",", parts: 2), 1)
   end
 
   defp region(binary) when is_binary(binary) do
     Enum.at(String.split(binary, ",", parts: 2), 0)
-  end
-
-  defp content_length!(headers) do
-    headers
-    |> Enum.find(fn {key, _value} -> String.downcase(key) == "content-length" end)
-    |> case do
-      {_key, value} when is_binary(value) -> String.to_integer(value)
-      {_key, [value | _]} -> String.to_integer(value)
-      nil -> raise "S3 response is missing content-length"
-    end
   end
 end

--- a/test/hexpm/http_test.exs
+++ b/test/hexpm/http_test.exs
@@ -250,6 +250,24 @@ defmodule Hexpm.HTTPTest do
     assert Agent.get(counter, & &1) == 5
   end
 
+  test "retry returns the last response once the attempts are used up" do
+    {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+    assert {:ok, 503, [], "unavailable"} =
+             HTTP.retry(
+               fn ->
+                 Agent.update(counter, &(&1 + 1))
+                 {:ok, 503, [], "unavailable"}
+               end,
+               "exhausted",
+               attempts: 3,
+               base_delay: 0,
+               statuses: [500..599]
+             )
+
+    assert Agent.get(counter, & &1) == 3
+  end
+
   test "patch/3", %{lasso: lasso} do
     Lasso.expect_once(lasso, "PATCH", "/patch", fn conn ->
       {:ok, reqbody, conn} = Conn.read_body(conn)

--- a/test/hexpm/store/gcs_test.exs
+++ b/test/hexpm/store/gcs_test.exs
@@ -79,10 +79,10 @@ defmodule Hexpm.Store.GCSTest do
       assert {"x-goog-meta-surrogate-key", "docs"} in headers
       assert {"cache-control", "public, max-age=3600"} in headers
       assert {"content-type", "text/html"} in headers
-      {:ok, 200, [], ""}
+      {:ok, 200, [{"ETag", ~s("abc123")}], ""}
     end)
 
-    assert :ok =
+    assert {:ok, %{etag: ~s("abc123")}} =
              GCS.put_file("bucket", "docs/a b?#.html", path,
                meta: [{"surrogate-key", "docs"}],
                cache_control: "public, max-age=3600",

--- a/test/hexpm/store/local_test.exs
+++ b/test/hexpm/store/local_test.exs
@@ -61,7 +61,8 @@ defmodule Hexpm.Store.LocalTest do
       bucket_dir = Path.join([tmp_dir, "store", "bucket"])
       File.mkdir_p!(bucket_dir)
 
-      Local.put("bucket", "file.txt", "content", [])
+      assert {:ok, %{etag: ~s("9a0364b9e99bb480dd25e1f0284c8555")}} =
+               Local.put("bucket", "file.txt", "content", [])
 
       assert File.read!(Path.join(bucket_dir, "file.txt")) == "content"
     end

--- a/test/hexpm/store/s3_test.exs
+++ b/test/hexpm/store/s3_test.exs
@@ -1,0 +1,80 @@
+defmodule Hexpm.Store.S3Test do
+  use ExUnit.Case, async: false
+
+  alias Hexpm.Store.S3
+
+  # An ExAws HTTP client that answers the requests S3.put and S3.put_file
+  # make, the way S3 does: a PUT gets its ETag in a header, a multipart
+  # upload gets it in the CompleteMultipartUpload body.
+  defmodule FakeClient do
+    @behaviour ExAws.Request.HttpClient
+
+    @impl true
+    def request(method, url, body, _headers, _opts) do
+      send(self(), {:s3, method, url, body})
+      {:ok, respond(method, URI.parse(url))}
+    end
+
+    defp respond(:put, %URI{query: nil}) do
+      %{status_code: 200, headers: [{"ETag", ~s("9a0364b9e99bb480dd25e1f0284c8555")}]}
+    end
+
+    defp respond(:post, %URI{query: "uploads=1"}) do
+      %{
+        status_code: 200,
+        headers: [],
+        body: """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <InitiateMultipartUploadResult><Bucket>b</Bucket><Key>k</Key><UploadId>upload-1</UploadId></InitiateMultipartUploadResult>
+        """
+      }
+    end
+
+    defp respond(:put, %URI{query: "partNumber=" <> _}) do
+      %{status_code: 200, headers: [{"ETag", ~s("part")}]}
+    end
+
+    defp respond(:post, %URI{query: "uploadId=" <> _}) do
+      %{
+        status_code: 200,
+        headers: [],
+        body: """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <CompleteMultipartUploadResult><Location>l</Location><Bucket>b</Bucket><Key>k</Key><ETag>&quot;3858f62230ac3c915f300c664312c11f-2&quot;</ETag></CompleteMultipartUploadResult>
+        """
+      }
+    end
+  end
+
+  setup do
+    overrides = [http_client: FakeClient, access_key_id: "key", secret_access_key: "secret"]
+    previous = Enum.map(overrides, fn {key, _} -> {key, Application.get_env(:ex_aws, key)} end)
+    Enum.each(overrides, fn {key, value} -> Application.put_env(:ex_aws, key, value) end)
+
+    on_exit(fn ->
+      Enum.each(previous, fn {key, value} -> Application.put_env(:ex_aws, key, value) end)
+    end)
+
+    :ok
+  end
+
+  test "put returns the ETag from the response header" do
+    assert S3.put("us-east-1,bucket", "packages/foo", "body", []) ==
+             {:ok, %{etag: ~s("9a0364b9e99bb480dd25e1f0284c8555")}}
+
+    assert_received {:s3, :put, "https://s3.amazonaws.com/bucket/packages/foo", "body"}
+  end
+
+  test "put_file returns the ETag from the multipart completion" do
+    path = Path.join(System.tmp_dir!(), "hexpm-s3-test-#{System.unique_integer([:positive])}")
+    File.write!(path, "tarball")
+    on_exit(fn -> File.rm(path) end)
+
+    assert S3.put_file("us-east-1,bucket", "tarballs/foo-1.0.0.tar", path, []) ==
+             {:ok, %{etag: ~s("3858f62230ac3c915f300c664312c11f-2")}}
+
+    assert_received {:s3, :post,
+                     "https://s3.amazonaws.com/bucket/tarballs/foo-1.0.0.tar?uploadId=upload-1",
+                     _}
+  end
+end

--- a/test/hexpm_web/controllers/api/organization_user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_user_controller_test.exs
@@ -46,26 +46,20 @@ defmodule HexpmWeb.API.OrganizationUserControllerTest do
       assert user["role"] == "read"
     end
 
-    test "sorts organization members by username", %{
-      user1: user1,
-      organization: organization
-    } do
+    test "sorts organization members by username", %{organization: organization} do
       zulu = insert(:user, username: "zulu_member")
       alpha = insert(:user, username: "alpha_member")
-      insert(:organization_user, organization: organization, user: user1)
       insert(:organization_user, organization: organization, user: zulu)
       insert(:organization_user, organization: organization, user: alpha)
 
       usernames =
         build_conn()
-        |> put_req_header("authorization", key_for(user1))
+        |> put_req_header("authorization", key_for(zulu))
         |> get("/api/orgs/#{organization.name}/members")
         |> json_response(200)
         |> Enum.map(& &1["username"])
 
-      assert usernames == Enum.sort(usernames)
-      assert "alpha_member" in usernames
-      assert "zulu_member" in usernames
+      assert usernames == ["alpha_member", "zulu_member"]
     end
   end
 

--- a/test/hexpm_web/controllers/api/package_controller_test.exs
+++ b/test/hexpm_web/controllers/api/package_controller_test.exs
@@ -76,11 +76,11 @@ defmodule HexpmWeb.API.PackageControllerTest do
       end
 
       conn = get(build_conn(), "/api/packages?search=#{package1.name}")
-      [package] = json_response(conn, 200)
-      [release] = package["releases"]
+      results = json_response(conn, 200)
+      assert %{"releases" => [release]} = Enum.find(results, &(&1["name"] == package1.name))
       assert release["has_docs"]
       conn = get(build_conn(), "/api/packages?search=name%3A#{package1.name}*")
-      assert [_] = json_response(conn, 200)
+      assert Enum.find(json_response(conn, 200), &(&1["name"] == package1.name))
 
       conn = get(build_conn(), "/api/packages?page=1")
       assert [_, _, _] = json_response(conn, 200)
@@ -89,7 +89,7 @@ defmodule HexpmWeb.API.PackageControllerTest do
       assert [] = json_response(conn, 200)
 
       conn = get(build_conn(), "/api/packages?search=#{package4.name}")
-      [package] = json_response(conn, 200)
+      package = Enum.find(json_response(conn, 200), &(&1["name"] == package4.name))
 
       assert %{
                "message" => "not backward compatible",


### PR DESCRIPTION
Store.put and Store.put_file now return {:ok, %{etag: etag}} on every
backend so callers can check what the CDN serves against what was
written. S3 reads it from the PUT response headers, or from the multipart
completion body for large files; GCS from the response ETag header; the
local and memory stores compute the MD5 S3 gives a single-part upload.
Nothing consumes the value yet; the purge verification built on top does.

HTTP.retry returned {:error, "status N"} once the status retries were
exhausted, which threw away the response body. It now returns the last
response so the caller can report the status and body.

