### PR TITLE
Run CodeQL and zizmor on every pull request

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: ["main"]
   pull_request:
-    branches: ["main"]
   schedule:
     - cron: "29 8 * * 1"
 


### PR DESCRIPTION
The security ruleset on main requires code scanning results from CodeQL and zizmor, but the workflow only ran for pull requests targeting main. A pull request in a stack targets the branch below it, so it never got scanned and could not merge (#1841 today).