### PR TITLE
Record the request id on audit logs written from a request

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -4,6 +4,7 @@ defmodule Hexpm.Accounts.AuditLog do
   schema "audit_logs" do
     field :user_agent, :string
     field :remote_ip, :string
+    field :request_id, :string
     field :action, :string
     field :params, :map
     field :user_data, :map
@@ -32,6 +33,7 @@ defmodule Hexpm.Accounts.AuditLog do
       oauth_token: oauth_token,
       user_agent: truncate_codepoints(audit_data.user_agent, 255),
       remote_ip: audit_data.remote_ip,
+      request_id: Map.get(audit_data, :request_id),
       action: action,
       params: params
     }
@@ -51,6 +53,7 @@ defmodule Hexpm.Accounts.AuditLog do
       oauth_token: oauth_token,
       user_agent: truncate_codepoints(audit_data.user_agent, 255),
       remote_ip: audit_data.remote_ip,
+      request_id: Map.get(audit_data, :request_id),
       action: "organization.create",
       params: params
     }
@@ -72,6 +75,7 @@ defmodule Hexpm.Accounts.AuditLog do
       oauth_token: oauth_token,
       user_agent: truncate_codepoints(audit_data.user_agent, 255),
       remote_ip: audit_data.remote_ip,
+      request_id: Map.get(audit_data, :request_id),
       action: action,
       params: params
     }
@@ -91,6 +95,7 @@ defmodule Hexpm.Accounts.AuditLog do
       oauth_token: oauth_token,
       user_agent: truncate_codepoints(audit_data.user_agent, 255),
       remote_ip: audit_data.remote_ip,
+      request_id: Map.get(audit_data, :request_id),
       action: action,
       params: params
     }

--- a/lib/hexpm_web/controllers/controller_helpers.ex
+++ b/lib/hexpm_web/controllers/controller_helpers.ex
@@ -337,7 +337,8 @@ defmodule HexpmWeb.ControllerHelpers do
       user: user_or_organization,
       auth_credential: Map.get(conn.assigns, :auth_credential),
       user_agent: conn.assigns.user_agent,
-      remote_ip: HexpmWeb.RequestHelpers.parse_ip(conn.remote_ip)
+      remote_ip: HexpmWeb.RequestHelpers.parse_ip(conn.remote_ip),
+      request_id: List.first(get_resp_header(conn, "x-request-id"))
     }
   end
 

--- a/lib/hexpm_web/controllers/test_controller.ex
+++ b/lib/hexpm_web/controllers/test_controller.ex
@@ -50,6 +50,7 @@ defmodule HexpmWeb.TestController do
           user: %User{},
           user_agent: "TEST",
           remote_ip: "127.0.0.1",
+          request_id: List.first(get_resp_header(conn, "x-request-id")),
           auth_credential: conn.assigns.auth_credential
         }
       )
@@ -107,7 +108,8 @@ defmodule HexpmWeb.TestController do
         user: user,
         auth_credential: nil,
         user_agent: conn.assigns[:user_agent],
-        remote_ip: HexpmWeb.RequestHelpers.parse_ip(conn.remote_ip)
+        remote_ip: HexpmWeb.RequestHelpers.parse_ip(conn.remote_ip),
+        request_id: List.first(get_resp_header(conn, "x-request-id"))
       }
 
       case Tokens.create_session_and_token_for_user(

--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -50,6 +50,8 @@ defmodule HexpmWeb.Endpoint do
     param_key: "request_logger",
     cookie_key: "request_logger"
 
+  # Plug.RequestId keeps a client-supplied x-request-id; ours is always generated.
+  plug :drop_request_id
   plug Plug.RequestId
   plug Plug.Telemetry, event_prefix: [:phoenix, :endpoint], log: false
   plug Logster.Plugs.ChangeLogLevel, to: :info
@@ -77,4 +79,6 @@ defmodule HexpmWeb.Endpoint do
   plug HexpmWeb.Plugs.CanonicalHost
 
   plug HexpmWeb.Router
+
+  defp drop_request_id(conn, _opts), do: delete_req_header(conn, "x-request-id")
 end

--- a/priv/repo/migrations/20260826150000_add_request_id_to_audit_logs.exs
+++ b/priv/repo/migrations/20260826150000_add_request_id_to_audit_logs.exs
@@ -1,0 +1,9 @@
+defmodule Hexpm.RepoBase.Migrations.AddRequestIdToAuditLogs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:audit_logs) do
+      add :request_id, :string
+    end
+  end
+end

--- a/test/hexpm/accounts/audit_log_test.exs
+++ b/test/hexpm/accounts/audit_log_test.exs
@@ -12,6 +12,22 @@ defmodule Hexpm.Accounts.AuditLogTest do
   end
 
   describe "build/4" do
+    test "carries the request id when the audit data has one", %{user: user, key: key} do
+      audit_data = %{
+        user: user,
+        auth_credential: key,
+        user_agent: "user_agent",
+        remote_ip: "127.0.0.1",
+        request_id: "GM9dSL6BM4-SdLoAABnD"
+      }
+
+      audit = AuditLog.build(audit_data, "key.generate", key)
+      assert audit.request_id == "GM9dSL6BM4-SdLoAABnD"
+
+      audit = AuditLog.build(Map.delete(audit_data, :request_id), "key.generate", key)
+      assert audit.request_id == nil
+    end
+
     test "action password.reset.init" do
       audit_data = %{
         user: nil,

--- a/test/hexpm_web/controllers/api/key_controller_test.exs
+++ b/test/hexpm_web/controllers/api/key_controller_test.exs
@@ -135,6 +135,8 @@ defmodule HexpmWeb.API.KeyControllerTest do
       assert log.user_id == c.eric.id
       assert log.action == "key.generate"
       assert %{"name" => "macbook"} = log.params
+      assert [request_id] = get_resp_header(conn, "x-request-id")
+      assert log.request_id == request_id
     end
 
     test "create key without authentication returns 401" do

--- a/test/hexpm_web/endpoint_test.exs
+++ b/test/hexpm_web/endpoint_test.exs
@@ -10,4 +10,15 @@ defmodule HexpmWeb.EndpointTest do
 
     :telemetry.detach(ref)
   end
+
+  test "ignores a client-supplied request id" do
+    conn =
+      build_conn()
+      |> put_req_header("x-request-id", "client-chosen-id-000000001")
+      |> get("/diffs")
+
+    assert [request_id] = get_resp_header(conn, "x-request-id")
+    assert request_id != "client-chosen-id-000000001"
+    assert byte_size(request_id) >= 20
+  end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -199,7 +199,8 @@ defmodule Hexpm.TestHelpers do
       user: user,
       auth_credential: Keyword.get(opts, :auth_credential, Keyword.get(opts, :key)),
       user_agent: Keyword.get(opts, :user_agent, "TEST"),
-      remote_ip: Keyword.get(opts, :remote_ip, "127.0.0.1")
+      remote_ip: Keyword.get(opts, :remote_ip, "127.0.0.1"),
+      request_id: Keyword.get(opts, :request_id)
     }
   end
 


### PR DESCRIPTION
Adds `audit_logs.request_id` (nullable string, migration included) and fills it from the `x-request-id` header the endpoint assigns, through `ControllerHelpers.audit_data/1`, so a row can be matched to the request's log line in `logs.stdout` and to the `request-id` metadata on the debug copy of a published tarball (`s3.hex.pm/debug/`). Audit data built without a request (`AuditLogs.admin/0`, `system/1`, background jobs) leaves it empty; `build/3` reads the key with `Map.get`, so nothing else has to change. No index: lookups by request id are rare and a scan of the table is seconds.

Tests: `build/3` carries the id and tolerates its absence; `POST /api/keys` writes a `key.generate` row whose `request_id` equals the response's `x-request-id`. Full suite 2,820 passed, no error or warning lines.

Second commit: `Plug.RequestId` reuses a client-supplied `x-request-id` of 20 to 200 bytes, which would let a client pick the value stored here and on the log line and the debug tarball. The endpoint now deletes the incoming header before the plug, so every id is generated; neither the hex client nor the load balancer sets that header. Test: a request with its own `x-request-id` gets a different one back.
