### PR TITLE
Report the number of connected Erlang nodes as a PromEx gauge

### DIFF
--- a/lib/hexpm/prom_ex/plugins/hexpm.ex
+++ b/lib/hexpm/prom_ex/plugins/hexpm.ex
@@ -3,10 +3,13 @@ defmodule Hexpm.PromEx.Plugins.Hexpm do
   PromEx plugin for hex.pm business metrics: the domain events emitted from
   the contexts (see `Hexpm.Repository.Releases` and `Hexpm.Accounts.Users`),
   registry builds (`Hexpm.Repository.RegistryWorker`) and CDN purges
-  (`Hexpm.CDN.PurgeWorker`, `Hexpm.CDN.Fastly`).
+  (`Hexpm.CDN.PurgeWorker`, `Hexpm.CDN.Fastly`), and the number of Erlang
+  nodes this node is connected to.
   """
 
   use PromEx.Plugin
+
+  @cluster_event [:hexpm, :cluster, :connected_nodes]
 
   @impl true
   def event_metrics(_opts) do
@@ -112,5 +115,28 @@ defmodule Hexpm.PromEx.Plugins.Hexpm do
         )
       ])
     ]
+  end
+
+  @impl true
+  def polling_metrics(opts) do
+    poll_rate = Keyword.get(opts, :poll_rate, 5_000)
+
+    Polling.build(
+      :hexpm_cluster_polling_metrics,
+      poll_rate,
+      {__MODULE__, :execute_cluster_metrics, []},
+      [
+        last_value("hexpm.cluster.connected_nodes",
+          event_name: @cluster_event,
+          measurement: :count,
+          description: "Erlang nodes this node is connected to, the length of Node.list/0."
+        )
+      ]
+    )
+  end
+
+  @doc false
+  def execute_cluster_metrics do
+    :telemetry.execute(@cluster_event, %{count: length(Node.list())}, %{})
   end
 end

--- a/test/hexpm/prom_ex/plugins/hexpm_test.exs
+++ b/test/hexpm/prom_ex/plugins/hexpm_test.exs
@@ -1,0 +1,33 @@
+defmodule Hexpm.PromEx.Plugins.HexpmTest do
+  use ExUnit.Case, async: true
+
+  alias Hexpm.PromEx.Plugins.Hexpm, as: Plugin
+
+  test "measures the number of connected nodes" do
+    ref = make_ref()
+    parent = self()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:hexpm, :cluster, :connected_nodes],
+      fn _event, measurements, _metadata, _config -> send(parent, {ref, measurements}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+    Plugin.execute_cluster_metrics()
+
+    assert_receive {^ref, %{count: count}}
+    assert count == length(Node.list())
+  end
+
+  test "polls the connected node count as a gauge" do
+    [polling] = [otp_app: :hexpm] |> Plugin.polling_metrics() |> List.wrap()
+
+    assert polling.measurements_mfa == {Plugin, :execute_cluster_metrics, []}
+
+    assert [%Telemetry.Metrics.LastValue{name: [:hexpm, :cluster, :connected_nodes]}] =
+             polling.metrics
+  end
+end


### PR DESCRIPTION
Adds a `hexpm_cluster_connected_nodes` gauge, polled every 5 s by PromEx, that reports `length(Node.list())` for each pod. The web pods have run with an empty `Node.list()` since December 2021 because the `hexpm` Service lost the label that `Cluster.Strategy.Kubernetes` selects on (fixed in hexpm/hexpm-ops#268), and nothing measured it: libcluster logs nothing when its endpoints query returns zero items, and PromEx's BEAM plugin has no distribution metrics.

Prometheus already labels scraped pods with `app` and `pod`, so with 3 web replicas the healthy state is `hexpm_cluster_connected_nodes{app="hexpm"} == 2` on every pod, and `min(hexpm_cluster_connected_nodes{app="hexpm"}) < count(hexpm_cluster_connected_nodes{app="hexpm"}) - 1` for longer than a rollout is the condition to alert or panel on. Worker pods don't start `Cluster.Supervisor` and report 0.
