### PR TITLE
Log one line per request instead of three

### DIFF
--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -51,7 +51,7 @@ defmodule HexpmWeb.Endpoint do
     cookie_key: "request_logger"
 
   plug Plug.RequestId
-  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint]
+  plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint], log: false
   plug Logster.Plugs.ChangeLogLevel, to: :info
   plug Logster.Plugs.Logger, excludes: [:params]
 

--- a/test/hexpm_web/endpoint_log_test.exs
+++ b/test/hexpm_web/endpoint_log_test.exs
@@ -1,0 +1,17 @@
+defmodule HexpmWeb.EndpointLogTest do
+  use HexpmWeb.ConnCase
+  import ExUnit.CaptureLog
+
+  setup do
+    level = Logger.level()
+    Logger.configure(level: :info)
+    on_exit(fn -> Logger.configure(level: level) end)
+  end
+
+  test "logs one line per request" do
+    log = capture_log(fn -> get(build_conn(), "/diffs") end)
+
+    assert [line] = String.split(log, "\n", trim: true)
+    assert line =~ ~r"^\[info\] .*\bstatus=200\b.*\bpath=/diffs\b.*\bmethod=GET\b"
+  end
+end


### PR DESCRIPTION
Every request logs three lines today: Phoenix.Logger's `GET /path` and `Sent 200 in 12ms`, and Logster's `state=set duration=12.4 status=200 path=/path method=GET format=json controller=... action=...`. On 2026-08-25 that was 2,909,678 requests and 8,728,000 of the 9,202,272 lines hexpm wrote to stdout (BigQuery `logs.stdout`, container `hexpm`). The Logster line has everything the two Phoenix lines have plus the controller and action, and the request id is on all three, so `log: false` on `Plug.Telemetry` turns the Phoenix pair off and Logster stays. That's two thirds of the request lines gone with the same information kept. Cloud Logging bills the whole entry including the Kubernetes metadata attached to each one, so entries matter more than message length.

Test: a request produces exactly one info line with the status, path and method. The test lowers the logger level to info for its own duration in a non-async module (the test config runs at error, and `capture_log`'s `:level` does not go below the configured level). Full suite 2,819 passed, no error or warning lines.
