### PR TITLE
Return the key id from /api/auth in x-hex-key-id

### DIFF
--- a/lib/hexpm_web/controllers/api/auth_controller.ex
+++ b/lib/hexpm_web/controllers/api/auth_controller.ex
@@ -40,8 +40,13 @@ defmodule HexpmWeb.API.AuthController do
 
   defp success(conn) do
     case conn.assigns.auth_credential do
-      %Key{} = key -> render(conn, :show, key: key)
-      _ -> send_resp(conn, 204, "")
+      %Key{} = key ->
+        conn
+        |> put_resp_header("x-hex-key-id", Integer.to_string(key.id))
+        |> render(:show, key: key)
+
+      _ ->
+        send_resp(conn, 204, "")
     end
   end
 end

--- a/test/hexpm_web/controllers/api/auth_controller_test.exs
+++ b/test/hexpm_web/controllers/api/auth_controller_test.exs
@@ -197,10 +197,13 @@ defmodule HexpmWeb.API.AuthControllerTest do
     end
 
     test "authenticate user api key", %{user_api_key: key} do
-      build_conn()
-      |> put_req_header("authorization", key.user_secret)
-      |> get("/api/auth", domain: "api")
-      |> response(200)
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key.user_secret)
+        |> get("/api/auth", domain: "api")
+
+      assert response(conn, 200)
+      assert get_resp_header(conn, "x-hex-key-id") == [Integer.to_string(key.id)]
 
       build_conn()
       |> put_req_header("authorization", key.user_secret)


### PR DESCRIPTION
`GET /api/auth` answered with an API key now carries the key's id in `x-hex-key-id`. The `repo` Fastly program (hexpm-ops PR `access-log-identity`) puts it in the access log line as `key:<id>`, next to `token:<jti>` for JWTs it verifies itself, so a private-repository request in the Fastly log joins the key or token that made it. The body is unchanged; OAuth tokens still get a 204.
