### PR TITLE
Widen the Oban job duration and queue time buckets

### DIFF
--- a/lib/hexpm/prom_ex.ex
+++ b/lib/hexpm/prom_ex.ex
@@ -24,7 +24,7 @@ defmodule Hexpm.PromEx do
   defp oban_plugins do
     case Application.fetch_env!(:hexpm, Oban)[:queues] do
       queues when queues in [false, []] -> []
-      _queues -> [{Plugins.Oban, poll_rate: :timer.minutes(1)}]
+      _queues -> [{Hexpm.PromEx.Plugins.Oban, poll_rate: :timer.minutes(1)}]
     end
   end
 

--- a/lib/hexpm/prom_ex/plugins/oban.ex
+++ b/lib/hexpm/prom_ex/plugins/oban.ex
@@ -1,0 +1,52 @@
+defmodule Hexpm.PromEx.Plugins.Oban do
+  @moduledoc """
+  `PromEx.Plugins.Oban` with job duration buckets that cover the jobs run here.
+
+  The upstream plugin hardcodes `[10, 100, 500, 1_000, 5_000, 20_000]` for the
+  job processing and queue time histograms and offers no option to change them.
+  A purge job may run for five minutes, a full registry build for thirty and
+  the stats job for an hour, so upstream's histograms put most of what runs
+  here in the overflow bucket.
+
+  The upstream metrics are returned under their own names with only those
+  buckets replaced, so the upstream Oban dashboard keeps working.
+  """
+
+  use PromEx.Plugin
+
+  alias PromEx.MetricTypes.Event
+  alias Telemetry.Metrics.Distribution
+
+  @buckets [10, 100, 500, 1_000, 5_000, 20_000, 60_000, 300_000, 900_000, 3_600_000]
+
+  @rebucketed [
+    [:job, :processing, :duration, :milliseconds],
+    [:job, :queue, :time, :milliseconds],
+    [:job, :exception, :duration, :milliseconds],
+    [:job, :exception, :queue, :time, :milliseconds]
+  ]
+
+  @impl true
+  def event_metrics(opts) do
+    opts
+    |> PromEx.Plugins.Oban.event_metrics()
+    |> Enum.map(&rebucket/1)
+  end
+
+  @impl true
+  def polling_metrics(opts), do: PromEx.Plugins.Oban.polling_metrics(opts)
+
+  defp rebucket(%Event{metrics: metrics} = event) do
+    %{event | metrics: Enum.map(metrics, &rebucket_metric/1)}
+  end
+
+  defp rebucket_metric(%Distribution{name: name, reporter_options: options} = metric) do
+    if Enum.any?(@rebucketed, &List.ends_with?(name, &1)) do
+      %{metric | reporter_options: Keyword.put(options, :buckets, @buckets)}
+    else
+      metric
+    end
+  end
+
+  defp rebucket_metric(metric), do: metric
+end

--- a/test/hexpm/prom_ex/plugins/oban_test.exs
+++ b/test/hexpm/prom_ex/plugins/oban_test.exs
@@ -1,0 +1,67 @@
+defmodule Hexpm.PromEx.Plugins.ObanTest do
+  use ExUnit.Case, async: true
+
+  alias Hexpm.PromEx.Plugins.Oban, as: Plugin
+  alias PromEx.Plugins.Oban, as: Upstream
+
+  @opts [otp_app: :hexpm, poll_rate: :timer.minutes(1)]
+
+  @rebucketed [
+    [:hexpm, :prom_ex, :oban, :job, :processing, :duration, :milliseconds],
+    [:hexpm, :prom_ex, :oban, :job, :queue, :time, :milliseconds],
+    [:hexpm, :prom_ex, :oban, :job, :exception, :duration, :milliseconds],
+    [:hexpm, :prom_ex, :oban, :job, :exception, :queue, :time, :milliseconds]
+  ]
+
+  defp metrics(module) do
+    @opts |> module.event_metrics() |> List.wrap() |> Enum.flat_map(& &1.metrics)
+  end
+
+  test "returns the upstream metrics under the upstream names and groups" do
+    ours = List.wrap(Plugin.event_metrics(@opts))
+    upstream = List.wrap(Upstream.event_metrics(@opts))
+
+    assert Enum.map(ours, & &1.group_name) == Enum.map(upstream, & &1.group_name)
+    assert Enum.map(metrics(Plugin), & &1.name) == Enum.map(metrics(Upstream), & &1.name)
+    assert Plugin.polling_metrics(@opts) == Upstream.polling_metrics(@opts)
+  end
+
+  test "extends the job duration and queue time buckets past the upstream ceiling" do
+    ours = Map.new(metrics(Plugin), &{&1.name, &1})
+    upstream = Map.new(metrics(Upstream), &{&1.name, &1})
+
+    for name <- @rebucketed do
+      buckets = ours[name].reporter_options[:buckets]
+      upstream_buckets = upstream[name].reporter_options[:buckets]
+
+      assert List.starts_with?(buckets, upstream_buckets),
+             "#{inspect(name)} should keep the upstream buckets so existing panels keep their resolution"
+
+      assert Enum.max(buckets) >= longest_worker_timeout(),
+             "#{inspect(name)} needs a bucket that holds the longest-running worker"
+
+      assert buckets == Enum.sort(buckets)
+    end
+  end
+
+  defp longest_worker_timeout() do
+    :hexpm
+    |> Application.spec(:modules)
+    |> Enum.filter(&(Code.ensure_loaded?(&1) and function_exported?(&1, :__opts__, 0)))
+    |> Enum.map(& &1.timeout(%Oban.Job{}))
+    |> Enum.filter(&is_integer/1)
+    |> Enum.max()
+  end
+
+  test "leaves every other upstream metric unchanged" do
+    pairs = Enum.zip(metrics(Upstream), metrics(Plugin))
+
+    for {upstream, ours} <- pairs do
+      if upstream.name in @rebucketed do
+        assert %{ours | reporter_options: upstream.reporter_options} == upstream
+      else
+        assert ours == upstream
+      end
+    end
+  end
+end

--- a/test/hexpm/prom_ex_test.exs
+++ b/test/hexpm/prom_ex_test.exs
@@ -3,7 +3,7 @@ defmodule Hexpm.PromExTest do
 
   defp oban_plugin() do
     Enum.find(Hexpm.PromEx.plugins(), fn
-      {PromEx.Plugins.Oban, _opts} -> true
+      {Hexpm.PromEx.Plugins.Oban, _opts} -> true
       _plugin -> false
     end)
   end
@@ -30,6 +30,6 @@ defmodule Hexpm.PromExTest do
     refute oban_plugin()
 
     put_queues(registry: 1)
-    assert {PromEx.Plugins.Oban, poll_rate: 60_000} = oban_plugin()
+    assert {Hexpm.PromEx.Plugins.Oban, poll_rate: 60_000} = oban_plugin()
   end
 end


### PR DESCRIPTION
`PromEx.Plugins.Oban` hardcodes `[10, 100, 500, 1_000, 5_000, 20_000]` ms for the job processing and queue time histograms with no option to change them (upstream master is the same). A purge job may run for five minutes, a full registry build for thirty and the stats job for an hour, so most of those land in the overflow bucket and the "Job Execution Time" heatmap has nothing above 20s.

`Hexpm.PromEx.Plugins.Oban` returns the upstream metrics under the same names with those four histograms rebucketed: the upstream values, then 60s, 5m, 15m and 1h. The dashboard's heatmaps group by `le`, so `oban.json` in hexpm-ops needs no change.
