### PR TITLE
Lock registry builds per repository and object instead of globally

### DIFF
--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -34,6 +34,7 @@ defmodule Hexpm.Repo do
   defdelegate preload(structs_or_struct_or_nil, preloads, opts \\ []), to: RepoBase
 
   defwrite(advisory_xact_lock(key, opts \\ []))
+  defwrite(advisory_xact_lock_shared(key, opts \\ []))
   defwrite(try_advisory_xact_lock?(key, opts \\ []))
   defwrite(try_advisory_lock?(key, opts \\ []))
   defwrite(advisory_unlock(key, opts \\ []))
@@ -77,7 +78,8 @@ defmodule Hexpm.RepoBase do
     diff: 4,
     email_outbox: 5,
     migrate: 6,
-    secret_scan: 7
+    secret_scan: 7,
+    registry_object: 8
   }
 
   def advisory_lock_key(key), do: Map.fetch!(@advisory_locks, key)
@@ -114,14 +116,27 @@ defmodule Hexpm.RepoBase do
   end
 
   def advisory_xact_lock(key, opts \\ []) do
+    xact_lock("pg_advisory_xact_lock", key, opts)
+  end
+
+  @doc """
+  Takes the shared form of the transaction lock: shared holders do not block
+  each other, an exclusive holder (`advisory_xact_lock/2` on the same key and
+  sub key) blocks them all and waits for them all.
+  """
+  def advisory_xact_lock_shared(key, opts \\ []) do
+    xact_lock("pg_advisory_xact_lock_shared", key, opts)
+  end
+
+  defp xact_lock(function, key, opts) do
     unless skip_advisory_locks?() do
       {sub_key, opts} = Keyword.pop(opts, :sub_key)
 
       {sql, params} =
         if sub_key do
-          {"SELECT pg_advisory_xact_lock($1, $2)", [Map.fetch!(@advisory_locks, key), sub_key]}
+          {"SELECT #{function}($1, $2)", [Map.fetch!(@advisory_locks, key), sub_key]}
         else
-          {"SELECT pg_advisory_xact_lock($1)", [Map.fetch!(@advisory_locks, key)]}
+          {"SELECT #{function}($1)", [Map.fetch!(@advisory_locks, key)]}
         end
 
       %Postgrex.Result{} = query!(sql, params, opts)

--- a/lib/hexpm/repository/registry_worker.ex
+++ b/lib/hexpm/repository/registry_worker.ex
@@ -4,13 +4,21 @@ defmodule Hexpm.Repository.RegistryWorker do
 
   Jobs come in four types: `package` (one `packages/<name>` object),
   `package_delete`, `repository` (`names` and `versions`) and `full`. A job
-  runs the build in a transaction that holds the `:registry` advisory lock,
-  so builds never interleave across nodes, and enqueues the CDN purge inside
-  that transaction, so the purge is only visible once the write is committed
-  and never runs while the lock is held. A job waits `:registry_lock_wait`
-  milliseconds for the lock and snoozes when it does not get it, so a build
-  queued behind a long full build neither holds a connection for minutes nor
-  spends its attempts on waiting.
+  runs the build in a transaction and enqueues the CDN purge inside it, so
+  the purge is only visible once the write is committed.
+
+  Builds of the same object must not interleave across nodes (the older read
+  would win the write), and a full build must not run beside anything that
+  writes the repository's objects (it deletes the package objects it did not
+  see). So a full build takes the `:registry` advisory lock exclusively for
+  its repository, and every other build takes it shared and then the
+  `:registry_object` lock, exclusively, for each object it writes, in sorted
+  order so two batches cannot deadlock. Package builds of different packages
+  and index builds run side by side, which is what makes a registry queue
+  concurrency above one do work. Each lock is waited for at most
+  `:registry_lock_wait` milliseconds; a job that does not get one snoozes,
+  so a build queued behind a long full build neither holds a connection for
+  minutes nor spends its attempts on waiting.
 
   Builds read the database when they run rather than carrying a change with
   them, so queued jobs are consolidated before the read, inside the
@@ -88,10 +96,12 @@ defmodule Hexpm.Repository.RegistryWorker do
   defp build(%Oban.Job{} = job) do
     Repo.transaction(
       fn ->
-        lock_registry(job)
+        set_lock_wait(job)
 
         with {:ok, work, consolidated} <- consolidate(job),
-             {:ok, purges} <- run(work) do
+             {:ok, loaded} <- load(work) do
+          lock_objects(loaded, job)
+          purges = run(loaded)
           keys = Enum.flat_map(purges, & &1.keys)
           verify = Enum.flat_map(purges, & &1.verify)
           if keys != [], do: Hexpm.CDN.purge(:fastly_hexrepo, keys, verify: verify)
@@ -111,73 +121,63 @@ defmodule Hexpm.Repository.RegistryWorker do
   rescue
     error in Postgrex.Error ->
       case error do
-        %{postgres: %{code: :lock_not_available}} -> {:snooze, @lock_snooze}
-        _other -> reraise error, __STACKTRACE__
+        %{postgres: %{code: code}} when code in [:lock_not_available, :deadlock_detected] ->
+          {:snooze, @lock_snooze}
+
+        _other ->
+          reraise error, __STACKTRACE__
       end
   end
 
   # lock_timeout is a session setting; SET LOCAL scopes it to this
-  # transaction, and it takes an integer of milliseconds.
-  defp lock_registry(job) do
+  # transaction, and it takes an integer of milliseconds. It bounds each
+  # lock acquisition on its own.
+  defp set_lock_wait(job) do
     wait = Application.fetch_env!(:hexpm, :registry_lock_wait)
     Repo.query!("SET LOCAL lock_timeout = #{wait}", [], timeout: timeout(job))
-    Repo.advisory_xact_lock(:registry, timeout: timeout(job))
   end
 
-  defp run({:packages, repository_id, ids}) do
-    with {:ok, repository} <- repository(repository_id) do
-      packages =
-        Repo.all(
-          from(p in Package,
-            where: p.id in ^ids and p.repository_id == ^repository_id,
-            order_by: p.id
-          )
-        )
+  # A full build excludes every other build of the repository; the rest
+  # share the repository and exclude each other per object.
+  defp lock_repository(:full, repository_id, job) do
+    Repo.advisory_xact_lock(:registry, sub_key: repository_id, timeout: timeout(job))
+  end
 
-      {:ok, if(packages == [], do: [], else: [RegistryBuilder.packages(repository, packages)])}
+  defp lock_repository(:shared, repository_id, job) do
+    Repo.advisory_xact_lock_shared(:registry, sub_key: repository_id, timeout: timeout(job))
+  end
+
+  defp lock_objects({:full, _repository}, _job), do: :ok
+
+  defp lock_objects(loaded, job) do
+    for key <- loaded |> objects() |> Enum.map(&object_lock_key/1) |> Enum.uniq() |> Enum.sort() do
+      Repo.advisory_xact_lock(:registry_object, sub_key: key, timeout: timeout(job))
     end
+
+    :ok
   end
 
-  # A package published again under the name after the delete was queued
-  # owns the object now; deleting it would undo that build.
-  defp run({:package_delete, repository_id, name}) do
-    with {:ok, repository} <- repository(repository_id) do
-      exists =
-        Repo.exists?(
-          from(p in Package, where: p.repository_id == ^repository_id and p.name == ^name)
-        )
+  defp objects({:packages, repository, packages}),
+    do: Enum.map(packages, &{repository.id, "packages/#{&1.name}"})
 
-      {:ok, if(exists, do: [], else: [RegistryBuilder.package_delete(repository, name)])}
-    end
-  end
+  defp objects({:package_delete, repository, name}), do: [{repository.id, "packages/#{name}"}]
+  defp objects({:repository, repository}), do: [{repository.id, :index}]
 
-  defp run({:repository, repository_id}) do
-    with {:ok, repository} <- repository(repository_id) do
-      {:ok, [RegistryBuilder.repository(repository)]}
-    end
-  end
-
-  defp run({:full, repository_id}) do
-    with {:ok, repository} <- repository(repository_id) do
-      {:ok, [RegistryBuilder.full(repository)]}
-    end
-  end
-
-  defp repository(id) do
-    case Repo.get(Repository, id) do
-      nil -> {:discard, :repository_not_found}
-      repository -> {:ok, repository}
-    end
-  end
+  @doc false
+  # The two-key advisory lock takes int4 sub keys.
+  def object_lock_key(object), do: :erlang.phash2(object, 2_147_483_648)
 
   # Returns what to build and how many queued jobs this one took over, or
-  # a discard when the job's subject is gone.
+  # a discard when the job's subject is gone. Takes the repository lock
+  # first, so a job that has to wait for it holds no sibling rows meanwhile.
   defp consolidate(%Oban.Job{args: %{"type" => "package", "package_id" => id}} = job) do
     case Repo.get(Package, id) do
       nil ->
         {:discard, :package_not_found}
 
       %Package{repository_id: repository_id} ->
+        lock_repository(:shared, repository_id, job)
+
         repository_packages =
           from(p in Package, where: p.repository_id == ^repository_id, select: p.id)
 
@@ -198,6 +198,7 @@ defmodule Hexpm.Repository.RegistryWorker do
   end
 
   defp consolidate(%Oban.Job{args: %{"type" => "full", "repository_id" => id}} = job) do
+    lock_repository(:full, id, job)
     package_ids = from(p in Package, where: p.repository_id == ^id, select: p.id)
 
     siblings =
@@ -215,6 +216,7 @@ defmodule Hexpm.Repository.RegistryWorker do
   end
 
   defp consolidate(%Oban.Job{args: %{"type" => "repository", "repository_id" => id}} = job) do
+    lock_repository(:shared, id, job)
     {:ok, {:repository, id}, cancel(same_args(job))}
   end
 
@@ -222,6 +224,7 @@ defmodule Hexpm.Repository.RegistryWorker do
          %Oban.Job{args: %{"type" => "package_delete", "repository_id" => id, "name" => name}} =
            job
        ) do
+    lock_repository(:shared, id, job)
     {:ok, {:package_delete, id, name}, cancel(same_args(job))}
   end
 
@@ -257,6 +260,59 @@ defmodule Hexpm.Repository.RegistryWorker do
       count + cancelled
     end)
   end
+
+  defp load({:packages, repository_id, ids}) do
+    with {:ok, repository} <- repository(repository_id) do
+      packages =
+        Repo.all(
+          from(p in Package,
+            where: p.id in ^ids and p.repository_id == ^repository_id,
+            order_by: p.id
+          )
+        )
+
+      {:ok, {:packages, repository, packages}}
+    end
+  end
+
+  defp load({:package_delete, repository_id, name}) do
+    with {:ok, repository} <- repository(repository_id),
+         do: {:ok, {:package_delete, repository, name}}
+  end
+
+  defp load({:repository, repository_id}) do
+    with {:ok, repository} <- repository(repository_id), do: {:ok, {:repository, repository}}
+  end
+
+  defp load({:full, repository_id}) do
+    with {:ok, repository} <- repository(repository_id), do: {:ok, {:full, repository}}
+  end
+
+  defp repository(id) do
+    case Repo.get(Repository, id) do
+      nil -> {:discard, :repository_not_found}
+      repository -> {:ok, repository}
+    end
+  end
+
+  defp run({:packages, _repository, []}), do: []
+
+  defp run({:packages, repository, packages}),
+    do: [RegistryBuilder.packages(repository, packages)]
+
+  # A package published again under the name after the delete was queued
+  # owns the object now; deleting it would undo that build.
+  defp run({:package_delete, repository, name}) do
+    exists =
+      Repo.exists?(
+        from(p in Package, where: p.repository_id == ^repository.id and p.name == ^name)
+      )
+
+    if exists, do: [], else: [RegistryBuilder.package_delete(repository, name)]
+  end
+
+  defp run({:repository, repository}), do: [RegistryBuilder.repository(repository)]
+  defp run({:full, repository}), do: [RegistryBuilder.full(repository)]
 
   defp log(%Oban.Job{id: id, args: args}, what, cancelled) do
     Logger.info(

--- a/test/hexpm/repository/registry_worker_lock_test.exs
+++ b/test/hexpm/repository/registry_worker_lock_test.exs
@@ -2,27 +2,28 @@ defmodule Hexpm.Repository.RegistryWorkerLockTest do
   use Hexpm.DataCase, async: false
   use Oban.Testing, repo: Hexpm.RepoBase
 
-  alias Hexpm.Repository.RegistryWorker
+  alias Hexpm.Repository.{RegistryWorker, Repository}
 
   setup do
+    previous = Application.get_env(:hexpm, :skip_advisory_locks)
     Application.put_env(:hexpm, :skip_advisory_locks, false)
-    on_exit(fn -> Application.put_env(:hexpm, :skip_advisory_locks, true) end)
+    on_exit(fn -> Application.put_env(:hexpm, :skip_advisory_locks, previous) end)
 
     package = insert(:package) |> Hexpm.Repo.preload(:repository)
     insert(:release, package: package, version: "0.0.1")
-    %{package: package}
+    other = insert(:package) |> Hexpm.Repo.preload(:repository)
+    insert(:release, package: other, version: "0.0.1")
+    %{package: package, other: other}
   end
 
-  test "snoozes instead of waiting when another build holds the registry lock", %{
-    package: package
-  } do
+  # Holds `sql` in a transaction on its own connection until released.
+  defp hold(sql, params) do
     parent = self()
 
     holder =
       spawn_link(fn ->
         :ok = Ecto.Adapters.SQL.Sandbox.checkout(Hexpm.RepoBase)
-        key = Hexpm.RepoBase.advisory_lock_key(:registry)
-        Hexpm.RepoBase.query!("SELECT pg_advisory_xact_lock($1)", [key])
+        Hexpm.RepoBase.query!(sql, params)
         send(parent, :locked)
 
         receive do
@@ -31,17 +32,96 @@ defmodule Hexpm.Repository.RegistryWorkerLockTest do
       end)
 
     assert_receive :locked
+    holder
+  end
 
-    assert perform_job(RegistryWorker, %{"type" => "package", "package_id" => package.id}) ==
-             {:snooze, 30}
+  defp hold_repository(mode) do
+    function =
+      case mode do
+        :full -> "pg_advisory_xact_lock"
+        :shared -> "pg_advisory_xact_lock_shared"
+      end
 
+    key = Hexpm.RepoBase.advisory_lock_key(:registry)
+    hold("SELECT #{function}($1, $2)", [key, Repository.hexpm().id])
+  end
+
+  defp hold_object(object) do
+    key = Hexpm.RepoBase.advisory_lock_key(:registry)
+    object_key = Hexpm.RepoBase.advisory_lock_key(:registry_object)
+
+    hold(
+      "SELECT pg_advisory_xact_lock_shared($1, $2), pg_advisory_xact_lock($3, $4)",
+      [key, Repository.hexpm().id, object_key, RegistryWorker.object_lock_key(object)]
+    )
+  end
+
+  defp package_args(package), do: %{"type" => "package", "package_id" => package.id}
+  defp package_object(package), do: {package.repository_id, "packages/#{package.name}"}
+  defp repository_args, do: %{"type" => "repository", "repository_id" => Repository.hexpm().id}
+  defp full_args, do: %{"type" => "full", "repository_id" => Repository.hexpm().id}
+
+  test "snoozes while a full build holds the repository", %{package: package} do
+    holder = hold_repository(:full)
+
+    assert perform_job(RegistryWorker, package_args(package)) == {:snooze, 30}
     refute Hexpm.Store.get(:repo_bucket, "packages/#{package.name}", [])
 
     send(holder, :release)
   end
 
-  test "builds once the lock is free", %{package: package} do
-    assert perform_job(RegistryWorker, %{"type" => "package", "package_id" => package.id}) == :ok
+  test "a full build snoozes while a package build holds the repository shared" do
+    holder = hold_repository(:shared)
+    assert perform_job(RegistryWorker, full_args()) == {:snooze, 30}
+    send(holder, :release)
+  end
+
+  test "builds beside another package build of a different package", %{
+    package: package,
+    other: other
+  } do
+    holder = hold_object(package_object(other))
+
+    assert perform_job(RegistryWorker, package_args(package)) == :ok
+    assert Hexpm.Store.get(:repo_bucket, "packages/#{package.name}", [])
+
+    send(holder, :release)
+  end
+
+  test "snoozes while another build holds the same object", %{package: package} do
+    holder = hold_object(package_object(package))
+
+    assert perform_job(RegistryWorker, package_args(package)) == {:snooze, 30}
+    refute Hexpm.Store.get(:repo_bucket, "packages/#{package.name}", [])
+
+    send(holder, :release)
+  end
+
+  test "an index build runs beside a package build", %{package: package} do
+    holder = hold_object(package_object(package))
+    assert perform_job(RegistryWorker, repository_args()) == :ok
+    send(holder, :release)
+  end
+
+  test "an index build snoozes while another index build runs" do
+    holder = hold_object({Repository.hexpm().id, :index})
+    assert perform_job(RegistryWorker, repository_args()) == {:snooze, 30}
+    send(holder, :release)
+  end
+
+  test "a snooze rolls the cancellation of queued siblings back", %{package: package} do
+    {:ok, sibling} = RegistryWorker.enqueue_package(package)
+    {:ok, job} = RegistryWorker.enqueue_package(package)
+    holder = hold_object(package_object(package))
+
+    assert RegistryWorker.perform(Repo.get!(Oban.Job, job.id)) == {:snooze, 30}
+    assert Repo.get!(Oban.Job, sibling.id).state == "available"
+
+    send(holder, :release)
+  end
+
+  test "builds once the locks are free", %{package: package} do
+    assert perform_job(RegistryWorker, package_args(package)) == :ok
     assert Hexpm.Store.get(:repo_bucket, "packages/#{package.name}", [])
   end
 end


### PR DESCRIPTION
Every registry build took one advisory lock, so package builds queued
behind an index build or a manual full build, and a registry queue
concurrency above one only added waiting. Two builds still must not
interleave when they write the same object (the older read would win the
write), and a full build must not run beside anything that writes its
repository's objects (it deletes the package objects it did not see).

A full build now takes the registry lock exclusively for its repository;
package, package_delete and repository builds take it shared and then an
exclusive registry_object lock per object they write, in sorted order so
overlapping batches cannot deadlock. The repository lock is taken before
the queued siblings are consolidated, so a job waiting for it holds no
sibling rows; the object locks are taken once the batch is known and
before anything is read for the build. Package builds of different packages
and index builds run side by side, across nodes and within one when
HEXPM_OBAN_REGISTRY_CONCURRENCY is above one. Consolidation is unchanged:
queued jobs are cancelled before the object locks are taken and the data is
read after, so a job whose insert commits after the cancel is still picked
up by the read or runs on its own, and a snooze rolls the cancellations
back. Repo gains advisory_xact_lock_shared/2.

Pods still running the single-key lock do not exclude the new ones during
a rolling deploy, so a manual full build should not run while one is in
progress.

