### PR TITLE
Count a log object's lines in parallel and give each object an hour

### DIFF
--- a/lib/hexpm/release_tasks/stats.ex
+++ b/lib/hexpm/release_tasks/stats.ex
@@ -42,6 +42,8 @@ defmodule Hexpm.ReleaseTasks.Stats do
 
   @ets __MODULE__
   @max_line_bytes 1_048_576
+  @count_batch_lines 5_000
+  @task_timeout 3_600_000
   @monitor_slug "hexpm-stats"
   @monitor_schedule "0 1 * * *"
 
@@ -69,7 +71,7 @@ defmodule Hexpm.ReleaseTasks.Stats do
   end
 
   def do_run(date, dryrun?) do
-    :ets.new(@ets, [:named_table, :public])
+    :ets.new(@ets, [:named_table, :public, write_concurrency: true])
 
     try do
       {repositories, packages, releases} =
@@ -161,7 +163,7 @@ defmodule Hexpm.ReleaseTasks.Stats do
     Hexpm.Tasks
     |> Task.Supervisor.async_stream_nolink(keys, &process_key(bucket, &1),
       max_concurrency: 10,
-      timeout: 600_000
+      timeout: @task_timeout
     )
     |> Enum.each(fn
       {:ok, _result} ->
@@ -184,7 +186,13 @@ defmodule Hexpm.ReleaseTasks.Stats do
         chunks
         |> gunzip(key)
         |> lines()
-        |> Enum.each(&count/1)
+        |> Stream.chunk_every(@count_batch_lines)
+        |> Task.async_stream(fn batch -> Enum.each(batch, &count/1) end,
+          max_concurrency: System.schedulers_online(),
+          ordered: false,
+          timeout: @task_timeout
+        )
+        |> Stream.run()
     end
   end
 

--- a/test/hexpm/release_tasks/stats_test.exs
+++ b/test/hexpm/release_tasks/stats_test.exs
@@ -347,6 +347,48 @@ defmodule Hexpm.ReleaseTasks.StatsTest do
              300_000
   end
 
+  test "counts every batch of a large object, including a partial last one", %{
+    package1: package1,
+    package2: package2
+  } do
+    lines =
+      for i <- 1..12_345 do
+        {package, version} =
+          case rem(i, 4) do
+            0 -> {package1.name, "0.0.1"}
+            1 -> {package1.name, "0.0.2"}
+            2 -> {package2.name, "0.0.1"}
+            3 -> {package2.name, "0.0.3-rc.1"}
+          end
+
+        ~s{<134>2025-09-09T21:05:03Z cache-bma-essb1270021 logging_gcs[226941]: 98.128.175.50 [09/Sep/2025:21:05:03 +0000] "GET /tarballs/#{package}-#{version}.tar" 200 "Hex/2.1.1" 0}
+      end
+
+    Store.put(
+      :logs_bucket,
+      "fastly_hex/dt=2025-09-09/daily.log.gz",
+      :zlib.gzip(Enum.join(lines, "\n") <> "\n"),
+      []
+    )
+
+    expect_monitor(:ok)
+    assert :ok = perform_job(Stats, %{"date" => "2025-09-09"})
+
+    counts =
+      for {package, version, expected} <- [
+            {package1, "0.0.1", 3_086},
+            {package1, "0.0.2", 3_087},
+            {package2, "0.0.1", 3_086},
+            {package2, "0.0.3-rc.1", 3_086}
+          ] do
+        release = Repo.get_by!(assoc(package, :releases), version: version)
+        {Repo.get_by!(Download, release_id: release.id, day: ~D[2025-09-09]).downloads, expected}
+      end
+
+    assert Enum.all?(counts, fn {got, expected} -> got == expected end), inspect(counts)
+    assert Enum.sum(Enum.map(counts, &elem(&1, 0))) == 12_345
+  end
+
   @tag :capture_log
   test "a log line longer than the limit fails the job" do
     Store.put(


### PR DESCRIPTION
Found on the cutover day: a dry run of 2026-08-02, a pre-cutover day the backfill copied in as one 604 MB object, died in `process_keys` on the 600 s per-object budget of `async_stream_nolink`. One process inflates, splits and regexes an object end to end, and at the rate of last night's run (1.37 GB in 739 s across ten tasks) that is about an hour for a Sunday and over two for a weekday. The composed hours of the two cutover days are 30 to 80 MB, a few minutes each, within the budget but not by much, and every ten-minute object it was sized for is gone.

The budget only bounded that processing time. A stalled download is caught by the HTTP stream itself, which fails when a chunk is not received within `receive_timeout` or not consumed within `ack_timeout`. Each object task and each counting batch now gets 3,600,000 ms, the same bound as the Oban job's `timeout/1`, so a run from Oban ends after an hour either way and a manual `run/2` from an iex cannot sit on one object for longer than that.

To make the single-object days take minutes instead of hours, `process_key` hands the line stream to counting tasks in batches of 5,000 lines, one task per scheduler, unordered, and the ETS table gets `write_concurrency`. The inflating process stays the only reader of the HTTP stream, so nothing about chunk acknowledgement or the 1 MiB line carry changes; a counting task that crashes takes its object's task down with it, and that reaches Oban as before. The nightly run keeps ten objects in flight, now with the parsing spread over the node's cores.

New test: a 12,345-line object, a partial last batch, four package/version combinations counted exactly. The existing 30,000-line and 300,000-line objects cover the multi-batch path. Full suite 2,818 passed.
