### PR TITLE
Report Oban metrics only from nodes that run queues

### DIFF
--- a/lib/hexpm/prom_ex.ex
+++ b/lib/hexpm/prom_ex.ex
@@ -10,14 +10,22 @@ defmodule Hexpm.PromEx do
       Plugins.Beam,
       {Plugins.Phoenix, router: HexpmWeb.Router, endpoint: HexpmWeb.Endpoint},
       {Plugins.Ecto, repos: [Hexpm.RepoBase]},
-      # Queue lengths come from counting the jobs table, which every node does
-      # on its own timer, so the default five seconds is a scan per node per
-      # five seconds for a number that does not move that fast.
-      {Plugins.Oban, poll_rate: :timer.minutes(1)},
       Hexpm.PromEx.Plugins.Hexpm,
       Hexpm.PromEx.Plugins.EctoLatency,
       Hexpm.PromEx.Plugins.OutboundHttp
-    ]
+    ] ++ oban_plugins()
+  end
+
+  # Queue lengths are counted from the jobs table and zero-filled from the
+  # node's own queue config, so a node that runs no queues never reports a
+  # zero and its gauges keep the last count they saw. Only nodes that run the
+  # queues report Oban metrics. The count is a scan of the table per node, so
+  # it runs once a minute rather than the default five seconds.
+  defp oban_plugins do
+    case Application.fetch_env!(:hexpm, Oban)[:queues] do
+      queues when queues in [false, []] -> []
+      _queues -> [{Plugins.Oban, poll_rate: :timer.minutes(1)}]
+    end
   end
 
   @impl true

--- a/test/hexpm/prom_ex_test.exs
+++ b/test/hexpm/prom_ex_test.exs
@@ -1,0 +1,35 @@
+defmodule Hexpm.PromExTest do
+  use ExUnit.Case, async: false
+
+  defp oban_plugin() do
+    Enum.find(Hexpm.PromEx.plugins(), fn
+      {PromEx.Plugins.Oban, _opts} -> true
+      _plugin -> false
+    end)
+  end
+
+  defp put_queues(queues) do
+    Application.put_env(
+      :hexpm,
+      Oban,
+      Keyword.put(Application.fetch_env!(:hexpm, Oban), :queues, queues)
+    )
+  end
+
+  setup do
+    config = Application.fetch_env!(:hexpm, Oban)
+    on_exit(fn -> Application.put_env(:hexpm, Oban, config) end)
+    :ok
+  end
+
+  test "reports Oban metrics only on nodes that run queues" do
+    put_queues(false)
+    refute oban_plugin()
+
+    put_queues([])
+    refute oban_plugin()
+
+    put_queues(registry: 1)
+    assert {PromEx.Plugins.Oban, poll_rate: 60_000} = oban_plugin()
+  end
+end


### PR DESCRIPTION
PromEx's Oban plugin counts queue lengths from the jobs table and zero-fills the result from the node's configured queues (`include_zeros_for_missing_queue_states/2` iterates `config.queues`). Web nodes run with `queues: false`, so they never emit a zero: once a poll on a web node saw a non-zero `available` count during a publish burst, that gauge kept the value until the pod restarted. The Oban dashboard takes the max across pods, so on 2026-08-29 it showed 33 registry and 79 purge jobs available while `oban_jobs` had none, and the `executing` gauges from web pods were stale the same way.

Web nodes no longer include the plugin. Worker nodes keep it and zero-fill every queue and state they run, so the gauges fall back to zero when the table does.
