### PR TITLE
Add a write-hold mode for masked database cutovers

### DIFF
--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -167,6 +167,7 @@ defmodule Hexpm.Application do
       {Cluster.Supervisor, [cluster_topologies(), [name: Hexpm.ClusterSupervisor]]},
       {Phoenix.PubSub, name: Hexpm.PubSub, adapter: Phoenix.PubSub.PG2},
       HexpmWeb.RateLimitPubSub,
+      Hexpm.WriteModePubSub,
       {PlugAttack.Storage.Ets, name: HexpmWeb.Plugs.Attack.Storage, clean_period: 60_000},
       {Hexpm.Cache,
        name: Hexpm.Cache,

--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -64,6 +64,43 @@ defmodule Hexpm.Repo do
       raise Hexpm.WriteInReadOnlyMode
     end
   end
+
+  @doc """
+  Restarts the database pool on this node against a different local port, for
+  cutting over to an instance whose proxy listens beside the current one.
+  Queries on this node fail between terminate and reconnect, so hold writes
+  first and expect a brief blip in reads.
+  """
+  def retarget_port!(port) when is_integer(port) do
+    # Hexpm.RepoBase.init/2 re-reads HEXPM_DATABASE_URL on every pool start,
+    # so the environment variable has to be rewritten too or the restarted
+    # pool comes back on the old port.
+    if url = System.get_env("HEXPM_DATABASE_URL") do
+      System.put_env("HEXPM_DATABASE_URL", put_url_port(url, port))
+    end
+
+    config =
+      :hexpm
+      |> Application.fetch_env!(Hexpm.RepoBase)
+      |> put_port(port)
+
+    Application.put_env(:hexpm, Hexpm.RepoBase, config)
+    :ok = Supervisor.terminate_child(Hexpm.Supervisor, Hexpm.RepoBase)
+    {:ok, _} = Supervisor.restart_child(Hexpm.Supervisor, Hexpm.RepoBase)
+    :ok
+  end
+
+  defp put_port(config, port) do
+    if url = config[:url] do
+      Keyword.put(config, :url, put_url_port(url, port))
+    else
+      Keyword.put(config, :port, port)
+    end
+  end
+
+  defp put_url_port(url, port) do
+    URI.to_string(%{URI.parse(url) | port: port})
+  end
 end
 
 defmodule Hexpm.RepoBase do

--- a/lib/hexpm/write_mode.ex
+++ b/lib/hexpm/write_mode.ex
@@ -1,9 +1,81 @@
 defmodule Hexpm.WriteMode do
+  @topic "write_mode"
+
   def enabled?() do
-    Application.get_env(:hexpm, :read_only_mode, false)
+    mode() == :read_only
   end
 
-  def configure!(read_only?) when is_boolean(read_only?) do
-    Application.put_env(:hexpm, :read_only_mode, read_only?)
+  def mode() do
+    case Application.get_env(:hexpm, :read_only_mode, false) do
+      false -> :write
+      :hold -> :hold
+      true -> :read_only
+    end
+  end
+
+  def configure!(mode) when mode in [false, :hold, true] do
+    Hexpm.WriteModePubSub.configure(mode)
+  end
+
+  def subscribe() do
+    Phoenix.PubSub.subscribe(Hexpm.PubSub, @topic)
+  end
+
+  def broadcast_from!(pid, mode) do
+    Phoenix.PubSub.broadcast_from!(Hexpm.PubSub, pid, @topic, {:write_mode, mode})
+  end
+
+  @doc """
+  Parks the calling process while the mode is `:hold`.
+
+  Returns `:ok` when writes may proceed, `:unavailable` when the mode is or
+  becomes `:read_only`, and `:timeout` when the deadline passes first. Only
+  masks pauses shorter than the caller's tolerance for latency; anything
+  longer must fall back to rejecting the request.
+  """
+  def await_write(timeout) do
+    case mode() do
+      :write ->
+        :ok
+
+      :read_only ->
+        :unavailable
+
+      :hold ->
+        :ok = Phoenix.PubSub.subscribe(Hexpm.PubSub, @topic)
+
+        try do
+          await(System.monotonic_time(:millisecond) + timeout)
+        after
+          Phoenix.PubSub.unsubscribe(Hexpm.PubSub, @topic)
+        end
+    end
+  end
+
+  defp await(deadline) do
+    # Re-read after subscribing: a release broadcast between the first mode
+    # check and the subscribe would otherwise never reach this process.
+    case mode() do
+      :write ->
+        :ok
+
+      :read_only ->
+        :unavailable
+
+      :hold ->
+        wait = deadline - System.monotonic_time(:millisecond)
+
+        if wait <= 0 do
+          :timeout
+        else
+          receive do
+            {:write_mode, false} -> :ok
+            {:write_mode, true} -> :unavailable
+            {:write_mode, :hold} -> await(deadline)
+          after
+            wait -> :timeout
+          end
+        end
+    end
   end
 end

--- a/lib/hexpm/write_mode.ex
+++ b/lib/hexpm/write_mode.ex
@@ -6,14 +6,14 @@ defmodule Hexpm.WriteMode do
   end
 
   def mode() do
-    case Application.get_env(:hexpm, :read_only_mode, false) do
-      false -> :write
-      :hold -> :hold
-      true -> :read_only
-    end
+    normalize(Application.get_env(:hexpm, :read_only_mode, false))
   end
 
-  def configure!(mode) when mode in [false, :hold, true] do
+  defp normalize(false), do: :write
+  defp normalize(true), do: :read_only
+  defp normalize(mode), do: mode
+
+  def configure!(mode) when mode in [false, :hold, :hold_all, true] do
     Hexpm.WriteModePubSub.configure(mode)
   end
 
@@ -26,7 +26,7 @@ defmodule Hexpm.WriteMode do
   end
 
   @doc """
-  Parks the calling process while the mode is `:hold`.
+  Parks the calling process while the mode is `:hold` or `:hold_all`.
 
   Returns `:ok` when writes may proceed, `:unavailable` when the mode is or
   becomes `:read_only`, and `:timeout` when the deadline passes first. Only
@@ -34,48 +34,65 @@ defmodule Hexpm.WriteMode do
   longer must fall back to rejecting the request.
   """
   def await_write(timeout) do
-    case mode() do
-      :write ->
-        :ok
+    await_mode(:write, timeout)
+  end
 
-      :read_only ->
-        :unavailable
+  @doc """
+  Parks the calling process while the mode is `:hold_all`.
 
-      :hold ->
+  Reads flow in every other mode; `:hold_all` exists so the seconds around a
+  connection pool restart hold the whole request instead of letting in-flight
+  queries die with connection errors.
+  """
+  def await_read(timeout) do
+    await_mode(:read, timeout)
+  end
+
+  defp await_mode(kind, timeout) do
+    case classify(kind, mode()) do
+      :park ->
         :ok = Phoenix.PubSub.subscribe(Hexpm.PubSub, @topic)
 
         try do
-          await(System.monotonic_time(:millisecond) + timeout)
+          await(kind, System.monotonic_time(:millisecond) + timeout)
         after
           Phoenix.PubSub.unsubscribe(Hexpm.PubSub, @topic)
         end
+
+      result ->
+        result
     end
   end
 
-  defp await(deadline) do
+  defp await(kind, deadline) do
     # Re-read after subscribing: a release broadcast between the first mode
     # check and the subscribe would otherwise never reach this process.
-    case mode() do
-      :write ->
-        :ok
-
-      :read_only ->
-        :unavailable
-
-      :hold ->
+    case classify(kind, mode()) do
+      :park ->
         wait = deadline - System.monotonic_time(:millisecond)
 
         if wait <= 0 do
           :timeout
         else
           receive do
-            {:write_mode, false} -> :ok
-            {:write_mode, true} -> :unavailable
-            {:write_mode, :hold} -> await(deadline)
+            {:write_mode, value} ->
+              case classify(kind, normalize(value)) do
+                :park -> await(kind, deadline)
+                result -> result
+              end
           after
             wait -> :timeout
           end
         end
+
+      result ->
+        result
     end
   end
+
+  defp classify(:write, :write), do: :ok
+  defp classify(:write, :read_only), do: :unavailable
+  defp classify(:write, hold) when hold in [:hold, :hold_all], do: :park
+  defp classify(:read, :hold_all), do: :park
+  defp classify(:read, _mode), do: :ok
 end

--- a/lib/hexpm/write_mode_pub_sub.ex
+++ b/lib/hexpm/write_mode_pub_sub.ex
@@ -1,0 +1,31 @@
+defmodule Hexpm.WriteModePubSub do
+  use GenServer
+
+  alias Hexpm.WriteMode
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, [], name: __MODULE__)
+  end
+
+  def configure(mode) do
+    GenServer.call(__MODULE__, {:configure, mode})
+  end
+
+  def init([]) do
+    WriteMode.subscribe()
+    {:ok, []}
+  end
+
+  # Serializing local sets and remote broadcasts through this process keeps a
+  # node's mode from being overwritten by its own earlier broadcast.
+  def handle_call({:configure, mode}, _from, []) do
+    Application.put_env(:hexpm, :read_only_mode, mode)
+    WriteMode.broadcast_from!(self(), mode)
+    {:reply, :ok, []}
+  end
+
+  def handle_info({:write_mode, mode}, []) do
+    Application.put_env(:hexpm, :read_only_mode, mode)
+    {:noreply, []}
+  end
+end

--- a/lib/hexpm_web/plugs/read_only.ex
+++ b/lib/hexpm_web/plugs/read_only.ex
@@ -15,22 +15,33 @@ defmodule HexpmWeb.Plugs.ReadOnly do
   end
 
   def call(conn, opts) do
-    if write_request?(conn, opts) and not allowed_route?(conn, opts) do
-      case WriteMode.mode() do
-        :write ->
-          conn
+    case WriteMode.mode() do
+      :write ->
+        conn
 
-        :read_only ->
-          unavailable(conn)
+      mode ->
+        cond do
+          write_request?(conn, opts) and not allowed_route?(conn, opts) ->
+            case mode do
+              :read_only -> unavailable(conn)
+              _hold -> hold(conn, &WriteMode.await_write/1)
+            end
 
-        :hold ->
-          case WriteMode.await_write(hold_timeout()) do
-            :ok -> conn
-            _ -> unavailable(conn)
-          end
-      end
-    else
-      conn
+          # Also parks the allowed write routes: nothing may touch the pool
+          # while it restarts onto the new primary.
+          mode == :hold_all ->
+            hold(conn, &WriteMode.await_read/1)
+
+          true ->
+            conn
+        end
+    end
+  end
+
+  defp hold(conn, awaiter) do
+    case awaiter.(hold_timeout()) do
+      :ok -> conn
+      _ -> unavailable(conn)
     end
   end
 

--- a/lib/hexpm_web/plugs/read_only.ex
+++ b/lib/hexpm_web/plugs/read_only.ex
@@ -15,11 +15,27 @@ defmodule HexpmWeb.Plugs.ReadOnly do
   end
 
   def call(conn, opts) do
-    if WriteMode.enabled?() and write_request?(conn, opts) and not allowed_route?(conn, opts) do
-      unavailable(conn)
+    if write_request?(conn, opts) and not allowed_route?(conn, opts) do
+      case WriteMode.mode() do
+        :write ->
+          conn
+
+        :read_only ->
+          unavailable(conn)
+
+        :hold ->
+          case WriteMode.await_write(hold_timeout()) do
+            :ok -> conn
+            _ -> unavailable(conn)
+          end
+      end
     else
       conn
     end
+  end
+
+  defp hold_timeout() do
+    Application.get_env(:hexpm, :write_hold_timeout, 25_000)
   end
 
   defp prepare_unavailable(conn) do

--- a/test/hexpm/repo_retarget_test.exs
+++ b/test/hexpm/repo_retarget_test.exs
@@ -1,0 +1,53 @@
+defmodule Hexpm.RepoRetargetTest do
+  # Restarts the shared database pool, so nothing else may be running.
+  use ExUnit.Case, async: false
+
+  # A restarted pool comes up in the ownership default mode (:auto), not the
+  # :manual sandbox mode test_helper configured; without restoring it, every
+  # test that runs afterwards commits real rows and the suite flakes on
+  # whatever runs downstream.
+  defp retarget_and_restore_sandbox!(target_port) do
+    :ok = Hexpm.Repo.retarget_port!(target_port)
+    Ecto.Adapters.SQL.Sandbox.mode(Hexpm.RepoBase, :manual)
+    :ok
+  end
+
+  test "retarget_port! restarts the pool against the requested port" do
+    config = Application.fetch_env!(:hexpm, Hexpm.RepoBase)
+    port = config[:port] || 5432
+
+    assert :ok = retarget_and_restore_sandbox!(port)
+    assert Application.fetch_env!(:hexpm, Hexpm.RepoBase)[:port] == port
+
+    # The restarted pool is a fresh sandbox in manual mode; prove it serves
+    # queries again after the restart.
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Hexpm.RepoBase)
+    assert %{rows: [[1]]} = Hexpm.RepoBase.query!("SELECT 1")
+    Ecto.Adapters.SQL.Sandbox.checkin(Hexpm.RepoBase)
+  end
+
+  test "retarget_port! rewrites HEXPM_DATABASE_URL, which init/2 prefers over config" do
+    config = Application.fetch_env!(:hexpm, Hexpm.RepoBase)
+    port = config[:port] || 5432
+
+    # A dead port in the environment variable proves the rewrite happens:
+    # init/2 re-reads the variable on pool start, so without the rewrite the
+    # restarted pool would target 1 and fail its queries.
+    System.put_env(
+      "HEXPM_DATABASE_URL",
+      "ecto://#{config[:username]}:#{config[:password]}@#{config[:hostname]}:1/#{config[:database]}"
+    )
+
+    on_exit(fn ->
+      System.delete_env("HEXPM_DATABASE_URL")
+      :ok = retarget_and_restore_sandbox!(port)
+    end)
+
+    assert :ok = retarget_and_restore_sandbox!(port)
+    assert URI.parse(System.get_env("HEXPM_DATABASE_URL")).port == port
+
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(Hexpm.RepoBase)
+    assert %{rows: [[1]]} = Hexpm.RepoBase.query!("SELECT 1")
+    Ecto.Adapters.SQL.Sandbox.checkin(Hexpm.RepoBase)
+  end
+end

--- a/test/hexpm/write_mode_test.exs
+++ b/test/hexpm/write_mode_test.exs
@@ -53,6 +53,45 @@ defmodule Hexpm.WriteModeTest do
     assert WriteMode.await_write(50) == :timeout
   end
 
+  test "await_write also parks during hold_all" do
+    WriteMode.configure!(:hold_all)
+
+    task = Task.async(fn -> WriteMode.await_write(5000) end)
+    assert nil == Task.yield(task, 100)
+
+    # Narrowing to the write-only hold keeps writes parked.
+    WriteMode.configure!(:hold)
+    assert nil == Task.yield(task, 100)
+
+    WriteMode.configure!(false)
+    assert Task.await(task) == :ok
+  end
+
+  test "await_read passes in every mode except hold_all" do
+    assert WriteMode.await_read(100) == :ok
+
+    WriteMode.configure!(:hold)
+    assert WriteMode.await_read(100) == :ok
+
+    WriteMode.configure!(true)
+    assert WriteMode.await_read(100) == :ok
+  end
+
+  test "await_read parks during hold_all and releases on any other mode" do
+    WriteMode.configure!(:hold_all)
+
+    task = Task.async(fn -> WriteMode.await_read(5000) end)
+    assert nil == Task.yield(task, 100)
+
+    WriteMode.configure!(:hold)
+    assert Task.await(task) == :ok
+  end
+
+  test "await_read times out when hold_all outlives the deadline" do
+    WriteMode.configure!(:hold_all)
+    assert WriteMode.await_read(50) == :timeout
+  end
+
   test "a broadcast from another node applies the mode locally" do
     Phoenix.PubSub.broadcast!(Hexpm.PubSub, "write_mode", {:write_mode, :hold})
 

--- a/test/hexpm/write_mode_test.exs
+++ b/test/hexpm/write_mode_test.exs
@@ -1,0 +1,76 @@
+defmodule Hexpm.WriteModeTest do
+  use ExUnit.Case, async: false
+
+  alias Hexpm.WriteMode
+
+  setup do
+    on_exit(fn -> WriteMode.configure!(false) end)
+    :ok
+  end
+
+  test "mode reflects the configured value" do
+    assert WriteMode.mode() == :write
+    refute WriteMode.enabled?()
+
+    WriteMode.configure!(:hold)
+    assert WriteMode.mode() == :hold
+    refute WriteMode.enabled?()
+
+    WriteMode.configure!(true)
+    assert WriteMode.mode() == :read_only
+    assert WriteMode.enabled?()
+  end
+
+  test "await_write passes writes through in write mode and rejects them in read-only" do
+    assert WriteMode.await_write(100) == :ok
+
+    WriteMode.configure!(true)
+    assert WriteMode.await_write(100) == :unavailable
+  end
+
+  test "await_write parks during hold and releases when writes resume" do
+    WriteMode.configure!(:hold)
+
+    task = Task.async(fn -> WriteMode.await_write(5000) end)
+    assert nil == Task.yield(task, 100)
+
+    WriteMode.configure!(false)
+    assert Task.await(task) == :ok
+  end
+
+  test "await_write parks during hold and rejects when the mode hardens to read-only" do
+    WriteMode.configure!(:hold)
+
+    task = Task.async(fn -> WriteMode.await_write(5000) end)
+    assert nil == Task.yield(task, 100)
+
+    WriteMode.configure!(true)
+    assert Task.await(task) == :unavailable
+  end
+
+  test "await_write times out when the hold outlives the deadline" do
+    WriteMode.configure!(:hold)
+    assert WriteMode.await_write(50) == :timeout
+  end
+
+  test "a broadcast from another node applies the mode locally" do
+    Phoenix.PubSub.broadcast!(Hexpm.PubSub, "write_mode", {:write_mode, :hold})
+
+    # The listener applies the mode asynchronously.
+    assert wait_until(fn -> WriteMode.mode() == :hold end)
+  end
+
+  defp wait_until(fun, tries \\ 50) do
+    cond do
+      fun.() ->
+        true
+
+      tries == 0 ->
+        false
+
+      true ->
+        Process.sleep(10)
+        wait_until(fun, tries - 1)
+    end
+  end
+end

--- a/test/hexpm_web/read_only_mode_test.exs
+++ b/test/hexpm_web/read_only_mode_test.exs
@@ -49,6 +49,54 @@ defmodule HexpmWeb.ReadOnlyModeTest do
     assert conn.private.logster_log_level == :info
   end
 
+  test "hold mode parks API writes and completes them when writes resume" do
+    Ecto.Adapters.SQL.Sandbox.mode(Hexpm.RepoBase, {:shared, self()})
+    user = insert(:user)
+    key = insert(:key, user: user)
+    WriteMode.configure!(:hold)
+
+    task =
+      Task.async(fn ->
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> post("/api/keys", %{name: "held-key"})
+      end)
+
+    assert nil == Task.yield(task, 300)
+
+    WriteMode.configure!(false)
+    conn = Task.await(task)
+    assert json_response(conn, 201)["name"] == "held-key"
+  end
+
+  test "hold mode falls back to the maintenance error when the deadline passes" do
+    Application.put_env(:hexpm, :write_hold_timeout, 50)
+    on_exit(fn -> Application.delete_env(:hexpm, :write_hold_timeout) end)
+
+    user = insert(:user)
+    key = insert(:key, user: user)
+    WriteMode.configure!(:hold)
+
+    conn =
+      build_conn()
+      |> put_req_header("authorization", key.user_secret)
+      |> post("/api/keys", %{name: "late-key"})
+
+    assert json_response(conn, 503)["error"] == "temporarily_unavailable"
+    assert get_resp_header(conn, "retry-after") == ["60"]
+  end
+
+  test "hold mode does not delay reads" do
+    user = insert(:user)
+    key = insert(:key, user: user)
+    WriteMode.configure!(:hold)
+
+    build_conn()
+    |> put_req_header("authorization", key.user_secret)
+    |> get("/api/auth", domain: "api")
+    |> response(200)
+  end
+
   test "Hexpm.Repo.insert_all is gated by read-only mode" do
     WriteMode.configure!(true)
 

--- a/test/hexpm_web/read_only_mode_test.exs
+++ b/test/hexpm_web/read_only_mode_test.exs
@@ -97,6 +97,35 @@ defmodule HexpmWeb.ReadOnlyModeTest do
     |> response(200)
   end
 
+  test "hold_all parks reads and completes them on release" do
+    user = insert(:user)
+    key = insert(:key, user: user)
+    Ecto.Adapters.SQL.Sandbox.mode(Hexpm.RepoBase, {:shared, self()})
+    WriteMode.configure!(:hold_all)
+
+    task =
+      Task.async(fn ->
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "api")
+      end)
+
+    assert nil == Task.yield(task, 100)
+
+    WriteMode.configure!(false)
+    assert response(Task.await(task), 200)
+  end
+
+  test "hold_all falls back to the maintenance error when the deadline passes" do
+    Application.put_env(:hexpm, :write_hold_timeout, 50)
+    on_exit(fn -> Application.delete_env(:hexpm, :write_hold_timeout) end)
+
+    WriteMode.configure!(:hold_all)
+
+    conn = get(build_conn(), "/api/packages/nonexistent", domain: "api")
+    assert conn.status == 503
+  end
+
   test "Hexpm.Repo.insert_all is gated by read-only mode" do
     WriteMode.configure!(true)
 


### PR DESCRIPTION
Two additional write modes turn a database cutover shorter than an HTTP timeout into a latency spike instead of failed requests: `:hold` parks write requests in-process rather than rejecting them, and `:hold_all` additionally parks reads for the seconds around the connection-pool restart so no in-flight query dies with a connection error.

Mechanism: `Hexpm.WriteMode.mode/0` returns `:write`, `:hold`, `:hold_all`, or `:read_only` (stored as `false | :hold | :hold_all | true` in the existing app env key). Under `:hold` the read-only plug parks write requests on a PubSub subscription with a deadline (`:write_hold_timeout`, default 25s); on release they proceed unchanged, and on deadline or a hardening to read-only they fall back to the 503 with Retry-After. Under `:hold_all` every request parks, including the allowed write routes; only the `/status` probe, which responds before the router, stays untouched. Mode changes serialize through `Hexpm.WriteModePubSub` so a node's mode cannot be overwritten by its own earlier broadcast. The deployed pods run unclustered, so the cutover tooling sets the mode on every pod directly and verifies each pod took the hold before anything irreversible. `Hexpm.Repo.retarget_port!/1` restarts the pool against a different local proxy port and rewrites `HEXPM_DATABASE_URL`, which `RepoBase.init/2` re-reads on every pool start.

The cutover this enables, automated in hexpm-ops `bin/pg-upgrade` (second cloud-sql-proxy sidecar at the new instance, native logical replication): hold writes on every pod, wait for replication lag zero, sync sequences from the frozen source, set the old databases `default_transaction_read_only`, disable the subscriptions, hold reads, drain two seconds, retarget every pod, release. Measured on staging with two pods under live probes: 19s held window, every write completed including one parked 17.7s, zero read failures, zero Sentry events. Measured on prod-clone rehearsals with two local app nodes: 16s window, with the read that earlier runs lost to the pool restart instead held 8.1s and completed.

Known limits: only masks pauses shorter than the deadline; Oban timer writes on web pods are not parked and rely on the database-level read-only guard; a pod that boots mid-window starts in `:write` (the env var knows nothing of the hold modes), which the same guard covers.

Validated with `mix format` and the full suite on four seeds: 2,839 tests and 31 properties, no failures.

