### PR TITLE
Reload stale LiveView clients and serve the digested favicon

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -50,7 +50,11 @@ config :hexpm, HexpmWeb.Endpoint,
   http: [port: 5000],
   server: false,
   secret_key_base: "38K8orQfRHMC6ZWXIdgItQEiumeY+L2Ls0fvYfTMt4AoG5+DSFsLG6vMajNcd5Td",
-  live_view: [signing_salt: "2UTSB72sZsF9KTlxefkIrFFPXTO7d+Ep"]
+  live_view: [signing_salt: "2UTSB72sZsF9KTlxefkIrFFPXTO7d+Ep"],
+  cache_static_manifest_latest: %{
+    "assets/app.css" => "assets/app-11111111111111111111111111111111.css",
+    "assets/app.js" => "assets/app-22222222222222222222222222222222.js"
+  }
 
 config :hexpm, Hexpm.Emails.Mailer, adapter: Swoosh.Adapters.Test
 config :swoosh, :api_client, false

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -17,11 +17,15 @@ defmodule HexpmWeb.Endpoint do
   #
   # You should set gzip to true if you are running phoenix.digest
   # when deploying your static files in production.
+  #
+  # only_matching also serves the digested /favicon-<hash>.ico that
+  # ~p"/favicon.ico" resolves to when the static manifest is loaded.
   plug Plug.Static,
     at: "/",
     from: :hexpm,
     gzip: true,
-    only: HexpmWeb.static_paths()
+    only: HexpmWeb.static_paths(),
+    only_matching: ~w(favicon)
 
   socket("/live", Phoenix.LiveView.Socket,
     websocket: [compress: true, connect_info: [:peer_data, :x_headers, session: @session_options]]

--- a/lib/hexpm_web/live/static_reload.ex
+++ b/lib/hexpm_web/live/static_reload.ex
@@ -1,0 +1,24 @@
+defmodule HexpmWeb.Live.StaticReload do
+  @moduledoc """
+  on_mount callback that forces a full page load when the connecting client's
+  tracked static assets are stale. A client that reconnects across a deploy
+  still runs the CSS and JS it loaded before the deploy, so markup rendered by
+  the new server would render unstyled and new hooks would be missing.
+  """
+
+  import Phoenix.LiveView
+
+  def on_mount(:default, _params, _session, socket) do
+    if connected?(socket) and static_changed?(socket) do
+      {:cont,
+       attach_hook(socket, :static_reload, :handle_params, fn _params, uri, socket ->
+         {:halt, redirect(socket, to: path_with_query(URI.parse(uri)))}
+       end)}
+    else
+      {:cont, socket}
+    end
+  end
+
+  defp path_with_query(%URI{path: path, query: nil}), do: path
+  defp path_with_query(%URI{path: path, query: query}), do: path <> "?" <> query
+end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -217,7 +217,7 @@ defmodule HexpmWeb.Router do
     get "/policies/dispute", PolicyController, :dispute
 
     live_session :packages,
-      on_mount: {HexpmWeb.Live.InitAssigns, :default},
+      on_mount: [{HexpmWeb.Live.InitAssigns, :default}, HexpmWeb.Live.StaticReload],
       session: {HexpmWeb.Live.InitAssigns, :session, []} do
       live "/packages", PackageLive.Index, :index
       live "/packages/:name/report", PackageReportLive, :new
@@ -233,7 +233,8 @@ defmodule HexpmWeb.Router do
     get "/preview/:package/:version", PreviewRedirectController, :version
     get "/preview/:package/:version/show/*filename", PreviewRedirectController, :version_file
 
-    live_session :preview, on_mount: {HexpmWeb.Live.InitAssigns, :default} do
+    live_session :preview,
+      on_mount: [{HexpmWeb.Live.InitAssigns, :default}, HexpmWeb.Live.StaticReload] do
       live "/packages/:package/:version/files", PreviewLive, :files
       live "/packages/:package/:version/files/*filename", PreviewLive, :files
       live "/packages/:repository/:package/:version/files", PreviewLive, :files

--- a/lib/hexpm_web/templates/layout/root.html.heex
+++ b/lib/hexpm_web/templates/layout/root.html.heex
@@ -53,7 +53,12 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
       nonce={assigns[:style_src_nonce]}
     />
-    <link rel="stylesheet" href={~p"/assets/app.css"} nonce={assigns[:style_src_nonce]} />
+    <link
+      phx-track-static
+      rel="stylesheet"
+      href={~p"/assets/app.css"}
+      nonce={assigns[:style_src_nonce]}
+    />
     <link rel="alternate" type="application/rss+xml" title="RSS - Blog" href="/feeds/blog.xml" />
 
     <%= if host = Application.get_env(:hexpm, :host) do %>
@@ -77,7 +82,7 @@
 
     {@inner_content}
 
-    <script src={~p"/assets/app.js"} nonce={assigns[:script_src_nonce]}>
+    <script phx-track-static src={~p"/assets/app.js"} nonce={assigns[:script_src_nonce]}>
     </script>
   </body>
 </html>

--- a/test/hexpm_web/live/static_reload_test.exs
+++ b/test/hexpm_web/live/static_reload_test.exs
@@ -1,0 +1,38 @@
+defmodule HexpmWeb.Live.StaticReloadTest do
+  use HexpmWeb.ConnCase, async: true
+  import Phoenix.LiveViewTest
+
+  setup do
+    %{conn: build_conn()}
+  end
+
+  # The digests here match cache_static_manifest_latest in config/test.exs.
+  test "redirects for a full page load when the client's assets are stale", %{conn: conn} do
+    conn =
+      put_connect_params(conn, %{
+        "_track_static" => [
+          "http://localhost:5000/assets/app-00000000000000000000000000000000.css",
+          "http://localhost:5000/assets/app-00000000000000000000000000000000.js"
+        ]
+      })
+
+    assert {:error, {:redirect, %{to: "/packages?search=phoenix"}}} =
+             live(conn, ~p"/packages?search=phoenix")
+  end
+
+  test "mounts when the client's assets are current", %{conn: conn} do
+    conn =
+      put_connect_params(conn, %{
+        "_track_static" => [
+          "http://localhost:5000/assets/app-11111111111111111111111111111111.css",
+          "http://localhost:5000/assets/app-22222222222222222222222222222222.js"
+        ]
+      })
+
+    assert {:ok, _view, _html} = live(conn, ~p"/packages")
+  end
+
+  test "mounts when the client does not track statics", %{conn: conn} do
+    assert {:ok, _view, _html} = live(conn, ~p"/packages")
+  end
+end


### PR DESCRIPTION
A LiveView client that reconnects across a deploy remounts against the new server code while still running the CSS and JS it loaded before the deploy, so patched markup renders against stale styles and new hooks are missing. Same fix as hexpm/bob#288: the asset tags now carry `phx-track-static`, and a `StaticReload` on_mount hook in both live sessions issues a full redirect to the current URL when a connecting client's tracked assets are stale, forcing a page load that fetches the current assets. The embedded LiveViews (navbar search suggestions, add-owner form) are excluded: a forced reload from an embed would reload the hosting page and discard in-progress input, and their stale-markup surface is limited to the embed itself.

The favicon fix is live today: `/hexsearch.xml` points the OpenSearch icon at `url(~p"/favicon.ico")`, which the static manifest resolves to `/favicon-<hash>.ico`, a name the exact-match `only:` list in Plug.Static rejects. https://hex.pm/favicon-1a8d3d20d304394814bd599da36b6a29.ico returns 404 in production right now. `only_matching: ~w(favicon)` serves the digested name; plain `/favicon.ico` requests keep working.