### PR TITLE
Set the app secret on worker pods and keep only web wiring web-only

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -59,7 +59,28 @@ if config_env() == :prod do
     jwt_signing_key: System.fetch_env!("HEXPM_JWT_SIGNING_KEY"),
     billing_key: System.fetch_env!("HEXPM_BILLING_KEY"),
     billing_url: System.fetch_env!("HEXPM_BILLING_URL"),
+    host: System.fetch_env!("HEXPM_HOST"),
+    dashboard_user: System.fetch_env!("HEXPM_DASHBOARD_USER"),
+    dashboard_password: System.fetch_env!("HEXPM_DASHBOARD_PASSWORD"),
+    img_url: System.fetch_env!("HEXPM_IMG_URL"),
+    img_proxy_secret: System.fetch_env!("HEXPM_IMG_PROXY_SECRET"),
+    readme_host: System.fetch_env!("HEXPM_README_HOST"),
+    readme_url: System.fetch_env!("HEXPM_README_URL"),
     secret_scan_notify: System.get_env("HEXPM_SECRET_SCAN_NOTIFY") == "true"
+
+  config :hexpm, :varsel,
+    report_url: System.fetch_env!("HEXPM_VARSEL_REPORT_URL"),
+    audience: System.fetch_env!("HEXPM_VARSEL_JWT_AUDIENCE"),
+    signing_key: System.fetch_env!("HEXPM_VARSEL_SIGNING_KEY"),
+    key_id: System.fetch_env!("HEXPM_VARSEL_KEY_ID")
+
+  config :hexpm, :hcaptcha,
+    sitekey: System.fetch_env!("HEXPM_HCAPTCHA_SITEKEY"),
+    secret: System.fetch_env!("HEXPM_HCAPTCHA_SECRET")
+
+  config :ueberauth, Ueberauth.Strategy.Github.OAuth,
+    client_id: System.fetch_env!("HEXPM_GITHUB_CLIENT_ID"),
+    client_secret: System.fetch_env!("HEXPM_GITHUB_CLIENT_SECRET")
 
   config :ex_aws,
     access_key_id: System.fetch_env!("HEXPM_AWS_ACCESS_KEY_ID"),
@@ -76,32 +97,45 @@ if config_env() == :prod do
 
   config :hexpm, Hexpm.Emails.Mailer, api_key: System.fetch_env!("HEXPM_SENDGRID_API_KEY")
 
+  # IP geolocation database for audit-log locations. Resolution order:
+  #
+  #   1. HEXPM_GEOIP_COUNTRY_PATH, if set.
+  #   2. priv/geoip/country.mmdb, which the Docker image bakes in at build time
+  #      (mix download_geoip) — so the official image works with zero config.
+  #
+  # Fail-soft: if no database is found, geolix logs an info message and returns
+  # nil for all lookups; the app boots normally and location fields are simply
+  # omitted until a database is provisioned.
+  default_geoip_path =
+    case :code.priv_dir(:hexpm) do
+      {:error, _} -> nil
+      priv_dir -> Path.join(to_string(priv_dir), "geoip/country.mmdb")
+    end
+
+  geoip_country_path = System.get_env("HEXPM_GEOIP_COUNTRY_PATH") || default_geoip_path
+
+  if geoip_country_path do
+    config :geolix,
+      databases: [
+        %{
+          id: :country,
+          adapter: Geolix.Adapter.MMDB2,
+          source: geoip_country_path
+        }
+      ]
+  end
+
   # Set on both web and worker deployments so Prometheus can scrape all pods
   if metrics_port = System.get_env("HEXPM_METRICS_PORT") do
     config :hexpm, metrics_port: String.to_integer(metrics_port)
   end
 
+  # Only the web server's own wiring may live in this block: everything else is
+  # shared, because Oban jobs read app config on worker pods too. The env vars
+  # below (HEXPM_PORT, HEXPM_SECRET_KEY_BASE, BEAM_PORT, ...) are the ones the
+  # worker deployment does not have to provide.
   if mode == :web do
     config :hexpm, Oban, queues: false, plugins: false, peer: false
-
-    config :hexpm, :varsel,
-      report_url: System.fetch_env!("HEXPM_VARSEL_REPORT_URL"),
-      audience: System.fetch_env!("HEXPM_VARSEL_JWT_AUDIENCE"),
-      signing_key: System.fetch_env!("HEXPM_VARSEL_SIGNING_KEY"),
-      key_id: System.fetch_env!("HEXPM_VARSEL_KEY_ID")
-
-    config :hexpm,
-      host: System.fetch_env!("HEXPM_HOST"),
-      dashboard_user: System.fetch_env!("HEXPM_DASHBOARD_USER"),
-      dashboard_password: System.fetch_env!("HEXPM_DASHBOARD_PASSWORD"),
-      img_url: System.fetch_env!("HEXPM_IMG_URL"),
-      img_proxy_secret: System.fetch_env!("HEXPM_IMG_PROXY_SECRET"),
-      readme_host: System.fetch_env!("HEXPM_README_HOST"),
-      readme_url: System.fetch_env!("HEXPM_README_URL")
-
-    config :hexpm, :hcaptcha,
-      sitekey: System.fetch_env!("HEXPM_HCAPTCHA_SITEKEY"),
-      secret: System.fetch_env!("HEXPM_HCAPTCHA_SECRET")
 
     hexpm_port =
       case System.get_env("HEXPM_PORT") do
@@ -128,38 +162,6 @@ if config_env() == :prod do
     config :kernel,
       inet_dist_listen_min: String.to_integer(System.fetch_env!("BEAM_PORT")),
       inet_dist_listen_max: String.to_integer(System.fetch_env!("BEAM_PORT"))
-
-    config :ueberauth, Ueberauth.Strategy.Github.OAuth,
-      client_id: System.fetch_env!("HEXPM_GITHUB_CLIENT_ID"),
-      client_secret: System.fetch_env!("HEXPM_GITHUB_CLIENT_SECRET")
-
-    # IP geolocation database for audit-log locations. Resolution order:
-    #
-    #   1. HEXPM_GEOIP_COUNTRY_PATH, if set.
-    #   2. priv/geoip/country.mmdb, which the Docker image bakes in at build time
-    #      (mix download_geoip) — so the official image works with zero config.
-    #
-    # Fail-soft: if no database is found, geolix logs an info message and returns
-    # nil for all lookups; the app boots normally and location fields are simply
-    # omitted until a database is provisioned.
-    default_geoip_path =
-      case :code.priv_dir(:hexpm) do
-        {:error, _} -> nil
-        priv_dir -> Path.join(to_string(priv_dir), "geoip/country.mmdb")
-      end
-
-    geoip_country_path = System.get_env("HEXPM_GEOIP_COUNTRY_PATH") || default_geoip_path
-
-    if geoip_country_path do
-      config :geolix,
-        databases: [
-          %{
-            id: :country,
-            adapter: Geolix.Adapter.MMDB2,
-            source: geoip_country_path
-          }
-        ]
-    end
   end
 
   if mode == :worker do

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -43,6 +43,7 @@ if config_env() == :prod do
     end
 
   config :hexpm,
+    secret: System.fetch_env!("HEXPM_SECRET"),
     private_key: System.fetch_env!("HEXPM_SIGNING_KEY"),
     repo_bucket: System.fetch_env!("HEXPM_REPO_BUCKET"),
     logs_bucket: System.fetch_env!("HEXPM_LOGS_BUCKET"),
@@ -91,7 +92,6 @@ if config_env() == :prod do
 
     config :hexpm,
       host: System.fetch_env!("HEXPM_HOST"),
-      secret: System.fetch_env!("HEXPM_SECRET"),
       dashboard_user: System.fetch_env!("HEXPM_DASHBOARD_USER"),
       dashboard_password: System.fetch_env!("HEXPM_DASHBOARD_PASSWORD"),
       img_url: System.fetch_env!("HEXPM_IMG_URL"),

--- a/test/hexpm/runtime_config_test.exs
+++ b/test/hexpm/runtime_config_test.exs
@@ -19,15 +19,36 @@ defmodule Hexpm.RuntimeConfigTest do
     "HEXPM_JWT_SIGNING_KEY" => "jwt-signing-key",
     "HEXPM_BILLING_KEY" => "billing-key",
     "HEXPM_BILLING_URL" => "https://billing.example.com",
+    "HEXPM_HOST" => "hex.example.com",
+    "HEXPM_DASHBOARD_USER" => "dashboard-user",
+    "HEXPM_DASHBOARD_PASSWORD" => "dashboard-password",
+    "HEXPM_IMG_URL" => "https://img.example.com",
+    "HEXPM_IMG_PROXY_SECRET" => "img-proxy-secret",
+    "HEXPM_README_HOST" => "readme.hex.example.com",
+    "HEXPM_README_URL" => "https://readme.hex.example.com",
+    "HEXPM_VARSEL_REPORT_URL" => "https://cna.example.com/reports",
+    "HEXPM_VARSEL_JWT_AUDIENCE" => "https://cna.example.com/reports",
+    "HEXPM_VARSEL_SIGNING_KEY" => "varsel-signing-key",
+    "HEXPM_VARSEL_KEY_ID" => "varsel-key-id",
+    "HEXPM_HCAPTCHA_SITEKEY" => "hcaptcha-sitekey",
+    "HEXPM_HCAPTCHA_SECRET" => "hcaptcha-secret",
+    "HEXPM_GITHUB_CLIENT_ID" => "github-client-id",
+    "HEXPM_GITHUB_CLIENT_SECRET" => "github-client-secret",
     "HEXPM_AWS_ACCESS_KEY_ID" => "aws-id",
     "HEXPM_AWS_ACCESS_KEY_SECRET" => "aws-secret",
     "HEXPM_SENTRY_DSN" => "https://sentry.example.com/1",
     "HEXPM_ENV" => "prod",
-    "HEXPM_HOST" => "hex.example.com",
     "HEXPM_EMAIL_HOST" => "hex.example.com",
     "HEXPM_LEVENSHTEIN_THRESHOLD" => "2",
     "HEXPM_SENDGRID_API_KEY" => "sendgrid-key"
   }
+
+  @web_env Map.merge(@shared_env, %{
+             "HEXPM_MODE" => "web",
+             "HEXPM_SECRET_KEY_BASE" => "secret-key-base",
+             "HEXPM_LIVE_VIEW_SIGNING_SALT" => "live-view-salt",
+             "BEAM_PORT" => "14000"
+           })
 
   @worker_env Map.merge(@shared_env, %{
                 "HEXPM_MODE" => "worker",
@@ -59,6 +80,25 @@ defmodule Hexpm.RuntimeConfigTest do
     config = read_runtime(Map.put(@worker_env, "HEXPM_SECRET_SCAN_NOTIFY", "true"))
 
     assert config[:hexpm][:secret_scan_notify] == true
+  end
+
+  # Oban jobs read the same app config web requests do, so any key set only in
+  # web mode is a latent crash on worker pods. Web pods mount the shared config
+  # maps and nothing else, so the reverse split (the worker-only keys) is real
+  # and stays.
+  test "only the web server's own wiring is web-only" do
+    web = read_runtime(@web_env)
+    worker = read_runtime(@worker_env)
+
+    assert Keyword.keys(web) -- Keyword.keys(worker) == [:kernel]
+
+    web_only = Keyword.keys(web[:hexpm]) -- Keyword.keys(worker[:hexpm])
+
+    assert web_only == [HexpmWeb.Endpoint],
+           "these :hexpm keys are set only in web mode: #{inspect(web_only)}. " <>
+             "Worker pods mount every env var web pods do, so unless the key " <>
+             "configures the web server itself it belongs in the shared block, " <>
+             "where jobs can read it too."
   end
 
   defp read_runtime(env) do

--- a/test/hexpm/runtime_config_test.exs
+++ b/test/hexpm/runtime_config_test.exs
@@ -1,0 +1,77 @@
+defmodule Hexpm.RuntimeConfigTest do
+  # Sync: reading runtime.exs goes through the VM-global process environment.
+  use ExUnit.Case, async: false
+
+  @shared_env %{
+    "HEXPM_SECRET" => "app-secret",
+    "HEXPM_SIGNING_KEY" => "signing-key",
+    "HEXPM_REPO_BUCKET" => "s3,us-east-1,repo",
+    "HEXPM_LOGS_BUCKET" => "gcs,logs",
+    "HEXPM_DOCS_BUCKET" => "gcs,docs",
+    "HEXPM_PREVIEW_BUCKET" => "gcs,preview",
+    "HEXPM_DIFF_BUCKET" => "gcs,diff",
+    "HEXPM_DIFF_CACHE_VERSION" => "1",
+    "HEXPM_CDN_URL" => "https://repo.example.com",
+    "HEXPM_DOCS_URL" => "https://docs.example.com",
+    "HEXPM_PRIVATE_DOCS_URL" => "https://private-docs.example.com",
+    "HEXPM_FASTLY_KEY" => "fastly-key",
+    "HEXPM_FASTLY_HEXREPO" => "fastly-hexrepo",
+    "HEXPM_JWT_SIGNING_KEY" => "jwt-signing-key",
+    "HEXPM_BILLING_KEY" => "billing-key",
+    "HEXPM_BILLING_URL" => "https://billing.example.com",
+    "HEXPM_AWS_ACCESS_KEY_ID" => "aws-id",
+    "HEXPM_AWS_ACCESS_KEY_SECRET" => "aws-secret",
+    "HEXPM_SENTRY_DSN" => "https://sentry.example.com/1",
+    "HEXPM_ENV" => "prod",
+    "HEXPM_HOST" => "hex.example.com",
+    "HEXPM_EMAIL_HOST" => "hex.example.com",
+    "HEXPM_LEVENSHTEIN_THRESHOLD" => "2",
+    "HEXPM_SENDGRID_API_KEY" => "sendgrid-key"
+  }
+
+  @worker_env Map.merge(@shared_env, %{
+                "HEXPM_MODE" => "worker",
+                "HEXPM_OBAN_PERIODIC_CONCURRENCY" => "5",
+                "HEXPM_OBAN_HEAVY_CONCURRENCY" => "10",
+                "HEXPM_OBAN_REGISTRY_CONCURRENCY" => "2",
+                "HEXPM_OBAN_PURGE_CONCURRENCY" => "5",
+                "HEXPM_DOCS_PRIVATE_BUCKET" => "docs-private",
+                "HEXPM_PREVIEW_QUEUE_ID" => "preview-queue",
+                "HEXPM_DOCS_QUEUE_ID" => "docs-queue",
+                "HEXPM_DOCS_TYPESENSE_URL" => "https://typesense.example.com",
+                "HEXPM_DOCS_TYPESENSE_API_KEY" => "typesense-key",
+                "HEXPM_DOCS_TYPESENSE_COLLECTION" => "hexdocs",
+                "HEXPM_DOCS_GITHUB_USER" => "docs-user",
+                "HEXPM_DOCS_GITHUB_TOKEN" => "docs-token",
+                "HEXPM_FASTLY_DOCS_KEY" => "fastly-docs-key",
+                "HEXPM_FASTLY_DOCS" => "fastly-docs",
+                "HEXPM_FASTLY_PRIVATE_DOCS" => "fastly-private-docs"
+              })
+
+  # The secret scan runs on worker pods only: web pods disable the Oban queues.
+  # It fingerprints findings with the app secret, so worker mode has to set it.
+  test "worker mode configures the secret scan" do
+    config = read_runtime(@worker_env)
+
+    assert config[:hexpm][:secret] == "app-secret"
+    assert config[:hexpm][:secret_scan_notify] == false
+
+    config = read_runtime(Map.put(@worker_env, "HEXPM_SECRET_SCAN_NOTIFY", "true"))
+
+    assert config[:hexpm][:secret_scan_notify] == true
+  end
+
+  defp read_runtime(env) do
+    previous = Map.new(env, fn {key, _value} -> {key, System.get_env(key)} end)
+
+    on_exit(fn ->
+      Enum.each(previous, fn
+        {key, nil} -> System.delete_env(key)
+        {key, value} -> System.put_env(key, value)
+      end)
+    end)
+
+    System.put_env(env)
+    Config.Reader.read!("config/runtime.exs", env: :prod)
+  end
+end


### PR DESCRIPTION
Every secret scan job in prod crashes with `ArgumentError: could not fetch application environment :secret` before scanning anything. The scan fingerprints findings with an HMAC keyed on the app secret, read with `Application.fetch_env!(:hexpm, :secret)` when the job builds its scanner options. The job runs on the heavy Oban queue, which only worker pods run, but runtime.exs set `:secret` inside the web-only block. Each job burns its five attempts and is discarded, so no release has been scanned since #1806 shipped.

This is the fourth occurrence of the class: email delivery from workers (#1760), `metrics_port` for Prometheus scraping (#1768), and `jwt_signing_key` for the Fastly purge job (#1841) were all keys read from worker pods but set only in the web block. The block never provided secret hygiene either: web pods mount only `hexpm-config` and `hexpm-secret`, worker pods mount those plus the worker-only pair, so every var the web block read was already in the worker pod's environment.

The second commit removes the class instead of patching this instance. Host, dashboard, img proxy, readme, varsel, hCaptcha, ueberauth, and geoip config move to the shared block; the web block keeps what worker pods cannot provide, the endpoint (`HEXPM_PORT`, `HEXPM_SECRET_KEY_BASE`, `HEXPM_LIVE_VIEW_SIGNING_SALT`), distribution (`BEAM_PORT`), and the `Oban queues: false` override. The worker block stays as is: its vars aren't mounted on web pods, deliberately, since they hold the Typesense admin key, docs GitHub token, and Fastly docs key. No ops change is needed; all newly-shared vars are in the shared config maps in prod and staging.

A new test evaluates runtime.exs in both modes with stub env vars and asserts the web-only surface is exactly `:kernel` and `HexpmWeb.Endpoint`, so adding a key to the web block fails a test instead of crashing a worker in prod. It also pins worker mode getting `:secret` and `secret_scan_notify`.

The jobs that already failed are in the discarded state (kept a year by the pruner). To scan the backlog after this deploys:

```elixir
import Ecto.Query
Oban.retry_all_jobs(where(Oban.Job, worker: "Hexpm.SecretScan.Worker", state: "discarded"))
```