### PR TITLE
Write audit archive objects at the top of the bucket

### DIFF
--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -281,9 +281,8 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
   defp archive(schema, run, seq, rows) do
     table = schema.__schema__(:source)
     archived_at = DateTime.to_iso8601(run.archived_at)
-    date = run.archived_at |> DateTime.to_date() |> Date.to_iso8601()
     seq = seq |> Integer.to_string() |> String.pad_leading(4, "0")
-    key = "#{table}/dt=#{date}/#{run.name}-#{seq}.json.gz"
+    key = "#{table}-#{run.name}-#{seq}.json.gz"
 
     lines =
       Enum.map(rows, fn {id, row} ->

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -655,10 +655,9 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
 
       PurgeExpiredRecords.run(batch_size: 2)
 
-      assert [first, second, third] = Enum.sort(Hexpm.Store.list(:audit_bucket, "oauth_tokens/"))
+      assert [first, second, third] = Enum.sort(Hexpm.Store.list(:audit_bucket, "oauth_tokens-"))
 
-      assert first =~
-               ~r"^oauth_tokens/dt=\d{4}-\d{2}-\d{2}/\d{8}T\d{6}Z-[0-9a-f]{8}-0001\.json\.gz$"
+      assert first =~ ~r"^oauth_tokens-\d{8}T\d{6}Z-[0-9a-f]{8}-0001\.json\.gz$"
 
       run = String.replace_suffix(first, "-0001.json.gz", "")
       assert second == run <> "-0002.json.gz"
@@ -787,7 +786,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
 
   defp archived_rows(table) do
     :audit_bucket
-    |> Hexpm.Store.list("#{table}/")
+    |> Hexpm.Store.list("#{table}-")
     |> Enum.sort()
     |> Enum.flat_map(&archived_lines/1)
   end


### PR DESCRIPTION
The audit transfer's first run (04:00 UTC 2026-08-27) loaded nothing: its log says `No files found matching: "gs://hexpm-audit-prod/*"` while the 02:00 purge had written 13 objects under `<table>/dt=2026-08-27/`. The Data Transfer Service wildcard doesn't match past a `/`.

Objects are now `<table>-<run>-<seq>.json.gz` at the top of the bucket, e.g. `oauth_tokens-20260827T020000Z-a1673381-0001.json.gz`; the run name carries the date. The transfer config is unchanged; hexpm-ops #265 updates the doc and the terraform comment. The 13 objects from the first run were copied to the new names by hand so the next 04:00 run loads them (the originals can't be deleted for ten years and are never matched).
