### PR TITLE
Drop grant_reference from archived OAuth tokens

### DIFF
--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -26,7 +26,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
   @redacted %{
     Hexpm.OAuth.AuthorizationCode => ~w(code code_challenge),
     Hexpm.OAuth.DeviceCode => ~w(device_code user_code verification_uri_complete),
-    Hexpm.OAuth.Token => ~w(refresh_token_hash),
+    Hexpm.OAuth.Token => ~w(refresh_token_hash grant_reference),
     Hexpm.UserSession => ~w(session_token),
     Hexpm.Accounts.PasswordReset => ~w(key),
     Hexpm.Accounts.AccountDeletionRequest => ~w(key),

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -507,7 +507,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
     @credentials %{
       "authorization_codes" => ~w(code code_challenge),
       "device_codes" => ~w(device_code user_code verification_uri_complete),
-      "oauth_tokens" => ~w(refresh_token_hash),
+      "oauth_tokens" => ~w(refresh_token_hash grant_reference),
       "user_sessions" => ~w(session_token),
       "password_resets" => ~w(key),
       "account_deletion_requests" => ~w(key),


### PR DESCRIPTION
`oauth_tokens.grant_reference` is the credential the client exchanged for the token, stored verbatim: the authorization code, the device code, or the full refresh-token JWT (`oauth_controller.ex` `handle_refresh_token_grant`, `device_codes.ex` `create_token`). All three are dead by the time the row is purged (the code and device code are single-use, the parent token is revoked in the same transaction as the child), but the archive redacts exactly this material from the other tables and keeps objects for ten years, so the purge now drops it with `refresh_token_hash`. The refresh chain stays recoverable through `user_session_id` and `inserted_at`.

The 69,453 token rows archived on 2026-08-27 and 2026-08-28 were scrubbed in BigQuery with `UPDATE archived_rows SET row = JSON_REMOVE(row, '$.grant_reference') WHERE source_table = 'oauth_tokens'` (0 rows with the key afterwards); the bucket objects keep it. Doc: hexpm-ops #266.
