### PR TITLE
Render additional package documentation files

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -123,7 +123,7 @@ window.liveSocket = liveSocket;
 var readmeFrame = document.getElementById("readme-frame");
 
 window.addEventListener("message", function (event) {
-  if (!event.data || !readmeFrame) return;
+  if (!event.data || !readmeFrame || event.source !== readmeFrame.contentWindow) return;
 
   if (
     event.data.type === "readme-height" &&
@@ -144,5 +144,33 @@ window.addEventListener("message", function (event) {
     readmeFrame.remove();
     var fallback = document.getElementById("readme-fallback");
     if (fallback) fallback.classList.remove("hidden");
+  }
+
+  if (event.data.type === "doc-files" && Array.isArray(event.data.kinds)) {
+    var kinds = event.data.kinds.filter(function (k) {
+      return typeof k === "string";
+    });
+
+    if (kinds.length > 1) {
+      document.querySelectorAll("[data-doc-kind]").forEach(function (el) {
+        if (kinds.indexOf(el.getAttribute("data-doc-kind")) >= 0) {
+          el.removeAttribute("hidden");
+        }
+      });
+
+      var sidebar = document.getElementById("doc-sidebar");
+      if (sidebar) {
+        sidebar.classList.remove("hidden");
+        sidebar.classList.add("flex");
+      }
+    }
+
+    if (typeof event.data.source === "string" && event.data.source.length <= 255) {
+      var source = document.getElementById("doc-source");
+      if (source) {
+        source.textContent = "From " + event.data.source;
+        source.classList.remove("hidden");
+      }
+    }
   }
 });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -152,9 +152,14 @@ window.addEventListener("message", function (event) {
       return typeof k === "string";
     });
 
-    if (kinds.length > 1) {
+    var hideRail = kinds.length === 0 || (kinds.length === 1 && kinds[0] === "readme");
+
+    if (!hideRail) {
       document.querySelectorAll("[data-doc-kind]").forEach(function (el) {
-        if (kinds.indexOf(el.getAttribute("data-doc-kind")) >= 0) {
+        if (
+          kinds.indexOf(el.getAttribute("data-doc-kind")) >= 0 ||
+          el.getAttribute("aria-current") === "page"
+        ) {
           el.removeAttribute("hidden");
         }
       });

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -162,7 +162,7 @@ window.addEventListener("message", function (event) {
       var sidebar = document.getElementById("doc-sidebar");
       if (sidebar) {
         sidebar.classList.remove("hidden");
-        sidebar.classList.add("flex");
+        sidebar.classList.add("md:flex");
       }
     }
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -121,9 +121,10 @@ window.liveSocket = liveSocket;
 
 // README iframe: show spinner until loaded, fall back to description if no readme
 var readmeFrame = document.getElementById("readme-frame");
+var readmeFrameWindow = readmeFrame && readmeFrame.contentWindow;
 
 window.addEventListener("message", function (event) {
-  if (!event.data || !readmeFrame || event.source !== readmeFrame.contentWindow) return;
+  if (!event.data || !readmeFrame || event.source !== readmeFrameWindow) return;
 
   if (
     event.data.type === "readme-height" &&

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -161,7 +161,6 @@ window.addEventListener("message", function (event) {
 
       var sidebar = document.getElementById("doc-sidebar");
       if (sidebar) {
-        sidebar.classList.remove("hidden");
         sidebar.classList.add("md:flex");
       }
     }

--- a/lib/hexpm/http.ex
+++ b/lib/hexpm/http.ex
@@ -31,9 +31,16 @@ defmodule Hexpm.HTTP do
 
   @impl Hexpm.HTTP.Interface
   def get(url, headers, opts \\ []) do
-    build_request(:get, url, headers, nil, opts)
-    |> Finch.request(Hexpm.Finch)
-    |> read_response()
+    case Keyword.pop(opts, :max_body_size) do
+      {nil, opts} ->
+        build_request(:get, url, headers, nil, opts)
+        |> Finch.request(Hexpm.Finch)
+        |> read_response()
+
+      {max_body_size, opts} ->
+        build_request(:get, url, headers, nil, opts)
+        |> stream_get(max_body_size)
+    end
   end
 
   @impl Hexpm.HTTP.Interface
@@ -67,6 +74,64 @@ defmodule Hexpm.HTTP do
   defp build_request(method, url, headers, body, opts) do
     params = encode_params(body, headers)
     Finch.build(method, url, headers, params, opts)
+  end
+
+  # Streams the response body, aborting as soon as more than `max_body_size`
+  # bytes have been received, without buffering the rest. Also rejects early
+  # if the response declares a content-length larger than the limit.
+  defp stream_get(request, max_body_size) do
+    acc = %{status: nil, headers: [], body: [], size: 0, too_large: false}
+
+    fun = fn
+      {:status, value}, acc ->
+        {:cont, %{acc | status: value}}
+
+      {:headers, value}, acc ->
+        headers = acc.headers ++ value
+
+        if content_length_too_large?(headers, max_body_size) do
+          {:halt, %{acc | headers: headers, too_large: true}}
+        else
+          {:cont, %{acc | headers: headers}}
+        end
+
+      {:data, value}, acc ->
+        size = acc.size + byte_size(value)
+
+        if size > max_body_size do
+          {:halt, %{acc | size: size, too_large: true}}
+        else
+          {:cont, %{acc | body: [acc.body, value], size: size}}
+        end
+
+      {:trailers, _value}, acc ->
+        {:cont, acc}
+    end
+
+    case Finch.stream_while(request, Hexpm.Finch, acc, fun) do
+      {:ok, %{too_large: true}} ->
+        {:error, :body_too_large}
+
+      {:ok, %{status: status, headers: headers, body: body}} ->
+        params = decode_body(IO.iodata_to_binary(body), headers)
+        {:ok, status, headers, params}
+
+      {:error, reason, _acc} ->
+        {:error, reason}
+    end
+  end
+
+  defp content_length_too_large?(headers, max_body_size) do
+    case List.keyfind(headers, "content-length", 0) do
+      {_, value} ->
+        case Integer.parse(value) do
+          {length, _} -> length > max_body_size
+          :error -> false
+        end
+
+      nil ->
+        false
+    end
   end
 
   defp encode_params(body, _headers) when is_binary(body) or is_nil(body) do

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -250,6 +250,7 @@ defmodule HexpmWeb.Components.PackageLayout do
                         kind
                       )
                     }
+                    aria-current={@doc_kind == kind && "page"}
                     class={mobile_tab_class(@doc_kind == kind)}
                   >
                     <div class="flex min-w-0 items-center gap-3">

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -237,25 +237,34 @@ defmodule HexpmWeb.Components.PackageLayout do
             </summary>
 
             <div class="package-tabs-mobile-menu absolute inset-x-0 top-full z-20 mt-2 overflow-hidden rounded-xl border border-grey-200 bg-white shadow-lg dark:border-grey-700 dark:bg-grey-800">
-              <%= for kind <- Files.kinds(), kind != :readme do %>
-                <a
-                  data-doc-kind={kind}
-                  hidden
-                  href={doc_page_path(assigns, kind)}
-                  class={mobile_tab_class(@doc_kind == kind)}
-                >
-                  <div class="flex min-w-0 items-center gap-3">
-                    {HexpmWeb.ViewIcons.icon(:heroicon, "document",
-                      class: "size-4.5 shrink-0 text-grey-500 dark:text-grey-300"
-                    )}
-                    <span class="truncate pl-4">{Files.label(kind)}</span>
-                  </div>
-                  <%= if @doc_kind == kind do %>
-                    {HexpmWeb.ViewIcons.icon(:heroicon, "check",
-                      class: "size-4 shrink-0 text-primary-default dark:text-white"
-                    )}
-                  <% end %>
-                </a>
+              <%= if ViewHelpers.main_repository?(@package) && @current_release do %>
+                <%= for kind <- Files.kinds(), kind != :readme do %>
+                  <a
+                    data-doc-kind={kind}
+                    hidden
+                    href={
+                      HexpmWeb.PackageView.doc_page_path(
+                        @package,
+                        @current_release,
+                        @version_pinned?,
+                        kind
+                      )
+                    }
+                    class={mobile_tab_class(@doc_kind == kind)}
+                  >
+                    <div class="flex min-w-0 items-center gap-3">
+                      {HexpmWeb.ViewIcons.icon(:heroicon, "document",
+                        class: "size-4.5 shrink-0 text-grey-500 dark:text-grey-300"
+                      )}
+                      <span class="truncate pl-4">{Files.label(kind)}</span>
+                    </div>
+                    <%= if @doc_kind == kind do %>
+                      {HexpmWeb.ViewIcons.icon(:heroicon, "check",
+                        class: "size-4 shrink-0 text-primary-default dark:text-white"
+                      )}
+                    <% end %>
+                  </a>
+                <% end %>
               <% end %>
               <%= for tab <- @tabs do %>
                 <a
@@ -693,17 +702,6 @@ defmodule HexpmWeb.Components.PackageLayout do
        do: ViewHelpers.path_for_release(package, release)
 
   defp readme_path(%{package: package}), do: ViewHelpers.path_for_package(package)
-
-  defp doc_page_path(assigns, :readme), do: readme_path(assigns)
-
-  defp doc_page_path(%{version_pinned?: true} = assigns, kind)
-       when not is_nil(assigns.current_release) do
-    "#{ViewHelpers.path_for_release(assigns.package, assigns.current_release)}/#{kind}"
-  end
-
-  defp doc_page_path(assigns, kind) do
-    "#{ViewHelpers.path_for_package(assigns.package)}/#{kind}"
-  end
 
   defp dependencies_tab_path(%{version_pinned?: true, package: package, current_release: release})
        when not is_nil(release),

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -20,6 +20,7 @@ defmodule HexpmWeb.Components.PackageLayout do
 
   alias Hexpm.Repository.Owners
   alias Hexpm.Security.Advisories
+  alias HexpmWeb.Docs.Files
   alias HexpmWeb.ViewHelpers
 
   @package_reports_enabled Application.compile_env!(:hexpm, [:features, :package_reports])
@@ -44,6 +45,7 @@ defmodule HexpmWeb.Components.PackageLayout do
   # Per-page assigns
   attr :active_tab, :atom, required: true
   attr :version_pinned?, :boolean, default: false
+  attr :doc_kind, :atom, default: :readme
 
   # Dependants tab data — only loaded on the dependants page
   attr :dependants, :list, default: []
@@ -235,6 +237,26 @@ defmodule HexpmWeb.Components.PackageLayout do
             </summary>
 
             <div class="package-tabs-mobile-menu absolute inset-x-0 top-full z-20 mt-2 overflow-hidden rounded-xl border border-grey-200 bg-white shadow-lg dark:border-grey-700 dark:bg-grey-800">
+              <%= for kind <- Files.kinds(), kind != :readme do %>
+                <a
+                  data-doc-kind={kind}
+                  hidden
+                  href={doc_page_path(assigns, kind)}
+                  class={mobile_tab_class(@doc_kind == kind)}
+                >
+                  <div class="flex min-w-0 items-center gap-3">
+                    {HexpmWeb.ViewIcons.icon(:heroicon, "document",
+                      class: "size-4.5 shrink-0 text-grey-500 dark:text-grey-300"
+                    )}
+                    <span class="truncate pl-4">{Files.label(kind)}</span>
+                  </div>
+                  <%= if @doc_kind == kind do %>
+                    {HexpmWeb.ViewIcons.icon(:heroicon, "check",
+                      class: "size-4 shrink-0 text-primary-default dark:text-white"
+                    )}
+                  <% end %>
+                </a>
+              <% end %>
               <%= for tab <- @tabs do %>
                 <a
                   href={tab.path}
@@ -576,7 +598,7 @@ defmodule HexpmWeb.Components.PackageLayout do
       %{
         active: assigns.active_tab == :readme,
         icon: "document-text",
-        label: "Readme",
+        label: "Documentation",
         path: readme_path(assigns)
       },
       %{
@@ -671,6 +693,17 @@ defmodule HexpmWeb.Components.PackageLayout do
        do: ViewHelpers.path_for_release(package, release)
 
   defp readme_path(%{package: package}), do: ViewHelpers.path_for_package(package)
+
+  defp doc_page_path(assigns, :readme), do: readme_path(assigns)
+
+  defp doc_page_path(%{version_pinned?: true} = assigns, kind)
+       when not is_nil(assigns.current_release) do
+    "#{ViewHelpers.path_for_release(assigns.package, assigns.current_release)}/#{kind}"
+  end
+
+  defp doc_page_path(assigns, kind) do
+    "#{ViewHelpers.path_for_package(assigns.package)}/#{kind}"
+  end
 
   defp dependencies_tab_path(%{version_pinned?: true, package: package, current_release: release})
        when not is_nil(release),

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -2,6 +2,7 @@ defmodule HexpmWeb.PackageController do
   use HexpmWeb, :controller
 
   alias Hexpm.Security.Advisories
+  alias HexpmWeb.Docs.Files
   alias HexpmWeb.PackageLayoutAssigns
 
   @packages_per_page 30
@@ -25,7 +26,29 @@ defmodule HexpmWeb.PackageController do
         end
 
       if release do
-        package(conn, repositories, package, releases, release, type)
+        package(conn, repositories, package, releases, release, type, :readme)
+      else
+        not_found(conn)
+      end
+    end)
+  end
+
+  def docs_file(conn, params) do
+    params = fixup_params(params)
+    kind = Files.parse_segment(conn.assigns.doc_kind)
+
+    access_package(conn, params, fn package, repositories ->
+      releases = Releases.all(package)
+
+      {release, type} =
+        if version = params["version"] do
+          {matching_release(releases, version), :release}
+        else
+          {Release.latest_version(releases, only_stable: true, unstable_fallback: true), :package}
+        end
+
+      if release && kind do
+        package(conn, repositories, package, releases, release, type, kind)
       else
         not_found(conn)
       end
@@ -222,7 +245,7 @@ defmodule HexpmWeb.PackageController do
     Enum.find(releases, &(to_string(&1.version) == version))
   end
 
-  defp package(conn, repositories, package, releases, release, type) do
+  defp package(conn, repositories, package, releases, release, type, doc_kind) do
     release =
       Releases.preload(release, [:requirements, :downloads, :publisher, :security_advisories])
 
@@ -241,7 +264,11 @@ defmodule HexpmWeb.PackageController do
       conn,
       "show.html",
       [
-        title: package.name,
+        title:
+          if(doc_kind == :readme,
+            do: package.name,
+            else: "#{Files.label(doc_kind)} · #{package.name}"
+          ),
         description: package.meta.description,
         container: "container",
         canonical_url: ~p"/packages/#{package}",
@@ -249,7 +276,8 @@ defmodule HexpmWeb.PackageController do
         version_pinned?: type == :release,
         dependants: dependants,
         audit_logs: audit_logs,
-        type: type
+        type: type,
+        doc_kind: doc_kind
       ] ++
         PackageLayoutAssigns.for_package(conn, package,
           releases: releases,

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -271,7 +271,7 @@ defmodule HexpmWeb.PackageController do
           ),
         description: package.meta.description,
         container: "container",
-        canonical_url: ~p"/packages/#{package}",
+        canonical_url: canonical_url(package, doc_kind),
         releases: releases,
         version_pinned?: type == :release,
         dependants: dependants,
@@ -287,6 +287,11 @@ defmodule HexpmWeb.PackageController do
         )
     )
   end
+
+  defp canonical_url(package, :readme), do: ~p"/packages/#{package}"
+
+  defp canonical_url(package, doc_kind),
+    do: "#{HexpmWeb.ViewHelpers.path_for_package(package)}/#{doc_kind}"
 
   defp show_docs_html_url(package, :package, _release, releases) do
     latest_release_with_docs =

--- a/lib/hexpm_web/controllers/readme_controller.ex
+++ b/lib/hexpm_web/controllers/readme_controller.ex
@@ -1,9 +1,10 @@
 defmodule HexpmWeb.ReadmeController do
   use HexpmWeb, :controller
 
+  alias HexpmWeb.Docs.Files
   alias HexpmWeb.Readme.{Sanitizer, TaskList, URLRewriter}
 
-  @readme_filenames ~w(README.md readme.md README.markdown readme.markdown README.txt readme.txt README readme)
+  @max_doc_size 2 * 1024 * 1024
 
   plug :put_root_layout, false
   plug :put_layout, false
@@ -14,7 +15,16 @@ defmodule HexpmWeb.ReadmeController do
     |> send_resp(404, "Not Found")
   end
 
-  def show(conn, %{"version" => version} = params) do
+  def show(conn, params), do: serve(conn, params, :readme)
+
+  def show_doc(conn, params) do
+    case Files.parse_segment(conn.assigns.doc_kind) do
+      nil -> not_found(conn, params)
+      kind -> serve(conn, params, kind)
+    end
+  end
+
+  defp serve(conn, %{"version" => version} = params, kind) do
     name = params["name"]
     package = Packages.get("hexpm", name)
 
@@ -22,16 +32,16 @@ defmodule HexpmWeb.ReadmeController do
       release = Enum.find(Releases.all(package), &(to_string(&1.version) == version))
 
       if release do
-        serve_readme(conn, package, release)
+        serve_doc(conn, package, release, kind)
       else
-        send_no_readme(conn)
+        send_not_found(conn, [])
       end
     else
-      send_no_readme(conn)
+      send_not_found(conn, [])
     end
   end
 
-  def show(conn, params) do
+  defp serve(conn, params, kind) do
     name = params["name"]
     package = Packages.get("hexpm", name)
 
@@ -47,62 +57,72 @@ defmodule HexpmWeb.ReadmeController do
       if release do
         conn
         |> put_resp_header("cache-control", "public, max-age=3600")
-        |> redirect(to: "/#{name}/#{release.version}")
+        |> redirect(to: doc_path(name, release.version, kind))
       else
-        send_no_readme(conn)
+        send_not_found(conn, [])
       end
     else
-      send_no_readme(conn)
+      send_not_found(conn, [])
     end
   end
 
-  defp serve_readme(conn, package, release) do
+  defp doc_path(name, version, :readme), do: "/#{name}/#{version}"
+  defp doc_path(name, version, kind), do: "/#{name}/#{version}/#{kind}"
+
+  defp serve_doc(conn, package, release, kind) do
     version = to_string(release.version)
 
-    case fetch_readme(package.name, version) do
-      {:ok, filename, content} ->
-        html = render_readme(filename, content, package.name, version)
+    case fetch_doc(package.name, version, kind) do
+      {:ok, filename, content, available} ->
+        html =
+          if byte_size(content) > @max_doc_size do
+            "<p>This file is too large to display on Hex.pm.</p>"
+          else
+            render_doc(filename, content, package.name, version)
+          end
 
         conn
         |> put_resp_header("cache-control", "public, max-age=86400")
-        |> render(:show, readme_html: html, parent_origins: parent_origins())
+        |> render(:show,
+          readme_html: html,
+          parent_origins: parent_origins(),
+          doc_kinds: Enum.map(available, &Atom.to_string/1),
+          doc_source: filename
+        )
 
-      :error ->
-        send_no_readme(conn)
+      {:error, available} ->
+        send_not_found(conn, available)
     end
   end
 
-  defp fetch_readme(package_name, version) do
+  defp fetch_doc(package_name, version, kind) do
     cdn_url = Application.fetch_env!(:hexpm, :cdn_url)
     file_list_url = "#{cdn_url}/preview-files/#{package_name}-#{version}.json"
 
     case Hexpm.HTTP.impl().get(file_list_url, []) do
       {:ok, 200, _headers, json} ->
         files = Jason.decode!(json)
+        available = Files.available_kinds(files)
 
-        case find_readme_file(files) do
+        case Files.resolve(kind, files) do
           nil ->
-            :error
+            {:error, available}
 
           filename ->
-            readme_url = "#{cdn_url}/preview/#{package_name}/#{version}/#{filename}"
+            doc_url = "#{cdn_url}/preview/#{package_name}/#{version}/#{filename}"
 
-            case Hexpm.HTTP.impl().get(readme_url, []) do
-              {:ok, 200, _headers, content} -> {:ok, filename, content}
-              _ -> :error
+            case Hexpm.HTTP.impl().get(doc_url, []) do
+              {:ok, 200, _headers, content} -> {:ok, filename, content, available}
+              _ -> {:error, available}
             end
         end
 
       _ ->
-        :error
+        {:error, []}
     end
   end
 
-  defp find_readme_file(files) do
-    Enum.find(@readme_filenames, &(&1 in files))
-  end
-
-  defp render_readme(filename, content, package_name, version) do
+  defp render_doc(filename, content, package_name, version) do
     ext = Path.extname(filename) |> String.downcase()
 
     html =
@@ -154,10 +174,13 @@ defmodule HexpmWeb.ReadmeController do
     |> String.replace("&#39;", "'")
   end
 
-  defp send_no_readme(conn) do
+  defp send_not_found(conn, available) do
     conn
     |> put_resp_header("cache-control", "public, max-age=3600")
-    |> render(:no_readme, parent_origins: parent_origins())
+    |> render(:no_readme,
+      parent_origins: parent_origins(),
+      doc_kinds: Enum.map(available, &Atom.to_string/1)
+    )
   end
 
   defp parent_origins do

--- a/lib/hexpm_web/controllers/readme_controller.ex
+++ b/lib/hexpm_web/controllers/readme_controller.ex
@@ -76,23 +76,43 @@ defmodule HexpmWeb.ReadmeController do
       {:ok, filename, content, available} ->
         html =
           if byte_size(content) > @max_doc_size do
-            "<p>This file is too large to display on Hex.pm.</p>"
+            too_large_notice(filename, package.name, version)
           else
             render_doc(filename, content, package.name, version)
           end
 
-        conn
-        |> put_resp_header("cache-control", "public, max-age=86400")
-        |> render(:show,
-          readme_html: html,
-          parent_origins: parent_origins(),
-          doc_kinds: Enum.map(available, &Atom.to_string/1),
-          doc_source: filename
-        )
+        render_show(conn, html, filename, available)
 
-      {:error, available} ->
-        send_not_found(conn, available)
+      {:error, :too_large, filename, available} ->
+        html = too_large_notice(filename, package.name, version)
+        render_show(conn, html, filename, available)
+
+      {:error, :not_found, available} ->
+        send_not_found(conn, available, cacheable: true)
+
+      {:error, :upstream_error, available} ->
+        send_not_found(conn, available, cacheable: false)
     end
+  end
+
+  defp render_show(conn, html, filename, available) do
+    conn
+    |> put_resp_header("cache-control", "public, max-age=86400")
+    |> render(:show,
+      readme_html: html,
+      parent_origins: parent_origins(),
+      doc_kinds: Enum.map(available, &Atom.to_string/1),
+      doc_source: filename
+    )
+  end
+
+  defp too_large_notice(filename, package_name, version) do
+    preview_url = Hexpm.Utils.preview_html_url(package_name, version)
+    escaped_filename = Plug.HTML.html_escape(filename)
+    escaped_url = Plug.HTML.html_escape(preview_url)
+
+    "<p>#{escaped_filename} is too large to display on Hex.pm. " <>
+      "<a href=\"#{escaped_url}\">View it in the file browser</a>.</p>"
   end
 
   defp fetch_doc(package_name, version, kind) do
@@ -100,25 +120,59 @@ defmodule HexpmWeb.ReadmeController do
     file_list_url = "#{cdn_url}/preview-files/#{package_name}-#{version}.json"
 
     case Hexpm.HTTP.impl().get(file_list_url, []) do
-      {:ok, 200, _headers, json} ->
-        files = Jason.decode!(json)
-        available = Files.available_kinds(files)
+      {:ok, 200, _headers, body} ->
+        case decode_file_list(body) do
+          {:ok, files} ->
+            resolved = Files.resolve_all(files)
+            available = Files.present_kinds(resolved)
 
-        case Files.resolve(kind, files) do
-          nil ->
-            {:error, available}
-
-          filename ->
-            doc_url = "#{cdn_url}/preview/#{package_name}/#{version}/#{filename}"
-
-            case Hexpm.HTTP.impl().get(doc_url, []) do
-              {:ok, 200, _headers, content} -> {:ok, filename, content, available}
-              _ -> {:error, available}
+            case Map.get(resolved, kind) do
+              nil -> {:error, :not_found, available}
+              filename -> fetch_document(cdn_url, package_name, version, filename, available)
             end
+
+          :error ->
+            {:error, :not_found, []}
         end
 
-      _ ->
-        {:error, []}
+      {:ok, status, _headers, _body} when status in 500..599 ->
+        {:error, :upstream_error, []}
+
+      {:ok, _status, _headers, _body} ->
+        {:error, :not_found, []}
+
+      {:error, _reason} ->
+        {:error, :upstream_error, []}
+    end
+  end
+
+  defp decode_file_list(body) when is_binary(body) do
+    case Jason.decode(body) do
+      {:ok, decoded} -> {:ok, decoded}
+      {:error, _} -> :error
+    end
+  end
+
+  defp decode_file_list(body), do: {:ok, body}
+
+  defp fetch_document(cdn_url, package_name, version, filename, available) do
+    doc_url = "#{cdn_url}/preview/#{package_name}/#{version}/#{filename}"
+
+    case Hexpm.HTTP.impl().get(doc_url, [], max_body_size: @max_doc_size) do
+      {:ok, 200, _headers, content} ->
+        {:ok, filename, content, available}
+
+      {:error, :body_too_large} ->
+        {:error, :too_large, filename, available}
+
+      {:ok, status, _headers, _body} when status in 500..599 ->
+        {:error, :upstream_error, available}
+
+      {:ok, _status, _headers, _body} ->
+        {:error, :not_found, available}
+
+      {:error, _reason} ->
+        {:error, :upstream_error, available}
     end
   end
 
@@ -174,9 +228,16 @@ defmodule HexpmWeb.ReadmeController do
     |> String.replace("&#39;", "'")
   end
 
-  defp send_not_found(conn, available) do
+  defp send_not_found(conn, available, opts \\ []) do
+    cache_control =
+      if Keyword.get(opts, :cacheable, true) do
+        "public, max-age=3600"
+      else
+        "no-store"
+      end
+
     conn
-    |> put_resp_header("cache-control", "public, max-age=3600")
+    |> put_resp_header("cache-control", cache_control)
     |> render(:no_readme,
       parent_origins: parent_origins(),
       doc_kinds: Enum.map(available, &Atom.to_string/1)

--- a/lib/hexpm_web/docs/files.ex
+++ b/lib/hexpm_web/docs/files.ex
@@ -5,7 +5,7 @@ defmodule HexpmWeb.Docs.Files do
   Maps documentation kinds (readme, changelog, license, ...) to the
   filenames that may back them in a release tarball. Matching is
   case-insensitive on the basename, restricted to the tarball root, and
-  prefers extensions in the order .md, .markdown, bare, .txt.
+  prefers extensions in the order .md, .markdown, .txt, bare.
   """
 
   @kinds [:readme, :changelog, :license, :security, :support, :acknowledgments, :threat_model]
@@ -20,7 +20,7 @@ defmodule HexpmWeb.Docs.Files do
     threat_model: ["THREAT_MODEL", "THREATMODEL", "THREAT-MODEL"]
   }
 
-  @extensions ["md", "markdown", "", "txt"]
+  @extensions ["md", "markdown", "txt", ""]
 
   @labels %{
     readme: "Readme",
@@ -32,6 +32,11 @@ defmodule HexpmWeb.Docs.Files do
     threat_model: "Threat Model"
   }
 
+  # Reverse lookup from an uppercased basename to the kind it belongs to,
+  # built once at compile time so resolve_all/1 can classify each file in a
+  # single pass.
+  @basename_to_kind for {kind, names} <- @basenames, name <- names, into: %{}, do: {name, kind}
+
   def kinds(), do: @kinds
 
   def label(kind) when kind in @kinds, do: @labels[kind]
@@ -40,29 +45,72 @@ defmodule HexpmWeb.Docs.Files do
     Enum.find(@kinds, &(Atom.to_string(&1) == segment))
   end
 
-  def resolve(kind, files) when kind in @kinds and is_list(files) do
-    root_files = Enum.reject(files, &String.contains?(&1, "/"))
-    basenames = @basenames[kind]
+  @doc """
+  Resolves every kind against `files` in a single pass, returning a map of
+  kind => winning filename for each kind that has a match.
+  """
+  def resolve_all(files) when is_list(files) do
+    files
+    |> Enum.filter(&is_binary/1)
+    |> Enum.reject(&String.contains?(&1, "/"))
+    |> Enum.reduce(%{}, fn filename, acc ->
+      case classify(filename) do
+        {kind, ext} ->
+          Map.update(acc, kind, %{ext => filename}, fn by_ext ->
+            Map.update(by_ext, ext, filename, &min(&1, filename))
+          end)
 
-    Enum.find_value(@extensions, fn ext ->
-      root_files
-      |> Enum.filter(&matches?(&1, basenames, ext))
-      |> Enum.sort()
-      |> List.first()
-    end)
-  end
-
-  def available_kinds(files) when is_list(files) do
-    Enum.filter(@kinds, &resolve(&1, files))
-  end
-
-  defp matches?(filename, basenames, ext) do
-    {base, file_ext} =
-      case Path.extname(filename) do
-        "" -> {filename, ""}
-        "." <> extension -> {Path.rootname(filename), String.downcase(extension)}
+        :nomatch ->
+          acc
       end
+    end)
+    |> Map.new(fn {kind, by_ext} -> {kind, pick(by_ext)} end)
+  end
 
-    file_ext == ext and String.upcase(base) in basenames
+  def resolve_all(_files), do: %{}
+
+  @doc """
+  Returns the kinds present in a `resolve_all/1` result, in canonical
+  `kinds/0` order.
+  """
+  def present_kinds(resolved) when is_map(resolved) do
+    Enum.filter(@kinds, &Map.has_key?(resolved, &1))
+  end
+
+  def resolve(kind, files) when kind in @kinds do
+    files
+    |> resolve_all()
+    |> Map.get(kind)
+  end
+
+  def available_kinds(files) do
+    files
+    |> resolve_all()
+    |> present_kinds()
+  end
+
+  defp pick(by_ext) do
+    Enum.find_value(@extensions, fn ext -> Map.get(by_ext, ext) end)
+  end
+
+  # Classifies a root-level filename as {kind, extension} if it matches one
+  # of the recognized basenames/extensions, or :nomatch otherwise. A
+  # filename ending in a bare "." (e.g. "README.") never matches anything.
+  defp classify(filename) do
+    with false <- String.ends_with?(filename, "."),
+         {base, ext} <- split_extension(filename),
+         kind when not is_nil(kind) <- @basename_to_kind[String.upcase(base)],
+         true <- ext in @extensions do
+      {kind, ext}
+    else
+      _ -> :nomatch
+    end
+  end
+
+  defp split_extension(filename) do
+    case Path.extname(filename) do
+      "" -> {filename, ""}
+      "." <> extension -> {Path.rootname(filename), String.downcase(extension)}
+    end
   end
 end

--- a/lib/hexpm_web/docs/files.ex
+++ b/lib/hexpm_web/docs/files.ex
@@ -1,0 +1,68 @@
+defmodule HexpmWeb.Docs.Files do
+  @moduledoc """
+  Recognition table for conventional package documentation files.
+
+  Maps documentation kinds (readme, changelog, license, ...) to the
+  filenames that may back them in a release tarball. Matching is
+  case-insensitive on the basename, restricted to the tarball root, and
+  prefers extensions in the order .md, .markdown, bare, .txt.
+  """
+
+  @kinds [:readme, :changelog, :license, :security, :support, :acknowledgments, :threat_model]
+
+  @basenames %{
+    readme: ["README"],
+    changelog: ["CHANGELOG"],
+    license: ["LICENSE"],
+    security: ["SECURITY"],
+    support: ["SUPPORT"],
+    acknowledgments: ["ACKNOWLEDGMENTS", "ACKNOWLEDGEMENTS"],
+    threat_model: ["THREAT_MODEL", "THREATMODEL", "THREAT-MODEL"]
+  }
+
+  @extensions ["md", "markdown", "", "txt"]
+
+  @labels %{
+    readme: "Readme",
+    changelog: "Changelog",
+    license: "License",
+    security: "Security",
+    support: "Support",
+    acknowledgments: "Acknowledgments",
+    threat_model: "Threat Model"
+  }
+
+  def kinds(), do: @kinds
+
+  def label(kind) when kind in @kinds, do: @labels[kind]
+
+  def parse_segment(segment) when is_binary(segment) do
+    Enum.find(@kinds, &(Atom.to_string(&1) == segment))
+  end
+
+  def resolve(kind, files) when kind in @kinds and is_list(files) do
+    root_files = Enum.reject(files, &String.contains?(&1, "/"))
+    basenames = @basenames[kind]
+
+    Enum.find_value(@extensions, fn ext ->
+      root_files
+      |> Enum.filter(&matches?(&1, basenames, ext))
+      |> Enum.sort()
+      |> List.first()
+    end)
+  end
+
+  def available_kinds(files) when is_list(files) do
+    Enum.filter(@kinds, &resolve(&1, files))
+  end
+
+  defp matches?(filename, basenames, ext) do
+    {base, file_ext} =
+      case Path.extname(filename) do
+        "" -> {filename, ""}
+        "." <> extension -> {Path.rootname(filename), String.downcase(extension)}
+      end
+
+    file_ext == ext and String.upcase(base) in basenames
+  end
+end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -99,6 +99,11 @@ defmodule HexpmWeb.Router do
   scope "/", HexpmWeb, host: "readme." do
     pipe_through :readme
 
+    for kind <- ~w(changelog license security support acknowledgments threat_model) do
+      get "/:name/:version/#{kind}", ReadmeController, :show_doc, assigns: %{doc_kind: kind}
+      get "/:name/#{kind}", ReadmeController, :show_doc, assigns: %{doc_kind: kind}
+    end
+
     get "/:name/:version", ReadmeController, :show
     get "/:name", ReadmeController, :show
     match :*, "/*path", ReadmeController, :not_found

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -99,9 +99,12 @@ defmodule HexpmWeb.Router do
   scope "/", HexpmWeb, host: "readme." do
     pipe_through :readme
 
-    for kind <- ~w(changelog license security support acknowledgments threat_model) do
-      get "/:name/:version/#{kind}", ReadmeController, :show_doc, assigns: %{doc_kind: kind}
-      get "/:name/#{kind}", ReadmeController, :show_doc, assigns: %{doc_kind: kind}
+    for kind <- HexpmWeb.Docs.Files.kinds(), kind != :readme do
+      kind_str = Atom.to_string(kind)
+
+      get "/:name/:version/#{kind}", ReadmeController, :show_doc, assigns: %{doc_kind: kind_str}
+
+      get "/:name/#{kind}", ReadmeController, :show_doc, assigns: %{doc_kind: kind_str}
     end
 
     get "/:name/:version", ReadmeController, :show
@@ -201,11 +204,13 @@ defmodule HexpmWeb.Router do
     get "/packages/:name/versions", PackageController, :versions
     get "/packages/:name/advisories", PackageController, :advisories
 
-    for kind <- ~w(changelog license security support acknowledgments threat_model) do
-      get "/packages/:name/#{kind}", PackageController, :docs_file, assigns: %{doc_kind: kind}
+    for kind <- HexpmWeb.Docs.Files.kinds(), kind != :readme do
+      kind_str = Atom.to_string(kind)
+
+      get "/packages/:name/#{kind}", PackageController, :docs_file, assigns: %{doc_kind: kind_str}
 
       get "/packages/:name/:version/#{kind}", PackageController, :docs_file,
-        assigns: %{doc_kind: kind}
+        assigns: %{doc_kind: kind_str}
     end
 
     get "/packages/:name/:version/dependencies", PackageController, :dependencies
@@ -218,6 +223,17 @@ defmodule HexpmWeb.Router do
     get "/packages/:repository/:name/dependents", PackageController, :dependents
     get "/packages/:repository/:name/versions", PackageController, :versions
     get "/packages/:repository/:name/advisories", PackageController, :advisories
+
+    for kind <- HexpmWeb.Docs.Files.kinds(), kind != :readme do
+      kind_str = Atom.to_string(kind)
+
+      get "/packages/:repository/:name/#{kind}", PackageController, :docs_file,
+        assigns: %{doc_kind: kind_str}
+
+      get "/packages/:repository/:name/:version/#{kind}", PackageController, :docs_file,
+        assigns: %{doc_kind: kind_str}
+    end
+
     get "/packages/:repository/:name/:version/dependencies", PackageController, :dependencies
     get "/packages/:repository/:name/:version", PackageController, :show
 

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -227,9 +227,6 @@ defmodule HexpmWeb.Router do
     for kind <- HexpmWeb.Docs.Files.kinds(), kind != :readme do
       kind_str = Atom.to_string(kind)
 
-      get "/packages/:repository/:name/#{kind}", PackageController, :docs_file,
-        assigns: %{doc_kind: kind_str}
-
       get "/packages/:repository/:name/:version/#{kind}", PackageController, :docs_file,
         assigns: %{doc_kind: kind_str}
     end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -200,6 +200,14 @@ defmodule HexpmWeb.Router do
     get "/packages/:name/dependencies", PackageController, :dependencies
     get "/packages/:name/versions", PackageController, :versions
     get "/packages/:name/advisories", PackageController, :advisories
+
+    for kind <- ~w(changelog license security support acknowledgments threat_model) do
+      get "/packages/:name/#{kind}", PackageController, :docs_file, assigns: %{doc_kind: kind}
+
+      get "/packages/:name/:version/#{kind}", PackageController, :docs_file,
+        assigns: %{doc_kind: kind}
+    end
+
     get "/packages/:name/:version/dependencies", PackageController, :dependencies
     get "/packages/:name/:version", PackageController, :show
     get "/packages/:repository/:name/owners", PackageOwnerController, :index

--- a/lib/hexpm_web/templates/package/show.html.heex
+++ b/lib/hexpm_web/templates/package/show.html.heex
@@ -66,7 +66,9 @@
               >
               </path>
             </svg>
-            Loading {HexpmWeb.Docs.Files.label(@doc_kind)}...
+            Loading {if @doc_kind == :readme,
+              do: "README",
+              else: HexpmWeb.Docs.Files.label(@doc_kind)}...
           </div>
 
           <%= if @doc_kind == :readme do %>
@@ -98,9 +100,15 @@
           >
           </iframe>
         <% else %>
-          <%= if description do %>
+          <%= if @doc_kind == :readme do %>
+            <%= if description do %>
+              <div class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed">
+                {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
+              </div>
+            <% end %>
+          <% else %>
             <div class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed">
-              {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
+              Documentation files are not available for private packages.
             </div>
           <% end %>
         <% end %>

--- a/lib/hexpm_web/templates/package/show.html.heex
+++ b/lib/hexpm_web/templates/package/show.html.heex
@@ -1,59 +1,110 @@
 <% description = @package.meta.description %>
 
-<.package_layout {@package_layout} active_tab={:readme} version_pinned?={@version_pinned?}>
+<.package_layout
+  {@package_layout}
+  active_tab={:readme}
+  version_pinned?={@version_pinned?}
+  doc_kind={@doc_kind}
+>
   <:inner_content>
-    <div class="bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-6">
+    <div class="flex gap-5 items-start">
       <%= if ViewHelpers.main_repository?(@package) and @current_release do %>
-        <div
-          id="readme-loading"
-          class="flex items-center justify-center py-12 text-grey-400 dark:text-grey-300"
+        <nav
+          id="doc-sidebar"
+          aria-label="Documentation files"
+          class="hidden w-[200px] shrink-0 flex-col gap-1 bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-4"
         >
-          <svg class="animate-spin h-6 w-6 mr-3" viewBox="0 0 24 24" fill="none">
-            <circle
-              class="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
+          <p class="text-[10px] font-medium uppercase tracking-wide text-grey-400 dark:text-grey-300 mb-2">
+            Files
+          </p>
+          <%= for kind <- HexpmWeb.Docs.Files.kinds() do %>
+            <a
+              data-doc-kind={kind}
+              hidden
+              href={doc_page_path(@package, @current_release, @version_pinned?, kind)}
+              aria-current={@doc_kind == kind && "page"}
+              class={[
+                "flex items-center gap-2 rounded px-2 py-1.5 text-sm font-medium transition-colors",
+                @doc_kind == kind &&
+                  "bg-grey-50 dark:bg-grey-700/60 text-grey-900 dark:text-white",
+                @doc_kind != kind &&
+                  "text-grey-500 dark:text-grey-300 hover:text-grey-700 dark:hover:text-grey-200"
+              ]}
             >
-            </circle>
-            <path
-              class="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            >
-            </path>
-          </svg>
-          Loading README...
-        </div>
-
-        <%= if description do %>
-          <div
-            id="readme-fallback"
-            class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed hidden"
+              {HexpmWeb.ViewIcons.icon(:heroicon, "document", class: "size-4 shrink-0")}
+              <span class="truncate">{HexpmWeb.Docs.Files.label(kind)}</span>
+            </a>
+          <% end %>
+          <p
+            id="doc-source"
+            class="hidden mt-4 pt-3 border-t border-grey-200 dark:border-grey-700 text-[10px] font-mono uppercase tracking-wide text-grey-400 dark:text-grey-300 truncate"
           >
-            {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
-          </div>
-        <% end %>
-
-        <iframe
-          id="readme-frame"
-          src={"#{ViewHelpers.doc_url(@package.name, @current_release.version, @doc_kind)}"}
-          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
-          loading="lazy"
-          referrerpolicy="no-referrer"
-          title={"README for #{ViewHelpers.package_name(@package)}"}
-          class="w-full border-0 opacity-0 h-0 overflow-hidden"
-        >
-        </iframe>
-      <% else %>
-        <%= if description do %>
-          <div class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed">
-            {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
-          </div>
-        <% end %>
+          </p>
+        </nav>
       <% end %>
+
+      <div class="flex-1 min-w-0 bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-6">
+        <%= if ViewHelpers.main_repository?(@package) and @current_release do %>
+          <div
+            id="readme-loading"
+            class="flex items-center justify-center py-12 text-grey-400 dark:text-grey-300"
+          >
+            <svg class="animate-spin h-6 w-6 mr-3" viewBox="0 0 24 24" fill="none">
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              >
+              </circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+              >
+              </path>
+            </svg>
+            Loading {HexpmWeb.Docs.Files.label(@doc_kind)}...
+          </div>
+
+          <%= if @doc_kind == :readme do %>
+            <%= if description do %>
+              <div
+                id="readme-fallback"
+                class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed hidden"
+              >
+                {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
+              </div>
+            <% end %>
+          <% else %>
+            <div
+              id="readme-fallback"
+              class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed hidden"
+            >
+              This package does not publish a {HexpmWeb.Docs.Files.label(@doc_kind)} file.
+            </div>
+          <% end %>
+
+          <iframe
+            id="readme-frame"
+            src={"#{ViewHelpers.doc_url(@package.name, @current_release.version, @doc_kind)}"}
+            sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+            loading="lazy"
+            referrerpolicy="no-referrer"
+            title={"#{HexpmWeb.Docs.Files.label(@doc_kind)} for #{ViewHelpers.package_name(@package)}"}
+            class="w-full border-0 opacity-0 h-0 overflow-hidden"
+          >
+          </iframe>
+        <% else %>
+          <%= if description do %>
+            <div class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed">
+              {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
+            </div>
+          <% end %>
+        <% end %>
+      </div>
     </div>
   </:inner_content>
 </.package_layout>

--- a/lib/hexpm_web/templates/package/show.html.heex
+++ b/lib/hexpm_web/templates/package/show.html.heex
@@ -39,7 +39,7 @@
 
         <iframe
           id="readme-frame"
-          src={"#{ViewHelpers.readme_url(@package.name, @current_release.version)}"}
+          src={"#{ViewHelpers.doc_url(@package.name, @current_release.version, @doc_kind)}"}
           sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
           loading="lazy"
           referrerpolicy="no-referrer"

--- a/lib/hexpm_web/templates/readme/no_readme.html.heex
+++ b/lib/hexpm_web/templates/readme/no_readme.html.heex
@@ -3,11 +3,11 @@
   <head><meta charset="utf-8" /></head>
   <body>
     <script nonce={@script_src_nonce}>
-      var origins = <%= raw(Jason.encode!(@parent_origins)) %>;
-      var docKinds = <%= raw(Jason.encode!(@doc_kinds)) %>;
+      var origins = <%= raw(Jason.encode!(@parent_origins, escape: :html_safe)) %>;
+      var docKinds = <%= raw(Jason.encode!(@doc_kinds, escape: :html_safe)) %>;
       origins.forEach(function(o) {
-        window.parent.postMessage({type: 'readme-not-found'}, o);
         window.parent.postMessage({type: 'doc-files', kinds: docKinds}, o);
+        window.parent.postMessage({type: 'readme-not-found'}, o);
       });
     </script>
   </body>

--- a/lib/hexpm_web/templates/readme/no_readme.html.heex
+++ b/lib/hexpm_web/templates/readme/no_readme.html.heex
@@ -4,8 +4,10 @@
   <body>
     <script nonce={@script_src_nonce}>
       var origins = <%= raw(Jason.encode!(@parent_origins)) %>;
+      var docKinds = <%= raw(Jason.encode!(@doc_kinds)) %>;
       origins.forEach(function(o) {
         window.parent.postMessage({type: 'readme-not-found'}, o);
+        window.parent.postMessage({type: 'doc-files', kinds: docKinds}, o);
       });
     </script>
   </body>

--- a/lib/hexpm_web/templates/readme/show.html.heex
+++ b/lib/hexpm_web/templates/readme/show.html.heex
@@ -22,7 +22,7 @@
     </article>
     <script nonce={@script_src_nonce}>
       document.addEventListener('DOMContentLoaded', function() {
-        var origins = <%= raw(Jason.encode!(@parent_origins)) %>;
+        var origins = <%= raw(Jason.encode!(@parent_origins, escape: :html_safe)) %>;
         function isAllowedOrigin(origin) {
           return origins[0] === "*" || origins.indexOf(origin) >= 0;
         }
@@ -47,8 +47,8 @@
         sendHeight();
         new ResizeObserver(sendHeight).observe(document.body);
 
-        var docKinds = <%= raw(Jason.encode!(@doc_kinds)) %>;
-        var docSource = <%= raw(Jason.encode!(@doc_source)) %>;
+        var docKinds = <%= raw(Jason.encode!(@doc_kinds, escape: :html_safe)) %>;
+        var docSource = <%= raw(Jason.encode!(@doc_source, escape: :html_safe)) %>;
         origins.forEach(function(o) {
           window.parent.postMessage({type: "doc-files", kinds: docKinds, source: docSource}, o);
         });

--- a/lib/hexpm_web/templates/readme/show.html.heex
+++ b/lib/hexpm_web/templates/readme/show.html.heex
@@ -46,6 +46,12 @@
 
         sendHeight();
         new ResizeObserver(sendHeight).observe(document.body);
+
+        var docKinds = <%= raw(Jason.encode!(@doc_kinds)) %>;
+        var docSource = <%= raw(Jason.encode!(@doc_source)) %>;
+        origins.forEach(function(o) {
+          window.parent.postMessage({type: "doc-files", kinds: docKinds, source: docSource}, o);
+        });
       });
     </script>
   </body>

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -177,6 +177,17 @@ defmodule HexpmWeb.PackageView do
     ~p"/packages/#{package.repository}/#{package}/dependents?#{options}"
   end
 
+  def doc_page_path(package, release, version_pinned?, kind) do
+    base =
+      if version_pinned? && release do
+        ViewHelpers.path_for_release(package, release)
+      else
+        ViewHelpers.path_for_package(package)
+      end
+
+    if kind == :readme, do: base, else: "#{base}/#{kind}"
+  end
+
   @doc """
   This function turns an audit_log struct into a short description.
 

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -530,6 +530,12 @@ defmodule HexpmWeb.ViewHelpers do
     "#{readme_url}/#{package_name}/#{version}"
   end
 
+  def doc_url(package_name, version, :readme), do: readme_url(package_name, version)
+
+  def doc_url(package_name, version, kind) do
+    "#{readme_url(package_name, version)}/#{kind}"
+  end
+
   def safe_url(url) when is_binary(url) do
     case URI.parse(url) do
       %URI{scheme: scheme} when scheme in ["http", "https", "mailto"] -> url

--- a/priv/preview/file_lists/decimal-0.1.0.json
+++ b/priv/preview/file_lists/decimal-0.1.0.json
@@ -1,1 +1,1 @@
-["README.md", "lib/decimal.ex", "mix.exs", "LICENSE"]
+["README.md", "CHANGELOG.md", "LICENSE", "lib/decimal.ex", "mix.exs"]

--- a/priv/preview/files/decimal/0.1.0/CHANGELOG.md
+++ b/priv/preview/files/decimal/0.1.0/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+- Initial release

--- a/priv/preview/files/decimal/0.1.0/CHANGELOG.md
+++ b/priv/preview/files/decimal/0.1.0/CHANGELOG.md
@@ -1,5 +1,270 @@
-# Changelog
+# CHANGELOG
 
-## v0.1.0
+## Unreleased
 
-- Initial release
+### Enhancements
+
+* Reduce the cost of every operation that goes through the context: results
+  that signal nothing no longer copy the context or write it back to the
+  process dictionary, the coefficient's digit count is computed once per
+  operation instead of up to four times, and digit counting no longer walks a
+  ladder of bignum comparisons before falling back to its estimate. Division
+  is ~1.9x faster, `add`/`sub`/`mult`/`round`/`normalize` ~1.3x, comparison of
+  same-scale values ~1.4x, parsing ~1.2x, all with 20-30% less allocation.
+
+* Make `Decimal.to_float/1` scale the operand with a computed shift instead of
+  one bit at a time: ~1.6x faster for typical values and ~11x for exponents
+  near the ends of the double range, with 96% fewer collections.
+
+### Bug fixes
+
+* Fix `Decimal.div/2` rounding the wrong way on inexact results. The long
+  division discarded its remainder instead of carrying it into rounding as
+  a sticky bit, so a guard digit of 5 with a nonzero tail was treated as an
+  exact tie (`:half_even`/`:half_down`) and a guard digit of 0 with a
+  nonzero tail was treated as zero (`:ceiling`/`:floor`/`:up`). Roughly 5%
+  of random divisions at the default precision were affected, including
+  `:ceiling`/`:floor` returning a result on the wrong side of the true
+  value. The same remainder is now also reflected in the `:inexact` flag,
+  which was previously suppressed when the remainder was a power of ten.
+
+* Re-round the coefficient when a rounding carry lengthens it past the
+  context precision. Rounding an all-nines coefficient up (e.g. `9.99` to
+  precision 2, or `Decimal.div(95, 10)` at precision 1) produced a
+  coefficient with one digit more than `precision` (`d(1, 100, -1)`,
+  `d(1, 10, 0)`) instead of re-rounding to exactly `precision` significant
+  digits (`d(1, 10, 0)`, `d(1, 1, 1)`). This affects every context
+  operation (`add`, `sub`, `mult`, `div`) and now matches the General
+  Decimal Arithmetic spec and Python's decimal.
+
+## v3.1.1 (2026-05-27)
+
+### Bug fixes
+
+* Fix `Decimal.parse/2` and `Decimal.new/2` rejecting inspect output for
+  values at the context's full precision with negative exponents (e.g.
+  `Decimal.new("0.3162277660168379331998893544432719")`). The
+  `:max_digits` limit no longer counts non-significant leading zeros.
+
+## v3.1.0 (2026-05-08)
+
+### Enhancements
+
+* `Decimal.new/2` now accepts an optional `opts` keyword list and
+  forwards it to `Decimal.parse/2`, allowing callers to override
+  `:max_digits` and `:max_exponent` when constructing a decimal from
+  a string.
+
+### Bug fixes
+
+* Fix infinite loop in `Decimal.to_integer/1` when the coefficient is
+  zero and the exponent is negative (e.g. `Decimal.new("0.0")`). Such
+  values now correctly convert to the integer `0`.
+
+## v3.0.0 (2026-05-07)
+
+### Note on the new defaults
+
+The new decimal128 defaults are more than sufficient for currency and
+other real-world numeric use cases. With `precision: 34` and a scale of
+2 (two digits after the decimal point for cents), values from `0.00` up
+to roughly `99_999_999_999_999_999_999_999_999_999_999.99` (~10³², 100
+nonillion) round-trip without rounding. Most upgrades from 2.x require
+no code changes.
+
+### Security
+
+* Make the v2.4.0 mitigations for CVE-2026-32686 the default. The
+  default `Decimal.Context` and the public parse, cast, and to_string
+  functions now follow IEEE 754 decimal128 limits, rejecting inputs
+  such as `1e1000000000` without materializing them.
+
+### Breaking changes
+
+* `Decimal.Context` defaults change from precision `28` and unbounded
+  `emax`/`emin` to decimal128 values: `precision: 34`, `emax: 6_144`,
+  `emin: -6_143`. Operation results whose adjusted exponent leaves that
+  band signal overflow or underflow.
+* `Decimal.parse/1` and `Decimal.cast/1` reject inputs whose digit count
+  exceeds `34` (decimal128 precision) or whose absolute exponent exceeds
+  `6_144` (decimal128 emax). Use `parse/2` / `cast/2` with
+  `max_digits: :infinity` and `max_exponent: :infinity` to restore
+  unbounded behavior.
+* `Decimal.parse/2` and `Decimal.cast/2` default `:max_digits` to `34`
+  and `:max_exponent` to `6_144` when not specified.
+* `Decimal.to_string/2` and `Decimal.to_string/3` raise `ArgumentError`
+  when the rendered output would exceed `6_178` digit characters
+  (precision + emax — the worst-case `:normal` width of any in-range
+  decimal128 value). `Inspect`, `String.Chars`, and `JSON.Encoder`
+  protocol implementations pass `max_digits: :infinity` so debug output
+  always succeeds.
+
+## v2.4.0 (2026-05-07)
+
+### Security
+
+* Mitigate exponent amplification (CVE-2026-32686).
+  Compact inputs such as `1e1000000` could force multi-second expansions
+  during arithmetic, parsing, normalization, comparison, or formatting.
+  `Decimal.add/2` and `Decimal.sub/2` now scale operands to `precision + 2`
+  digits with a sticky bit instead of materializing the full coefficient.
+
+### Enhancements
+
+* Add `:max_digits` and `:max_exponent` options to `Decimal.parse/2` and
+  `Decimal.cast/2` to reject pathological inputs without expansion
+* Add `:max_digits` option to `Decimal.to_string/3` to cap formatted output
+  before materialization
+* Add `:emax` and `:emin` fields to `Decimal.Context` for IBM General Decimal
+  Arithmetic-style overflow and underflow signaling
+* Optimize hot paths for large decimals: `coef_length`, `normalize`,
+  `to_integer`, `integer?`, parsing, and large-coefficient string formatting
+
+## v2.3.0 (2024-12-13)
+
+* Implement the upcoming [`JSON.Encoder`](https://hexdocs.pm/elixir/main/JSON.Encoder.html)
+  protocol
+
+## v2.2.0 (2024-11-13)
+
+* Add `Decimal.gte?/2` and `Decimal.lte?/2`
+* Add `Decimal.compare/3` and `Decimal.eq?/3` with threshold as parameter
+
+## v2.1.1 (2023-04-26)
+
+Decimal v2.1 requires Elixir v1.8+.
+
+### Bug fixes
+
+* Fix `Decimal.compare/2` when comparing against `0`
+
+## v2.1.0 (2023-04-26)
+
+Decimal v2.1 requires Elixir v1.8+.
+
+### Enhancements
+
+* Improve error message from `Decimal.to_integer/1` during precision loss
+* `Inspect` protocol implementation returns strings in the `Decimal.new(...)` format
+* Add `Decimal.scale/1`
+* Optimize `Decimal.compare/2` for numbers with large exponents
+
+### Bug fixes
+
+* Fix `Decimal.integer?/1` spec
+* Fix `Decimal.integer?/1` check on 0 with >1 significant digits
+
+## v2.0.0 (2020-09-08)
+
+Decimal v2.0 requires Elixir v1.2+.
+
+### Enhancements
+
+* Add `Decimal.integer?/1`
+
+### Breaking changes
+
+* Change `Decimal.compare/2` to return `:lt | :eq | :gt`
+* Change `Decimal.cast/1` to return `{:ok, t} | :error`
+* Change `Decimal.parse/1` to return `{t, binary} | :error`
+* Remove `:message` and `:result` fields from `Decimal.Error`
+* Remove sNaN
+* Rename qNaN to NaN
+* Remove deprecated support for floats in `Decimal.new/1`
+* Remove deprecated `Decimal.minus/1`
+* Remove deprecated `Decimal.plus/1`
+* Remove deprecated `Decimal.reduce/1`
+* Remove deprecated `Decimal.with_context/2`, `Decimal.get_context/1`, `Decimal.set_context/1`,
+  and `Decimal.update_context/1`
+* Remove deprecated `Decimal.decimal?/1`
+
+### Deprecations
+
+* Deprecate `Decimal.cmp/2`
+
+## v1.9.0 (2020-09-08)
+
+### Enhancements
+
+* Add `Decimal.negate/1`
+* Add `Decimal.apply_context/1`
+* Add `Decimal.normalize/1`
+* Add `Decimal.Context.with/2`, `Decimal.Context.get/1`, `Decimal.Context.set/2`,
+  and `Decimal.Context.update/1`
+* Add `Decimal.is_decimal/1`
+
+### Deprecations
+
+* Deprecate `Decimal.minus/1` in favour of the new `Decimal.negate/1`
+* Deprecate `Decimal.plus/1` in favour of the new `Decimal.apply_context/1`
+* Deprecate `Decimal.reduce/1` in favour of the new `Decimal.normalize/1`
+* Deprecate `Decimal.with_context/2`, `Decimal.get_context/1`, `Decimal.set_context/2`,
+  and `Decimal.update_context/1` in favour of new functions on the `Decimal.Context` module
+* Deprecate `Decimal.decimal?/1` in favour of the new `Decimal.is_decimal/1`
+
+## v1.8.1 (2019-12-20)
+
+### Bug fixes
+
+* Fix Decimal.compare/2 with string arguments
+* Set :signal on error
+
+## v1.8.0 (2019-06-24)
+
+### Enhancements
+
+* Add `Decimal.cast/1`
+* Add `Decimal.eq?/2`, `Decimal.gt?/2`, and `Decimal.lt?/2`
+* Add guards to `Decimal.new/3` to prevent invalid Decimal numbers
+
+## v1.7.0 (2019-02-16)
+
+### Enhancements
+
+* Add `Decimal.sqrt/1`
+
+## v1.6.0 (2018-11-22)
+
+### Enhancements
+
+* Support for canonical XSD representation on `Decimal.to_string/2`
+
+### Bugfixes
+
+* Fix exponent off-by-one when converting from decimal to float
+* Fix negative?/1 and positive?/1 specs
+
+### Deprecations
+
+* Deprecate passing float to `Decimal.new/1` in favor of `Decimal.from_float/1`
+
+## v1.5.0 (2018-03-24)
+
+### Enhancements
+
+* Add `Decimal.positive?/1` and `Decimal.negative?/1`
+* Accept integers and strings in arithmetic functions, e.g.: `Decimal.add(1, "2.0")`
+* Add `Decimal.from_float/1`
+
+### Soft deprecations (no warnings emitted)
+
+* Soft deprecate passing float to `new/1` in favor of `from_float/1`
+
+## v1.4.1 (2017-10-12)
+
+### Bugfixes
+
+* Include the given value as part of the error reason
+* Fix `:half_even` `:lists.last` bug (empty signif)
+* Fix error message for round
+* Fix `:half_down` rounding error when remainder is greater than 5
+* Fix `Decimal.new/1` float conversion with bigger precision than 4
+* Fix precision default value
+
+## v1.4.0 (2017-06-25)
+
+### Bugfixes
+
+* Fix `Decimal.to_integer/1` for large coefficients
+* Fix rounding of ~0 values
+* Fix errors when comparing and adding two infinities

--- a/priv/preview/files/decimal/0.1.0/LICENSE
+++ b/priv/preview/files/decimal/0.1.0/LICENSE
@@ -1,4 +1,176 @@
-Apache License, Version 2.0
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/priv/preview/files/decimal/0.1.0/LICENSE
+++ b/priv/preview/files/decimal/0.1.0/LICENSE
@@ -1,0 +1,4 @@
+Apache License, Version 2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -880,7 +880,7 @@ defmodule HexpmWeb.PackageControllerTest do
         |> test_login(user1)
         |> get("/packages/#{repository1.name}/#{package3.name}/0.0.1/changelog")
 
-      assert response(conn, 200) =~ "Changelog"
+      assert response(conn, 200) =~ "Documentation files are not available for private packages."
     end
 
     test "renders for repository/name unversioned changelog", %{
@@ -893,7 +893,22 @@ defmodule HexpmWeb.PackageControllerTest do
         |> test_login(user1)
         |> get("/packages/#{repository1.name}/#{package3.name}/changelog")
 
-      assert response(conn, 200) =~ "Changelog"
+      assert response(conn, 200) =~ "Documentation files are not available for private packages."
+    end
+
+    test "doc page sets canonical URL to its own page, not the bare package page" do
+      package = insert(:package)
+
+      insert(:release,
+        package: package,
+        version: "0.0.1",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      conn = get(build_conn(), "/packages/#{package.name}/changelog")
+
+      assert response(conn, 200) =~
+               ~s(<link href="/packages/#{package.name}/changelog" rel="canonical">)
     end
   end
 

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -869,6 +869,32 @@ defmodule HexpmWeb.PackageControllerTest do
       assert body =~ ~s(aria-current="page")
       assert body =~ "does not publish a Security file"
     end
+
+    test "renders for repository/name/version/changelog triple", %{
+      package3: package3,
+      repository1: repository1,
+      user1: user1
+    } do
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> get("/packages/#{repository1.name}/#{package3.name}/0.0.1/changelog")
+
+      assert response(conn, 200) =~ "Changelog"
+    end
+
+    test "renders for repository/name unversioned changelog", %{
+      package3: package3,
+      repository1: repository1,
+      user1: user1
+    } do
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> get("/packages/#{repository1.name}/#{package3.name}/changelog")
+
+      assert response(conn, 200) =~ "Changelog"
+    end
   end
 
   defp escape(html) do

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -796,6 +796,48 @@ defmodule HexpmWeb.PackageControllerTest do
     end
   end
 
+  describe "doc file pages" do
+    test "GET /packages/:name/changelog renders show layout with changelog iframe" do
+      package = insert(:package)
+
+      insert(:release,
+        package: package,
+        version: "0.0.1",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      conn = get(build_conn(), "/packages/#{package.name}/changelog")
+
+      assert response(conn, 200) =~ "readme-frame"
+      assert response(conn, 200) =~ "/#{package.name}/0.0.1/changelog"
+    end
+
+    test "GET /packages/:name/:version/changelog pins the version" do
+      package = insert(:package)
+
+      insert(:release,
+        package: package,
+        version: "0.0.1",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      insert(:release,
+        package: package,
+        version: "0.0.2",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      conn = get(build_conn(), "/packages/#{package.name}/0.0.1/changelog")
+
+      assert response(conn, 200) =~ "/#{package.name}/0.0.1/changelog"
+    end
+
+    test "unknown package 404s" do
+      conn = get(build_conn(), "/packages/nonexistent_pkg/changelog")
+      assert response(conn, 404)
+    end
+  end
+
   defp escape(html) do
     {:safe, safe} = Phoenix.HTML.html_escape(html)
     IO.iodata_to_binary(safe)

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -836,6 +836,39 @@ defmodule HexpmWeb.PackageControllerTest do
       conn = get(build_conn(), "/packages/nonexistent_pkg/changelog")
       assert response(conn, 404)
     end
+
+    test "show page renders hidden doc sidebar and Documentation tab" do
+      package = insert(:package)
+
+      insert(:release,
+        package: package,
+        version: "0.0.1",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      body = response(get(build_conn(), "/packages/#{package.name}"), 200)
+
+      assert body =~ "Documentation"
+      assert body =~ ~s(id="doc-sidebar")
+      assert body =~ ~s(data-doc-kind="changelog")
+      assert body =~ ~s(data-doc-kind="threat_model")
+      assert body =~ ~s(id="doc-source")
+    end
+
+    test "doc page marks its sidebar entry active and shows kind-specific fallback" do
+      package = insert(:package)
+
+      insert(:release,
+        package: package,
+        version: "0.0.1",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      body = response(get(build_conn(), "/packages/#{package.name}/security"), 200)
+
+      assert body =~ ~s(aria-current="page")
+      assert body =~ "does not publish a Security file"
+    end
   end
 
   defp escape(html) do

--- a/test/hexpm_web/controllers/readme_controller_test.exs
+++ b/test/hexpm_web/controllers/readme_controller_test.exs
@@ -17,16 +17,19 @@ defmodule HexpmWeb.ReadmeControllerTest do
   defp mock_file_list_and_readme(package_name, version, filename, content) do
     file_list = Jason.encode!([filename])
 
-    Mox.expect(Hexpm.HTTP.Mock, :get, 2, fn url, _headers ->
-      cond do
-        String.contains?(url, "/preview-files/#{package_name}-#{version}.json") ->
-          {:ok, 200, [], file_list}
+    Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+      if String.contains?(url, "/preview-files/#{package_name}-#{version}.json") do
+        {:ok, 200, [], file_list}
+      else
+        {:ok, 404, [], ""}
+      end
+    end)
 
-        String.ends_with?(url, "/#{filename}") ->
-          {:ok, 200, [], content}
-
-        true ->
-          {:ok, 404, [], ""}
+    Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers, _opts ->
+      if String.ends_with?(url, "/#{filename}") do
+        {:ok, 200, [], content}
+      else
+        {:ok, 404, [], ""}
       end
     end)
   end
@@ -52,16 +55,19 @@ defmodule HexpmWeb.ReadmeControllerTest do
   defp mock_files_and_content(package_name, version, files, filename, content) do
     file_list = Jason.encode!(files)
 
-    Mox.expect(Hexpm.HTTP.Mock, :get, 2, fn url, _headers ->
-      cond do
-        String.contains?(url, "/preview-files/#{package_name}-#{version}.json") ->
-          {:ok, 200, [], file_list}
+    Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+      if String.contains?(url, "/preview-files/#{package_name}-#{version}.json") do
+        {:ok, 200, [], file_list}
+      else
+        {:ok, 404, [], ""}
+      end
+    end)
 
-        String.ends_with?(url, "/#{filename}") ->
-          {:ok, 200, [], content}
-
-        true ->
-          {:ok, 404, [], ""}
+    Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers, _opts ->
+      if String.ends_with?(url, "/#{filename}") do
+        {:ok, 200, [], content}
+      else
+        {:ok, 404, [], ""}
       end
     end)
   end
@@ -443,7 +449,162 @@ defmodule HexpmWeb.ReadmeControllerTest do
 
       assert conn.status == 200
       assert conn.resp_body =~ "too large to display"
+      assert conn.resp_body =~ "CHANGELOG.md"
+      assert conn.resp_body =~ Hexpm.Utils.preview_html_url(package.name, "1.0.0")
       refute conn.resp_body =~ "aaaaaaaaaa"
+    end
+
+    test "document fetch aborted for exceeding max body size renders a too-large notice", %{
+      package: package
+    } do
+      file_list = Jason.encode!(["CHANGELOG.md"])
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+        if String.contains?(url, "/preview-files/#{package.name}-1.0.0.json") do
+          {:ok, 200, [], file_list}
+        else
+          {:ok, 404, [], ""}
+        end
+      end)
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn _url, _headers, _opts ->
+        {:error, :body_too_large}
+      end)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "too large to display"
+      assert conn.resp_body =~ "CHANGELOG.md"
+    end
+
+    test "upstream failure fetching file list is not cached", %{package: package} do
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn _url, _headers ->
+        {:ok, 502, [], ""}
+      end)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+
+    test "connection error fetching file list is not cached", %{package: package} do
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn _url, _headers ->
+        {:error, :timeout}
+      end)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+
+    test "upstream failure fetching document is not cached", %{package: package} do
+      file_list = Jason.encode!(["CHANGELOG.md"])
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+        if String.contains?(url, "/preview-files/#{package.name}-1.0.0.json") do
+          {:ok, 200, [], file_list}
+        else
+          {:ok, 404, [], ""}
+        end
+      end)
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn _url, _headers, _opts ->
+        {:ok, 503, [], ""}
+      end)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+      assert get_resp_header(conn, "cache-control") == ["no-store"]
+    end
+
+    test "genuinely missing file is still cached", %{package: package} do
+      mock_file_list(package.name, "1.0.0", ["README.md"])
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=3600"]
+    end
+
+    test "non-list JSON file list degrades to not-found without crashing", %{package: package} do
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+        if String.contains?(url, "/preview-files/#{package.name}-1.0.0.json") do
+          {:ok, 200, [], Jason.encode!(%{"not" => "a list"})}
+        else
+          {:ok, 404, [], ""}
+        end
+      end)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+    end
+
+    test "already-decoded (non-binary) JSON file list body is tolerated", %{package: package} do
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+        if String.contains?(url, "/preview-files/#{package.name}-1.0.0.json") do
+          {:ok, 200, [{"content-type", "application/json"}], ["CHANGELOG.md"]}
+        else
+          {:ok, 404, [], ""}
+        end
+      end)
+
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn _url, _headers, _opts ->
+        {:ok, 200, [], "# Changelog"}
+      end)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Changelog"
+    end
+
+    test "invalid JSON file list degrades to not-found without a 500", %{package: package} do
+      Mox.expect(Hexpm.HTTP.Mock, :get, fn url, _headers ->
+        if String.contains?(url, "/preview-files/#{package.name}-1.0.0.json") do
+          {:ok, 200, [], "not json {{{"}
+        else
+          {:ok, 404, [], ""}
+        end
+      end)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
     end
 
     test "readme show page also reports doc-files", %{package: package} do

--- a/test/hexpm_web/controllers/readme_controller_test.exs
+++ b/test/hexpm_web/controllers/readme_controller_test.exs
@@ -49,6 +49,23 @@ defmodule HexpmWeb.ReadmeControllerTest do
     end)
   end
 
+  defp mock_files_and_content(package_name, version, files, filename, content) do
+    file_list = Jason.encode!(files)
+
+    Mox.expect(Hexpm.HTTP.Mock, :get, 2, fn url, _headers ->
+      cond do
+        String.contains?(url, "/preview-files/#{package_name}-#{version}.json") ->
+          {:ok, 200, [], file_list}
+
+        String.ends_with?(url, "/#{filename}") ->
+          {:ok, 200, [], content}
+
+        true ->
+          {:ok, 404, [], ""}
+      end
+    end)
+  end
+
   describe "show/2" do
     test "renders README for package with version", %{package: package} do
       mock_file_list_and_readme(
@@ -338,6 +355,114 @@ defmodule HexpmWeb.ReadmeControllerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "http://localhost:5000/img/fetch/"
       refute conn.resp_body =~ ~s[src="https://example.com/logo.png"]
+    end
+  end
+
+  describe "show_doc/2" do
+    test "renders a markdown changelog", %{package: package} do
+      mock_files_and_content(
+        package.name,
+        "1.0.0",
+        ["README.md", "CHANGELOG.md"],
+        "CHANGELOG.md",
+        "# Changelog\n\n## v1.0.0\n\n- First release"
+      )
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "First release"
+      assert conn.resp_body =~ ~s("doc-files")
+      assert conn.resp_body =~ ~s(["readme","changelog"])
+      assert conn.resp_body =~ "CHANGELOG.md"
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=86400"]
+    end
+
+    test "renders a bare LICENSE file as escaped pre", %{package: package} do
+      mock_files_and_content(
+        package.name,
+        "1.0.0",
+        ["README.md", "LICENSE"],
+        "LICENSE",
+        "Apache License <2.0>"
+      )
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/license")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Apache License &lt;2.0&gt;"
+    end
+
+    test "missing kind renders not-found page that still reports doc-files", %{package: package} do
+      mock_file_list(package.name, "1.0.0", ["README.md", "CHANGELOG.md"])
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/security")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+      assert conn.resp_body =~ ~s(["readme","changelog"])
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=3600"]
+    end
+
+    test "unknown kind segment is a 404", %{package: package} do
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/contributing")
+
+      assert conn.status == 404
+    end
+
+    test "versionless doc URL redirects to latest version", %{package: package} do
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/changelog")
+
+      assert conn.status == 302
+      assert get_resp_header(conn, "location") == ["/#{package.name}/1.0.0/changelog"]
+    end
+
+    test "oversized file renders a too-large notice", %{package: package} do
+      big = String.duplicate("a", 2 * 1024 * 1024 + 1)
+      mock_files_and_content(package.name, "1.0.0", ["CHANGELOG.md"], "CHANGELOG.md", big)
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0/changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "too large to display"
+      refute conn.resp_body =~ "aaaaaaaaaa"
+    end
+
+    test "readme show page also reports doc-files", %{package: package} do
+      mock_files_and_content(
+        package.name,
+        "1.0.0",
+        ["README.md", "LICENSE"],
+        "README.md",
+        "# Hello"
+      )
+
+      conn =
+        build_conn()
+        |> Map.put(:host, "readme.localhost")
+        |> get("/#{package.name}/1.0.0")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ ~s(["readme","license"])
+      assert conn.resp_body =~ ~s("README.md")
     end
   end
 end

--- a/test/hexpm_web/docs/files_test.exs
+++ b/test/hexpm_web/docs/files_test.exs
@@ -1,0 +1,86 @@
+defmodule HexpmWeb.Docs.FilesTest do
+  use ExUnit.Case, async: true
+
+  alias HexpmWeb.Docs.Files
+
+  test "kinds/0 returns the seven kinds in canonical order" do
+    assert Files.kinds() ==
+             [:readme, :changelog, :license, :security, :support, :acknowledgments, :threat_model]
+  end
+
+  test "label/1" do
+    assert Files.label(:readme) == "Readme"
+    assert Files.label(:threat_model) == "Threat Model"
+    assert Files.label(:acknowledgments) == "Acknowledgments"
+  end
+
+  test "parse_segment/1" do
+    assert Files.parse_segment("changelog") == :changelog
+    assert Files.parse_segment("threat_model") == :threat_model
+    assert Files.parse_segment("bogus") == nil
+    assert Files.parse_segment("threat-model") == nil
+  end
+
+  describe "resolve/2" do
+    test "finds exact conventional names" do
+      assert Files.resolve(:changelog, ["CHANGELOG.md", "mix.exs"]) == "CHANGELOG.md"
+      assert Files.resolve(:license, ["LICENSE"]) == "LICENSE"
+      assert Files.resolve(:security, ["SECURITY.md"]) == "SECURITY.md"
+    end
+
+    test "is case-insensitive on the basename" do
+      assert Files.resolve(:changelog, ["Changelog.md"]) == "Changelog.md"
+      assert Files.resolve(:changelog, ["changelog.md"]) == "changelog.md"
+      assert Files.resolve(:changelog, ["ChangeLog"]) == "ChangeLog"
+    end
+
+    test "prefers .md, then .markdown, then bare, then .txt" do
+      files = ["CHANGELOG.txt", "CHANGELOG", "CHANGELOG.markdown", "CHANGELOG.md"]
+      assert Files.resolve(:changelog, files) == "CHANGELOG.md"
+
+      assert Files.resolve(:changelog, ["CHANGELOG.txt", "CHANGELOG", "CHANGELOG.markdown"]) ==
+               "CHANGELOG.markdown"
+
+      assert Files.resolve(:changelog, ["CHANGELOG.txt", "CHANGELOG"]) == "CHANGELOG"
+      assert Files.resolve(:changelog, ["CHANGELOG.txt"]) == "CHANGELOG.txt"
+    end
+
+    test "breaks ties within an extension lexicographically" do
+      assert Files.resolve(:changelog, ["Changelog.md", "CHANGELOG.md"]) == "CHANGELOG.md"
+    end
+
+    test "only matches the tarball root" do
+      assert Files.resolve(:changelog, ["docs/CHANGELOG.md", "lib/foo.ex"]) == nil
+    end
+
+    test "does not match unrelated extensions or prefixed names" do
+      assert Files.resolve(:license, ["LICENSE.rapidxml"]) == nil
+      assert Files.resolve(:readme, ["README.ja.md"]) == nil
+    end
+
+    test "acknowledgments matches both spellings" do
+      assert Files.resolve(:acknowledgments, ["ACKNOWLEDGMENTS.md"]) == "ACKNOWLEDGMENTS.md"
+      assert Files.resolve(:acknowledgments, ["ACKNOWLEDGEMENTS.md"]) == "ACKNOWLEDGEMENTS.md"
+    end
+
+    test "threat_model matches separator variants" do
+      assert Files.resolve(:threat_model, ["THREAT_MODEL.md"]) == "THREAT_MODEL.md"
+      assert Files.resolve(:threat_model, ["THREATMODEL.md"]) == "THREATMODEL.md"
+      assert Files.resolve(:threat_model, ["THREAT-MODEL.md"]) == "THREAT-MODEL.md"
+      assert Files.resolve(:threat_model, ["threat-model"]) == "threat-model"
+    end
+
+    test "readme resolution matches conventional names" do
+      assert Files.resolve(:readme, ["README.md", "LICENSE"]) == "README.md"
+      assert Files.resolve(:readme, ["readme.markdown"]) == "readme.markdown"
+      # bare now beats .txt (intentional change from the old README list)
+      assert Files.resolve(:readme, ["README.txt", "README"]) == "README"
+    end
+  end
+
+  test "available_kinds/1 returns kinds in canonical order" do
+    files = ["LICENSE", "README.md", "CHANGELOG.md", "mix.exs", "lib/a.ex"]
+    assert Files.available_kinds(files) == [:readme, :changelog, :license]
+    assert Files.available_kinds(["mix.exs"]) == []
+  end
+end

--- a/test/hexpm_web/docs/files_test.exs
+++ b/test/hexpm_web/docs/files_test.exs
@@ -34,15 +34,15 @@ defmodule HexpmWeb.Docs.FilesTest do
       assert Files.resolve(:changelog, ["ChangeLog"]) == "ChangeLog"
     end
 
-    test "prefers .md, then .markdown, then bare, then .txt" do
+    test "prefers .md, then .markdown, then .txt, then bare" do
       files = ["CHANGELOG.txt", "CHANGELOG", "CHANGELOG.markdown", "CHANGELOG.md"]
       assert Files.resolve(:changelog, files) == "CHANGELOG.md"
 
       assert Files.resolve(:changelog, ["CHANGELOG.txt", "CHANGELOG", "CHANGELOG.markdown"]) ==
                "CHANGELOG.markdown"
 
-      assert Files.resolve(:changelog, ["CHANGELOG.txt", "CHANGELOG"]) == "CHANGELOG"
-      assert Files.resolve(:changelog, ["CHANGELOG.txt"]) == "CHANGELOG.txt"
+      assert Files.resolve(:changelog, ["CHANGELOG.txt", "CHANGELOG"]) == "CHANGELOG.txt"
+      assert Files.resolve(:changelog, ["CHANGELOG"]) == "CHANGELOG"
     end
 
     test "breaks ties within an extension lexicographically" do
@@ -73,8 +73,22 @@ defmodule HexpmWeb.Docs.FilesTest do
     test "readme resolution matches conventional names" do
       assert Files.resolve(:readme, ["README.md", "LICENSE"]) == "README.md"
       assert Files.resolve(:readme, ["readme.markdown"]) == "readme.markdown"
-      # bare now beats .txt (intentional change from the old README list)
-      assert Files.resolve(:readme, ["README.txt", "README"]) == "README"
+      assert Files.resolve(:readme, ["README.txt", "README"]) == "README.txt"
+    end
+
+    test "does not match a filename ending in a bare trailing dot" do
+      assert Files.resolve(:readme, ["README."]) == nil
+      assert Files.resolve(:readme, ["README"]) == "README"
+      assert Files.resolve(:readme, ["README.md"]) == "README.md"
+    end
+
+    test "tolerates malformed file lists instead of raising" do
+      assert Files.resolve(:readme, ["README.md", nil]) == "README.md"
+      assert Files.resolve(:readme, [1, "README.md"]) == "README.md"
+      assert Files.resolve(:readme, [["nested"], "README.md"]) == "README.md"
+      assert Files.resolve(:readme, [%{}]) == nil
+      assert Files.resolve(:readme, %{"files" => []}) == nil
+      assert Files.resolve(:readme, nil) == nil
     end
   end
 
@@ -82,5 +96,56 @@ defmodule HexpmWeb.Docs.FilesTest do
     files = ["LICENSE", "README.md", "CHANGELOG.md", "mix.exs", "lib/a.ex"]
     assert Files.available_kinds(files) == [:readme, :changelog, :license]
     assert Files.available_kinds(["mix.exs"]) == []
+  end
+
+  test "available_kinds/1 tolerates malformed file lists instead of raising" do
+    assert Files.available_kinds(["README.md", nil, 1, ["x"], %{}]) == [:readme]
+    assert Files.available_kinds(%{"files" => []}) == []
+    assert Files.available_kinds(nil) == []
+  end
+
+  describe "resolve_all/1" do
+    test "matches resolve/2 for every kind on a mixed file list" do
+      files = [
+        "README.md",
+        "CHANGELOG.txt",
+        "LICENSE",
+        "docs/SECURITY.md",
+        "support.MD",
+        "ACKNOWLEDGEMENTS.markdown",
+        "THREAT-MODEL.md",
+        nil,
+        1,
+        ["nested"],
+        %{}
+      ]
+
+      resolved = Files.resolve_all(files)
+
+      for kind <- Files.kinds() do
+        assert Map.get(resolved, kind) == Files.resolve(kind, files)
+      end
+    end
+
+    test "returns an empty map for a malformed file list" do
+      assert Files.resolve_all(%{"files" => []}) == %{}
+      assert Files.resolve_all(nil) == %{}
+    end
+  end
+
+  describe "present_kinds/1" do
+    test "returns kinds in canonical order regardless of map insertion order" do
+      resolved = %{
+        threat_model: "THREAT_MODEL.md",
+        readme: "README.md",
+        license: "LICENSE"
+      }
+
+      assert Files.present_kinds(resolved) == [:readme, :license, :threat_model]
+    end
+
+    test "returns an empty list for an empty map" do
+      assert Files.present_kinds(%{}) == []
+    end
   end
 end


### PR DESCRIPTION
Closes #1569.

Extends README rendering to six more conventional documentation files: Changelog, License, Security, Support, Acknowledgments, Threat Model.

## Recognition

Root of the tarball only, no `.github/`. Bare filename, `.md`, `.markdown`, or `.txt`, case-insensitive, with `.md` preferred and a bare file beating `.txt` (matches README's existing preference order). `Acknowledgments` also matches the British spelling, `Threat Model` also matches `THREATMODEL` and `THREAT-MODEL`. All of this lives in `HexpmWeb.Docs.Files`, one table to extend for future file types.

## Rendering

`ReadmeController` becomes a general doc renderer on the `readme.` host: `/:name/:version/:kind` alongside the existing `/:name/:version`. Same pipeline as README today (Earmark, sanitizer, URL rewriter, Makeup), same CSP, same iframe sandbox. Bare and `.txt` files render as escaped `<pre>`, which covers the majority of LICENSE files.

Fetched documents over 2MB don't render inline; the page links out to HexPreview instead. The underlying HTTP client (`Hexpm.HTTP`) now supports a `max_body_size` option that aborts the fetch mid-stream rather than buffering the whole response first.

## Package page

First tab renamed from "Readme" to "Documentation". A file sidebar (desktop) and dropdown group (mobile) list the available files, populated client-side from a `doc-files` postMessage the iframe already had the data to send. A package with only a README looks exactly like it does today, no extra chrome. Deep links to a file the package doesn't publish show an explanation instead of a blank page.

## Testing

New tests for the filename table, the doc controller, and the package page routes/tabs. Existing README behavior is unchanged. `mix test` is green except for 9 pre-existing OAuth failures unrelated to this change.
