### PR TITLE
Stop logging LiveView socket connects

### DIFF
--- a/lib/hexpm_web/endpoint.ex
+++ b/lib/hexpm_web/endpoint.ex
@@ -28,7 +28,11 @@ defmodule HexpmWeb.Endpoint do
     only_matching: ~w(favicon)
 
   socket("/live", Phoenix.LiveView.Socket,
-    websocket: [compress: true, connect_info: [:peer_data, :x_headers, session: @session_options]]
+    websocket: [
+      compress: true,
+      log: false,
+      connect_info: [:peer_data, :x_headers, session: @session_options]
+    ]
   )
 
   if Code.ensure_loaded?(Tidewave) do


### PR DESCRIPTION
`log: false` on the LiveView socket. Measured on 2026-08-29 in `logs.stdout` for the hexpm pods: 2,980,706 log entries, of which 327,116 (11%) were the four-line `CONNECTED TO Phoenix.LiveView.Socket` blocks from 81,779 connects, 34 MiB of the day's 449 MiB of text. The Logster request line for the `/live/websocket` upgrade stays, so the connect itself is still visible; what goes is the block with the transport, serializer and the connect parameters.

For the record, the two things I thought a `_Default` sink exclusion would be for: this, and the load balancer health checks, which turn out not to be logged at all (6 `path=/status` lines that day). The rest of `_Default`'s volume is the LB request log (2.93 GiB logical for the day) and the app's request lines (2.64 M), neither of which we want to drop, so there is nothing left for an infra-side filter to do.
