### PR TITLE
Store ids in grant_reference instead of the exchanged credential

### DIFF
--- a/lib/hexpm/oauth/device_codes.ex
+++ b/lib/hexpm/oauth/device_codes.ex
@@ -278,7 +278,7 @@ defmodule Hexpm.OAuth.DeviceCodes do
               device_code_record.client_id,
               final_scopes,
               "urn:ietf:params:oauth:grant-type:device_code",
-              device_code_record.device_code,
+              grant_reference(device_code_record),
               user_session_id: session.id,
               with_refresh_token: true
             )
@@ -318,11 +318,13 @@ defmodule Hexpm.OAuth.DeviceCodes do
     end
   end
 
+  defp grant_reference(device_code_record), do: "device_code:#{device_code_record.id}"
+
   defp get_device_token(device_code_record) do
     from(t in Token,
       where:
         t.grant_type == "urn:ietf:params:oauth:grant-type:device_code" and
-          t.grant_reference == ^device_code_record.device_code and
+          t.grant_reference == ^grant_reference(device_code_record) and
           t.client_id == ^device_code_record.client_id and
           is_nil(t.revoked_at),
       order_by: [desc: t.inserted_at, desc: t.id],
@@ -386,7 +388,7 @@ defmodule Hexpm.OAuth.DeviceCodes do
     from(t in Token,
       where:
         t.grant_type == "urn:ietf:params:oauth:grant-type:device_code" and
-          t.grant_reference == ^device_code_record.device_code and
+          t.grant_reference == ^grant_reference(device_code_record) and
           t.client_id == ^device_code_record.client_id and
           is_nil(t.revoked_at)
     )

--- a/lib/hexpm/release_tasks/purge_expired_records.ex
+++ b/lib/hexpm/release_tasks/purge_expired_records.ex
@@ -26,7 +26,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecords do
   @redacted %{
     Hexpm.OAuth.AuthorizationCode => ~w(code code_challenge),
     Hexpm.OAuth.DeviceCode => ~w(device_code user_code verification_uri_complete),
-    Hexpm.OAuth.Token => ~w(refresh_token_hash grant_reference),
+    Hexpm.OAuth.Token => ~w(refresh_token_hash),
     Hexpm.UserSession => ~w(session_token),
     Hexpm.Accounts.PasswordReset => ~w(key),
     Hexpm.Accounts.AccountDeletionRequest => ~w(key),

--- a/lib/hexpm_web/controllers/api/oauth_controller.ex
+++ b/lib/hexpm_web/controllers/api/oauth_controller.ex
@@ -115,7 +115,7 @@ defmodule HexpmWeb.API.OAuthController do
              client.client_id,
              used_auth_code.scopes,
              "authorization_code",
-             used_auth_code.code,
+             "authorization_code:#{used_auth_code.id}",
              name: safe_param(params, "name"),
              with_refresh_token: true,
              usage_info: usage_info,
@@ -179,7 +179,7 @@ defmodule HexpmWeb.API.OAuthController do
              client.client_id,
              token.granted_scopes,
              "refresh_token",
-             params["refresh_token"],
+             "token:#{token.jti}",
              with_refresh_token: true,
              user_session_id: token.user_session_id,
              usage_info: usage_info
@@ -216,7 +216,7 @@ defmodule HexpmWeb.API.OAuthController do
              client.client_id,
              scopes,
              "client_credentials",
-             api_key_secret,
+             "key:#{auth_info.auth_credential.id}",
              name: safe_param(params, "name"),
              usage_info: usage_info
            ) do

--- a/priv/repo/migrations/20260830090000_replace_grant_reference_secrets.exs
+++ b/priv/repo/migrations/20260830090000_replace_grant_reference_secrets.exs
@@ -1,0 +1,23 @@
+defmodule Hexpm.RepoBase.Migrations.ReplaceGrantReferenceSecrets do
+  use Ecto.Migration
+
+  def up do
+    execute("""
+    UPDATE oauth_tokens t
+    SET grant_reference = 'device_code:' || d.id
+    FROM device_codes d
+    WHERE t.grant_type = 'urn:ietf:params:oauth:grant-type:device_code'
+      AND t.grant_reference = d.device_code
+    """)
+
+    execute("""
+    UPDATE oauth_tokens
+    SET grant_reference = NULL
+    WHERE grant_reference IS NOT NULL
+      AND grant_reference !~ '^(key|token|authorization_code|device_code):'
+    """)
+  end
+
+  def down do
+  end
+end

--- a/test/hexpm/oauth/device_flow_test.exs
+++ b/test/hexpm/oauth/device_flow_test.exs
@@ -220,7 +220,7 @@ defmodule Hexpm.OAuth.DeviceFlowTest do
           client.client_id,
           device_code.scopes,
           "urn:ietf:params:oauth:grant-type:device_code",
-          device_code.device_code
+          "device_code:#{device_code.id}"
         )
 
       assert {:error, changeset} = Repo.insert(duplicate)
@@ -234,7 +234,7 @@ defmodule Hexpm.OAuth.DeviceFlowTest do
       from(t in Token,
         where:
           t.grant_type == "urn:ietf:params:oauth:grant-type:device_code" and
-            t.grant_reference == ^device_code.device_code and
+            t.grant_reference == ^"device_code:#{device_code.id}" and
             t.client_id == ^client.client_id and
             is_nil(t.revoked_at)
       )
@@ -262,7 +262,7 @@ defmodule Hexpm.OAuth.DeviceFlowTest do
       oauth_token =
         Repo.get_by(Token,
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-          grant_reference: device_code.device_code,
+          grant_reference: "device_code:#{device_code.id}",
           client_id: client.client_id
         )
 
@@ -287,7 +287,7 @@ defmodule Hexpm.OAuth.DeviceFlowTest do
       oauth_token =
         Repo.get_by(Token,
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-          grant_reference: device_code.device_code,
+          grant_reference: "device_code:#{device_code.id}",
           client_id: client.client_id
         )
         |> Repo.preload(:user_session)

--- a/test/hexpm/release_tasks/purge_expired_records_test.exs
+++ b/test/hexpm/release_tasks/purge_expired_records_test.exs
@@ -507,7 +507,7 @@ defmodule Hexpm.ReleaseTasks.PurgeExpiredRecordsTest do
     @credentials %{
       "authorization_codes" => ~w(code code_challenge),
       "device_codes" => ~w(device_code user_code verification_uri_complete),
-      "oauth_tokens" => ~w(refresh_token_hash grant_reference),
+      "oauth_tokens" => ~w(refresh_token_hash),
       "user_sessions" => ~w(session_token),
       "password_resets" => ~w(key),
       "account_deletion_requests" => ~w(key),

--- a/test/hexpm_web/controllers/device_controller_test.exs
+++ b/test/hexpm_web/controllers/device_controller_test.exs
@@ -401,7 +401,7 @@ defmodule HexpmWeb.DeviceControllerTest do
       token =
         Repo.get_by(Hexpm.OAuth.Token,
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-          grant_reference: device_code.device_code
+          grant_reference: "device_code:#{device_code.id}"
         )
 
       assert token.scopes == ["api:read"]
@@ -429,7 +429,7 @@ defmodule HexpmWeb.DeviceControllerTest do
       token =
         Repo.get_by(Hexpm.OAuth.Token,
           grant_type: "urn:ietf:params:oauth:grant-type:device_code",
-          grant_reference: device_code.device_code
+          grant_reference: "device_code:#{device_code.id}"
         )
 
       assert token.scopes == ["api:read"]


### PR DESCRIPTION
`oauth_tokens.grant_reference` stored the credential presented at the token endpoint, verbatim: for `client_credentials` the `client_secret` parameter, which is the API key itself (`handle_client_credentials_grant`), for `refresh_token` the parent refresh JWT, for the two code grants the code. Keys are hashed everywhere else; this column has held them in clear for up to a day per token since the grant shipped.

The references are now `key:<id>`, `token:<jti>` (the parent token), `authorization_code:<id>` and `device_code:<id>`. The device-code lookups (`get_device_token`, `revoke_live_device_tokens`) compare against the new form, so the migration rewrites live device-code references by joining `device_codes`, and sets every other old-format reference to NULL. With no secret in the column, `PurgeExpiredRecords` archives it again (#1864 had dropped it), so the archive records which key or parent token minted each token.
