### PR TITLE
Render additional package documentation files

### DIFF
--- a/lib/hexpm/docs/files.ex
+++ b/lib/hexpm/docs/files.ex
@@ -1,0 +1,119 @@
+defmodule Hexpm.Docs.Files do
+  @moduledoc """
+  Recognition table for conventional documentation files in a release.
+
+  Matched case-insensitively at the tarball root, preferring .md, .markdown,
+  .txt then bare -- Preview's existing README priority.
+  """
+
+  @type resolved :: %{atom => String.t()}
+
+  @kinds_and_labels [
+    readme: "Readme",
+    changelog: "Changelog",
+    license: "License",
+    security: "Security",
+    support: "Support"
+    # ACKNOWLEDGMENTS and THREAT_MODEL were in none of the 2,680 packages
+    # surveyed on #1569; add a kind here and its basenames below for one.
+  ]
+
+  @kinds Keyword.keys(@kinds_and_labels)
+
+  @basenames %{
+    readme: ["README"],
+    changelog: ["CHANGELOG"],
+    license: ["LICENSE"],
+    security: ["SECURITY"],
+    support: ["SUPPORT"]
+  }
+
+  @extensions ["md", "markdown", "txt", ""]
+
+  @extension_rank @extensions |> Enum.with_index() |> Map.new()
+
+  @basename_to_kind for {kind, names} <- @basenames, name <- names, into: %{}, do: {name, kind}
+
+  @doc "Recognized kinds, in canonical order."
+  @spec kinds() :: [atom]
+  def kinds(), do: Keyword.keys(@kinds_and_labels)
+
+  @doc "Label for a kind, falling back to its string form."
+  @spec label(atom) :: String.t()
+  def label(kind), do: Keyword.get(@kinds_and_labels, kind, to_string(kind))
+
+  @spec parse_segment(term) :: atom | nil
+  for kind <- @kinds do
+    def parse_segment(unquote(Atom.to_string(kind))), do: unquote(kind)
+  end
+
+  def parse_segment(_segment), do: nil
+
+  @doc """
+  Every kind resolvable from `files`, as kind => filename. Malformed input
+  resolves to nothing rather than raising; `files` comes from the tarball index.
+  """
+  @spec resolve_all(term) :: resolved
+  def resolve_all(files) when is_list(files) do
+    files
+    |> Enum.filter(&is_binary/1)
+    |> Enum.reject(&String.contains?(&1, "/"))
+    |> Enum.flat_map(fn filename ->
+      case classify(filename) do
+        {kind, ext} -> [{kind, ext, filename}]
+        :nomatch -> []
+      end
+    end)
+    |> Enum.group_by(&elem(&1, 0))
+    |> Map.new(fn {kind, matches} ->
+      {_kind, _ext, filename} =
+        Enum.min_by(matches, fn {_, ext, name} -> {@extension_rank[ext], name} end)
+
+      {kind, filename}
+    end)
+  end
+
+  def resolve_all(_files), do: %{}
+
+  @doc "Kinds present in a `resolve_all/1` result, in canonical order."
+  @spec present_kinds(resolved) :: [atom]
+  def present_kinds(resolved) do
+    Enum.filter(@kinds, &Map.has_key?(resolved, &1))
+  end
+
+  @doc """
+  Kinds to list in navigation: every kind in `resolved`, plus `active` so a
+  deep link to a file the release lacks still shows as the current page.
+  """
+  @spec nav_kinds(resolved, atom) :: [atom]
+  def nav_kinds(resolved, active) do
+    resolved |> Map.put_new(active, nil) |> present_kinds()
+  end
+
+  @spec resolve(atom, term) :: String.t() | nil
+  def resolve(kind, files) when kind in @kinds do
+    files |> resolve_all() |> Map.get(kind)
+  end
+
+  def resolve(_kind, _files), do: nil
+
+  defp classify(filename) do
+    case split_extension(filename) do
+      {base, ext} when ext in @extensions ->
+        case Map.fetch(@basename_to_kind, String.upcase(base, :ascii)) do
+          {:ok, kind} -> {kind, ext}
+          :error -> :nomatch
+        end
+
+      _ ->
+        :nomatch
+    end
+  end
+
+  defp split_extension(filename) do
+    case Path.extname(filename) do
+      "." <> ext when ext != "" -> {Path.rootname(filename), String.downcase(ext)}
+      _ -> {filename, ""}
+    end
+  end
+end

--- a/lib/hexpm/preview/preview.ex
+++ b/lib/hexpm/preview/preview.ex
@@ -1,12 +1,12 @@
 defmodule Hexpm.Preview do
   require Logger
 
+  alias Hexpm.Docs.Files
   alias Hexpm.Preview.{Bucket, Sitemaps}
   alias Hexpm.Repository.{Assets, Releases}
   alias Hexpm.Repository.Sitemaps, as: RepositorySitemaps
 
   @max_file_size 100 * 1000
-  @readme_filenames ~w(README.md readme.md README.markdown readme.markdown README.txt readme.txt README readme)
 
   defmodule StaleTarballError do
     defexception [:key]
@@ -45,15 +45,36 @@ defmodule Hexpm.Preview do
     end
   end
 
-  def readme(repository, package, version) do
+  def doc(repository, package, version, kind) do
     with files when is_list(files) <- Bucket.get_file_list(repository, package, version),
-         filename when is_binary(filename) <- Enum.find(@readme_filenames, &(&1 in files)),
+         filename when is_binary(filename) <- Files.resolve(kind, files),
          contents when is_binary(contents) <-
            Bucket.get_file(repository, package, version, filename) do
       {:ok, filename, contents}
     else
       _ -> :error
     end
+  end
+
+  def readme(repository, package, version), do: doc(repository, package, version, :readme)
+
+  @doc """
+  Fetches a release's base documentation files to add to the dropdown. Errors
+  are rescued to prevent file resolution errors from breaking the page.
+  """
+  def doc_kinds(repository, package, version) do
+    case Bucket.get_file_list(repository, package, version) do
+      files when is_list(files) -> Files.resolve_all(files)
+      _ -> %{}
+    end
+  rescue
+    error ->
+      Logger.warning(
+        "Failed to resolve doc kinds for #{repository}/#{package} #{version}: " <>
+          Exception.message(error)
+      )
+
+      %{}
   end
 
   def raw_file(repository, package, version, filename) do

--- a/lib/hexpm_web/components/package_layout.ex
+++ b/lib/hexpm_web/components/package_layout.ex
@@ -18,6 +18,7 @@ defmodule HexpmWeb.Components.PackageLayout do
 
   import HexpmWeb.Components.Badge
 
+  alias Hexpm.Docs.Files
   alias Hexpm.Repository.Owners
   alias Hexpm.Security.Advisories
   alias HexpmWeb.ViewHelpers
@@ -44,6 +45,8 @@ defmodule HexpmWeb.Components.PackageLayout do
   attr :version_pinned?, :boolean, default: false
   attr :wide?, :boolean, default: false
   attr :source_filename, :string, default: nil
+  attr :doc_kind, :atom, default: :readme
+  attr :doc_kinds, :map, default: %{}
 
   # Dependants tab data — only loaded on the dependants page
   attr :dependants, :list, default: []
@@ -83,11 +86,17 @@ defmodule HexpmWeb.Components.PackageLayout do
       )
 
     tabs = package_tabs(assigns)
+    doc_kind_entries = doc_kind_entries(assigns)
+    mobile_entries = mobile_entries(tabs, doc_kind_entries)
+
+    # `active` marks the desktop section; `checked?` the one mobile checkmark.
+    active_package_tab = Enum.find(mobile_entries, & &1.checked?)
 
     assigns =
       assigns
       |> assign(:tabs, tabs)
-      |> assign(:active_package_tab, Enum.find(tabs, & &1.active))
+      |> assign(:mobile_entries, mobile_entries)
+      |> assign(:active_package_tab, active_package_tab)
 
     flash_visible = assigns.current_release && assigns.current_release.vulnerable?
     assigns = assign(assigns, :flash_visible, flash_visible)
@@ -224,18 +233,15 @@ defmodule HexpmWeb.Components.PackageLayout do
             </summary>
 
             <div class="package-tabs-mobile-menu absolute inset-x-0 top-full z-20 mt-2 overflow-hidden rounded-xl border border-grey-200 bg-white shadow-lg dark:border-grey-700 dark:bg-grey-800">
-              <%= for tab <- @tabs do %>
-                <a
-                  href={tab.path}
-                  class={mobile_tab_class(tab.active)}
-                >
+              <%= for entry <- @mobile_entries do %>
+                <a href={entry.path} class={mobile_tab_class(entry.active)}>
                   <div class="flex min-w-0 items-center gap-3">
-                    {HexpmWeb.ViewIcons.icon(:heroicon, tab.icon,
+                    {HexpmWeb.ViewIcons.icon(:heroicon, entry.icon,
                       class: "size-4.5 shrink-0 text-grey-500 dark:text-grey-300"
                     )}
-                    <span class="truncate">{tab.label}</span>
+                    <span class={["truncate", entry.indent? && "pl-4"]}>{entry.label}</span>
                   </div>
-                  <%= if tab.active do %>
+                  <%= if entry.checked? do %>
                     {HexpmWeb.ViewIcons.icon(:heroicon, "check",
                       class: "size-4 shrink-0 text-primary-default dark:text-white"
                     )}
@@ -561,40 +567,55 @@ defmodule HexpmWeb.Components.PackageLayout do
     do: "/packages/#{package.repository.name}/#{package.name}/advisories"
 
   defp package_tabs(assigns) do
-    [
-      %{
-        active: assigns.active_tab == :readme,
-        icon: "document-text",
-        label: "Readme",
-        path: readme_path(assigns)
-      },
-      %{
-        active: assigns.active_tab == :versions,
-        icon: "tag",
-        label:
-          "#{assigns.versions_count} #{pluralize(assigns.versions_count, "Version", "Versions")}",
-        path: ViewHelpers.path_for_releases(assigns.package)
-      }
-    ] ++
-      dependency_tab(assigns) ++
-      [
-        %{
-          active: assigns.active_tab == :dependants,
-          icon: "puzzle-piece",
-          label: dependants_label(assigns.dependants_count),
-          path: dependents_path(assigns.package)
-        }
-      ] ++
-      advisories_tab(assigns) ++
-      files_tab(assigns) ++
-      [
-        %{
-          active: assigns.active_tab == :activity,
-          icon: "clock",
-          label: "Activity",
-          path: audit_logs_path(assigns.package)
-        }
-      ] ++ owners_tab(assigns)
+    ([
+       %{
+         id: :readme,
+         active: assigns.active_tab == :readme,
+         icon: "document-text",
+         label: "Documentation",
+         path: readme_path(assigns),
+         indent?: false
+       },
+       %{
+         id: :versions,
+         active: assigns.active_tab == :versions,
+         icon: "tag",
+         label:
+           "#{assigns.versions_count} #{pluralize(assigns.versions_count, "Version", "Versions")}",
+         path: ViewHelpers.path_for_releases(assigns.package),
+         indent?: false
+       }
+     ] ++
+       dependency_tab(assigns) ++
+       [
+         %{
+           id: :dependants,
+           active: assigns.active_tab == :dependants,
+           icon: "puzzle-piece",
+           label: dependants_label(assigns.dependants_count),
+           path: dependents_path(assigns.package),
+           indent?: false
+         }
+       ] ++
+       advisories_tab(assigns) ++
+       files_tab(assigns) ++
+       [
+         %{
+           id: :activity,
+           active: assigns.active_tab == :activity,
+           icon: "clock",
+           label: "Activity",
+           path: audit_logs_path(assigns.package),
+           indent?: false
+         }
+       ] ++ owners_tab(assigns))
+    |> Enum.map(fn
+      %{id: :readme} = tab ->
+        Map.put(tab, :checked?, assigns.active_tab == :readme && assigns.doc_kind == :readme)
+
+      tab ->
+        Map.put(tab, :checked?, tab.active)
+    end)
   end
 
   defp files_tab(%{current_release: nil}), do: []
@@ -602,10 +623,12 @@ defmodule HexpmWeb.Components.PackageLayout do
   defp files_tab(assigns) do
     [
       %{
+        id: :files,
         active: assigns.active_tab == :files,
         icon: "code-bracket",
         label: "Files",
-        path: files_path(assigns)
+        path: files_path(assigns),
+        indent?: false
       }
     ]
   end
@@ -622,10 +645,12 @@ defmodule HexpmWeb.Components.PackageLayout do
     if is_full_owner do
       [
         %{
+          id: :owners,
           active: assigns.active_tab == :owners,
           icon: "user-group",
           label: "Owners",
-          path: ViewHelpers.path_for_owners(assigns.package)
+          path: ViewHelpers.path_for_owners(assigns.package),
+          indent?: false
         }
       ]
     else
@@ -638,11 +663,13 @@ defmodule HexpmWeb.Components.PackageLayout do
   defp dependency_tab(assigns) do
     [
       %{
+        id: :dependencies,
         active: assigns.active_tab == :dependencies,
         icon: "cube",
         label:
           "#{assigns.dependency_count} #{pluralize(assigns.dependency_count, "Dependency", "Dependencies")}",
-        path: dependencies_tab_path(assigns)
+        path: dependencies_tab_path(assigns),
+        indent?: false
       }
     ]
   end
@@ -658,10 +685,12 @@ defmodule HexpmWeb.Components.PackageLayout do
     else
       [
         %{
+          id: :advisories,
           active: assigns.active_tab == :advisories,
           icon: "shield-exclamation",
           label: "#{count} #{pluralize(count, "Advisory", "Advisories")}",
-          path: advisories_path(assigns.package)
+          path: advisories_path(assigns.package),
+          indent?: false
         }
       ]
     end
@@ -717,6 +746,33 @@ defmodule HexpmWeb.Components.PackageLayout do
 
   defp dependants_label(count),
     do: "#{count} #{pluralize(count, "Dependant", "Dependants")}"
+
+  defp doc_kind_entries(assigns) do
+    assigns.doc_kinds
+    |> Files.nav_kinds(assigns.doc_kind)
+    |> Enum.reject(&(&1 == :readme))
+    |> Enum.map(fn kind ->
+      active = assigns.doc_kind == kind
+
+      %{
+        id: kind,
+        active: active,
+        checked?: active,
+        icon: "document",
+        label: Files.label(kind),
+        path: ViewHelpers.path_for_doc(assigns.package, assigns.current_release, kind),
+        indent?: true
+      }
+    end)
+  end
+
+  # Splices doc-kind entries under the Documentation tab by identity, not position.
+  defp mobile_entries(tabs, doc_kind_entries) do
+    Enum.flat_map(tabs, fn
+      %{id: :readme} = tab -> [tab | doc_kind_entries]
+      tab -> [tab]
+    end)
+  end
 
   defp path_for_tab(:dependencies, package, release, _filename),
     do: ViewHelpers.path_for_dependencies(package, release)

--- a/lib/hexpm_web/controllers/package_controller.ex
+++ b/lib/hexpm_web/controllers/package_controller.ex
@@ -1,8 +1,9 @@
 defmodule HexpmWeb.PackageController do
   use HexpmWeb, :controller
 
+  alias Hexpm.Docs.Files
   alias Hexpm.Security.Advisories
-  alias HexpmWeb.PackageLayoutAssigns
+  alias HexpmWeb.{PackageLayoutAssigns, ViewHelpers}
 
   @packages_per_page 30
   @versions_per_page 100
@@ -24,7 +25,22 @@ defmodule HexpmWeb.PackageController do
         end
 
       if release do
-        package(conn, package, releases, release, type)
+        package(conn, package, releases, release, type, :readme)
+      else
+        not_found(conn)
+      end
+    end)
+  end
+
+  def docs_file(conn, params) do
+    params = fixup_params(params)
+    %{doc_kind: kind} = conn.assigns
+
+    access_package(conn, params, fn package, _repositories ->
+      releases = Releases.all(package)
+
+      if release = matching_release(releases, params["version"]) do
+        package(conn, package, releases, release, :release, kind)
       else
         not_found(conn)
       end
@@ -231,7 +247,7 @@ defmodule HexpmWeb.PackageController do
     Enum.find(releases, &(to_string(&1.version) == version))
   end
 
-  defp package(conn, package, releases, release, type) do
+  defp package(conn, package, releases, release, type, doc_kind) do
     release =
       Releases.preload(release, [:requirements, :downloads, :publisher, :security_advisories])
 
@@ -245,13 +261,14 @@ defmodule HexpmWeb.PackageController do
       conn,
       "show.html",
       [
-        title: package.name,
+        title: doc_title(package, doc_kind),
         description: package.meta.description,
         container: "container",
-        canonical_url: ~p"/packages/#{package}",
+        canonical_url: doc_canonical_url(package, release, doc_kind),
         releases: releases,
         version_pinned?: type == :release,
-        type: type
+        type: type,
+        doc_kind: doc_kind
       ] ++
         PackageLayoutAssigns.for_package(conn, package,
           releases: releases,
@@ -261,6 +278,13 @@ defmodule HexpmWeb.PackageController do
         )
     )
   end
+
+  defp doc_title(package, :readme), do: package.name
+  defp doc_title(package, doc_kind), do: "#{package.name} · #{Files.label(doc_kind)}"
+
+  # Absolute because this also feeds `og:url`.
+  defp doc_canonical_url(package, release, doc_kind),
+    do: HexpmWeb.Endpoint.url() <> ViewHelpers.path_for_doc(package, release, doc_kind)
 
   defp show_docs_html_url(package, :package, _release, releases) do
     latest_release_with_docs =

--- a/lib/hexpm_web/controllers/readme_controller.ex
+++ b/lib/hexpm_web/controllers/readme_controller.ex
@@ -1,12 +1,14 @@
 defmodule HexpmWeb.ReadmeController do
   use HexpmWeb, :controller
 
+  alias Hexpm.Docs.Files
   alias Hexpm.Preview
   alias HexpmWeb.Readme.Renderer
   alias HexpmWeb.ReadmeToken
 
   plug :put_root_layout, false
   plug :put_layout, false
+  plug :put_doc_kind when action in [:show]
 
   @private_cache_control "private, no-store"
 
@@ -16,14 +18,28 @@ defmodule HexpmWeb.ReadmeController do
     |> send_resp(404, "Not Found")
   end
 
+  defp put_doc_kind(conn, _opts) do
+    case conn.params do
+      %{"kind" => kind} ->
+        case Files.parse_segment(kind) do
+          nil -> conn |> not_found(conn.params) |> halt()
+          kind -> assign(conn, :doc_kind, kind)
+        end
+
+      _ ->
+        assign(conn, :doc_kind, :readme)
+    end
+  end
+
   def show(conn, %{"repository" => repository, "version" => version, "token" => token} = params) do
     name = params["name"]
+    kind = conn.assigns.doc_kind
 
     with :ok <- ReadmeToken.verify(token, repository, name, version),
          package when not is_nil(package) <- Packages.get(repository, name),
          release when not is_nil(release) <-
            Enum.find(Releases.all(package), &(to_string(&1.version) == version)) do
-      serve_readme(conn, repository, package, release, @private_cache_control)
+      serve_readme(conn, repository, package, release, kind, @private_cache_control)
     else
       _ -> send_no_readme(conn, @private_cache_control)
     end
@@ -35,44 +51,40 @@ defmodule HexpmWeb.ReadmeController do
 
   def show(conn, %{"version" => version} = params) do
     name = params["name"]
-    package = Packages.get("hexpm", name)
+    kind = conn.assigns.doc_kind
 
-    if package do
-      release = Enum.find(Releases.all(package), &(to_string(&1.version) == version))
-
-      if release do
-        serve_readme(conn, "hexpm", package, release, "public, max-age=86400")
-      else
-        send_no_readme(conn)
-      end
+    with package when not is_nil(package) <- Packages.get("hexpm", name),
+         release when not is_nil(release) <-
+           Enum.find(Releases.all(package), &(to_string(&1.version) == version)) do
+      serve_readme(conn, "hexpm", package, release, kind, "public, max-age=86400")
     else
-      send_no_readme(conn)
+      _ -> send_no_readme(conn)
     end
   end
 
   def show(conn, params) do
     name = params["name"]
 
-    case Releases.latest_version("hexpm", name,
-           only_stable: true,
-           unstable_fallback: true
-         ) do
+    case Releases.latest_version("hexpm", name, only_stable: true, unstable_fallback: true) do
       nil ->
         send_no_readme(conn)
 
       version ->
         conn
         |> put_resp_header("cache-control", "public, max-age=3600")
-        |> redirect(to: "/#{name}/#{version}")
+        |> redirect(to: doc_path(name, version, conn.assigns.doc_kind))
     end
   end
 
-  defp serve_readme(conn, repository, package, release, cache_control) do
+  defp doc_path(name, version, :readme), do: "/#{name}/#{version}"
+  defp doc_path(name, version, kind), do: "/#{name}/#{version}?" <> URI.encode_query(kind: kind)
+
+  defp serve_readme(conn, repository, package, release, kind, cache_control) do
     version = to_string(release.version)
 
-    case Preview.readme(repository, package.name, version) do
+    case Preview.doc(repository, package.name, version, kind) do
       {:ok, filename, content} ->
-        html = render_readme(repository, filename, content, package.name, version)
+        html = Renderer.render(repository, filename, content, package.name, version)
 
         conn
         |> put_resp_header("cache-control", cache_control)
@@ -81,10 +93,6 @@ defmodule HexpmWeb.ReadmeController do
       :error ->
         send_no_readme(conn, cache_control)
     end
-  end
-
-  defp render_readme(repository, filename, content, package_name, version) do
-    Renderer.render(repository, filename, content, package_name, version)
   end
 
   defp send_no_readme(conn, cache_control \\ "public, max-age=3600") do

--- a/lib/hexpm_web/live/diff_live.ex
+++ b/lib/hexpm_web/live/diff_live.ex
@@ -34,7 +34,8 @@ defmodule HexpmWeb.DiffLive do
           current_release: release,
           graph_release: release,
           sidebar?: false,
-          dependants_count?: false
+          dependants_count?: false,
+          doc_kinds?: false
         )
 
       socket =

--- a/lib/hexpm_web/live/preview_live.ex
+++ b/lib/hexpm_web/live/preview_live.ex
@@ -59,7 +59,7 @@ defmodule HexpmWeb.PreviewLive do
       socket =
         socket
         |> assign(repository: repository)
-        |> assign_package(package, release, releases)
+        |> assign_package(package, release, releases, source.files)
         |> assign_source(repository, package_name, version, source)
 
       {:noreply, socket}
@@ -103,7 +103,7 @@ defmodule HexpmWeb.PreviewLive do
     ~p"/packages/#{repository}/#{package}/#{version}/files/#{Path.split(filename)}"
   end
 
-  defp assign_package(socket, package, release, releases) do
+  defp assign_package(socket, package, release, releases, files) do
     version = to_string(release.version)
 
     if socket.assigns.package &&
@@ -119,7 +119,8 @@ defmodule HexpmWeb.PreviewLive do
           current_release: release,
           graph_release: release,
           sidebar?: false,
-          dependants_count?: false
+          dependants_count?: false,
+          doc_kinds: Hexpm.Docs.Files.resolve_all(files)
         )
 
       socket

--- a/lib/hexpm_web/package_layout_assigns.ex
+++ b/lib/hexpm_web/package_layout_assigns.ex
@@ -16,6 +16,7 @@ defmodule HexpmWeb.PackageLayoutAssigns do
   and every tab gets it.
   """
 
+  alias Hexpm.Preview
   alias Hexpm.Repository.{Downloads, Owners, Packages, Release, Releases}
 
   @doc """
@@ -38,6 +39,15 @@ defmodule HexpmWeb.PackageLayoutAssigns do
       defaults to `true`
     * `:dependants_count?` — load the dependant count used in the tab label;
       defaults to `true`
+    * `:doc_kinds?` — resolve which documentation-file kinds (changelog,
+      license, ...) the current release has, for the mobile tab dropdown's
+      doc-kind entries; defaults to `true`. Requires a resolvable
+      `current_release` -- when there isn't one, this resolves to `%{}`
+      regardless of the option.
+    * `:doc_kinds` — precomputed doc kinds map to use instead of calling
+      `Preview.doc_kinds/3`, for a caller that already has the release's
+      file list (e.g. `Preview.source/4`) and would otherwise fetch it a
+      second time. Ignored when `:doc_kinds?` is `false`.
   """
   def for_package(conn_or_socket, package, opts \\ []) do
     current_user = conn_or_socket.assigns.current_user
@@ -46,6 +56,7 @@ defmodule HexpmWeb.PackageLayoutAssigns do
     graph_release = opts[:graph_release]
     sidebar? = Keyword.get(opts, :sidebar?, true)
     dependants_count? = Keyword.get(opts, :dependants_count?, true)
+    doc_kinds? = Keyword.get(opts, :doc_kinds?, true)
 
     owners =
       cond do
@@ -90,10 +101,23 @@ defmodule HexpmWeb.PackageLayoutAssigns do
           Keyword.get_lazy(opts, :dependants_count, fn ->
             Packages.count_dependants(repositories, package)
           end)
+        end,
+      doc_kinds:
+        if doc_kinds? do
+          Keyword.get_lazy(opts, :doc_kinds, fn -> doc_kinds(package, current_release) end)
+        else
+          %{}
         end
     ]
 
     [{:package_layout, Map.new(layout)} | layout]
+  end
+
+  # Needs a release to resolve a version against, so `%{}` without one.
+  defp doc_kinds(_package, nil), do: %{}
+
+  defp doc_kinds(package, current_release) do
+    Preview.doc_kinds(package.repository.name, package.name, to_string(current_release.version))
   end
 
   # The layout shows a security banner for the release on screen, so that one

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -280,6 +280,17 @@ defmodule HexpmWeb.Router do
     get "/packages/:name/versions", PackageController, :versions
     get "/packages/:name/advisories", PackageController, :advisories
     get "/packages/:name/:version/dependencies", PackageController, :dependencies
+
+    # Before the `:show` routes: Phoenix matches in declaration order, not by
+    # specificity, so `/packages/:repository/:name/:version` would shadow these.
+    for kind <- Hexpm.Docs.Files.kinds(), kind != :readme do
+      get "/packages/:name/:version/#{kind}", PackageController, :docs_file,
+        assigns: %{doc_kind: kind}
+
+      get "/packages/:repository/:name/:version/#{kind}", PackageController, :docs_file,
+        assigns: %{doc_kind: kind}
+    end
+
     get "/packages/:name/:version", PackageController, :show
     get "/packages/:repository/:name/owners", PackageOwnerController, :index
     post "/packages/:repository/:name/owners", PackageOwnerController, :create

--- a/lib/hexpm_web/templates/package/show.html.heex
+++ b/lib/hexpm_web/templates/package/show.html.heex
@@ -1,58 +1,54 @@
-<% description = @package.meta.description %>
+<% sidebar_kinds = Hexpm.Docs.Files.nav_kinds(@doc_kinds, @doc_kind) %>
 
-<.package_layout {@package_layout} active_tab={:readme} version_pinned?={@version_pinned?}>
+<.package_layout
+  {@package_layout}
+  active_tab={:readme}
+  version_pinned?={@version_pinned?}
+  doc_kind={@doc_kind}
+>
   <:inner_content>
-    <div class="bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-6">
-      <%= if @current_release do %>
-        <div
-          id="readme-loading"
-          class="flex items-center justify-center py-12 text-grey-400 dark:text-grey-300"
+    <div class="flex gap-5 items-start">
+      <%= if match?([_, _ | _], sidebar_kinds) do %>
+        <nav
+          aria-label="Documentation files"
+          class="hidden md:flex w-[200px] shrink-0 flex-col gap-1 bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-4"
         >
-          <svg class="animate-spin h-6 w-6 mr-3" viewBox="0 0 24 24" fill="none">
-            <circle
-              class="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
+          <p class="text-[10px] font-medium uppercase tracking-wide text-grey-400 dark:text-grey-300 mb-2">
+            Files
+          </p>
+          <%= for kind <- sidebar_kinds do %>
+            <a
+              href={ViewHelpers.path_for_doc(@package, @current_release, kind)}
+              aria-current={@doc_kind == kind && "page"}
+              class={[
+                "flex items-center gap-2 rounded px-2 py-1.5 text-sm font-medium transition-colors",
+                @doc_kind == kind &&
+                  "bg-grey-50 dark:bg-grey-700/60 text-grey-900 dark:text-white",
+                @doc_kind != kind &&
+                  "text-grey-500 dark:text-grey-300 hover:text-grey-700 dark:hover:text-grey-200"
+              ]}
             >
-            </circle>
-            <path
-              class="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-            >
-            </path>
-          </svg>
-          Loading README...
-        </div>
-
-        <%= if description do %>
-          <div
-            id="readme-fallback"
-            class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed hidden"
-          >
-            {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
-          </div>
-        <% end %>
-
-        <iframe
-          id="readme-frame"
-          src={"#{ViewHelpers.readme_url(@package, @current_release.version)}"}
-          sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
-          loading="lazy"
-          referrerpolicy="no-referrer"
-          title={"README for #{ViewHelpers.package_name(@package)}"}
-          class="w-full border-0 opacity-0 h-0 overflow-hidden"
-        ></iframe>
-      <% else %>
-        <%= if description do %>
-          <div class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed">
-            {ViewHelpers.text_length(description, 300) |> text_to_html(insert_brs: false)}
-          </div>
-        <% end %>
+              {HexpmWeb.ViewIcons.icon(:heroicon, "document", class: "size-4 shrink-0")}
+              <span class="truncate">{Hexpm.Docs.Files.label(kind)}</span>
+            </a>
+          <% end %>
+          <%= if filename = Map.get(@doc_kinds, @doc_kind) do %>
+            <p class="mt-4 pt-3 border-t border-grey-200 dark:border-grey-700 text-[10px] font-mono uppercase tracking-wide text-grey-400 dark:text-grey-300 truncate">
+              From {filename}
+            </p>
+          <% end %>
+        </nav>
       <% end %>
+
+      <div class="flex-1 min-w-0 bg-white dark:bg-grey-800 border border-grey-200 dark:border-grey-700 rounded-lg p-6">
+        <.doc_content
+          package={@package}
+          release={@current_release}
+          doc_kind={@doc_kind}
+          doc_kinds={@doc_kinds}
+          description={@package.meta.description}
+        />
+      </div>
     </div>
   </:inner_content>
 </.package_layout>

--- a/lib/hexpm_web/views/package_view.ex
+++ b/lib/hexpm_web/views/package_view.ex
@@ -286,4 +286,99 @@ defmodule HexpmWeb.PackageView do
   defp cvss_version(<<"CVSS:3.1/", _::binary>>), do: "3.1"
   defp cvss_version(<<"CVSS:3.0/", _::binary>>), do: "3.0"
   defp cvss_version(_), do: "3.1"
+
+  def doc_content(%{release: nil} = assigns) do
+    ~H"""
+    <div :if={@description} class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed">
+      {description_html(@description)}
+    </div>
+    """
+  end
+
+  # The readme frame always renders: the iframe reports its own absence.
+  def doc_content(%{doc_kind: :readme} = assigns) do
+    ~H"""
+    <.doc_frame package={@package} release={@release} doc_kind={:readme}>
+      <:fallback>{description_html(@description)}</:fallback>
+    </.doc_frame>
+    """
+  end
+
+  def doc_content(%{doc_kind: kind, doc_kinds: kinds} = assigns) when is_map_key(kinds, kind) do
+    ~H"""
+    <.doc_frame package={@package} release={@release} doc_kind={@doc_kind}>
+      <:fallback>{unpublished_text(@doc_kind)}</:fallback>
+    </.doc_frame>
+    """
+  end
+
+  def doc_content(assigns) do
+    ~H"""
+    <p class="text-grey-600 dark:text-grey-300 leading-relaxed">
+      {unpublished_text(@doc_kind)}
+    </p>
+    """
+  end
+
+  defp description_html(nil), do: nil
+
+  defp description_html(description) do
+    description |> ViewHelpers.text_length(300) |> text_to_html(insert_brs: false)
+  end
+
+  defp unpublished_text(doc_kind) do
+    "This package does not publish a #{Hexpm.Docs.Files.label(doc_kind)} file."
+  end
+
+  # The ids are load-bearing: assets/js/app.js drives this iframe by them.
+  defp doc_frame(assigns) do
+    assigns = assign_new(assigns, :doc_kind, fn -> :readme end)
+
+    ~H"""
+    <div
+      id="readme-loading"
+      class="flex items-center justify-center py-12 text-grey-400 dark:text-grey-300"
+    >
+      <svg class="animate-spin h-6 w-6 mr-3" viewBox="0 0 24 24" fill="none">
+        <circle
+          class="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          stroke-width="4"
+        >
+        </circle>
+        <path
+          class="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+        >
+        </path>
+      </svg>
+      Loading {doc_frame_title(@doc_kind)}...
+    </div>
+
+    <div
+      id="readme-fallback"
+      class="text-grey-600 dark:text-grey-300 mb-8 leading-relaxed hidden"
+    >
+      {render_slot(@fallback)}
+    </div>
+
+    <iframe
+      id="readme-frame"
+      src={ViewHelpers.readme_url(@package, @release.version, @doc_kind)}
+      sandbox="allow-scripts allow-popups allow-popups-to-escape-sandbox"
+      loading="lazy"
+      referrerpolicy="no-referrer"
+      title={"#{doc_frame_title(@doc_kind)} for #{ViewHelpers.package_name(@package)}"}
+      class="w-full border-0 opacity-0 h-0 overflow-hidden"
+    ></iframe>
+    """
+  end
+
+  # README is an acronym; `Files.label(:readme)` is "Readme".
+  defp doc_frame_title(:readme), do: "README"
+  defp doc_frame_title(kind), do: Hexpm.Docs.Files.label(kind)
 end

--- a/lib/hexpm_web/views/view_helpers.ex
+++ b/lib/hexpm_web/views/view_helpers.ex
@@ -52,6 +52,14 @@ defmodule HexpmWeb.ViewHelpers do
     ~p"/packages/#{package.repository}/#{package}/versions"
   end
 
+  # `:readme` has no `/readme` route -- the bare release URL renders it.
+  def path_for_doc(%Package{} = package, release, :readme),
+    do: path_for_release(package, release)
+
+  # Not `~p`: the router has one literal route per kind, nothing to verify against.
+  def path_for_doc(%Package{} = package, release, kind),
+    do: "#{path_for_release(package, release)}/#{kind}"
+
   def path_for_diff(%Package{repository_id: 1} = package, version, previous_version) do
     versions = "#{previous_version}..#{version}"
     ~p"/diff/#{package}/#{versions}"
@@ -551,17 +559,31 @@ defmodule HexpmWeb.ViewHelpers do
   def main_repository?(%{repository_id: 1}), do: true
   def main_repository?(_), do: false
 
-  def readme_url(%Package{repository_id: 1} = package, version) do
+  def readme_url(package, version, kind \\ :readme)
+
+  def readme_url(%Package{repository_id: 1} = package, version, kind) do
     readme_url = Application.fetch_env!(:hexpm, :readme_url)
-    "#{readme_url}/#{package.name}/#{version}"
+    "#{readme_url}/#{package.name}/#{version}#{doc_query(kind: doc_query_kind(kind))}"
   end
 
-  def readme_url(%Package{} = package, version) do
+  def readme_url(%Package{} = package, version, kind) do
     readme_url = Application.fetch_env!(:hexpm, :readme_url)
     repository = package.repository.name
     version = to_string(version)
     token = HexpmWeb.ReadmeToken.sign(repository, package.name, version)
-    "#{readme_url}/#{repository}/#{package.name}/#{version}?token=#{token}"
+
+    "#{readme_url}/#{repository}/#{package.name}/#{version}" <>
+      doc_query(token: token, kind: doc_query_kind(kind))
+  end
+
+  defp doc_query_kind(:readme), do: nil
+  defp doc_query_kind(kind), do: kind
+
+  defp doc_query(params) do
+    case Enum.reject(params, fn {_key, value} -> is_nil(value) end) do
+      [] -> ""
+      params -> "?" <> URI.encode_query(params)
+    end
   end
 
   def safe_url(url) when is_binary(url) do

--- a/test/hexpm/docs/files_test.exs
+++ b/test/hexpm/docs/files_test.exs
@@ -1,0 +1,133 @@
+defmodule Hexpm.Docs.FilesTest do
+  use ExUnit.Case, async: true
+
+  alias Hexpm.Docs.Files
+
+  test "kinds/0 returns the kinds in canonical order" do
+    assert Files.kinds() ==
+             [:readme, :changelog, :license, :security, :support]
+  end
+
+  test "label/1" do
+    assert Files.label(:readme) == "Readme"
+    assert Files.label(:support) == "Support"
+  end
+
+  test "label/1 degrades to the atom's string form for an unrecognized kind instead of raising" do
+    assert Files.label(:bogus) == "bogus"
+  end
+
+  test "parse_segment/1" do
+    assert Files.parse_segment("changelog") == :changelog
+    assert Files.parse_segment("support") == :support
+    assert Files.parse_segment("bogus") == nil
+    assert Files.parse_segment("Support") == nil
+  end
+
+  test "parse_segment/1 returns nil for non-binary input instead of raising" do
+    assert Files.parse_segment(["changelog"]) == nil
+    assert Files.parse_segment(nil) == nil
+    assert Files.parse_segment("") == nil
+    assert Files.parse_segment(:changelog) == nil
+  end
+
+  describe "resolve/2" do
+    test "finds exact conventional names" do
+      assert Files.resolve(:changelog, ["CHANGELOG.md", "mix.exs"]) == "CHANGELOG.md"
+      assert Files.resolve(:license, ["LICENSE"]) == "LICENSE"
+      assert Files.resolve(:security, ["SECURITY.md"]) == "SECURITY.md"
+    end
+
+    test "is case-insensitive on the basename and extension" do
+      assert Files.resolve(:changelog, ["Changelog.md"]) == "Changelog.md"
+      assert Files.resolve(:changelog, ["changelog.md"]) == "changelog.md"
+      assert Files.resolve(:changelog, ["ChangeLog"]) == "ChangeLog"
+      assert Files.resolve(:readme, ["readme.MD"]) == "readme.MD"
+    end
+
+    test "prefers .md, then .markdown, then .txt, then bare -- matching Preview's existing order" do
+      assert Files.resolve(:changelog, [
+               "CHANGELOG",
+               "CHANGELOG.txt",
+               "CHANGELOG.markdown",
+               "CHANGELOG.md"
+             ]) ==
+               "CHANGELOG.md"
+
+      assert Files.resolve(:changelog, ["CHANGELOG", "CHANGELOG.txt", "CHANGELOG.markdown"]) ==
+               "CHANGELOG.markdown"
+
+      assert Files.resolve(:changelog, ["CHANGELOG", "CHANGELOG.txt"]) == "CHANGELOG.txt"
+      assert Files.resolve(:changelog, ["CHANGELOG"]) == "CHANGELOG"
+    end
+
+    test "breaks ties within an extension lexicographically" do
+      assert Files.resolve(:changelog, ["Changelog.md", "CHANGELOG.md"]) == "CHANGELOG.md"
+    end
+
+    test "only matches the tarball root" do
+      assert Files.resolve(:changelog, ["docs/CHANGELOG.md", "lib/foo.ex"]) == nil
+    end
+
+    test "does not match unrelated extensions, prefixed names, or a dangling dot" do
+      assert Files.resolve(:license, ["LICENSE.rapidxml"]) == nil
+      assert Files.resolve(:readme, ["README.ja.md"]) == nil
+      assert Files.resolve(:readme, ["README."]) == nil
+    end
+
+    test "returns nil instead of raising for an unrecognized kind" do
+      assert Files.resolve(:bogus, ["README.md"]) == nil
+    end
+  end
+
+  describe "resolve_all/1 and present_kinds/1" do
+    test "resolve_all returns every resolvable kind in one pass" do
+      files = ["README.md", "CHANGELOG.md", "LICENSE", "mix.exs", "lib/a.ex"]
+
+      assert Files.resolve_all(files) == %{
+               readme: "README.md",
+               changelog: "CHANGELOG.md",
+               license: "LICENSE"
+             }
+    end
+
+    test "present_kinds returns kinds in canonical order" do
+      resolved = %{license: "LICENSE", readme: "README.md", changelog: "CHANGELOG.md"}
+      assert Files.present_kinds(resolved) == [:readme, :changelog, :license]
+    end
+
+    test "resolve_all tolerates malformed input without raising" do
+      assert Files.resolve_all(["README.md", nil, 42, ["nested"], %{}]) == %{readme: "README.md"}
+      assert Files.resolve_all(%{"files" => []}) == %{}
+      assert Files.resolve_all(nil) == %{}
+    end
+
+    test "present_kinds on an empty result is empty" do
+      assert Files.present_kinds(%{}) == []
+    end
+
+    test "a recognized basename with an unrecognized extension is not resolved" do
+      assert Files.resolve_all(["LICENSE.rapidxml"]) == %{}
+      assert Files.resolve(:license, ["LICENSE.rapidxml"]) == nil
+    end
+
+    test "does not fold non-ASCII homoglyphs into ASCII basenames" do
+      # U+017F LATIN SMALL LETTER LONG S
+      assert Files.resolve_all(["LICENſE.md"]) == %{}
+      # U+0131 LATIN SMALL LETTER DOTLESS I
+      assert Files.resolve_all(["lıcense.md"]) == %{}
+    end
+  end
+
+  describe "nav_kinds/2" do
+    test "includes every present kind plus the active kind even when absent" do
+      resolved = %{readme: "README.md", license: "LICENSE"}
+      assert Files.nav_kinds(resolved, :changelog) == [:readme, :changelog, :license]
+    end
+
+    test "does not duplicate the active kind when it is already present" do
+      resolved = %{readme: "README.md", changelog: "CHANGELOG.md"}
+      assert Files.nav_kinds(resolved, :changelog) == [:readme, :changelog]
+    end
+  end
+end

--- a/test/hexpm/preview/preview_test.exs
+++ b/test/hexpm/preview/preview_test.exs
@@ -126,6 +126,74 @@ defmodule Hexpm.PreviewTest do
     assert Preview.get_latest_version("other", "scoped") == nil
   end
 
+  describe "doc/4" do
+    test "resolves and reads a non-readme kind" do
+      put_release("hexpm", "doc_package", "1.0.0", [
+        {"README.md", "readme"},
+        {"CHANGELOG.md", "changelog contents"}
+      ])
+
+      assert Preview.doc("hexpm", "doc_package", "1.0.0", :changelog) ==
+               {:ok, "CHANGELOG.md", "changelog contents"}
+    end
+
+    test "returns :error for a kind the release does not have" do
+      put_release("hexpm", "no_changelog", "1.0.0", [{"README.md", "readme"}])
+
+      assert Preview.doc("hexpm", "no_changelog", "1.0.0", :changelog) == :error
+    end
+
+    test "readme/3 is doc/4 with :readme" do
+      put_release("hexpm", "readme_only", "1.0.0", [{"README.md", "hello"}])
+
+      assert Preview.readme("hexpm", "readme_only", "1.0.0") ==
+               Preview.doc("hexpm", "readme_only", "1.0.0", :readme)
+    end
+
+    test "returns :error when the file list names a file whose object is missing" do
+      Hexpm.Store.put(
+        :preview_bucket,
+        "file_lists/partial_doc-1.0.0.json",
+        JSON.encode!(["CHANGELOG.md"])
+      )
+
+      # deliberately no object written for files/partial_doc/1.0.0/CHANGELOG.md
+      assert Preview.doc("hexpm", "partial_doc", "1.0.0", :changelog) == :error
+    end
+  end
+
+  describe "doc_kinds/3" do
+    test "returns every resolvable kind for a release" do
+      put_release("hexpm", "multi_doc", "1.0.0", [
+        {"README.md", "readme"},
+        {"CHANGELOG.md", "changelog"},
+        {"LICENSE", "license"}
+      ])
+
+      assert Preview.doc_kinds("hexpm", "multi_doc", "1.0.0") == %{
+               readme: "README.md",
+               changelog: "CHANGELOG.md",
+               license: "LICENSE"
+             }
+    end
+
+    test "returns an empty map for a package with no file list" do
+      assert Preview.doc_kinds("hexpm", "missing_entirely", "1.0.0") == %{}
+    end
+
+    test "returns an empty map instead of raising when the file list is unreadable" do
+      # Runs on every package page, so it must degrade rather than crash.
+      Hexpm.Store.put(
+        :preview_bucket,
+        "file_lists/broken_doc_kinds-1.0.0.json",
+        "not valid json",
+        []
+      )
+
+      assert Preview.doc_kinds("hexpm", "broken_doc_kinds", "1.0.0") == %{}
+    end
+  end
+
   defp put_release(repository, package, version, files) do
     prefix = if repository == "hexpm", do: "", else: "repos/#{repository}/"
     filenames = Enum.map(files, &elem(&1, 0))

--- a/test/hexpm_web/controllers/package_controller_test.exs
+++ b/test/hexpm_web/controllers/package_controller_test.exs
@@ -492,6 +492,181 @@ defmodule HexpmWeb.PackageControllerTest do
     end
   end
 
+  describe "GET /packages/:name/:version/:kind" do
+    test "renders a recognized doc kind" do
+      package =
+        doc_package("doc_kind_pkg", [{"README.md", "# Readme"}, {"CHANGELOG.md", "# Changelog"}])
+
+      body = response(get(build_conn(), "/packages/#{package.name}/1.0.0/changelog"), 200)
+
+      assert body =~ "readme-frame"
+      assert body =~ "/#{package.name}/1.0.0?kind=changelog"
+    end
+
+    test "renders a recognized doc kind for a repository-scoped package", %{
+      user1: user1,
+      repository1: repository1
+    } do
+      package =
+        doc_package(
+          "repo_doc_kind_pkg",
+          [{"README.md", "# Readme"}, {"CHANGELOG.md", "# Changelog"}],
+          repository_id: repository1.id,
+          repository: repository1.name
+        )
+
+      conn =
+        build_conn()
+        |> test_login(user1)
+        |> get("/packages/#{repository1.name}/#{package.name}/1.0.0/changelog")
+
+      body = response(conn, 200)
+
+      assert [doc_url] =
+               body
+               |> LazyHTML.from_document()
+               |> LazyHTML.query("#readme-frame")
+               |> LazyHTML.attribute("src")
+
+      assert doc_url =~ "token="
+      assert doc_url =~ "kind=changelog"
+    end
+
+    test "404s for a version the package does not have" do
+      package = insert(:package, name: "doc_kind_missing_version")
+
+      insert(:release,
+        package: package,
+        version: "1.0.0",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      conn = get(build_conn(), "/packages/#{package.name}/9.9.9/changelog")
+      assert response(conn, 404)
+    end
+
+    test "unknown package 404s" do
+      conn = get(build_conn(), "/packages/nonexistent_doc_pkg/1.0.0/changelog")
+      assert response(conn, 404)
+    end
+  end
+
+  describe "Documentation sidebar" do
+    test "shows only the kinds the release actually has" do
+      package =
+        doc_package("sidebar_pkg", [
+          {"README.md", "# Readme"},
+          {"CHANGELOG.md", "# Changelog"},
+          {"LICENSE", "MIT"}
+        ])
+
+      body = response(get(build_conn(), "/packages/#{package.name}"), 200)
+
+      document = LazyHTML.from_document(body)
+
+      labels =
+        document
+        |> LazyHTML.query(~s(nav[aria-label="Documentation files"] a))
+        |> Enum.map(&(LazyHTML.text(&1, separator: " ") |> String.trim()))
+
+      assert "Changelog" in labels
+      assert "License" in labels
+      refute "Security" in labels
+    end
+
+    test "no sidebar for a readme-only package" do
+      package = doc_package("readme_only_pkg", [{"README.md", "# Readme"}])
+
+      body = response(get(build_conn(), "/packages/#{package.name}"), 200)
+
+      refute body =~ "aria-label=\"Documentation files\""
+    end
+
+    test "deep link to a missing kind explains it and stays the active entry" do
+      package = doc_package("missing_kind_pkg", [{"README.md", "# Readme"}])
+
+      body = response(get(build_conn(), "/packages/#{package.name}/1.0.0/security"), 200)
+
+      assert body =~ "does not publish a Security file"
+
+      document = LazyHTML.from_document(body)
+
+      assert [security_link] = LazyHTML.query(document, "a[aria-current=page]") |> Enum.to_list()
+      assert LazyHTML.text(security_link, separator: " ") =~ "Security"
+
+      assert [_ | _] =
+               LazyHTML.query(document, ".package-tabs-mobile-menu a")
+               |> Enum.filter(&(LazyHTML.text(&1, separator: " ") =~ "Security"))
+
+      assert [_ | _] =
+               LazyHTML.query(document, ".package-tabs-mobile-menu a")
+               |> Enum.filter(&(LazyHTML.text(&1, separator: " ") =~ "Documentation"))
+    end
+
+    test "the active sidebar entry carries aria-current" do
+      package =
+        doc_package("active_entry_pkg", [
+          {"README.md", "# Readme"},
+          {"CHANGELOG.md", "# Changelog"}
+        ])
+
+      body = response(get(build_conn(), "/packages/#{package.name}/1.0.0/changelog"), 200)
+
+      document = LazyHTML.from_document(body)
+      assert [changelog_link] = LazyHTML.query(document, "a[aria-current=page]") |> Enum.to_list()
+      assert LazyHTML.text(changelog_link, separator: " ") =~ "Changelog"
+    end
+
+    test "mobile dropdown lists the available doc kinds" do
+      package = doc_package("mobile_doc_pkg", [{"README.md", "# Readme"}, {"LICENSE", "MIT"}])
+
+      body = response(get(build_conn(), "/packages/#{package.name}"), 200)
+
+      document = LazyHTML.from_document(body)
+
+      assert [_ | _] =
+               LazyHTML.query(document, ".package-tabs-mobile-menu a[href$=\"/license\"]")
+               |> Enum.to_list()
+    end
+
+    test "following the sidebar's Readme link does not 404" do
+      package =
+        doc_package("docfile_link_pkg", [
+          {"README.md", "# Readme"},
+          {"CHANGELOG.md", "# Changelog"}
+        ])
+
+      body = response(get(build_conn(), "/packages/#{package.name}/1.0.0/changelog"), 200)
+
+      document = LazyHTML.from_document(body)
+
+      assert [readme_link] =
+               LazyHTML.query(document, "nav[aria-label=\"Documentation files\"] a")
+               |> Enum.filter(&(LazyHTML.text(&1, separator: " ") =~ "Readme"))
+
+      assert [readme_href] = LazyHTML.attribute(readme_link, "href")
+      refute readme_href =~ "/readme"
+
+      response(get(build_conn(), readme_href), 200)
+    end
+
+    test "mobile dropdown shows doc kinds on non-Documentation tabs too" do
+      package =
+        doc_package("versions_tab_doc_kinds_pkg", [
+          {"README.md", "# Readme"},
+          {"CHANGELOG.md", "# Changelog"}
+        ])
+
+      body = response(get(build_conn(), "/packages/#{package.name}/versions"), 200)
+
+      document = LazyHTML.from_document(body)
+
+      assert [_ | _] =
+               LazyHTML.query(document, ".package-tabs-mobile-menu a[href$=\"/changelog\"]")
+               |> Enum.to_list()
+    end
+  end
+
   describe "GET /packages/:name/audit-logs" do
     test "sets title correctly" do
       _package = insert(:package, name: "Test")
@@ -923,6 +1098,38 @@ defmodule HexpmWeb.PackageControllerTest do
   defp escape(html) do
     {:safe, safe} = Phoenix.HTML.html_escape(html)
     IO.iodata_to_binary(safe)
+  end
+
+  defp put_doc_files(package_name, version, files, opts) do
+    prefix = if repo = opts[:repository], do: "repos/#{repo}/", else: ""
+
+    Hexpm.Store.put(
+      :preview_bucket,
+      "#{prefix}file_lists/#{package_name}-#{version}.json",
+      JSON.encode!(Enum.map(files, &elem(&1, 0)))
+    )
+
+    Enum.each(files, fn {name, content} ->
+      Hexpm.Store.put(
+        :preview_bucket,
+        "#{prefix}files/#{package_name}/#{version}/#{name}",
+        content
+      )
+    end)
+  end
+
+  defp doc_package(name, files, opts \\ []) do
+    package = insert(:package, [name: name] ++ Keyword.take(opts, [:repository_id]))
+
+    insert(:release,
+      package: package,
+      version: "1.0.0",
+      meta: build(:release_metadata, app: name)
+    )
+
+    put_doc_files(name, "1.0.0", files, Keyword.take(opts, [:repository]))
+
+    package
   end
 
   defp advise(package, id, version) do

--- a/test/hexpm_web/controllers/readme_controller_test.exs
+++ b/test/hexpm_web/controllers/readme_controller_test.exs
@@ -32,6 +32,12 @@ defmodule HexpmWeb.ReadmeControllerTest do
     )
   end
 
+  defp readme_get(path) do
+    build_conn()
+    |> Map.put(:host, "readme.localhost")
+    |> get(path)
+  end
+
   describe "show/2 for private packages" do
     setup do
       repository = insert(:repository)
@@ -422,6 +428,117 @@ defmodule HexpmWeb.ReadmeControllerTest do
       assert conn.status == 200
       assert conn.resp_body =~ "http://localhost:5000/img/fetch/"
       refute conn.resp_body =~ ~s[src="https://example.com/logo.png"]
+    end
+  end
+
+  describe "show/2 with a kind" do
+    test "renders a recognized doc kind", %{package: package} do
+      mock_file_list_and_readme(
+        package.name,
+        "1.0.0",
+        "CHANGELOG.md",
+        "# Changelog\n\nv1.0.0 notes"
+      )
+
+      conn = readme_get("/#{package.name}/1.0.0?kind=changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Changelog"
+      assert conn.resp_body =~ "v1.0.0 notes"
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=86400"]
+    end
+
+    test "renders the not-found page when the requested kind is missing", %{package: package} do
+      mock_file_list(package.name, "1.0.0", ["README.md"])
+
+      conn = readme_get("/#{package.name}/1.0.0?kind=changelog")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "readme-not-found"
+    end
+
+    test "404s for an unrecognized kind", %{package: package} do
+      conn = readme_get("/#{package.name}/1.0.0?kind=bogus")
+
+      assert conn.status == 404
+    end
+
+    test "preserves the kind through the versionless redirect", %{package: package} do
+      conn = readme_get("/#{package.name}?kind=changelog")
+
+      assert conn.status == 302
+      assert get_resp_header(conn, "location") == ["/#{package.name}/1.0.0?kind=changelog"]
+      assert get_resp_header(conn, "cache-control") == ["public, max-age=3600"]
+    end
+
+    test "no kind param behaves exactly like :readme (back-compat)", %{package: package} do
+      mock_file_list_and_readme(package.name, "1.0.0", "README.md", "# Hi")
+
+      conn = readme_get("/#{package.name}/1.0.0")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Hi"
+    end
+  end
+
+  describe "show/2 for private packages with a kind" do
+    setup do
+      repository = insert(:repository)
+      package = insert(:package, repository_id: repository.id, name: "private_docs")
+
+      insert(
+        :release,
+        package: package,
+        version: "1.0.0",
+        meta: build(:release_metadata, app: package.name)
+      )
+
+      Hexpm.Store.put(
+        :preview_bucket,
+        "repos/#{repository.name}/file_lists/#{package.name}-1.0.0.json",
+        JSON.encode!(["README.md", "SECURITY.md"])
+      )
+
+      Hexpm.Store.put(
+        :preview_bucket,
+        "repos/#{repository.name}/files/#{package.name}/1.0.0/SECURITY.md",
+        "# Report a vulnerability"
+      )
+
+      %{repository: repository, private_package: package}
+    end
+
+    test "renders a recognized kind with a valid token", %{
+      repository: repository,
+      private_package: package
+    } do
+      token = HexpmWeb.ReadmeToken.sign(repository.name, package.name, "1.0.0")
+
+      conn = readme_get("/#{repository.name}/#{package.name}/1.0.0?token=#{token}&kind=security")
+
+      assert conn.status == 200
+      assert conn.resp_body =~ "Report a vulnerability"
+      assert get_resp_header(conn, "cache-control") == ["private, no-store"]
+    end
+
+    test "404s for an unrecognized kind even with a valid token", %{
+      repository: repository,
+      private_package: package
+    } do
+      token = HexpmWeb.ReadmeToken.sign(repository.name, package.name, "1.0.0")
+
+      conn = readme_get("/#{repository.name}/#{package.name}/1.0.0?token=#{token}&kind=bogus")
+
+      assert conn.status == 404
+    end
+
+    test "repository-scoped URL with no token at all 404s regardless of kind", %{
+      repository: repository,
+      private_package: package
+    } do
+      conn = readme_get("/#{repository.name}/#{package.name}/1.0.0?kind=security")
+
+      assert conn.status == 404
     end
   end
 end


### PR DESCRIPTION
Closes #1569.

Extends README rendering to six more conventional documentation files: Changelog, License, Security, Support, Acknowledgments, Threat Model (per [1569](https://github.com/hexpm/hexpm/issues/1569). Reuses the existing `Hexpm.Preview` context and `HexpmWeb.Readme.Renderer` — the same infrastructure that already renders README — rather than adding anything new to fetch or render files.

## Finding the files

I check the root of the tarball only. Bare filename, `.md`, `.markdown`, or `.txt`, case-insensitive, with `.md` preferred and `.txt` beating a bare file — matching README's existing filename priority exactly. Acknowledgments also matches the British spelling, Threat Model also matches `THREATMODEL` and `THREAT-MODEL`. They all sit in `Hexpm.Docs.Files`, one table to extend for future file types.

## Backend

`Hexpm.Preview.readme/3` is a thin wrapper around a new `doc/4`, which reads any of the above file types the same way (`Bucket.get_file_list` → resolve a filename → `Bucket.get_file`). `ReadmeController` reads an optional `?kind=` query param rather than a new route — same precedent as the existing `?token=` on the private path, and avoids a routing collision a path-based `:kind` segment would hit against the existing all-dynamic `/:repository/:name/:version` route. `HexpmWeb.ReadmeToken` is untouched; it already authorizes a whole release, which covers every kind.

The parent package page gets one route per file type (kind) (`/packages/:name/:version/changelog`, etc.) generated from `Hexpm.Docs.Files.kinds/0`. These have to be literal, not a dynamic `:kind` param, for the same routing-collision reason as above — verified with `Phoenix.Router.route_info/4` that the literal routes don't shadow or get shadowed by any existing route.

## Package page

First tab renamed from "Readme" to "Documentation". The package controller now computes which kinds a release actually has (via the same `Bucket.get_file_list` call the existing Files tab already makes) and renders the sidebar (desktop) and mobile dropdown entries server-side — no client-side JS anywhere in this change. A package with only a README renders identically to today. A deep link to a kind the package doesn't publish shows an explanation in place of the iframe, without an unnecessary fetch.


### Screeonshots to follow

#### Light Desktop
<img width="1280" height="1000" alt="image" src="https://github.com/user-attachments/assets/7d682120-5f06-4ebc-a21b-1272311ba5fb" />

#### Dark Desktop
<img width="1280" height="1000" alt="image" src="https://github.com/user-attachments/assets/ad8deee4-58ea-4131-a5a7-ae02e569d240" />

####Light Mobile
<img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/f7c7f6f4-0114-43e6-8a2d-19cf2484dcb2" />

#### Dark Mobile
<img width="780" height="1688" alt="image" src="https://github.com/user-attachments/assets/4051a5b8-897a-4dc7-a64d-47064eb075a4" />

