### PR TITLE
Snooze preview and hexdocs jobs when the archive changes while processing

### DIFF
--- a/lib/hexpm/hexdocs/bucket.ex
+++ b/lib/hexpm/hexdocs/bucket.ex
@@ -1,5 +1,5 @@
 defmodule Hexpm.Hexdocs.Bucket do
-  alias Hexpm.Hexdocs.{Debouncer, FileRewriter, Utils}
+  alias Hexpm.Hexdocs.{Debouncer, Utils}
 
   @special_package_names Map.keys(Application.compile_env!(:hexpm, :hexdocs_special_packages))
   @gcs_put_debounce Application.compile_env!(:hexpm, :hexdocs_gcs_put_debounce)
@@ -124,56 +124,37 @@ defmodule Hexpm.Hexdocs.Bucket do
     {path, docs_config_cdn_key(repository, package), data, public?(repository)}
   end
 
-  def delete(repository, package, version, all_versions) do
-    deleting_latest? = Utils.latest_version?(package, version, all_versions)
-    new_latest = Utils.latest_version(all_versions -- [version])
-
-    cond do
-      deleting_latest? and new_latest ->
-        key = build_key(repository, package, new_latest)
-        tarball_path = Hexpm.TmpDir.tmp_file("docs-tarball")
-
-        case Hexpm.Store.get_to_file(:repo_bucket, key, tarball_path) do
-          :ok ->
-            {dir, files} =
-              Hexpm.Hexdocs.Tar.unpack_to_dir!({:file, tarball_path},
-                repository: repository,
-                package: package,
-                version: new_latest
-              )
-
-            FileRewriter.rewrite_files(dir, files)
-            uploads = list_upload_files(repository, package, new_latest, dir, files, :both)
-            paths = MapSet.new(uploads, &elem(&1, 0))
-            versions = [version, new_latest]
-            uploaded = upload_new_files(uploads)
-            delete_old_docs(repository, package, versions, paths, :both)
-
-            targets =
-              page_targets(repository, uploaded) ++
-                deleted_page_targets(repository, package, [version])
-
-            purge_hexdocs_cache(repository, package, versions, :both, targets)
-
-          nil ->
-            raise "Hexdocs archive not found in store: #{key}"
-        end
-
-      deleting_latest? ->
-        delete_old_docs(repository, package, [version], [], :both)
-        targets = deleted_page_targets(repository, package, [version, nil])
-        purge_hexdocs_cache(repository, package, [version], :both, targets)
-
-      true ->
-        delete_old_docs(repository, package, [version], [], :versioned)
-        targets = deleted_page_targets(repository, package, [version])
-        purge_hexdocs_cache(repository, package, [version], :versioned, targets)
-    end
+  def delete(repository, package, version, :both) do
+    delete_old_docs(repository, package, [version], [], :both)
+    targets = deleted_page_targets(repository, package, [version, nil])
+    purge_hexdocs_cache(repository, package, [version], :both, targets)
   end
 
-  defp build_key("hexpm", package, version), do: Path.join("docs", "#{package}-#{version}.tar.gz")
+  def delete(repository, package, version, :versioned) do
+    delete_old_docs(repository, package, [version], [], :versioned)
+    targets = deleted_page_targets(repository, package, [version])
+    purge_hexdocs_cache(repository, package, [version], :versioned, targets)
+  end
 
-  defp build_key(repository, package, version),
+  @doc "Replaces the removed latest `version` with `new_latest`, unpacked in `dir`."
+  def promote(repository, package, version, new_latest, dir, files) do
+    uploads = list_upload_files(repository, package, new_latest, dir, files, :both)
+    paths = MapSet.new(uploads, &elem(&1, 0))
+    versions = [version, new_latest]
+    uploaded = upload_new_files(uploads)
+    delete_old_docs(repository, package, versions, paths, :both)
+
+    targets =
+      page_targets(repository, uploaded) ++
+        deleted_page_targets(repository, package, [version])
+
+    purge_hexdocs_cache(repository, package, versions, :both, targets)
+  end
+
+  def archive_key("hexpm", package, version),
+    do: Path.join("docs", "#{package}-#{version}.tar.gz")
+
+  def archive_key(repository, package, version),
     do: Path.join(["repos", repository, "docs", "#{package}-#{version}.tar.gz"])
 
   defp list_upload_files(repository, package, version, dir, files, upload_type) do

--- a/lib/hexpm/hexdocs/hexdocs.ex
+++ b/lib/hexpm/hexdocs/hexdocs.ex
@@ -2,7 +2,7 @@ defmodule Hexpm.Hexdocs do
   require Logger
 
   alias Hexpm.Hexdocs.{Bucket, FileRewriter, PackageSitemap, Search, SourceRepo, Tar, Utils}
-  alias Hexpm.Repository.{Packages, Releases, Sitemaps}
+  alias Hexpm.Repository.{Assets, Packages, Releases, Sitemaps}
 
   @special_packages Application.compile_env!(:hexpm, :hexdocs_special_packages)
   @special_package_names Map.keys(@special_packages)
@@ -12,15 +12,23 @@ defmodule Hexpm.Hexdocs do
   # it has been told not to keep.
   @noindex_pages ~w(404.html search.html)
 
+  defmodule StaleArchiveError do
+    defexception [:key]
+
+    @impl true
+    def message(%{key: key}), do: "Hexdocs archive changed while processing: #{key}"
+  end
+
   def upload(key) do
     {repository, package, version} = key_components!(key)
     start = System.monotonic_time(:millisecond)
     Logger.info("UPLOAD #{key}")
 
     {version, all_versions, retired_versions} = versions(repository, package, version)
-    {dir, files} = download_and_unpack!(key, repository, package, version)
+    {dir, files, checksum} = download_and_unpack!(key, repository, package, version)
     FileRewriter.rewrite_files(dir, files)
     Bucket.upload(repository, package, version, all_versions, retired_versions, dir, files)
+    ensure_archive_current!(key, checksum)
 
     if Utils.latest_version?(package, version, all_versions) do
       update_index_sitemap(repository, key)
@@ -43,7 +51,7 @@ defmodule Hexpm.Hexdocs do
           :error when package in @special_package_names -> version
         end
 
-      {dir, files} = download_and_unpack!(key, repository, package, version)
+      {dir, files, checksum} = download_and_unpack!(key, repository, package, version)
 
       files_with_content =
         Enum.flat_map(files, fn path ->
@@ -63,6 +71,8 @@ defmodule Hexpm.Hexdocs do
           Search.delete(package, version)
           Logger.info("SKIPPING SEARCH INDEX #{key} (invalid or missing search items)")
       end
+
+      ensure_archive_current!(key, checksum)
     else
       Logger.warning("SKIPPING SEARCH INDEX #{key} (repository is not hexpm)")
     end
@@ -87,7 +97,7 @@ defmodule Hexpm.Hexdocs do
 
   def sitemap(key) do
     {repository, package, version} = key_components!(key)
-    {_dir, files} = download_and_unpack!(key, repository, package, version)
+    {_dir, files, _checksum} = download_and_unpack!(key, repository, package, version)
     update_index_sitemap(repository, key)
     update_package_sitemap(repository, key, package, files)
     :ok
@@ -142,14 +152,28 @@ defmodule Hexpm.Hexdocs do
 
     case Hexpm.Store.get_to_file(:repo_bucket, key, path) do
       :ok ->
-        Tar.unpack_to_dir!({:file, path},
-          repository: repository,
-          package: package,
-          version: version
-        )
+        {dir, files} =
+          Tar.unpack_to_dir!({:file, path},
+            repository: repository,
+            package: package,
+            version: version
+          )
+
+        {dir, files, Assets.file_checksum(path)}
 
       nil ->
         raise "Hexdocs archive not found in store: #{key}"
+    end
+  end
+
+  defp ensure_archive_current!(key, checksum) do
+    path = Hexpm.TmpDir.tmp_file("docs-tarball")
+
+    if Hexpm.Store.get_to_file(:repo_bucket, key, path) == :ok and
+         Assets.file_checksum(path) == checksum do
+      :ok
+    else
+      raise StaleArchiveError, key: key
     end
   end
 

--- a/lib/hexpm/hexdocs/hexdocs.ex
+++ b/lib/hexpm/hexdocs/hexdocs.ex
@@ -83,15 +83,40 @@ defmodule Hexpm.Hexdocs do
   def delete(key) do
     {repository, package, version} = key_components!(key)
 
-    if package in @special_package_names do
-      :ok
-    else
-      version = Version.parse!(version)
-      {all_versions, _retired_versions} = Releases.docs_versions(repository, package)
-      Bucket.delete(repository, package, version, all_versions)
-      update_index_sitemap(repository, key)
-      if repository == "hexpm", do: Search.delete(package, version)
-      :ok
+    cond do
+      package in @special_package_names ->
+        :ok
+
+      Releases.docs_exist?(repository, package, version) ->
+        upload(key)
+
+      true ->
+        version = Version.parse!(version)
+        {all_versions, _retired_versions} = Releases.docs_versions(repository, package)
+        delete_docs(repository, package, version, all_versions)
+        update_index_sitemap(repository, key)
+        if repository == "hexpm", do: Search.delete(package, version)
+        :ok
+    end
+  end
+
+  defp delete_docs(repository, package, version, all_versions) do
+    latest? = Utils.latest_version?(package, version, all_versions)
+    new_latest = if latest?, do: Utils.latest_version(all_versions -- [version])
+
+    cond do
+      new_latest ->
+        key = Bucket.archive_key(repository, package, new_latest)
+        {dir, files, checksum} = download_and_unpack!(key, repository, package, new_latest)
+        FileRewriter.rewrite_files(dir, files)
+        Bucket.promote(repository, package, version, new_latest, dir, files)
+        ensure_archive_current!(key, checksum)
+
+      latest? ->
+        Bucket.delete(repository, package, version, :both)
+
+      true ->
+        Bucket.delete(repository, package, version, :versioned)
     end
   end
 

--- a/lib/hexpm/hexdocs/queue.ex
+++ b/lib/hexpm/hexdocs/queue.ex
@@ -27,7 +27,7 @@ defmodule Hexpm.Hexdocs.Queue do
   @impl Broadway
   def handle_message(_processor, %Broadway.Message{} = message, _context) do
     with {:ok, data} <- JSON.decode(message.data),
-         {:ok, jobs} <- jobs_for(data),
+         {:ok, jobs} <- jobs_for(data, message.metadata[:message_id]),
          {:ok, _inserted} <- insert_jobs(jobs) do
       message
     else
@@ -39,55 +39,70 @@ defmodule Hexpm.Hexdocs.Queue do
 
   defp insert_jobs(jobs) do
     Hexpm.Repo.transaction(fn ->
-      Enum.map(jobs, fn {worker, key} ->
-        key
-        |> then(&worker.new(%{key: &1}))
+      Enum.map(jobs, fn {worker, args} ->
+        args
+        |> worker.new()
         |> Oban.insert!()
       end)
     end)
   end
 
-  defp jobs_for(%{"Event" => "s3:TestEvent"}), do: {:ok, []}
+  defp jobs_for(%{"Event" => "s3:TestEvent"}, _message_id), do: {:ok, []}
 
-  defp jobs_for(%{"Records" => records}) when is_list(records) do
+  defp jobs_for(%{"Records" => records}, message_id) when is_list(records) do
     Enum.reduce_while(records, {:ok, []}, fn record, {:ok, jobs} ->
-      case jobs_for_record(record) do
+      case jobs_for_record(record, message_id) do
         {:ok, record_jobs} -> {:cont, {:ok, jobs ++ record_jobs}}
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
   end
 
-  defp jobs_for(%{"hexdocs:upload" => key}) when is_binary(key),
-    do: {:ok, [{Workers.Upload, key}]}
+  defp jobs_for(%{"hexdocs:upload" => key}, _message_id) when is_binary(key),
+    do: {:ok, [{Workers.Upload, %{key: key}}]}
 
-  defp jobs_for(%{"hexdocs:search" => key}) when is_binary(key),
-    do: {:ok, [{Workers.Search, key}]}
+  defp jobs_for(%{"hexdocs:search" => key}, _message_id) when is_binary(key),
+    do: {:ok, [{Workers.Search, %{key: key}}]}
 
-  defp jobs_for(%{"hexdocs:sitemap" => key}) when is_binary(key),
-    do: {:ok, [{Workers.Sitemap, key}]}
+  defp jobs_for(%{"hexdocs:sitemap" => key}, _message_id) when is_binary(key),
+    do: {:ok, [{Workers.Sitemap, %{key: key}}]}
 
-  defp jobs_for(data), do: {:error, {:unsupported_hexdocs_message, data}}
+  defp jobs_for(data, _message_id), do: {:error, {:unsupported_hexdocs_message, data}}
 
-  defp jobs_for_record(%{"eventName" => "ObjectCreated:" <> _, "s3" => s3}) do
-    key = decode_s3_key(s3)
+  defp jobs_for_record(%{"eventName" => "ObjectCreated:" <> _, "s3" => s3}, message_id) do
+    jobs_for_object(s3, message_id, &created_workers/1)
+  end
+
+  defp jobs_for_record(%{"eventName" => "ObjectRemoved:" <> _, "s3" => s3}, message_id) do
+    jobs_for_object(s3, message_id, &removed_workers/1)
+  end
+
+  defp jobs_for_record(record, _message_id), do: {:error, {:unsupported_s3_record, record}}
+
+  defp created_workers("hexpm"), do: [Workers.Upload, Workers.Search]
+  defp created_workers(_repository), do: [Workers.Upload]
+
+  defp removed_workers(_repository), do: [Workers.Delete]
+
+  defp jobs_for_object(%{"object" => %{"key" => encoded_key} = object}, message_id, workers) do
+    key = URI.decode_www_form(encoded_key)
 
     case Hexpm.Hexdocs.key_components(key) do
-      {:ok, "hexpm", _package, _version} -> {:ok, [{Workers.Upload, key}, {Workers.Search, key}]}
-      {:ok, _repository, _package, _version} -> {:ok, [{Workers.Upload, key}]}
-      :error -> {:ok, []}
+      {:ok, repository, _package, _version} ->
+        args = job_args(key, object_generation(object) || message_id)
+        {:ok, Enum.map(workers.(repository), &{&1, args})}
+
+      :error ->
+        {:ok, []}
     end
   end
 
-  defp jobs_for_record(%{"eventName" => "ObjectRemoved:" <> _, "s3" => s3}) do
-    key = decode_s3_key(s3)
+  defp jobs_for_object(s3, _message_id, _workers), do: {:error, {:malformed_s3_object, s3}}
 
-    if Hexpm.Hexdocs.key_components(key) == :error,
-      do: {:ok, []},
-      else: {:ok, [{Workers.Delete, key}]}
+  defp job_args(key, nil), do: %{key: key}
+  defp job_args(key, generation), do: %{key: key, generation: generation}
+
+  defp object_generation(object) do
+    object["sequencer"] || object["versionId"] || object["eTag"]
   end
-
-  defp jobs_for_record(record), do: {:error, {:unsupported_s3_record, record}}
-
-  defp decode_s3_key(%{"object" => %{"key" => key}}), do: URI.decode_www_form(key)
 end

--- a/lib/hexpm/hexdocs/workers.ex
+++ b/lib/hexpm/hexdocs/workers.ex
@@ -53,11 +53,21 @@ defmodule Hexpm.Hexdocs.Workers.Delete do
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
+  require Logger
+
+  @stale_snooze 15
+
   @impl Oban.Worker
   def timeout(_job), do: 270_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"key" => key}}), do: Hexpm.Hexdocs.delete(key)
+  def perform(%Oban.Job{args: %{"key" => key}}) do
+    Hexpm.Hexdocs.delete(key)
+  rescue
+    Hexpm.Hexdocs.StaleArchiveError ->
+      Logger.info("STALE DOCS ARCHIVE #{key} snooze=#{@stale_snooze}s")
+      {:snooze, @stale_snooze}
+  end
 end
 
 defmodule Hexpm.Hexdocs.Workers.Sitemap do

--- a/lib/hexpm/hexdocs/workers.ex
+++ b/lib/hexpm/hexdocs/workers.ex
@@ -5,11 +5,21 @@ defmodule Hexpm.Hexdocs.Workers.Upload do
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
+  require Logger
+
+  @stale_snooze 15
+
   @impl Oban.Worker
   def timeout(_job), do: 270_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"key" => key}}), do: Hexpm.Hexdocs.upload(key)
+  def perform(%Oban.Job{args: %{"key" => key}}) do
+    Hexpm.Hexdocs.upload(key)
+  rescue
+    Hexpm.Hexdocs.StaleArchiveError ->
+      Logger.info("STALE DOCS ARCHIVE #{key} snooze=#{@stale_snooze}s")
+      {:snooze, @stale_snooze}
+  end
 end
 
 defmodule Hexpm.Hexdocs.Workers.Search do
@@ -19,11 +29,21 @@ defmodule Hexpm.Hexdocs.Workers.Search do
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
+  require Logger
+
+  @stale_snooze 15
+
   @impl Oban.Worker
   def timeout(_job), do: 270_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"key" => key}}), do: Hexpm.Hexdocs.search(key)
+  def perform(%Oban.Job{args: %{"key" => key}}) do
+    Hexpm.Hexdocs.search(key)
+  rescue
+    Hexpm.Hexdocs.StaleArchiveError ->
+      Logger.info("STALE DOCS ARCHIVE #{key} snooze=#{@stale_snooze}s")
+      {:snooze, @stale_snooze}
+  end
 end
 
 defmodule Hexpm.Hexdocs.Workers.Delete do

--- a/lib/hexpm/preview/preview.ex
+++ b/lib/hexpm/preview/preview.ex
@@ -8,6 +8,13 @@ defmodule Hexpm.Preview do
   @max_file_size 100 * 1000
   @readme_filenames ~w(README.md readme.md README.markdown readme.markdown README.txt readme.txt README readme)
 
+  defmodule StaleTarballError do
+    defexception [:key]
+
+    @impl true
+    def message(%{key: key}), do: "Preview tarball changed while processing: #{key}"
+  end
+
   @doc """
   Reads the file a request asked for.
 
@@ -227,7 +234,7 @@ defmodule Hexpm.Preview do
         delete_contents(repository, package, version)
 
       not tarball_current?(repository, package, version, checksum) ->
-        raise "Preview tarball changed while processing: #{Bucket.tarball_key(repository, package, version)}"
+        raise StaleTarballError, key: Bucket.tarball_key(repository, package, version)
 
       latest_version?(repository, package, version) ->
         Bucket.update_latest_version(repository, package, version)
@@ -244,7 +251,7 @@ defmodule Hexpm.Preview do
         delete_contents(repository, package, version)
 
       not tarball_current?(repository, package, version, checksum) ->
-        raise "Preview tarball changed while processing: #{Bucket.tarball_key(repository, package, version)}"
+        raise StaleTarballError, key: Bucket.tarball_key(repository, package, version)
 
       not latest_version?(repository, package, version) ->
         reconcile_latest(repository, package)
@@ -270,7 +277,7 @@ defmodule Hexpm.Preview do
             reconcile_latest(repository, package)
 
           not tarball_current?(repository, package, latest, checksum) ->
-            raise "Preview tarball changed while processing: #{Bucket.tarball_key(repository, package, latest)}"
+            raise StaleTarballError, key: Bucket.tarball_key(repository, package, latest)
 
           not latest_version?(repository, package, latest) ->
             reconcile_latest(repository, package)

--- a/lib/hexpm/preview/workers.ex
+++ b/lib/hexpm/preview/workers.ex
@@ -5,11 +5,21 @@ defmodule Hexpm.Preview.Workers.Upload do
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
+  require Logger
+
+  @stale_snooze 15
+
   @impl Oban.Worker
   def timeout(_job), do: 270_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"key" => key}}), do: Hexpm.Preview.upload(key)
+  def perform(%Oban.Job{args: %{"key" => key}}) do
+    Hexpm.Preview.upload(key)
+  rescue
+    Hexpm.Preview.StaleTarballError ->
+      Logger.info("STALE PREVIEW TARBALL #{key} snooze=#{@stale_snooze}s")
+      {:snooze, @stale_snooze}
+  end
 end
 
 defmodule Hexpm.Preview.Workers.Delete do
@@ -19,9 +29,19 @@ defmodule Hexpm.Preview.Workers.Delete do
     max_attempts: 5,
     unique: [period: :infinity, states: :incomplete, fields: [:worker, :args]]
 
+  require Logger
+
+  @stale_snooze 15
+
   @impl Oban.Worker
   def timeout(_job), do: 270_000
 
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"key" => key}}), do: Hexpm.Preview.delete(key)
+  def perform(%Oban.Job{args: %{"key" => key}}) do
+    Hexpm.Preview.delete(key)
+  rescue
+    Hexpm.Preview.StaleTarballError ->
+      Logger.info("STALE PREVIEW TARBALL #{key} snooze=#{@stale_snooze}s")
+      {:snooze, @stale_snooze}
+  end
 end

--- a/lib/hexpm/repository/releases.ex
+++ b/lib/hexpm/repository/releases.ex
@@ -54,13 +54,23 @@ defmodule Hexpm.Repository.Releases do
   end
 
   def exists?(repository, package, version) when is_binary(repository) and is_binary(package) do
+    release_query(repository, package, version)
+    |> Repo.exists?()
+  end
+
+  def docs_exist?(repository, package, version)
+      when is_binary(repository) and is_binary(package) do
+    from(r in release_query(repository, package, version), where: r.has_docs)
+    |> Repo.exists?()
+  end
+
+  defp release_query(repository, package, version) do
     from(r in Release,
       join: p in assoc(r, :package),
       join: repository in assoc(p, :repository),
       where: repository.name == ^repository and p.name == ^package and r.version == ^version,
       select: true
     )
-    |> Repo.exists?()
   end
 
   def latest_version(repository, package, opts)

--- a/test/hexpm/hexdocs/queue_test.exs
+++ b/test/hexpm/hexdocs/queue_test.exs
@@ -16,19 +16,72 @@ defmodule Hexpm.Hexdocs.QueueTest do
     }
 
     assert %{status: :ok} = handle(data)
-    assert_enqueued(worker: Workers.Upload, args: %{key: "docs/demo-1.0.0.tar.gz"})
-    assert_enqueued(worker: Workers.Search, args: %{key: "docs/demo-1.0.0.tar.gz"})
+
+    assert_enqueued(
+      worker: Workers.Upload,
+      args: %{key: "docs/demo-1.0.0.tar.gz", generation: "0001"}
+    )
+
+    assert_enqueued(
+      worker: Workers.Search,
+      args: %{key: "docs/demo-1.0.0.tar.gz", generation: "0001"}
+    )
   end
 
   test "inserts private uploads without search and removal jobs" do
-    assert %{status: :ok} =
-             handle(%{"Records" => [created("repos/org/docs/demo-1.0.0.tar.gz")]})
+    key = "repos/org/docs/demo-1.0.0.tar.gz"
+    assert %{status: :ok} = handle(%{"Records" => [created(key)]})
 
-    assert_enqueued(worker: Workers.Upload)
+    assert_enqueued(worker: Workers.Upload, args: %{key: key, generation: "0001"})
     refute_enqueued(worker: Workers.Search)
 
     assert %{status: :ok} = handle(%{"Records" => [removed("docs/demo-1.0.0.tar.gz")]})
-    assert_enqueued(worker: Workers.Delete)
+
+    assert_enqueued(
+      worker: Workers.Delete,
+      args: %{key: "docs/demo-1.0.0.tar.gz", generation: "0001"}
+    )
+  end
+
+  test "keeps distinct object generations for the same key" do
+    key = "docs/demo-1.0.0.tar.gz"
+
+    assert %{status: :ok} = handle(%{"Records" => [created(key, "0001")]})
+    assert %{status: :ok} = handle(%{"Records" => [created(key, "0002")]})
+
+    assert_enqueued(worker: Workers.Upload, args: %{key: key, generation: "0001"})
+    assert_enqueued(worker: Workers.Upload, args: %{key: key, generation: "0002"})
+    assert_enqueued(worker: Workers.Search, args: %{key: key, generation: "0001"})
+    assert_enqueued(worker: Workers.Search, args: %{key: key, generation: "0002"})
+    assert length(all_enqueued()) == 4
+  end
+
+  test "uses each available object generation field before the message id" do
+    records = [
+      record("ObjectCreated:Put", %{
+        "key" => "docs/demo-1.0.0.tar.gz",
+        "versionId" => "version-id"
+      }),
+      record("ObjectCreated:Put", %{"key" => "docs/demo-2.0.0.tar.gz", "eTag" => "etag"}),
+      record("ObjectCreated:Put", %{"key" => "docs/demo-3.0.0.tar.gz"})
+    ]
+
+    assert %{status: :ok} = handle(%{"Records" => records})
+
+    assert_enqueued(
+      worker: Workers.Upload,
+      args: %{key: "docs/demo-1.0.0.tar.gz", generation: "version-id"}
+    )
+
+    assert_enqueued(
+      worker: Workers.Upload,
+      args: %{key: "docs/demo-2.0.0.tar.gz", generation: "etag"}
+    )
+
+    assert_enqueued(
+      worker: Workers.Upload,
+      args: %{key: "docs/demo-3.0.0.tar.gz", generation: "message-1"}
+    )
   end
 
   test "supports custom upload, search, and sitemap messages" do
@@ -38,13 +91,21 @@ defmodule Hexpm.Hexdocs.QueueTest do
           {"hexdocs:sitemap", Workers.Sitemap}
         ] do
       assert %{status: :ok} = handle(%{event => "docs/demo-1.0.0.tar.gz"})
-      assert_enqueued(worker: worker)
+      assert [%{args: args}] = all_enqueued(worker: worker)
+      assert args == %{"key" => "docs/demo-1.0.0.tar.gz"}
     end
   end
 
   test "fails the whole message before inserting any jobs when a record is invalid" do
     data = %{"Records" => [created("docs/demo-1.0.0.tar.gz"), %{"eventName" => "unknown"}]}
     assert %{status: {:failed, {:unsupported_s3_record, _record}}} = handle(data)
+    assert all_enqueued() == []
+  end
+
+  test "fails malformed S3 object payloads" do
+    data = %{"Records" => [%{"eventName" => "ObjectCreated:Put", "s3" => %{"object" => %{}}}]}
+
+    assert %{status: {:failed, {:malformed_s3_object, _s3}}} = handle(data)
     assert all_enqueued() == []
   end
 
@@ -58,13 +119,21 @@ defmodule Hexpm.Hexdocs.QueueTest do
   defp handle(data) do
     message = %Broadway.Message{
       data: JSON.encode!(data),
+      metadata: %{message_id: "message-1"},
       acknowledger: {Broadway.NoopAcknowledger, nil, nil}
     }
 
     Queue.handle_message(:default, message, %{})
   end
 
-  defp created(key), do: record("ObjectCreated:Put", key)
-  defp removed(key), do: record("ObjectRemoved:Delete", key)
-  defp record(event, key), do: %{"eventName" => event, "s3" => %{"object" => %{"key" => key}}}
+  defp created(key, generation \\ "0001"), do: record("ObjectCreated:Put", key, generation)
+  defp removed(key, generation \\ "0001"), do: record("ObjectRemoved:Delete", key, generation)
+
+  defp record(event, key, generation) do
+    record(event, %{"key" => key, "sequencer" => generation})
+  end
+
+  defp record(event, object) do
+    %{"eventName" => event, "s3" => %{"object" => object}}
+  end
 end

--- a/test/hexpm/hexdocs/workers_test.exs
+++ b/test/hexpm/hexdocs/workers_test.exs
@@ -54,9 +54,26 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") =~ "plausible"
     assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/index.html") =~ "plausible"
 
+    Ecto.Changeset.change(release, has_docs: false) |> Repo.update!()
     assert :ok = perform_job(Workers.Delete, %{key: key})
     assert :ok = perform_job(Workers.Delete, %{key: key})
     assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") == nil
+  end
+
+  test "a stale delete event restores docs that still exist" do
+    package = insert(:package, name: "stale_delete_docs", docs_updated_at: DateTime.utc_now())
+    release = insert(:release, package: package, version: "1.0.0", has_docs: true)
+    key = "docs/#{package.name}-#{release.version}.tar.gz"
+
+    Hexpm.Store.put(
+      :repo_bucket,
+      key,
+      create_docs_tar([{"index.html", "<html><head></head></html>"}])
+    )
+
+    assert :ok = perform_job(Workers.Delete, %{key: key})
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") =~ "plausible"
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/index.html") =~ "plausible"
   end
 
   test "upload and delete verify the purged pages through their index.html" do
@@ -87,6 +104,7 @@ defmodule Hexpm.Hexdocs.WorkersTest do
       }
     )
 
+    Ecto.Changeset.change(release, has_docs: false) |> Repo.update!()
     assert :ok = perform_job(Workers.Delete, %{key: key})
 
     assert_enqueued(
@@ -282,6 +300,25 @@ defmodule Hexpm.Hexdocs.WorkersTest do
 
       assert {:snooze, 15} = perform_job(Workers.Search, %{key: key, generation: "0001"})
     end)
+  end
+
+  test "deleting latest docs snoozes when the fallback archive changes while promoting" do
+    package =
+      insert(:package, name: "replaced_fallback_docs", docs_updated_at: DateTime.utc_now())
+
+    fallback = insert(:release, package: package, version: "1.0.0", has_docs: true)
+    removed = insert(:release, package: package, version: "2.0.0", has_docs: false)
+    fallback_key = "docs/#{package.name}-#{fallback.version}.tar.gz"
+    removed_key = "docs/#{package.name}-#{removed.version}.tar.gz"
+    Hexpm.Store.put(:repo_bucket, fallback_key, create_docs_tar([{"index.html", "old"}]))
+    Hexpm.Store.put(:docs_bucket, "#{package.name}/index.html", "removed latest")
+    use_replacing_store(fallback_key, create_docs_tar([{"index.html", "new"}]))
+
+    assert {:snooze, 15} = perform_job(Workers.Delete, %{key: removed_key, generation: "0001"})
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") =~ "old"
+
+    assert :ok = perform_job(Workers.Delete, %{key: removed_key, generation: "0001"})
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") =~ "new"
   end
 
   defp use_replacing_store(key, replacement) do

--- a/test/hexpm/hexdocs/workers_test.exs
+++ b/test/hexpm/hexdocs/workers_test.exs
@@ -4,6 +4,40 @@ defmodule Hexpm.Hexdocs.WorkersTest do
 
   alias Hexpm.Hexdocs.Workers
 
+  defmodule ReplacingStore do
+    @behaviour Hexpm.Store.Behaviour
+    @replacement_key {__MODULE__, :replacement}
+
+    defdelegate list(bucket, prefix), to: Hexpm.Store.Memory
+    defdelegate get(bucket, key, opts), to: Hexpm.Store.Memory
+    defdelegate size(bucket, key), to: Hexpm.Store.Memory
+    defdelegate stream(bucket, key), to: Hexpm.Store.Memory
+    defdelegate put(bucket, key, body, opts), to: Hexpm.Store.Memory
+    defdelegate put_file(bucket, key, path, opts), to: Hexpm.Store.Memory
+    defdelegate delete(bucket, key), to: Hexpm.Store.Memory
+    defdelegate delete_many(bucket, keys), to: Hexpm.Store.Memory
+
+    # Serves the object once and then replaces it, so a job unpacks one
+    # archive and finds another when it checks the store afterwards.
+    def get_to_file(bucket, key, path, opts) do
+      result = Hexpm.Store.Memory.get_to_file(bucket, key, path, opts)
+
+      case :persistent_term.get(@replacement_key, nil) do
+        {^key, body} ->
+          :persistent_term.erase(@replacement_key)
+          Hexpm.Store.Memory.put(bucket, key, body, [])
+
+        _other ->
+          :ok
+      end
+
+      result
+    end
+
+    def replace_after_read(key, body), do: :persistent_term.put(@replacement_key, {key, body})
+    def clear, do: :persistent_term.erase(@replacement_key)
+  end
+
   test "upload and delete are repeatable for public documentation" do
     package = insert(:package, name: "worker_docs", docs_updated_at: DateTime.utc_now())
     release = insert(:release, package: package, version: "1.0.0", has_docs: true)
@@ -212,6 +246,53 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     assert_raise Hexpm.Hexdocs.Tar.UnpackError, fn ->
       perform_job(Workers.Search, %{key: key})
     end
+  end
+
+  test "upload snoozes when the archive changes while docs are uploading" do
+    package = insert(:package, name: "replaced_docs", docs_updated_at: DateTime.utc_now())
+    release = insert(:release, package: package, version: "1.0.0", has_docs: true)
+    key = "docs/#{package.name}-#{release.version}.tar.gz"
+    index = "<html><head></head></html>"
+
+    Hexpm.Store.put(
+      :repo_bucket,
+      key,
+      create_docs_tar([{"index.html", index}, {"old.html", "old"}])
+    )
+
+    use_replacing_store(key, create_docs_tar([{"index.html", index}, {"new.html", "new"}]))
+
+    assert {:snooze, 15} = perform_job(Workers.Upload, %{key: key, generation: "0001"})
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/old.html") =~ "old"
+
+    assert :ok = perform_job(Workers.Upload, %{key: key, generation: "0002"})
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/old.html") == nil
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/new.html") =~ "new"
+  end
+
+  test "search snoozes when the archive changes while indexing" do
+    package = insert(:package, name: "replaced_search_docs")
+    release = insert(:release, package: package, version: "1.0.0", has_docs: true)
+    key = "docs/#{package.name}-#{release.version}.tar.gz"
+    Hexpm.Store.put(:repo_bucket, key, create_docs_tar([{"index.html", "old"}]))
+    use_replacing_store(key, create_docs_tar([{"index.html", "new"}]))
+
+    use_search_mock(fn ->
+      expect(Hexpm.Hexdocs.Search.Mock, :delete, fn _name, _version -> :ok end)
+
+      assert {:snooze, 15} = perform_job(Workers.Search, %{key: key, generation: "0001"})
+    end)
+  end
+
+  defp use_replacing_store(key, replacement) do
+    original = Application.fetch_env!(:hexpm, :repo_bucket)
+    Application.put_env(:hexpm, :repo_bucket, {ReplacingStore, "repo_bucket"})
+    ReplacingStore.replace_after_read(key, replacement)
+
+    on_exit(fn ->
+      ReplacingStore.clear()
+      Application.put_env(:hexpm, :repo_bucket, original)
+    end)
   end
 
   defp use_search_mock(fun) do

--- a/test/hexpm/preview/workers_test.exs
+++ b/test/hexpm/preview/workers_test.exs
@@ -231,7 +231,7 @@ defmodule Hexpm.Preview.WorkersTest do
     )
   end
 
-  test "upload retries when the source tarball changes while files are uploading" do
+  test "upload snoozes when the source tarball changes while files are uploading" do
     package = insert(:package, name: "replacement_preview")
     release = insert(:release, package: package, version: "1.0.0")
     key = "tarballs/#{package.name}-#{release.version}.tar"
@@ -244,16 +244,27 @@ defmodule Hexpm.Preview.WorkersTest do
       Hexpm.Store.Memory.put("repo_bucket", key, replacement, [])
     end)
 
-    assert_raise RuntimeError, ~r/Preview tarball changed while processing/, fn ->
-      perform_job(Workers.Upload, %{key: key, generation: "0001"})
-    end
-
+    assert {:snooze, 15} = perform_job(Workers.Upload, %{key: key, generation: "0001"})
     assert :ok = perform_job(Workers.Upload, %{key: key, generation: "0002"})
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/old.txt") == nil
     assert Hexpm.Store.get(:preview_bucket, "files/#{package.name}/1.0.0/new.txt") == "new"
 
     assert JSON.decode!(Hexpm.Store.get(:preview_bucket, "file_lists/#{package.name}-1.0.0.json")) ==
              ["new.txt"]
+  end
+
+  test "delete snoozes when the source tarball changes while it restores the release" do
+    package = insert(:package, name: "replacement_delete_preview")
+    release = insert(:release, package: package, version: "1.0.0")
+    key = "tarballs/#{package.name}-#{release.version}.tar"
+    put_tarball(key, package.name, to_string(release.version), [{"old.txt", "old"}])
+    replacement = tarball(package.name, to_string(release.version), [{"new.txt", "new"}])
+
+    use_action_store("files/#{package.name}/1.0.0/old.txt", fn ->
+      Hexpm.Store.Memory.put("repo_bucket", key, replacement, [])
+    end)
+
+    assert {:snooze, 15} = perform_job(Workers.Delete, %{key: key, generation: "0001"})
   end
 
   @tag :capture_log


### PR DESCRIPTION
A publish that replaces a tarball while `Preview.Workers.Upload` is processing it fails the job's post-write checksum check. The job raised, which retried it through Oban and, since #1841, reported every attempt to Sentry. The stale read is the expected outcome of a concurrent replace, so the preview workers now rescue `Hexpm.Preview.StaleTarballError` and return `{:snooze, 15}`: the same reschedule, with no error and no spent attempt.

Hexdocs had the same race with no guard. Its jobs carried only the key, and uniqueness over incomplete states deduplicated a docs publish that arrived while an upload of the same key was executing, so the second archive was never processed. In prod `audit_logs` over the last 30 days, 58 `docs.publish` entries came within 25 s of a previous publish of the same package and version. The hexdocs queue now puts the S3 object generation in the job args like the preview queue does, upload and search checksum the archive after writing and snooze on a mismatch, and a malformed S3 record fails the message instead of raising.

`Hexdocs.delete/1` removed the docs whenever an `ObjectRemoved` job ran, so a removal processed after the same version was published again took live docs down. It now checks the release's `has_docs` first and runs the upload instead when the docs exist, as `Preview.delete/1` does. Promoting the next version after deleting the latest downloaded that archive inside `Bucket.delete` with no check that it stayed the same; the download now goes through `Hexdocs.download_and_unpack!/4`, `Bucket.promote/6` writes it, and the archive is checksummed afterwards so `Workers.Delete` snoozes on a mismatch too.

Fixes HEXPM-D8
