### PR TITLE
Stream log objects in the stats job

### DIFF
--- a/lib/hexpm/http.ex
+++ b/lib/hexpm/http.ex
@@ -5,9 +5,14 @@ defmodule Hexpm.HTTP.Interface do
   @type opts() :: Keyword.t()
   @type response() ::
           {:ok, Mint.Types.status(), Mint.Types.headers(), binary()} | {:error, Exception.t()}
+  @type chunked_response() ::
+          {:ok, Mint.Types.status(), Mint.Types.headers(), Enumerable.t()}
+          | {:error, Exception.t()}
 
   @callback get(url(), headers()) :: response()
   @callback get(url(), headers(), opts()) :: response()
+  @callback stream(url(), headers()) :: chunked_response()
+  @callback stream(url(), headers(), opts()) :: chunked_response()
   @callback head(url(), headers()) :: response()
   @callback head(url(), headers(), opts()) :: response()
   @callback post(url(), headers(), params()) :: response()
@@ -28,6 +33,7 @@ defmodule Hexpm.HTTP do
   @default_attempts 3
   @default_base_delay 100
   @request_opts [:pool_timeout, :receive_timeout, :request_timeout]
+  @ack_timeout 60_000
 
   def impl() do
     Application.get_env(:hexpm, :http_impl, __MODULE__)
@@ -35,6 +41,35 @@ defmodule Hexpm.HTTP do
 
   @impl Hexpm.HTTP.Interface
   def get(url, headers, opts \\ []), do: do_request(:get, url, headers, nil, opts)
+
+  @doc """
+  GETs `url` and returns the body as a stream of chunks instead of a binary.
+  The status and headers are read before this returns; the body is read from
+  the connection as the stream is consumed, one chunk in flight, so a
+  response of any size is handled in bounded memory. The stream has to be
+  consumed by the process that called `stream/3`. Halting it early closes
+  the request, and so does a chunk that is not consumed within
+  `:ack_timeout` (60 seconds), so an abandoned stream does not keep its
+  connection.
+  """
+  @impl Hexpm.HTTP.Interface
+  def stream(url, headers, opts \\ []) do
+    {ack_timeout, opts} = Keyword.pop(opts, :ack_timeout, @ack_timeout)
+    {request_opts, build_opts} = Keyword.split(opts, @request_opts)
+    request = Finch.build(:get, url, headers, nil, build_opts)
+    ref = make_ref()
+    parent = self()
+
+    task =
+      Task.Supervisor.async_nolink(Hexpm.Tasks, fn ->
+        stream_request(request, request_opts, parent, ref, ack_timeout)
+      end)
+
+    with {:ok, status} <- stream_await(:status, task, ref),
+         {:ok, response_headers} <- stream_await(:headers, task, ref) do
+      {:ok, status, response_headers, stream_body(task, ref)}
+    end
+  end
 
   @impl Hexpm.HTTP.Interface
   def head(url, headers, opts \\ []), do: do_request(:head, url, headers, nil, opts)
@@ -299,6 +334,109 @@ defmodule Hexpm.HTTP do
 
       {:error, reason, _response} ->
         {:error, reason}
+    end
+  end
+
+  defp stream_request(request, request_opts, parent, ref, ack_timeout) do
+    parent_ref = Process.monitor(parent)
+
+    fun = fn
+      {:status, status}, acc ->
+        send(parent, {ref, :status, status})
+        {:cont, acc}
+
+      {:headers, headers}, acc ->
+        send(parent, {ref, :headers, headers})
+        {:cont, acc}
+
+      {:data, data}, acc ->
+        send(parent, {ref, :data, data})
+
+        receive do
+          {^ref, :next} -> {:cont, acc}
+          {^ref, :halt} -> {:halt, acc}
+          {:DOWN, ^parent_ref, _, _, _} -> {:halt, acc}
+        after
+          ack_timeout -> {:halt, :unconsumed}
+        end
+
+      {:trailers, _headers}, acc ->
+        {:cont, acc}
+    end
+
+    case Finch.stream_while(request, Hexpm.Finch, nil, fun, request_opts) do
+      {:ok, :unconsumed} ->
+        {:error, %RuntimeError{message: "a body chunk was not consumed within #{ack_timeout}ms"}}
+
+      {:ok, _acc} ->
+        :done
+
+      {:error, reason, _acc} ->
+        {:error, reason}
+    end
+  end
+
+  defp stream_await(tag, %Task{ref: task_ref}, ref) do
+    receive do
+      {^ref, ^tag, value} ->
+        {:ok, value}
+
+      {^task_ref, {:error, reason}} ->
+        Process.demonitor(task_ref, [:flush])
+        {:error, reason}
+
+      {:DOWN, ^task_ref, _, _, reason} ->
+        {:error, stream_exit(reason)}
+    end
+  end
+
+  defp stream_body(task, ref) do
+    Stream.resource(
+      fn -> :running end,
+      fn
+        :running -> stream_next(task, ref)
+        :done -> {:halt, :done}
+      end,
+      fn
+        :done ->
+          :ok
+
+        :running ->
+          send(task.pid, {ref, :halt})
+          Task.shutdown(task, :brutal_kill)
+          stream_flush(ref)
+      end
+    )
+  end
+
+  defp stream_next(%Task{ref: task_ref} = task, ref) do
+    receive do
+      {^ref, :data, chunk} ->
+        send(task.pid, {ref, :next})
+        {[chunk], :running}
+
+      {^task_ref, :done} ->
+        Process.demonitor(task_ref, [:flush])
+        {:halt, :done}
+
+      {^task_ref, {:error, reason}} ->
+        Process.demonitor(task_ref, [:flush])
+        raise reason
+
+      {:DOWN, ^task_ref, _, _, reason} ->
+        raise stream_exit(reason)
+    end
+  end
+
+  defp stream_exit(reason) do
+    %RuntimeError{message: "HTTP stream exited: #{inspect(reason)}"}
+  end
+
+  defp stream_flush(ref) do
+    receive do
+      {^ref, _tag, _value} -> stream_flush(ref)
+    after
+      0 -> :ok
     end
   end
 

--- a/lib/hexpm/release_tasks/stats.ex
+++ b/lib/hexpm/release_tasks/stats.ex
@@ -41,6 +41,7 @@ defmodule Hexpm.ReleaseTasks.Stats do
   >x
 
   @ets __MODULE__
+  @max_line_bytes 1_048_576
   @monitor_slug "hexpm-stats"
   @monitor_schedule "0 1 * * *"
 
@@ -156,13 +157,7 @@ defmodule Hexpm.ReleaseTasks.Stats do
 
   defp process_keys(bucket, keys) do
     Hexpm.Tasks
-    |> Task.Supervisor.async_stream_nolink(
-      keys,
-      fn key ->
-        Store.get(bucket, key, [])
-        |> maybe_unzip(key)
-        |> process_file()
-      end,
+    |> Task.Supervisor.async_stream_nolink(keys, &process_key(bucket, &1),
       max_concurrency: 10,
       timeout: 600_000
     )
@@ -178,19 +173,81 @@ defmodule Hexpm.ReleaseTasks.Stats do
     end)
   end
 
-  defp process_file(file) do
-    lines = String.split(file, "\n")
+  defp process_key(bucket, key) do
+    case Store.stream(bucket, key) do
+      nil ->
+        raise "#{key} is gone from the logs bucket"
 
-    Enum.each(lines, fn line ->
-      case parse_line(line) do
-        {repository, package, version} ->
-          key = {repository, package, version}
-          :ets.update_counter(@ets, key, 1, {key, 0})
+      chunks ->
+        chunks
+        |> gunzip(key)
+        |> lines()
+        |> Enum.each(&count/1)
+    end
+  end
 
-        nil ->
-          :ok
-      end
+  # inflateEnd runs only when the input ended, where it raises data_error for
+  # a truncated object; on any other exit the original exception stays.
+  defp gunzip(chunks, key) do
+    if String.ends_with?(key, ".gz") do
+      Stream.transform(
+        chunks,
+        fn ->
+          z = :zlib.open()
+          :ok = :zlib.inflateInit(z, 31, :reset)
+          z
+        end,
+        fn chunk, z -> {inflate(z, chunk), z} end,
+        fn z ->
+          :zlib.inflateEnd(z)
+          {[], z}
+        end,
+        fn z -> :zlib.close(z) end
+      )
+    else
+      chunks
+    end
+  end
+
+  # safeInflate returns a bounded piece of output per call, so a chunk that
+  # expands a thousandfold is still handled a piece at a time.
+  defp inflate(z, chunk) do
+    Stream.unfold({:input, chunk}, fn
+      :done -> nil
+      {:input, data} -> inflated(:zlib.safeInflate(z, data))
+      :more -> inflated(:zlib.safeInflate(z, []))
     end)
+  end
+
+  defp inflated({:continue, output}), do: {IO.iodata_to_binary(output), :more}
+  defp inflated({:finished, output}), do: {IO.iodata_to_binary(output), :done}
+
+  defp lines(chunks) do
+    Stream.transform(
+      chunks,
+      fn -> "" end,
+      fn chunk, carry ->
+        {carry, complete} = List.pop_at(String.split(carry <> chunk, "\n"), -1)
+
+        if byte_size(carry) > @max_line_bytes do
+          raise "[stats] a log line is longer than #{@max_line_bytes} bytes"
+        end
+
+        {complete, carry}
+      end,
+      fn
+        "" -> {[], ""}
+        carry -> {[carry], ""}
+      end,
+      fn _carry -> :ok end
+    )
+  end
+
+  defp count(line) do
+    case parse_line(line) do
+      {_repository, _package, _version} = key -> :ets.update_counter(@ets, key, 1, {key, 0})
+      nil -> :ok
+    end
   end
 
   def parse_line(line) do
@@ -219,14 +276,6 @@ defmodule Hexpm.ReleaseTasks.Stats do
     from(r in Release, select: {{r.package_id, r.version}, r.id})
     |> Repo.all()
     |> Map.new(fn {{pid, vsn}, rid} -> {{pid, to_string(vsn)}, rid} end)
-  end
-
-  defp maybe_unzip(data, key) do
-    if String.ends_with?(key, ".gz") do
-      :zlib.gunzip(data)
-    else
-      data
-    end
   end
 
   defp nillify(""), do: nil

--- a/lib/hexpm/store/behaviour.ex
+++ b/lib/hexpm/store/behaviour.ex
@@ -13,6 +13,11 @@ defmodule Hexpm.Store.Behaviour do
 
   @callback list(bucket, prefix) :: [key]
   @callback get(bucket, key, opts) :: body | nil
+  @doc """
+  The object body as a stream of binary chunks, `nil` when the object does
+  not exist. The stream has to be consumed by the process that called it.
+  """
+  @callback stream(bucket, key) :: Enumerable.t() | nil
   @callback size(bucket, key) :: non_neg_integer() | nil
   @callback get_to_file(bucket, key, Path.t(), opts) :: :ok | nil
   @callback put(bucket, key, body, opts) :: {:ok, %{etag: etag}}

--- a/lib/hexpm/store/gcs.ex
+++ b/lib/hexpm/store/gcs.ex
@@ -28,6 +28,35 @@ defmodule Hexpm.Store.GCS do
     end
   end
 
+  def stream(bucket, key) do
+    url = url(bucket, key)
+
+    case retry(url, fn -> stream_request(url) end) do
+      {:ok, 200, _headers, chunks} -> chunks
+      {:ok, 404, _headers, _body} -> nil
+      {:ok, status, _headers, _body} -> raise "GCS GET #{url} returned status #{status}"
+      {:error, reason} -> raise "GCS GET #{url} failed: #{inspect(reason)}"
+    end
+  end
+
+  # Any response but a 200 is read to the end here, so a retry never leaves
+  # a half-read response holding its connection. A failure while reading it
+  # is returned as an error so the retry sees it.
+  defp stream_request(url) do
+    case Hexpm.HTTP.impl().stream(url, headers()) do
+      {:ok, 200, _headers, _chunks} = response -> response
+      {:ok, status, headers, chunks} -> drain(chunks, status, headers)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp drain(chunks, status, headers) do
+    Stream.run(chunks)
+    {:ok, status, headers, ""}
+  rescue
+    exception -> {:error, exception}
+  end
+
   def get_to_file(bucket, key, destination, opts) do
     case get(bucket, key, opts) do
       nil -> nil

--- a/lib/hexpm/store/local.ex
+++ b/lib/hexpm/store/local.ex
@@ -1,5 +1,6 @@
 defmodule Hexpm.Store.Local do
   @behaviour Hexpm.Store.Behaviour
+  @chunk_size 65_536
 
   # only used during development (not safe)
 
@@ -33,6 +34,14 @@ defmodule Hexpm.Store.Local do
     case File.stat(path) do
       {:ok, stat} -> stat.size
       {:error, :enoent} -> nil
+    end
+  end
+
+  def stream(bucket, key) do
+    path = safe_path!(bucket, key)
+
+    if File.regular?(path) do
+      File.stream!(path, @chunk_size)
     end
   end
 

--- a/lib/hexpm/store/memory.ex
+++ b/lib/hexpm/store/memory.ex
@@ -5,6 +5,7 @@ defmodule Hexpm.Store.Memory do
   @behaviour Hexpm.Store.Behaviour
 
   @table __MODULE__
+  @chunk_size 65_536
   @ownership __MODULE__.Ownership
   @key :store
 
@@ -44,6 +45,20 @@ defmodule Hexpm.Store.Memory do
     case get(bucket, key, []) do
       nil -> nil
       body -> byte_size(body)
+    end
+  end
+
+  def stream(bucket, key) do
+    case get(bucket, key, []) do
+      nil ->
+        nil
+
+      body ->
+        Stream.unfold(body, fn
+          "" -> nil
+          <<chunk::binary-size(@chunk_size), rest::binary>> -> {chunk, rest}
+          chunk -> {chunk, ""}
+        end)
     end
   end
 

--- a/lib/hexpm/store/s3.ex
+++ b/lib/hexpm/store/s3.ex
@@ -27,6 +27,17 @@ defmodule Hexpm.Store.S3 do
     end
   end
 
+  def stream(bucket, key) do
+    case size(bucket, key) do
+      nil ->
+        nil
+
+      _size ->
+        S3.download_file(bucket(bucket), key, :memory)
+        |> ExAws.stream!(region: region(bucket))
+    end
+  end
+
   def get_to_file(bucket, key, destination, _opts) do
     case size(bucket, key) do
       nil ->

--- a/lib/hexpm/store/store.ex
+++ b/lib/hexpm/store/store.ex
@@ -30,6 +30,11 @@ defmodule Hexpm.Store do
     impl.size(bucket, key)
   end
 
+  def stream(bucket, key) do
+    {impl, bucket} = impl_bucket(bucket)
+    impl.stream(bucket, key)
+  end
+
   def fetch(bucket, key, opts \\ []) do
     {impl, bucket} = impl_bucket(bucket)
 

--- a/test/hexpm/http_test.exs
+++ b/test/hexpm/http_test.exs
@@ -148,6 +148,127 @@ defmodule Hexpm.HTTPTest do
              )
   end
 
+  test "stream/3 yields the body chunks in order", %{lasso: lasso} do
+    body = Base.encode64(:crypto.strong_rand_bytes(600_000))
+
+    Lasso.expect_once(lasso, "GET", "/stream", fn conn ->
+      Conn.resp(conn, 200, body)
+    end)
+
+    assert {:ok, 200, headers, chunks} =
+             HTTP.stream(lasso_url(lasso, "/stream"), [], receive_timeout: @receive_timeout)
+
+    assert {"content-length", _} = List.keyfind(headers, "content-length", 0)
+
+    chunks = Enum.to_list(chunks)
+    assert length(chunks) > 1
+    assert IO.iodata_to_binary(chunks) == body
+  end
+
+  test "stream/3 reads the next chunk only after the previous one was consumed", %{
+    lasso: lasso
+  } do
+    test_process = self()
+
+    Lasso.expect_once(lasso, "GET", "/lazy", fn conn ->
+      conn = Conn.send_chunked(conn, 200)
+      {:ok, conn} = Conn.chunk(conn, "first")
+      send(test_process, {:first_sent, self()})
+
+      receive do
+        :send_second -> :ok
+      after
+        @server_step_timeout -> raise "the first chunk was never consumed"
+      end
+
+      {:ok, conn} = Conn.chunk(conn, "second")
+      conn
+    end)
+
+    assert {:ok, 200, _headers, chunks} =
+             HTTP.stream(lasso_url(lasso, "/lazy"), [], receive_timeout: @receive_timeout)
+
+    assert_receive {:first_sent, server}, @server_await_timeout
+
+    chunks =
+      Enum.reduce(chunks, [], fn chunk, acc ->
+        if acc == [], do: send(server, :send_second)
+        [chunk | acc]
+      end)
+
+    assert Enum.reverse(chunks) == ["first", "second"]
+  end
+
+  test "stream/3 stops the request when the stream is halted early", %{lasso: lasso} do
+    test_process = self()
+
+    Lasso.expect_once(lasso, "GET", "/halt", fn conn ->
+      conn = Conn.send_chunked(conn, 200)
+      {:ok, conn} = Conn.chunk(conn, "first")
+      send(test_process, {:first_sent, self()})
+
+      receive do
+        :finish -> :ok
+      after
+        @server_step_timeout -> :ok
+      end
+
+      conn
+    end)
+
+    assert {:ok, 200, _headers, chunks} =
+             HTTP.stream(lasso_url(lasso, "/halt"), [], receive_timeout: @receive_timeout)
+
+    assert_receive {:first_sent, server}, @server_await_timeout
+    [task] = stream_tasks()
+
+    assert Enum.take(chunks, 1) == ["first"]
+
+    refute Process.alive?(task)
+    refute_received {_ref, :data, _chunk}
+    send(server, :finish)
+  end
+
+  test "stream/3 ends the request when a chunk is not consumed in time", %{lasso: lasso} do
+    Lasso.expect_once(lasso, "GET", "/unconsumed", fn conn ->
+      Conn.resp(conn, 200, "body")
+    end)
+
+    assert {:ok, 200, _headers, chunks} =
+             HTTP.stream(lasso_url(lasso, "/unconsumed"), [],
+               ack_timeout: 100,
+               receive_timeout: @receive_timeout
+             )
+
+    [task] = stream_tasks()
+    ref = Process.monitor(task)
+    assert_receive {:DOWN, ^ref, _, _, _}, @server_await_timeout
+
+    assert_raise RuntimeError, ~r/not consumed within 100ms/, fn -> Enum.to_list(chunks) end
+    assert stream_tasks() == []
+  end
+
+  test "stream/3 raises when the connection drops mid-body" do
+    {:ok, listener} =
+      :gen_tcp.listen(0, [:binary, active: false, reuseaddr: true, ip: {127, 0, 0, 1}])
+
+    {:ok, port} = :inet.port(listener)
+    on_exit(fn -> :gen_tcp.close(listener) end)
+
+    spawn_link(fn ->
+      {:ok, socket} = :gen_tcp.accept(listener, @server_step_timeout)
+      {:ok, _request} = :gen_tcp.recv(socket, 0, @server_step_timeout)
+      :ok = :gen_tcp.send(socket, "HTTP/1.1 200 OK\r\ncontent-length: 100\r\n\r\nfirst")
+      :gen_tcp.close(socket)
+    end)
+
+    assert {:ok, 200, _headers, chunks} =
+             HTTP.stream("http://127.0.0.1:#{port}/drop", [], receive_timeout: @receive_timeout)
+
+    assert_raise Finch.TransportError, fn -> Enum.to_list(chunks) end
+    assert stream_tasks() == []
+  end
+
   test "head/2", %{lasso: lasso} do
     Lasso.expect_once(lasso, "HEAD", "/head", fn conn ->
       conn
@@ -390,6 +511,13 @@ defmodule Hexpm.HTTPTest do
       end)
 
     {"https://#{hostname}:#{port}/pinned", certificate[:cacerts], server}
+  end
+
+  defp stream_tasks() do
+    for pid <- Task.Supervisor.children(Hexpm.Tasks),
+        {:dictionary, dictionary} <- [Process.info(pid, :dictionary)],
+        self() in List.wrap(dictionary[:"$callers"]),
+        do: pid
   end
 
   defp lasso_url(lasso, path) do

--- a/test/hexpm/preview/workers_test.exs
+++ b/test/hexpm/preview/workers_test.exs
@@ -10,6 +10,7 @@ defmodule Hexpm.Preview.WorkersTest do
     defdelegate list(bucket, prefix), to: Hexpm.Store.Memory
     defdelegate get(bucket, key, opts), to: Hexpm.Store.Memory
     defdelegate size(bucket, key), to: Hexpm.Store.Memory
+    defdelegate stream(bucket, key), to: Hexpm.Store.Memory
     defdelegate get_to_file(bucket, key, path, opts), to: Hexpm.Store.Memory
     defdelegate put(bucket, key, body, opts), to: Hexpm.Store.Memory
     defdelegate delete(bucket, key), to: Hexpm.Store.Memory
@@ -30,6 +31,7 @@ defmodule Hexpm.Preview.WorkersTest do
 
     defdelegate get(bucket, key, opts), to: Hexpm.Store.Memory
     defdelegate size(bucket, key), to: Hexpm.Store.Memory
+    defdelegate stream(bucket, key), to: Hexpm.Store.Memory
     defdelegate get_to_file(bucket, key, path, opts), to: Hexpm.Store.Memory
     defdelegate put(bucket, key, body, opts), to: Hexpm.Store.Memory
     defdelegate delete(bucket, key), to: Hexpm.Store.Memory

--- a/test/hexpm/release_tasks/stats_test.exs
+++ b/test/hexpm/release_tasks/stats_test.exs
@@ -9,6 +9,26 @@ defmodule Hexpm.ReleaseTasks.StatsTest do
 
   setup :verify_on_exit!
 
+  defmodule DroppingStore do
+    @behaviour Hexpm.Store.Behaviour
+
+    defdelegate list(bucket, prefix), to: Hexpm.Store.Memory
+    defdelegate get(bucket, key, opts), to: Hexpm.Store.Memory
+    defdelegate size(bucket, key), to: Hexpm.Store.Memory
+    defdelegate get_to_file(bucket, key, path, opts), to: Hexpm.Store.Memory
+    defdelegate put(bucket, key, body, opts), to: Hexpm.Store.Memory
+    defdelegate put_file(bucket, key, path, opts), to: Hexpm.Store.Memory
+    defdelegate delete(bucket, key), to: Hexpm.Store.Memory
+    defdelegate delete_many(bucket, keys), to: Hexpm.Store.Memory
+
+    def stream(bucket, key) do
+      Stream.concat(
+        Hexpm.Store.Memory.stream(bucket, key),
+        Stream.map([:eof], fn _ -> raise "connection dropped" end)
+      )
+    end
+  end
+
   setup do
     repository1 = insert(:repository)
     [package1, package2, package3] = insert_list(3, :package)
@@ -101,6 +121,80 @@ defmodule Hexpm.ReleaseTasks.StatsTest do
     refute Enum.find(downloads, &(&1.release_id == rel4.id))
   end
 
+  test "counts a multi-member gzip object in full", %{
+    repository1: repository1,
+    package1: package1,
+    package2: package2,
+    package4: package4
+  } do
+    replaces = [
+      repository1: repository1.name,
+      package1: package1.name,
+      package2: package2.name,
+      package4: package4.name
+    ]
+
+    logfile =
+      :zlib.gzip(read_log("fastly_logs_1.txt", replaces)) <>
+        :zlib.gzip(read_log("fastly_logs_2.txt", replaces))
+
+    Store.put(
+      :logs_bucket,
+      "fastly_hex/2013-11-01T14:00:00.000-tzletcEGGiI7atIAAAAA.log.gz",
+      logfile,
+      []
+    )
+
+    expect_monitor(:ok)
+    assert :ok = perform_job(Stats, %{"date" => "2013-11-01"})
+
+    rel1 = Repo.get_by!(assoc(package1, :releases), version: "0.0.1")
+    rel2 = Repo.get_by!(assoc(package1, :releases), version: "0.0.2")
+    rel3 = Repo.get_by!(assoc(package2, :releases), version: "0.0.2")
+    rel5 = Repo.get_by!(assoc(package4, :releases), version: "0.0.1")
+
+    downloads = Hexpm.Repo.all(Download)
+    assert length(downloads) == 4
+
+    assert Enum.find(downloads, &(&1.release_id == rel1.id)).downloads == 6
+    assert Enum.find(downloads, &(&1.release_id == rel2.id)).downloads == 3
+    assert Enum.find(downloads, &(&1.release_id == rel3.id)).downloads == 1
+    assert Enum.find(downloads, &(&1.release_id == rel5.id)).downloads == 1
+  end
+
+  test "counts lines that straddle stream chunks", %{package1: package1} do
+    versions = ~w(0.0.1 0.0.2 0.1.0)
+
+    lines =
+      for i <- 1..30_000 do
+        version = Enum.at(versions, rem(i, 3))
+        agent = Base.encode16(:crypto.strong_rand_bytes(16))
+
+        ~s{<134>2025-09-09T21:05:03Z cache-bma-essb1270021 logging_gcs[226941]: 98.128.175.50 [09/Sep/2025:21:05:03 +0000] "GET /tarballs/#{package1.name}-#{version}.tar" 200 "#{agent}" 0}
+      end
+
+    logfile = :zlib.gzip(Enum.join(lines, "\n") <> "\n")
+    assert byte_size(logfile) > 4 * 65_536
+
+    Store.put(
+      :logs_bucket,
+      "fastly_hex/2025-09-09T21:00:00.000-tzletcEGGiI7atIAAAAA.log.gz",
+      logfile,
+      []
+    )
+
+    expect_monitor(:ok)
+    assert :ok = perform_job(Stats, %{"date" => "2025-09-09"})
+
+    downloads = Hexpm.Repo.all(Download)
+    assert length(downloads) == 3
+
+    for version <- versions do
+      release = Repo.get_by!(assoc(package1, :releases), version: version)
+      assert Enum.find(downloads, &(&1.release_id == release.id)).downloads == 10_000
+    end
+  end
+
   test "scheduled jobs process the previous UTC date", %{package1: package1} do
     release = Repo.get_by!(assoc(package1, :releases), version: "0.0.1")
 
@@ -152,6 +246,70 @@ defmodule Hexpm.ReleaseTasks.StatsTest do
         scheduled_at: DateTime.new!(~D[2013-11-02], ~T[01:00:00], "Etc/UTC")
       )
     end
+  end
+
+  @tag :capture_log
+  test "a failure while reading an object is reported as itself", %{package1: package1} do
+    app_env(:hexpm, :logs_bucket, {DroppingStore, "logs_bucket"})
+
+    Store.put(
+      :logs_bucket,
+      "fastly_hex/2013-11-01T14:00:00.000-tzletcEGGiI7atIAAAAA.log.gz",
+      :zlib.gzip(read_log("fastly_logs_2.txt", package1: package1.name)),
+      []
+    )
+
+    expect_monitor(:error)
+
+    error =
+      assert_raise RuntimeError, fn ->
+        perform_job(Stats, %{"date" => "2013-11-01"})
+      end
+
+    assert Exception.message(error) =~ "connection dropped"
+    refute Exception.message(error) =~ "data_error"
+  end
+
+  test "counts an object that expands a thousandfold", %{package1: package1} do
+    line =
+      ~s{<134>2025-09-09T21:05:03Z cache-bma-essb1270021 logging_gcs[226941]: 98.128.175.50 [09/Sep/2025:21:05:03 +0000] "GET /tarballs/#{package1.name}-0.0.1.tar" 200 "Hex/2.1.1" 0\n}
+
+    logfile = :zlib.gzip(String.duplicate(line, 300_000))
+    assert byte_size(logfile) * 100 < byte_size(line) * 300_000
+
+    Store.put(
+      :logs_bucket,
+      "fastly_hex/2025-09-09T21:00:00.000-tzletcEGGiI7atIAAAAA.log.gz",
+      logfile,
+      []
+    )
+
+    expect_monitor(:ok)
+    assert :ok = perform_job(Stats, %{"date" => "2025-09-09"})
+
+    release = Repo.get_by!(assoc(package1, :releases), version: "0.0.1")
+
+    assert Repo.get_by!(Download, release_id: release.id, day: ~D[2025-09-09]).downloads ==
+             300_000
+  end
+
+  @tag :capture_log
+  test "a log line longer than the limit fails the job" do
+    Store.put(
+      :logs_bucket,
+      "fastly_hex/2013-11-01T14:00:00.000-tzletcEGGiI7atIAAAAA.log.gz",
+      :zlib.gzip(String.duplicate("x", 2 * 1024 * 1024)),
+      []
+    )
+
+    expect_monitor(:error)
+
+    error =
+      assert_raise RuntimeError, fn ->
+        perform_job(Stats, %{"date" => "2013-11-01"})
+      end
+
+    assert Exception.message(error) =~ "longer than 1048576 bytes"
   end
 
   defp expect_monitor(final_status) do

--- a/test/hexpm/store/gcs_test.exs
+++ b/test/hexpm/store/gcs_test.exs
@@ -22,6 +22,73 @@ defmodule Hexpm.Store.GCSTest do
 
   def auth_headers, do: [{"authorization", "Bearer token"}]
 
+  test "streams object bodies" do
+    expect(Hexpm.HTTP.Mock, :stream, fn url, headers ->
+      assert url == "https://storage.example/bucket/fastly_hex/day.log.gz"
+      assert headers == [{"authorization", "Bearer token"}]
+      {:ok, 200, [], Stream.map(["first", "second"], & &1)}
+    end)
+
+    assert GCS.stream("bucket", "fastly_hex/day.log.gz") |> Enum.to_list() == ["first", "second"]
+  end
+
+  test "streams nil for a missing object after reading its body" do
+    test_process = self()
+
+    expect(Hexpm.HTTP.Mock, :stream, fn _url, _headers ->
+      body = Stream.map(["not found"], fn chunk -> send(test_process, {:read, chunk}) end)
+      {:ok, 404, [], body}
+    end)
+
+    assert GCS.stream("bucket", "missing") == nil
+    assert_received {:read, "not found"}
+  end
+
+  test "retries a transient stream status after reading its body" do
+    test_process = self()
+
+    expect(Hexpm.HTTP.Mock, :stream, 2, fn _url, _headers ->
+      attempt = Process.get(:gcs_stream_attempt, 0)
+      Process.put(:gcs_stream_attempt, attempt + 1)
+
+      if attempt == 0 do
+        body = Stream.map(["unavailable"], fn chunk -> send(test_process, {:read, chunk}) end)
+        {:ok, 503, [], body}
+      else
+        {:ok, 200, [], ["contents"]}
+      end
+    end)
+
+    assert GCS.stream("bucket", "file") |> Enum.to_list() == ["contents"]
+    assert_received {:read, "unavailable"}
+  end
+
+  test "retries when reading a transient error body fails" do
+    expect(Hexpm.HTTP.Mock, :stream, 2, fn _url, _headers ->
+      attempt = Process.get(:gcs_stream_attempt, 0)
+      Process.put(:gcs_stream_attempt, attempt + 1)
+
+      if attempt == 0 do
+        body = Stream.map([:closed], fn _ -> raise Finch.TransportError, reason: :closed end)
+        {:ok, 503, [], body}
+      else
+        {:ok, 200, [], ["contents"]}
+      end
+    end)
+
+    assert GCS.stream("bucket", "file") |> Enum.to_list() == ["contents"]
+  end
+
+  test "raises for terminal stream failures" do
+    expect(Hexpm.HTTP.Mock, :stream, fn _url, _headers ->
+      {:ok, 403, [], ["forbidden"]}
+    end)
+
+    assert_raise RuntimeError, ~r/returned status 403/, fn ->
+      GCS.stream("bucket", "file")
+    end
+  end
+
   test "reads object bodies without decoding json" do
     expect(Hexpm.HTTP.Mock, :get, fn url, headers, opts ->
       assert url == "https://storage.example/bucket/files/package/1.0.0/data.json"

--- a/test/hexpm/store/local_test.exs
+++ b/test/hexpm/store/local_test.exs
@@ -16,6 +16,23 @@ defmodule Hexpm.Store.LocalTest do
     :ok
   end
 
+  describe "stream/2" do
+    @tag :tmp_dir
+    test "streams the file in chunks", %{tmp_dir: tmp_dir} do
+      bucket_dir = Path.join([tmp_dir, "store", "bucket"])
+      File.mkdir_p!(bucket_dir)
+      content = :crypto.strong_rand_bytes(200_000)
+      File.write!(Path.join(bucket_dir, "file.bin"), content)
+
+      chunks = Local.stream("bucket", "file.bin") |> Enum.to_list()
+      assert length(chunks) == 4
+      assert IO.iodata_to_binary(chunks) == content
+
+      assert Hexpm.Store.stream({Local, "bucket"}, "file.bin") |> Enum.to_list() == chunks
+      assert Local.stream("bucket", "missing.bin") == nil
+    end
+  end
+
   describe "get/3" do
     @tag :tmp_dir
     test "works for valid paths", %{tmp_dir: tmp_dir} do

--- a/test/hexpm/store/s3_test.exs
+++ b/test/hexpm/store/s3_test.exs
@@ -9,11 +9,39 @@ defmodule Hexpm.Store.S3Test do
   defmodule FakeClient do
     @behaviour ExAws.Request.HttpClient
 
+    @object "logs/day.log.gz"
+
+    # Two full 1 MiB download parts and a 4-byte tail.
+    def object_body, do: String.duplicate("0123456789abcdef", 131_072) <> "tail"
+
     @impl true
-    def request(method, url, body, _headers, _opts) do
+    def request(method, url, body, headers, _opts) do
       send(self(), {:s3, method, url, body})
-      {:ok, respond(method, URI.parse(url))}
+      {:ok, respond(method, URI.parse(url), headers)}
     end
+
+    defp respond(:head, %URI{path: "/bucket/" <> @object}, _headers) do
+      %{
+        status_code: 200,
+        headers: [{"Content-Length", Integer.to_string(byte_size(object_body()))}]
+      }
+    end
+
+    defp respond(:head, %URI{}, _headers) do
+      %{status_code: 404, headers: [], body: ""}
+    end
+
+    defp respond(:get, %URI{path: "/bucket/" <> @object}, headers) do
+      "bytes=" <> range =
+        Enum.find_value(headers, fn {key, value} ->
+          if String.downcase(to_string(key)) == "range", do: value
+        end)
+
+      [first, last] = range |> String.split("-") |> Enum.map(&String.to_integer/1)
+      %{status_code: 200, headers: [], body: binary_part(object_body(), first, last - first + 1)}
+    end
+
+    defp respond(method, uri, _headers), do: respond(method, uri)
 
     defp respond(:put, %URI{query: nil}) do
       %{status_code: 200, headers: [{"ETag", ~s("9a0364b9e99bb480dd25e1f0284c8555")}]}
@@ -56,6 +84,14 @@ defmodule Hexpm.Store.S3Test do
     end)
 
     :ok
+  end
+
+  test "stream returns the object body in ranged chunks and nil for a missing object" do
+    chunks = S3.stream("us-east-1,bucket", "logs/day.log.gz") |> Enum.to_list()
+
+    assert Enum.map(chunks, &byte_size/1) == [1_048_576, 1_048_576, 4]
+    assert IO.iodata_to_binary(chunks) == FakeClient.object_body()
+    assert S3.stream("us-east-1,bucket", "logs/missing.log.gz") == nil
   end
 
   test "put returns the ETag from the response header" do

--- a/test/support/diff_store.ex
+++ b/test/support/diff_store.ex
@@ -3,6 +3,7 @@ defmodule Hexpm.Diff.TestStore do
 
   defdelegate list(bucket, prefix), to: Hexpm.Store.Memory
   defdelegate size(bucket, key), to: Hexpm.Store.Memory
+  defdelegate stream(bucket, key), to: Hexpm.Store.Memory
   defdelegate get_to_file(bucket, key, destination, opts), to: Hexpm.Store.Memory
   defdelegate put_file(bucket, key, path, opts), to: Hexpm.Store.Memory
   defdelegate delete(bucket, key), to: Hexpm.Store.Memory


### PR DESCRIPTION
The stats job downloaded each Fastly log object into memory, gunzipped
it as one binary and split the result into lines. Objects were a few
megabytes each, but the access-log layout change puts up to a day of
logs into one object (0.5 to 1.4 GB compressed), which ten concurrent
tasks cannot hold on a worker with a 6 GiB limit.

Store.stream/2 returns an object body as a stream of chunks: 64 KiB
pieces for the memory and local stores, ExAws download chunks for S3
and response data chunks for GCS. Hexpm.HTTP.stream/3 backs the GCS
implementation. A task under Hexpm.Tasks runs Finch.stream_while and
hands one chunk at a time to the caller, blocking until the caller asks
for the next one, so at most one chunk is in flight per object. Halting
the stream early or the caller exiting stops the request, and so does a
chunk left unconsumed for 60 seconds, so an abandoned stream cannot
keep its connection. A non-200 response is read to the end before the
retry so no half-read response holds its connection, and a failure
while reading it is retried too.

The stats job inflates each chunk with safeInflate on a zlib stream
opened with inflateInit(z, 31, :reset), which continues across
concatenated gzip members and yields a bounded piece of output per
call, so a chunk that expands a thousandfold is still handled a piece
at a time. Lines are split with a carry for the partial line at each
boundary, capped at 1 MiB so an object without newlines cannot grow it.
A truncated object still fails the job: inflateEnd raises data_error
when the input ended before the stream did, and it only runs on that
path so a failure mid-stream surfaces as itself.


First step of the access-log storage change (the hexpm-ops PRs). Ships first so that any day in the new bucket can be re-run, including the backfilled days of up to 1.4 GB compressed in one object.

Followed by https://github.com/hexpm/hexpm/pull/1855.