### PR TITLE
Revoke organization access on back-channel logout

### DIFF
--- a/lib/hexpm/accounts/audit_log.ex
+++ b/lib/hexpm/accounts/audit_log.ex
@@ -293,7 +293,8 @@ defmodule Hexpm.Accounts.AuditLog do
               "sso.login",
               "sso.jit.configure",
               "sso.enforcement.configure",
-              "sso.break_glass"
+              "sso.break_glass",
+              "sso.backchannel_logout"
             ] do
     Map.put(params, :organization, serialize(organization))
   end

--- a/lib/hexpm/accounts/sso.ex
+++ b/lib/hexpm/accounts/sso.ex
@@ -41,6 +41,7 @@ defmodule Hexpm.Accounts.SSO do
     @email_mismatch_category
   ]
   @seats_notice_seconds 60 * 60
+  @jwks_cooldown_seconds 10 * 60
 
   def available?, do: Features.available?()
 
@@ -1371,9 +1372,16 @@ defmodule Hexpm.Accounts.SSO do
   The provider says a session of theirs ended, by logout or deactivation, so
   the organization access that authentication created is revoked: the sessions
   from that provider session when the token carries a `sid`, everything the
-  identity holds when it does not. An unknown subject and a token with nothing
-  left to revoke both succeed, because from the provider's side the logout is
-  done and there is nothing here for it to retry.
+  identity holds when it does not. A sid-scoped token also revokes sessions
+  whose provider session is unknown, since nothing ties them to a session that
+  is still alive. A pending link consent for the subject is cancelled too;
+  without that, a consent screen open across the logout would mint fresh
+  access from a provider session that already ended. An unknown subject and a
+  token with nothing left to revoke both succeed, because from the provider's
+  side the logout is done and there is nothing here for it to retry.
+
+  Revocation takes the connection lock `complete_callback/5` holds, so it
+  cannot interleave with a login writing new access for the same identity.
   """
   def backchannel_logout(%Organization{} = organization, logout_token)
       when is_binary(logout_token) do
@@ -1382,13 +1390,25 @@ defmodule Hexpm.Accounts.SSO do
         {:error, :not_configured}
 
       connection ->
-        case OIDC.impl().validate_logout_token(connection, logout_token) do
+        opts = [
+          refresh_jwks: not recent_logout_token_failure?(connection, @jwks_cooldown_seconds)
+        ]
+
+        case OIDC.impl().validate_logout_token(connection, logout_token, opts) do
           {:ok, claims} ->
             maybe_update_jwks(connection, claims)
-            revoke_backchannel_sessions(connection, organization, claims)
+
+            case Repo.transaction(fn ->
+                   connection = locked_connection!(connection.id)
+                   revoke_backchannel_sessions(connection, organization, claims)
+                   cancel_pending_links(connection, claims)
+                 end) do
+              {:ok, _result} -> :ok
+              {:error, reason} -> {:error, reason}
+            end
 
           {:error, %Error{} = error} ->
-            record_failure(connection, error)
+            record_logout_token_failure(connection, error)
             {:error, error}
         end
     end
@@ -1417,7 +1437,7 @@ defmodule Hexpm.Accounts.SSO do
       query =
         case claims.sid do
           nil -> query
-          sid -> from(session in query, where: session.sid == ^sid)
+          sid -> from(session in query, where: session.sid == ^sid or is_nil(session.sid))
         end
 
       {revoked_count, _} = Repo.update_all(query, [])
@@ -1434,6 +1454,81 @@ defmodule Hexpm.Accounts.SSO do
       )
     end
 
+    :ok
+  end
+
+  defp cancel_pending_links(connection, claims) do
+    now = DateTime.utc_now()
+
+    query =
+      from(transaction in SSOTransaction,
+        where: transaction.connection_id == ^connection.id,
+        where: transaction.kind == "login",
+        where: transaction.subject == ^claims.subject,
+        where: not is_nil(transaction.link_token_hash),
+        where: is_nil(transaction.linked_at),
+        where: is_nil(transaction.cancelled_at),
+        update: [
+          set: [
+            cancelled_at: ^now,
+            link_token_hash: nil,
+            issuer: nil,
+            subject: nil,
+            provider_email: nil,
+            sid: nil,
+            updated_at: ^now
+          ]
+        ]
+      )
+
+    query =
+      case claims.sid do
+        nil ->
+          query
+
+        sid ->
+          from(transaction in query, where: transaction.sid == ^sid or is_nil(transaction.sid))
+      end
+
+    Repo.update_all(query, [])
+    :ok
+  end
+
+  # The refusal is the throttle: while a recently rejected logout token sits in
+  # the failure log, an unknown signing key does not get to trigger another
+  # outbound JWKS fetch. Legitimate key rotation validates cleanly on its first
+  # refresh and never lands here.
+  defp recent_logout_token_failure?(connection, within_seconds) do
+    cutoff = DateTime.add(DateTime.utc_now(), -within_seconds, :second)
+
+    Repo.exists?(
+      from(failure in Failure,
+        where: failure.connection_id == ^connection.id,
+        where: failure.stage == "logout_token",
+        where: failure.inserted_at > ^cutoff
+      )
+    )
+  end
+
+  # The endpoint is unauthenticated, and the failure log keeps twenty rows, so
+  # recording every garbage POST would let anyone push the diagnostics an
+  # administrator needs out of view. One row per code per hour keeps the
+  # signal without the eviction.
+  defp record_logout_token_failure(connection, %Error{} = error) do
+    code = to_string(stable_failure_code(error.code))
+    cutoff = DateTime.add(DateTime.utc_now(), -3600, :second)
+
+    recent? =
+      Repo.exists?(
+        from(failure in Failure,
+          where: failure.connection_id == ^connection.id,
+          where: failure.stage == "logout_token",
+          where: failure.code == ^code,
+          where: failure.inserted_at > ^cutoff
+        )
+      )
+
+    unless recent?, do: record_failure(connection, error)
     :ok
   end
 
@@ -2276,6 +2371,8 @@ defmodule Hexpm.Accounts.SSO do
       "events_invalid" => "The logout token did not carry the back-channel logout event",
       "nonce_present" => "The logout token carried a nonce, which the specification forbids",
       "issued_at_too_old" => "The logout token was issued more than five minutes ago",
+      "jti_missing" => "The logout token carried no token identifier",
+      "sid_invalid" => "The logout token carried an unusable session identifier",
       "invalid" => "The logout token could not be validated"
     }
   end

--- a/lib/hexpm/accounts/sso.ex
+++ b/lib/hexpm/accounts/sso.ex
@@ -808,7 +808,8 @@ defmodule Hexpm.Accounts.SSO do
                   link_token_hash: nil,
                   issuer: nil,
                   subject: nil,
-                  provider_email: nil
+                  provider_email: nil,
+                  sid: nil
                 })
               )
 
@@ -824,6 +825,7 @@ defmodule Hexpm.Accounts.SSO do
                   identity,
                   user,
                   user_session_id,
+                  transaction.sid,
                   audit_data
                 )
 
@@ -857,7 +859,8 @@ defmodule Hexpm.Accounts.SSO do
             link_token_hash: nil,
             issuer: nil,
             subject: nil,
-            provider_email: nil
+            provider_email: nil,
+            sid: nil
           })
         )
       else
@@ -1058,7 +1061,7 @@ defmodule Hexpm.Accounts.SSO do
   rather than adding a second one, which is what the unique index on
   `(user_session_id, organization_id)` enforces.
   """
-  def establish_org_session!(%Identity{} = identity, user_session_id) do
+  def establish_org_session!(%Identity{} = identity, user_session_id, sid \\ nil) do
     now = DateTime.utc_now()
 
     Repo.update_all(
@@ -1089,7 +1092,8 @@ defmodule Hexpm.Accounts.SSO do
       identity_id: identity.id,
       authenticated_at: now,
       expires_at: DateTime.add(now, lifetime, :second),
-      revoked_at: nil
+      revoked_at: nil,
+      sid: sid
     })
     |> Repo.insert_or_update!()
   end
@@ -1097,9 +1101,9 @@ defmodule Hexpm.Accounts.SSO do
   # The organization access an authentication produces, and the entry that
   # records it. Both paths that authenticate go through here, so a login and a
   # link cannot come to disagree about what an authentication logs.
-  defp establish_login!(transaction, connection, identity, user, user_session_id, audit_data) do
+  defp establish_login!(transaction, connection, identity, user, user_session_id, sid, audit_data) do
     org_session =
-      establish_org_session!(identity, authenticated_session(transaction, user_session_id))
+      establish_org_session!(identity, authenticated_session(transaction, user_session_id), sid)
 
     insert_audit!(%{audit_data | user: user}, "sso.login", {
       connection.organization,
@@ -1144,7 +1148,8 @@ defmodule Hexpm.Accounts.SSO do
         granted_from_user_session_id: from_user_session_id,
         identity_id: source.identity_id,
         authenticated_at: source.authenticated_at,
-        expires_at: source.expires_at
+        expires_at: source.expires_at,
+        sid: source.sid
       })
       |> Repo.insert!()
     end)
@@ -1360,6 +1365,78 @@ defmodule Hexpm.Accounts.SSO do
     )
   end
 
+  @doc """
+  Handles a back-channel logout token from the organization's provider.
+
+  The provider says a session of theirs ended, by logout or deactivation, so
+  the organization access that authentication created is revoked: the sessions
+  from that provider session when the token carries a `sid`, everything the
+  identity holds when it does not. An unknown subject and a token with nothing
+  left to revoke both succeed, because from the provider's side the logout is
+  done and there is nothing here for it to retry.
+  """
+  def backchannel_logout(%Organization{} = organization, logout_token)
+      when is_binary(logout_token) do
+    case get_connection(organization) do
+      nil ->
+        {:error, :not_configured}
+
+      connection ->
+        case OIDC.impl().validate_logout_token(connection, logout_token) do
+          {:ok, claims} ->
+            maybe_update_jwks(connection, claims)
+            revoke_backchannel_sessions(connection, organization, claims)
+
+          {:error, %Error{} = error} ->
+            record_failure(connection, error)
+            {:error, error}
+        end
+    end
+  end
+
+  defp revoke_backchannel_sessions(connection, organization, claims) do
+    identity =
+      from(identity in Identity,
+        where: identity.connection_id == ^connection.id,
+        where: identity.issuer == ^claims.issuer,
+        where: identity.subject == ^claims.subject,
+        preload: [:user]
+      )
+      |> Repo.one(log: false)
+
+    if identity do
+      now = DateTime.utc_now()
+
+      query =
+        from(session in OrgSession,
+          where: session.identity_id == ^identity.id,
+          where: is_nil(session.revoked_at),
+          update: [set: [revoked_at: ^now, updated_at: ^now]]
+        )
+
+      query =
+        case claims.sid do
+          nil -> query
+          sid -> from(session in query, where: session.sid == ^sid)
+        end
+
+      {revoked_count, _} = Repo.update_all(query, [])
+
+      insert_audit!(
+        %{user: identity.user, auth_credential: nil, user_agent: "hexpm", remote_ip: nil},
+        "sso.backchannel_logout",
+        {organization,
+         %{
+           user_id: identity.user_id,
+           revoked_count: revoked_count,
+           sid_scoped: not is_nil(claims.sid)
+         }}
+      )
+    end
+
+    :ok
+  end
+
   def failures(%Connection{} = connection) do
     from(failure in Failure,
       where: failure.connection_id == ^connection.id,
@@ -1537,6 +1614,7 @@ defmodule Hexpm.Accounts.SSO do
         identity,
         identity.user,
         user_session_id,
+        claims[:sid],
         audit_data
       )
 
@@ -1741,6 +1819,7 @@ defmodule Hexpm.Accounts.SSO do
       issuer: claims.issuer,
       subject: claims.subject,
       provider_email: claims.email,
+      sid: claims[:sid],
       link_token_hash: hash(link_token)
     })
 
@@ -2189,7 +2268,15 @@ defmodule Hexpm.Accounts.SSO do
       "id_token_invalid_after_jwks_refresh" =>
         "The identity token failed validation even after refreshing the signing keys",
       "invalid_response" => "The provider response could not be read",
-      "provider_error" => "The provider returned an error instead of an authorization code"
+      "provider_error" => "The provider returned an error instead of an authorization code",
+      "expired" => "The logout token had already expired",
+      "required_claim_missing" =>
+        "The logout token was missing a required claim, such as the subject",
+      "signature_invalid" => "The logout token signature could not be verified",
+      "events_invalid" => "The logout token did not carry the back-channel logout event",
+      "nonce_present" => "The logout token carried a nonce, which the specification forbids",
+      "issued_at_too_old" => "The logout token was issued more than five minutes ago",
+      "invalid" => "The logout token could not be validated"
     }
   end
 

--- a/lib/hexpm/accounts/sso/oidc.ex
+++ b/lib/hexpm/accounts/sso/oidc.ex
@@ -17,6 +17,9 @@ defmodule Hexpm.Accounts.SSO.OIDC do
   @callback exchange_code(Connection.t(), Transaction.t(), String.t(), String.t(), String.t()) ::
               {:ok, map()} | {:error, Error.t()}
 
+  @callback validate_logout_token(Connection.t(), String.t()) ::
+              {:ok, map()} | {:error, Error.t()}
+
   def impl do
     Application.fetch_env!(:hexpm, :organization_sso)
     |> Keyword.fetch!(:oidc_impl)

--- a/lib/hexpm/accounts/sso/oidc.ex
+++ b/lib/hexpm/accounts/sso/oidc.ex
@@ -17,7 +17,7 @@ defmodule Hexpm.Accounts.SSO.OIDC do
   @callback exchange_code(Connection.t(), Transaction.t(), String.t(), String.t(), String.t()) ::
               {:ok, map()} | {:error, Error.t()}
 
-  @callback validate_logout_token(Connection.t(), String.t()) ::
+  @callback validate_logout_token(Connection.t(), String.t(), keyword()) ::
               {:ok, map()} | {:error, Error.t()}
 
   def impl do

--- a/lib/hexpm/accounts/sso/oidc/oidcc.ex
+++ b/lib/hexpm/accounts/sso/oidc/oidcc.ex
@@ -12,6 +12,7 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
   @clock_skew_seconds 60
   @logout_event "http://schemas.openid.net/event/backchannel-logout"
   @logout_token_max_age_seconds 300
+  @sid_max_bytes 4096
 
   @impl true
   def discover(issuer) do
@@ -105,11 +106,13 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
   end
 
   @impl true
-  def validate_logout_token(%Connection{} = connection, logout_token)
+  def validate_logout_token(connection, logout_token, opts \\ [])
+
+  def validate_logout_token(%Connection{} = connection, logout_token, opts)
       when is_binary(logout_token) do
     with_adapter(fn ref ->
       with {:ok, client_context} <- client_context(connection, connection.client_secret),
-           {:ok, claims} <- validate_logout_jwt(logout_token, client_context, ref),
+           {:ok, claims} <- validate_logout_jwt(logout_token, client_context, ref, opts),
            :ok <- validate_logout_claims(claims, connection) do
         {refreshed_jwks, refreshed_jwks_expires_at} = refreshed_jwks(ref)
 
@@ -199,14 +202,23 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
       {:error, :token_validation_exception}
   end
 
-  defp validate_logout_jwt(logout_token, client_context, ref) do
-    opts = %{
+  # The refresh hook is what turns an unknown `kid` into an outbound JWKS
+  # fetch, and this endpoint takes unauthenticated input, so the caller decides
+  # per request whether that fetch is on the table.
+  defp validate_logout_jwt(logout_token, client_context, ref, opts) do
+    validate_opts = %{
       signing_algs: allowed_signing_algorithms(client_context.provider_configuration),
-      trusted_audiences: [],
-      refresh_jwks: refresh_jwks_fun(client_context, ref)
+      trusted_audiences: []
     }
 
-    case oidcc_validate_jwt(logout_token, client_context, opts, ref) do
+    validate_opts =
+      if Keyword.get(opts, :refresh_jwks, true) do
+        Map.put(validate_opts, :refresh_jwks, refresh_jwks_fun(client_context, ref))
+      else
+        validate_opts
+      end
+
+    case oidcc_validate_jwt(logout_token, client_context, validate_opts, ref) do
       {:ok, claims} -> {:ok, claims}
       {:error, reason} -> logout_token_error(reason)
     end
@@ -366,6 +378,8 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
       not OIDC.valid_subject?(claims["sub"]) -> error(:logout_token, :subject_invalid)
       not logout_event?(claims["events"]) -> error(:logout_token, :events_invalid)
       is_map_key(claims, "nonce") -> error(:logout_token, :nonce_present)
+      not valid_jti?(claims["jti"]) -> error(:logout_token, :jti_missing)
+      not valid_logout_sid?(claims["sid"]) -> error(:logout_token, :sid_invalid)
       not is_integer(issued_at) -> error(:logout_token, :issued_at_invalid)
       issued_at > now + @clock_skew_seconds -> error(:logout_token, :issued_at_in_future)
       issued_at < now - @logout_token_max_age_seconds -> error(:logout_token, :issued_at_too_old)
@@ -375,6 +389,15 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
 
   defp logout_event?(%{@logout_event => event}) when is_map(event), do: true
   defp logout_event?(_events), do: false
+
+  defp valid_jti?(jti), do: is_binary(jti) and jti != ""
+
+  # A sid the sessions cannot carry must fail the logout rather than silently
+  # widen it to everything the identity holds.
+  defp valid_logout_sid?(nil), do: true
+
+  defp valid_logout_sid?(sid),
+    do: is_binary(sid) and sid != "" and byte_size(sid) <= @sid_max_bytes
 
   defp client_context(connection, client_secret) do
     with {:ok, _uri} <- Issuer.validate_syntax(connection.issuer),
@@ -561,9 +584,13 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
   defp optional_binary(value) when is_binary(value), do: value
   defp optional_binary(_value), do: nil
 
-  # An unusable sid degrades to sub-wide revocation rather than failing the
-  # authentication or the logout, which errs toward revoking more.
-  defp optional_sid(sid) when is_binary(sid) and sid != "" and byte_size(sid) <= 255, do: sid
+  # At authentication an unusable sid is dropped rather than failing the login;
+  # the session then reads as coming from an unknown provider session, which
+  # any logout for the identity revokes. Logout tokens reject unusable sids in
+  # `valid_logout_sid?/1` instead, so this clause never widens one.
+  defp optional_sid(sid) when is_binary(sid) and sid != "" and byte_size(sid) <= @sid_max_bytes,
+    do: sid
+
   defp optional_sid(_sid), do: nil
 
   defp error(stage, code), do: {:error, %Error{stage: stage, code: code}}

--- a/lib/hexpm/accounts/sso/oidc/oidcc.ex
+++ b/lib/hexpm/accounts/sso/oidc/oidcc.ex
@@ -10,6 +10,8 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
   @fallback_cache_seconds 3_600
   @http_timeout 5_000
   @clock_skew_seconds 60
+  @logout_event "http://schemas.openid.net/event/backchannel-logout"
+  @logout_token_max_age_seconds 300
 
   @impl true
   def discover(issuer) do
@@ -94,6 +96,28 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
            subject: claims["sub"],
            email: optional_binary(claims["email"]),
            email_verified: claims["email_verified"] == true,
+           sid: optional_sid(claims["sid"]),
+           jwks_document: refreshed_jwks,
+           jwks_expires_at: refreshed_jwks_expires_at
+         }}
+      end
+    end)
+  end
+
+  @impl true
+  def validate_logout_token(%Connection{} = connection, logout_token)
+      when is_binary(logout_token) do
+    with_adapter(fn ref ->
+      with {:ok, client_context} <- client_context(connection, connection.client_secret),
+           {:ok, claims} <- validate_logout_jwt(logout_token, client_context, ref),
+           :ok <- validate_logout_claims(claims, connection) do
+        {refreshed_jwks, refreshed_jwks_expires_at} = refreshed_jwks(ref)
+
+        {:ok,
+         %{
+           issuer: claims["iss"],
+           subject: claims["sub"],
+           sid: optional_sid(claims["sid"]),
            jwks_document: refreshed_jwks,
            jwks_expires_at: refreshed_jwks_expires_at
          }}
@@ -174,6 +198,48 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
 
       {:error, :token_validation_exception}
   end
+
+  defp validate_logout_jwt(logout_token, client_context, ref) do
+    opts = %{
+      signing_algs: allowed_signing_algorithms(client_context.provider_configuration),
+      trusted_audiences: [],
+      refresh_jwks: refresh_jwks_fun(client_context, ref)
+    }
+
+    case oidcc_validate_jwt(logout_token, client_context, opts, ref) do
+      {:ok, claims} -> {:ok, claims}
+      {:error, reason} -> logout_token_error(reason)
+    end
+  end
+
+  defp oidcc_validate_jwt(logout_token, client_context, opts, ref) do
+    Oidcc.Token.validate_jwt(logout_token, client_context, opts)
+  rescue
+    exception ->
+      :telemetry.execute(
+        [:hexpm, :sso, :oidc, :token_validation_exception],
+        %{count: 1},
+        %{exception: exception.__struct__, phase: token_phase(ref)}
+      )
+
+      {:error, :token_validation_exception}
+  end
+
+  defp logout_token_error(%Error{} = error), do: {:error, error}
+  defp logout_token_error(:token_expired), do: error(:logout_token, :expired)
+
+  defp logout_token_error({:missing_claim, _claim, _claims}),
+    do: error(:logout_token, :required_claim_missing)
+
+  defp logout_token_error({:none_alg_used, _claims}),
+    do: error(:logout_token, :signature_invalid)
+
+  defp logout_token_error(:no_matching_key), do: error(:logout_token, :signature_invalid)
+
+  defp logout_token_error({:no_matching_key_with_kid, _kid}),
+    do: error(:logout_token, :signature_invalid)
+
+  defp logout_token_error(_reason), do: error(:logout_token, :invalid)
 
   # oidcc retries validation itself once the refreshed keys come back, so the
   # fetch only has to hand the raw document on for persistence.
@@ -284,6 +350,31 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
       true -> :ok
     end
   end
+
+  # The signature, `iss`, `aud`, `exp`, and required-claims checks ran in
+  # oidcc, and requiring `sub` there is deliberate: a sid-only logout token is
+  # rejected, which sso.md records as a limitation. What oidcc has no notion of
+  # is checked here: the logout `events` member, the spec's prohibition on
+  # `nonce`, and a freshness window on `iat`, since a logout token is a
+  # one-shot signal rather than a credential with its own lifetime.
+  defp validate_logout_claims(claims, connection) do
+    now = DateTime.utc_now() |> DateTime.to_unix()
+    issued_at = claims["iat"]
+
+    cond do
+      claims["iss"] != connection.issuer -> error(:logout_token, :issuer_mismatch)
+      not OIDC.valid_subject?(claims["sub"]) -> error(:logout_token, :subject_invalid)
+      not logout_event?(claims["events"]) -> error(:logout_token, :events_invalid)
+      is_map_key(claims, "nonce") -> error(:logout_token, :nonce_present)
+      not is_integer(issued_at) -> error(:logout_token, :issued_at_invalid)
+      issued_at > now + @clock_skew_seconds -> error(:logout_token, :issued_at_in_future)
+      issued_at < now - @logout_token_max_age_seconds -> error(:logout_token, :issued_at_too_old)
+      true -> :ok
+    end
+  end
+
+  defp logout_event?(%{@logout_event => event}) when is_map(event), do: true
+  defp logout_event?(_events), do: false
 
   defp client_context(connection, client_secret) do
     with {:ok, _uri} <- Issuer.validate_syntax(connection.issuer),
@@ -469,6 +560,11 @@ defmodule Hexpm.Accounts.SSO.OIDC.Oidcc do
 
   defp optional_binary(value) when is_binary(value), do: value
   defp optional_binary(_value), do: nil
+
+  # An unusable sid degrades to sub-wide revocation rather than failing the
+  # authentication or the logout, which errs toward revoking more.
+  defp optional_sid(sid) when is_binary(sid) and sid != "" and byte_size(sid) <= 255, do: sid
+  defp optional_sid(_sid), do: nil
 
   defp error(stage, code), do: {:error, %Error{stage: stage, code: code}}
 end

--- a/lib/hexpm/accounts/sso/org_session.ex
+++ b/lib/hexpm/accounts/sso/org_session.ex
@@ -7,6 +7,9 @@ defmodule Hexpm.Accounts.SSO.OrgSession do
     field :authenticated_at, :utc_datetime_usec
     field :expires_at, :utc_datetime_usec
     field :revoked_at, :utc_datetime_usec
+    # The provider session this authentication came from, so a sid-scoped
+    # back-channel logout token can end exactly the access that session created.
+    field :sid, :string, redact: true
 
     belongs_to :user, User
     belongs_to :organization, Organization
@@ -62,7 +65,8 @@ defmodule Hexpm.Accounts.SSO.OrgSession do
       :identity_id,
       :authenticated_at,
       :expires_at,
-      :revoked_at
+      :revoked_at,
+      :sid
     ])
     |> validate_required([
       :user_id,

--- a/lib/hexpm/accounts/sso/transaction.ex
+++ b/lib/hexpm/accounts/sso/transaction.ex
@@ -20,6 +20,7 @@ defmodule Hexpm.Accounts.SSO.Transaction do
     field :issuer, :string
     field :subject, :string, redact: true
     field :provider_email, :string, redact: true
+    field :sid, :string, redact: true
     field :link_token_hash, :binary, redact: true
     field :entrypoint, :string
     field :linked_at, :utc_datetime_usec
@@ -78,6 +79,7 @@ defmodule Hexpm.Accounts.SSO.Transaction do
       :issuer,
       :subject,
       :provider_email,
+      :sid,
       :link_token_hash,
       :linked_at,
       :cancelled_at,

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -1108,6 +1108,7 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
       sso_identities: if(connection, do: SSO.identities(connection), else: []),
       sso_failures: if(connection, do: SSO.failures(connection), else: []),
       sso_callback_url: SSOEnforcement.callback_url(),
+      sso_backchannel_logout_url: SSOEnforcement.backchannel_logout_url(organization),
       sso_login_url: url(~p"/sso/org/#{organization}"),
       sso_domains: OrganizationDomains.all(organization),
       sso_personal_keys: sso_personal_keys(organization, connection),

--- a/lib/hexpm_web/controllers/sso_backchannel_logout_controller.ex
+++ b/lib/hexpm_web/controllers/sso_backchannel_logout_controller.ex
@@ -1,0 +1,63 @@
+defmodule HexpmWeb.SSOBackchannelLogoutController do
+  use HexpmWeb, :controller
+
+  # OpenID Connect Back-Channel Logout 1.0. The provider POSTs a signed logout
+  # token here, server to server, when one of its sessions ends. The token is
+  # the authentication: the endpoint carries no session and no secret, and
+  # everything it can do is revoke organization access that the same provider
+  # created. Replays are not tracked, because re-revoking revoked sessions
+  # changes nothing.
+
+  alias Hexpm.Accounts.SSO
+  alias HexpmWeb.Plugs.Attack
+
+  plug :put_no_store
+  plug :require_sso_available
+  plug :rate_limit
+
+  def create(conn, %{"organization" => name} = params) do
+    organization = Organizations.get(name)
+
+    if is_nil(organization) or not SSO.reachable?(organization) do
+      not_found(conn)
+    else
+      handle(conn, organization, params["logout_token"])
+    end
+  end
+
+  defp handle(conn, organization, logout_token) when is_binary(logout_token) do
+    case SSO.backchannel_logout(organization, logout_token) do
+      :ok -> send_resp(conn, 200, "")
+      {:error, :not_configured} -> not_found(conn)
+      {:error, _error} -> send_resp(conn, 400, "")
+    end
+  end
+
+  defp handle(conn, _organization, _logout_token), do: send_resp(conn, 400, "")
+
+  defp require_sso_available(conn, _opts) do
+    if SSO.available?() do
+      conn
+    else
+      conn
+      |> not_found()
+      |> halt()
+    end
+  end
+
+  defp rate_limit(conn, _opts) do
+    case Attack.sso_backchannel_logout_ip_throttle(conn.remote_ip) do
+      {:allow, _data} ->
+        conn
+
+      {:block, _data} ->
+        conn
+        |> send_resp(429, "")
+        |> halt()
+    end
+  end
+
+  defp put_no_store(conn, _opts) do
+    put_resp_header(conn, "cache-control", "no-store")
+  end
+end

--- a/lib/hexpm_web/plugs/attack.ex
+++ b/lib/hexpm_web/plugs/attack.ex
@@ -232,6 +232,21 @@ defmodule HexpmWeb.Plugs.Attack do
     )
   end
 
+  # Roomier than the callback throttle: a provider deactivating members in bulk
+  # sends one token per session from a handful of egress addresses.
+  def sso_backchannel_logout_ip_throttle(ip, opts \\ []) do
+    time = opts[:time] || System.system_time(:millisecond)
+    unless opts[:time], do: RateLimitPubSub.broadcast({:sso_backchannel_logout_ip, ip}, time)
+
+    timed_throttle(
+      {:sso_backchannel_logout_ip, ip},
+      time: time,
+      storage: @storage,
+      limit: 200,
+      period: @sso_period
+    )
+  end
+
   def tfa_ip_throttle(ip, opts \\ []) do
     time = opts[:time] || System.system_time(:millisecond)
 

--- a/lib/hexpm_web/rate_limit_pub_sub.ex
+++ b/lib/hexpm_web/rate_limit_pub_sub.ex
@@ -50,4 +50,9 @@ defmodule HexpmWeb.RateLimitPubSub do
     Attack.sso_callback_ip_throttle(ip, time: time)
     {:noreply, []}
   end
+
+  def handle_info({:throttle, {:sso_backchannel_logout_ip, ip}, time}, []) do
+    Attack.sso_backchannel_logout_ip_throttle(ip, time: time)
+    {:noreply, []}
+  end
 end

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -102,6 +102,16 @@ defmodule HexpmWeb.Router do
     plug HexpmWeb.Plugs.ReadmeContentSecurityPolicy
   end
 
+  # Server-to-server POST from an identity provider: no session, no CSRF token,
+  # and not the :api pipeline either, whose :authenticate would read the request
+  # as an API call.
+  pipeline :sso_backchannel do
+    plug :accepts, ["json"]
+    plug :user_agent, required: false
+    plug :validate_url
+    plug HexpmWeb.Plugs.Attack
+  end
+
   pipeline :admin do
     plug HexpmWeb.Plugs.DashboardAuth
   end
@@ -138,6 +148,13 @@ defmodule HexpmWeb.Router do
     get "/preview_sitemap.xml", PreviewRedirectController, :sitemap
     get "/preview/sitemap.xml", SitemapController, :preview_index
     get "/preview/:package/sitemap.xml", SitemapController, :preview_package
+  end
+
+  scope "/", HexpmWeb do
+    pipe_through :sso_backchannel
+
+    post "/sso/backchannel-logout/:organization", SSOBackchannelLogoutController, :create,
+      log: false
   end
 
   scope "/", HexpmWeb do

--- a/lib/hexpm_web/sso_enforcement.ex
+++ b/lib/hexpm_web/sso_enforcement.ex
@@ -188,6 +188,14 @@ defmodule HexpmWeb.SSOEnforcement do
   def callback_url, do: url(~p"/sso/callback")
 
   @doc """
+  Where the provider posts back-channel logout tokens. Per organization,
+  because the organization name is how the receiving end finds the connection.
+  """
+  def backchannel_logout_url(organization) do
+    url(~p"/sso/backchannel-logout/#{organization}")
+  end
+
+  @doc """
   Lets the browser follow a form submission through to this organization's
   provider.
 

--- a/lib/hexpm_web/templates/dashboard/audit_log/components/audit_log_card.ex
+++ b/lib/hexpm_web/templates/dashboard/audit_log/components/audit_log_card.ex
@@ -456,6 +456,13 @@ defmodule HexpmWeb.Dashboard.AuditLog.Components.AuditLogCard do
     "Reached #{org} without a current SSO session"
   end
 
+  defp humanize_action(%AuditLog{
+         action: "sso.backchannel_logout",
+         params: %{"organization" => %{"name" => org}}
+       }) do
+    "#{org}'s identity provider ended this member's SSO sessions"
+  end
+
   defp humanize_action(%AuditLog{action: "password.reset.init"}) do
     "Requested a password reset"
   end

--- a/lib/hexpm_web/templates/dashboard/organization/components/sso_tab.ex
+++ b/lib/hexpm_web/templates/dashboard/organization/components/sso_tab.ex
@@ -15,6 +15,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.SSOTab do
   attr :identities, :list, required: true
   attr :failures, :list, required: true
   attr :callback_url, :string, required: true
+  attr :backchannel_logout_url, :string, required: true
   attr :login_url, :string, required: true
   attr :domains, :list, default: []
   attr :personal_keys, :list, default: []
@@ -48,6 +49,7 @@ defmodule HexpmWeb.Dashboard.Organization.Components.SSOTab do
         </div>
         <div class="mt-4 grid gap-4">
           <.readonly_value label="Redirect URI" value={@callback_url} />
+          <.readonly_value label="Back-Channel Logout URI" value={@backchannel_logout_url} />
           <.readonly_value label="Required scopes" value="openid email" />
           <.readonly_value
             :if={@connection && Connection.enabled?(@connection)}

--- a/lib/hexpm_web/templates/dashboard/organization/index.html.heex
+++ b/lib/hexpm_web/templates/dashboard/organization/index.html.heex
@@ -104,6 +104,7 @@
               />
             <% :sso -> %>
               <.sso_tab
+                backchannel_logout_url={@sso_backchannel_logout_url}
                 callback_url={@sso_callback_url}
                 connection={@sso_connection}
                 domains={@sso_domains}

--- a/lib/hexpm_web/templates/docs/organization_sso.html.md
+++ b/lib/hexpm_web/templates/docs/organization_sso.html.md
@@ -20,7 +20,7 @@ You need:
 * A Hexpm account for every person who will use SSO.
 * Existing organization membership for every person who will link an SSO identity.
 
-Open the Hexpm organization dashboard, select **SSO**, and keep the **Redirect URI** shown there available while configuring Okta.
+Open the Hexpm organization dashboard, select **SSO**, and keep the **Redirect URI** and **Back-Channel Logout URI** shown there available while configuring Okta.
 
 ### Create the Okta application
 
@@ -30,7 +30,7 @@ In the Okta Admin Console, follow Okta's [OIDC app-integration instructions](htt
 2. Choose **OIDC - OpenID Connect** as the sign-in method and **Web Application** as the application type.
 3. Select the **Authorization Code** grant type.
 4. Add the exact **Redirect URI** from the Hexpm SSO dashboard as a sign-in redirect URI. Do not use a wildcard.
-5. Leave the sign-out redirect URIs empty. This release does not use OIDC logout.
+5. Leave the sign-out redirect URIs empty; Hexpm does not use RP-initiated logout. If your Okta org supports back-channel logout, enable it for the application and set the **Back-Channel Logout URI** from the Hexpm SSO dashboard, so sign-outs and deactivations in Okta end members' organization access sessions promptly. This is optional; without it, sessions end on their own lifetime.
 6. Under **Login initiated by**, select **App Only** if members will always start from the organization login URL. To let them start from Okta instead, select **Either Okta or App** and set the **Initiate login URI** described below. The URI appears on the Hexpm SSO dashboard only after SSO login is enabled, so this step needs a second pass through Okta once setup is finished.
 7. Assign only the people or groups who should be able to use the Hexpm integration.
 8. Save the application, then copy its **Client ID** and **Client secret**.
@@ -128,6 +128,14 @@ When one lapses in the browser you are sent to the provider and back, and unless
 
 Shorter is stricter and more interruptive. The lifetime is what bounds how long someone your provider has deactivated keeps reaching the organization, so it is the number to pick deliberately.
 
+### Provider-initiated logout
+
+If you set the **Back-Channel Logout URI** in your provider, the provider tells Hexpm when a member's provider session ends, whether they signed out or were deactivated, and Hexpm revokes the organization access sessions that provider session created. A logout token naming only the subject revokes every organization access session the member's linked identity holds. The member's next request goes back through the provider, which is where a deactivated account stops.
+
+Delivery is best-effort: it is one HTTPS request from your provider, and if it is lost nothing retries it here. The session lifetime is still what bounds how long a deactivated member keeps access, so back-channel logout shortens the window in practice without replacing the lifetime as the guarantee.
+
+Hexpm requires the `sub` claim in logout tokens and rejects tokens carrying only a `sid`; Okta sends `sub`. Microsoft Entra does not send back-channel logout tokens, so Entra deactivations wait out the session lifetime. Each received logout is written to the organization's audit log, and rejected logout tokens appear under **Recent failures** with the `logout_token` stage.
+
 ### The Hex CLI
 
 When a CLI session's authentication lapses, the next `mix deps.get` asks:
@@ -188,7 +196,7 @@ There is no sixth. If you are evaluating Hexpm against a compliance requirement,
 Two windows, and they are different:
 
 * **Removing a member in Hexpm** takes effect within thirty minutes. The CLI's access token is a capability the edge verifies without a database lookup, so it keeps its scopes until it is next refreshed. Web access ends immediately.
-* **Deactivating someone in your provider only** takes effect when their organization access session expires, which is the lifetime you set. Hexpm does not learn about a provider-side deactivation until then.
+* **Deactivating someone in your provider only** takes effect when the provider sends a back-channel logout token, if you configured that, and otherwise when their organization access session expires, which is the lifetime you set. The logout token is the fast path; the lifetime is the guarantee.
 
 SCIM closes the second one and is not in this release. Until it ships, the session lifetime is what bounds it, which is the reason to pick that number deliberately rather than take the default.
 
@@ -259,4 +267,4 @@ Do not send client secrets, authorization codes, tokens, cookies, or raw callbac
 
 Enabled organizations can use the organization login URL and third-party-initiated login. Custom Okta dashboard tiles and Microsoft Entra are not supported, and there is no public Okta Integration Network listing. Tiles and Entra both work and have been exercised privately; supporting them is an open release decision rather than an untested path. The OIN listing is different in kind: the integration was built and exercised, but it was never submitted for review, so no listing exists to install from.
 
-This release does not support SAML, account creation, SCIM, group or role synchronization, or OIDC logout.
+This release supports OIDC back-channel logout. It does not support SAML, account creation, SCIM, group or role synchronization, RP-initiated logout, or front-channel logout.

--- a/lib/hexpm_web/templates/docs/organization_sso.html.md
+++ b/lib/hexpm_web/templates/docs/organization_sso.html.md
@@ -130,7 +130,7 @@ Shorter is stricter and more interruptive. The lifetime is what bounds how long 
 
 ### Provider-initiated logout
 
-If you set the **Back-Channel Logout URI** in your provider, the provider tells Hexpm when a member's provider session ends, whether they signed out or were deactivated, and Hexpm revokes the organization access sessions that provider session created. A logout token naming only the subject revokes every organization access session the member's linked identity holds. The member's next request goes back through the provider, which is where a deactivated account stops.
+If you set the **Back-Channel Logout URI** in your provider, the provider tells Hexpm when a member's provider session ends, whether they signed out or were deactivated, and Hexpm revokes the organization access sessions that provider session created, together with any of the member's sessions whose provider session Hexpm does not know. A logout token naming only the subject revokes every organization access session the member's linked identity holds. The member's next request goes back through the provider, which is where a deactivated account stops.
 
 Delivery is best-effort: it is one HTTPS request from your provider, and if it is lost nothing retries it here. The session lifetime is still what bounds how long a deactivated member keeps access, so back-channel logout shortens the window in practice without replacing the lifetime as the guarantee.
 

--- a/priv/repo/migrations/20260901120000_add_sid_to_organization_sso.exs
+++ b/priv/repo/migrations/20260901120000_add_sid_to_organization_sso.exs
@@ -1,0 +1,13 @@
+defmodule Hexpm.RepoBase.Migrations.AddSidToOrganizationSso do
+  use Ecto.Migration
+
+  def change do
+    alter table(:organization_sso_sessions) do
+      add :sid, :text
+    end
+
+    alter table(:organization_sso_transactions) do
+      add :sid, :text
+    end
+  end
+end

--- a/test/hexpm/accounts/sso/oidcc_test.exs
+++ b/test/hexpm/accounts/sso/oidcc_test.exs
@@ -907,6 +907,189 @@ defmodule Hexpm.Accounts.SSO.OIDC.OidccTest do
     end
   end
 
+  test "exchange_code carries the provider session id through, dropping unusable ones",
+       context do
+    for {sid_claim, expected} <- [
+          {"provider-session-1", "provider-session-1"},
+          {String.duplicate("s", 256), nil},
+          {"", nil},
+          {123, nil}
+        ] do
+      token = signed_id_token(context.key, "key-1", context.transaction, %{"sid" => sid_claim})
+      expect_token_response(token)
+
+      assert {:ok, %{sid: ^expected}} =
+               Oidcc.exchange_code(
+                 context.connection,
+                 context.transaction,
+                 "authorization-code",
+                 context.transaction.redirect_uri,
+                 context.connection.client_secret
+               )
+    end
+  end
+
+  describe "validate_logout_token/2" do
+    test "accepts a conforming logout token", context do
+      token = logout_token(context.key)
+
+      assert {:ok, claims} = Oidcc.validate_logout_token(context.connection, token)
+      assert claims.issuer == @issuer
+      assert claims.subject == "00u123"
+      assert claims.sid == "provider-session-1"
+      assert claims.jwks_document == nil
+    end
+
+    test "accepts a token with no sid", context do
+      token = logout_token(context.key, %{}, ["sid"])
+
+      assert {:ok, %{sid: nil}} = Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a sid-only token, since the subject is required", context do
+      token = logout_token(context.key, %{}, ["sub"])
+
+      assert {:error, %Error{stage: :logout_token, code: :required_claim_missing}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a token carrying a nonce", context do
+      token = logout_token(context.key, %{"nonce" => "nonce"})
+
+      assert {:error, %Error{stage: :logout_token, code: :nonce_present}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a token without the back-channel logout event", context do
+      for events <- [
+            :drop,
+            %{},
+            %{"http://schemas.openid.net/event/other" => %{}},
+            %{"http://schemas.openid.net/event/backchannel-logout" => "not-an-object"}
+          ] do
+        token =
+          case events do
+            :drop -> logout_token(context.key, %{}, ["events"])
+            events -> logout_token(context.key, %{"events" => events})
+          end
+
+        assert {:error, %Error{stage: :logout_token, code: :events_invalid}} =
+                 Oidcc.validate_logout_token(context.connection, token)
+      end
+    end
+
+    test "rejects an expired token", context do
+      now = DateTime.utc_now() |> DateTime.to_unix()
+      token = logout_token(context.key, %{"exp" => now - 10})
+
+      assert {:error, %Error{stage: :logout_token, code: :expired}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a token issued too long ago even when it has not expired", context do
+      now = DateTime.utc_now() |> DateTime.to_unix()
+      token = logout_token(context.key, %{"iat" => now - 400, "exp" => now + 100})
+
+      assert {:error, %Error{stage: :logout_token, code: :issued_at_too_old}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a token issued in the future", context do
+      now = DateTime.utc_now() |> DateTime.to_unix()
+      token = logout_token(context.key, %{"iat" => now + 120})
+
+      assert {:error, %Error{stage: :logout_token, code: :issued_at_in_future}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a token for another audience or issuer", context do
+      for overrides <- [%{"aud" => "someone-else"}, %{"iss" => "https://other.example.com"}] do
+        token = logout_token(context.key, overrides)
+
+        assert {:error, %Error{stage: :logout_token}} =
+                 Oidcc.validate_logout_token(context.connection, token)
+      end
+    end
+
+    test "rejects a token signed with an unknown key", context do
+      other_key = JOSE.JWK.generate_key({:rsa, 1_024})
+      token = logout_token(other_key)
+
+      assert {:error, %Error{stage: :logout_token}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a symmetrically signed token", context do
+      claims = default_logout_token_claims()
+
+      token =
+        %{"kty" => "oct", "k" => Base.url_encode64("client-secret", padding: false)}
+        |> JOSE.JWK.from_map()
+        |> JOSE.JWT.sign(%{"alg" => "HS256", "kid" => "key-1"}, claims)
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      assert {:error, %Error{stage: :logout_token}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "rejects a string that is not a token", context do
+      assert {:error, %Error{stage: :logout_token}} =
+               Oidcc.validate_logout_token(context.connection, "not-a-jwt")
+    end
+
+    test "refreshes the signing keys for an unknown kid and hands the document back",
+         context do
+      rotated_key = JOSE.JWK.generate_key({:rsa, 1_024})
+      {_, rotated_public} = rotated_key |> JOSE.JWK.to_public_map()
+      rotated_public = Map.put(rotated_public, "kid", "key-2")
+
+      rotated_document = %{"keys" => [rotated_public]}
+      expect_json_get(@jwks_uri, rotated_document, "max-age=300")
+
+      token =
+        rotated_key
+        |> JOSE.JWT.sign(%{"alg" => "RS256", "kid" => "key-2"}, default_logout_token_claims())
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      assert {:ok, claims} = Oidcc.validate_logout_token(context.connection, token)
+      assert claims.subject == "00u123"
+      assert claims.jwks_document == rotated_document
+      assert claims.jwks_expires_at
+    end
+
+    test "drops an unusable sid rather than failing the logout", context do
+      token = logout_token(context.key, %{"sid" => String.duplicate("s", 256)})
+
+      assert {:ok, %{sid: nil}} = Oidcc.validate_logout_token(context.connection, token)
+    end
+  end
+
+  defp logout_token(key, overrides \\ %{}, drops \\ []) do
+    claims =
+      default_logout_token_claims()
+      |> Map.merge(overrides)
+      |> Map.drop(drops)
+
+    sign_id_token(key, "key-1", claims)
+  end
+
+  defp default_logout_token_claims do
+    now = DateTime.utc_now() |> DateTime.to_unix()
+
+    %{
+      "iss" => @issuer,
+      "sub" => "00u123",
+      "aud" => "client-id",
+      "iat" => now,
+      "exp" => now + 120,
+      "jti" => "logout-jti",
+      "events" => %{"http://schemas.openid.net/event/backchannel-logout" => %{}},
+      "sid" => "provider-session-1"
+    }
+  end
+
   defp expect_json_get(url, document, cache_control \\ "max-age=600") do
     expect(Hexpm.HTTP.Mock, :get, fn received_url, headers, opts ->
       assert received_url == url

--- a/test/hexpm/accounts/sso/oidcc_test.exs
+++ b/test/hexpm/accounts/sso/oidcc_test.exs
@@ -911,7 +911,7 @@ defmodule Hexpm.Accounts.SSO.OIDC.OidccTest do
        context do
     for {sid_claim, expected} <- [
           {"provider-session-1", "provider-session-1"},
-          {String.duplicate("s", 256), nil},
+          {String.duplicate("s", 4097), nil},
           {"", nil},
           {123, nil}
         ] do
@@ -1059,10 +1059,34 @@ defmodule Hexpm.Accounts.SSO.OIDC.OidccTest do
       assert claims.jwks_expires_at
     end
 
-    test "drops an unusable sid rather than failing the logout", context do
-      token = logout_token(context.key, %{"sid" => String.duplicate("s", 256)})
+    test "rejects an unusable sid rather than widening the logout", context do
+      for sid <- [String.duplicate("s", 4097), 123, ""] do
+        token = logout_token(context.key, %{"sid" => sid})
 
-      assert {:ok, %{sid: nil}} = Oidcc.validate_logout_token(context.connection, token)
+        assert {:error, %Error{stage: :logout_token, code: :sid_invalid}} =
+                 Oidcc.validate_logout_token(context.connection, token)
+      end
+    end
+
+    test "rejects a token without a token identifier", context do
+      token = logout_token(context.key, %{}, ["jti"])
+
+      assert {:error, %Error{stage: :logout_token, code: :jti_missing}} =
+               Oidcc.validate_logout_token(context.connection, token)
+    end
+
+    test "does not fetch signing keys for an unknown kid when the caller forbids it",
+         context do
+      rotated_key = JOSE.JWK.generate_key({:rsa, 1_024})
+
+      token =
+        rotated_key
+        |> JOSE.JWT.sign(%{"alg" => "RS256", "kid" => "key-2"}, default_logout_token_claims())
+        |> JOSE.JWS.compact()
+        |> elem(1)
+
+      assert {:error, %Error{stage: :logout_token}} =
+               Oidcc.validate_logout_token(context.connection, token, refresh_jwks: false)
     end
   end
 

--- a/test/hexpm/accounts/sso_test.exs
+++ b/test/hexpm/accounts/sso_test.exs
@@ -578,9 +578,10 @@ defmodule Hexpm.Accounts.SSOTest do
 
     test "an unlinked subject hands a member to the link consent step", context do
       transaction = start_transaction(context, context.member)
+      claims = Map.put(valid_claims(), :sid, "provider-session-1")
 
       assert {:ok, {:link, transaction_id, link_token}} =
-               complete(transaction, valid_claims(), context.member)
+               complete(transaction, claims, context.member)
 
       assert transaction_id == transaction.id
       refute Repo.exists?(Identity)
@@ -605,12 +606,30 @@ defmodule Hexpm.Accounts.SSOTest do
       # Consent completes an authentication, so it unlocks the organization.
       assert org_session.identity_id == identity.id
 
+      # The provider session survived the consent round trip onto the org
+      # session and left the transaction stash.
+      assert org_session.sid == "provider-session-1"
+      refute Repo.get!(SSO.Transaction, transaction_id).sid
+
       assert SSO.current_org_session(user_session.id, context.organization.id).id ==
                org_session.id
 
       actions = context.organization |> AuditLogs.all_by() |> Enum.map(& &1.action)
       assert "sso.identity.link" in actions
       assert "sso.login" in actions
+    end
+
+    test "an authentication records the provider session it came from", context do
+      identity = link_identity(context, context.member)
+      user_session = browser_session(context.member)
+      transaction = start_transaction(context, context.member)
+      claims = Map.put(valid_claims(), :sid, "provider-session-1")
+
+      assert {:ok, {:login, _user, org_session, _return_path}} =
+               complete(transaction, claims, context.member, user_session.id)
+
+      assert org_session.identity_id == identity.id
+      assert org_session.sid == "provider-session-1"
     end
 
     test "an unlinked subject refuses a nonmember and creates nothing", context do

--- a/test/hexpm/accounts/sso_test.exs
+++ b/test/hexpm/accounts/sso_test.exs
@@ -619,6 +619,43 @@ defmodule Hexpm.Accounts.SSOTest do
       assert "sso.login" in actions
     end
 
+    test "a logout token cancels a pending link consent", context do
+      transaction = start_transaction(context, context.member)
+      claims = Map.put(valid_claims(), :sid, "provider-session-1")
+
+      assert {:ok, {:link, transaction_id, link_token}} =
+               complete(transaction, claims, context.member)
+
+      expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn _connection,
+                                                                      _token,
+                                                                      _opts ->
+        {:ok,
+         %{
+           issuer: "https://identity.example.com/oauth2/default",
+           subject: "00u123",
+           sid: "provider-session-1",
+           jwks_document: nil,
+           jwks_expires_at: nil
+         }}
+      end)
+
+      assert :ok = SSO.backchannel_logout(context.organization, "logout-token")
+
+      user = Repo.preload(context.member, :emails)
+      user_session = browser_session(context.member)
+
+      assert {:error, :link_cancelled} =
+               SSO.complete_link(
+                 transaction_id,
+                 link_token,
+                 user,
+                 user_session.id,
+                 audit_data(user)
+               )
+
+      refute Repo.exists?(SSO.OrgSession)
+    end
+
     test "an authentication records the provider session it came from", context do
       identity = link_identity(context, context.member)
       user_session = browser_session(context.member)

--- a/test/hexpm_web/controllers/sso_backchannel_logout_controller_test.exs
+++ b/test/hexpm_web/controllers/sso_backchannel_logout_controller_test.exs
@@ -1,0 +1,216 @@
+defmodule HexpmWeb.SSOBackchannelLogoutControllerTest do
+  use HexpmWeb.ConnCase, async: false
+
+  import Mox
+
+  alias Hexpm.Accounts.AuditLog
+  alias Hexpm.Accounts.SSO
+  alias Hexpm.Accounts.SSO.{Connection, Error, OrgSession}
+
+  setup :verify_on_exit!
+
+  setup do
+    organization = insert(:organization)
+    user = insert(:user)
+    insert(:organization_user, organization: organization, user: user)
+    connection = insert(:organization_sso_connection, organization: organization)
+
+    identity =
+      insert(:organization_sso_identity,
+        organization: organization,
+        connection: connection,
+        user: user
+      )
+
+    enable_beta_for(organization)
+
+    %{organization: organization, user: user, connection: connection, identity: identity}
+  end
+
+  test "a sid-scoped token ends the sessions from that provider session and no other",
+       context do
+    {_session, revoked} = establish_session(context, "sid-1")
+    {survivor_session, _survivor} = establish_session(context, "sid-2")
+    copy = grant_copy(context, revoked)
+
+    expect_logout_token(context.connection, ok_claims(sid: "sid-1"))
+
+    conn = post_logout(context.organization)
+
+    assert response(conn, 200) == ""
+    assert get_resp_header(conn, "cache-control") == ["no-store"]
+
+    assert Repo.get!(OrgSession, revoked.id).revoked_at
+    assert Repo.get!(OrgSession, copy.id).revoked_at
+    assert SSO.current_org_session(survivor_session.id, context.organization.id)
+
+    assert [audit] = audit_entries("sso.backchannel_logout")
+    assert audit.params["organization"]["id"] == context.organization.id
+    assert audit.params["user_id"] == context.user.id
+    assert audit.params["sid_scoped"] == true
+    assert audit.params["revoked_count"] == 2
+  end
+
+  test "a token with no sid ends everything the identity holds, sessions without a sid included",
+       context do
+    {no_sid_session, _no_sid} = establish_session(context, nil)
+    {sid_session, _with_sid} = establish_session(context, "sid-1")
+
+    expect_logout_token(context.connection, ok_claims(sid: nil))
+
+    assert response(post_logout(context.organization), 200)
+
+    refute SSO.current_org_session(no_sid_session.id, context.organization.id)
+    refute SSO.current_org_session(sid_session.id, context.organization.id)
+  end
+
+  test "an unknown subject succeeds and revokes nothing", context do
+    {session, _org_session} = establish_session(context, "sid-1")
+
+    expect_logout_token(context.connection, ok_claims(subject: "00u-somebody-else"))
+
+    assert response(post_logout(context.organization), 200)
+    assert SSO.current_org_session(session.id, context.organization.id)
+    assert audit_entries("sso.backchannel_logout") == []
+  end
+
+  test "a replayed token succeeds and changes nothing further", context do
+    {session, org_session} = establish_session(context, "sid-1")
+
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, 2, fn _connection, _token ->
+      ok_claims(sid: "sid-1")
+    end)
+
+    assert response(post_logout(context.organization), 200)
+    revoked_at = Repo.get!(OrgSession, org_session.id).revoked_at
+    assert revoked_at
+
+    assert response(post_logout(context.organization), 200)
+    assert Repo.get!(OrgSession, org_session.id).revoked_at == revoked_at
+    refute SSO.current_org_session(session.id, context.organization.id)
+  end
+
+  test "an invalid token is refused and recorded for the administrator", context do
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn _connection, _token ->
+      {:error, %Error{stage: :logout_token, code: :nonce_present}}
+    end)
+
+    assert response(post_logout(context.organization), 400)
+
+    assert [failure] = SSO.failures(context.connection)
+    assert failure.stage == "logout_token"
+    assert failure.code == "nonce_present"
+  end
+
+  test "a refreshed signing-key document is persisted", context do
+    expires_at = DateTime.add(DateTime.utc_now(), 600, :second)
+    jwks = %{"keys" => [%{"kid" => "rotated"}]}
+
+    expect_logout_token(
+      context.connection,
+      ok_claims(jwks_document: jwks, jwks_expires_at: expires_at)
+    )
+
+    assert response(post_logout(context.organization), 200)
+    assert Repo.get!(Connection, context.connection.id).jwks_document == jwks
+  end
+
+  test "a request without a logout token is a bad request", context do
+    conn =
+      build_conn()
+      |> post("/sso/backchannel-logout/#{context.organization.name}", %{})
+
+    assert response(conn, 400)
+  end
+
+  test "an organization without a connection is not found", context do
+    other = insert(:organization)
+    enable_beta_for([context.organization, other])
+
+    conn =
+      build_conn()
+      |> post("/sso/backchannel-logout/#{other.name}", %{"logout_token" => "logout-token"})
+
+    assert response(conn, 404)
+  end
+
+  test "an unknown organization is not found" do
+    conn =
+      build_conn()
+      |> post("/sso/backchannel-logout/nobody", %{"logout_token" => "logout-token"})
+
+    assert response(conn, 404)
+  end
+
+  test "an organization outside the beta is not found", context do
+    enable_beta_for([])
+
+    assert response(post_logout(context.organization), 404)
+  end
+
+  test "the endpoint does not exist while SSO is off", context do
+    config = Application.fetch_env!(:hexpm, :organization_sso)
+    app_env(:hexpm, :organization_sso, Keyword.put(config, :mode, :off))
+
+    assert response(post_logout(context.organization), 404)
+  end
+
+  defp post_logout(organization) do
+    build_conn()
+    |> post("/sso/backchannel-logout/#{organization.name}", %{"logout_token" => "logout-token"})
+  end
+
+  defp ok_claims(overrides) do
+    {:ok,
+     Enum.into(overrides, %{
+       issuer: "https://identity.example.com/oauth2/default",
+       subject: "00u123",
+       sid: nil,
+       jwks_document: nil,
+       jwks_expires_at: nil
+     })}
+  end
+
+  defp expect_logout_token(connection, result) do
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn received, token ->
+      assert received.id == connection.id
+      assert token == "logout-token"
+      result
+    end)
+  end
+
+  defp establish_session(context, sid) do
+    {:ok, session, _token} =
+      Hexpm.UserSessions.create_browser_session(context.user, audit: audit_data(context.user))
+
+    org_session = SSO.establish_org_session!(context.identity, session.id, sid)
+    {session, org_session}
+  end
+
+  defp grant_copy(context, source) do
+    {:ok, session, _token} =
+      Hexpm.UserSessions.create_browser_session(context.user, audit: audit_data(context.user))
+
+    [copy] = SSO.grant_org_sessions!(source.user_session_id, session.id, context.user.id)
+    assert copy.sid == source.sid
+    copy
+  end
+
+  defp audit_entries(action) do
+    Repo.all(from(log in AuditLog, where: log.action == ^action))
+  end
+
+  defp enable_beta_for(organizations) do
+    config = Application.fetch_env!(:hexpm, :organization_sso)
+    organizations = List.wrap(organizations)
+
+    app_env(
+      :hexpm,
+      :organization_sso,
+      Keyword.merge(config,
+        mode: :beta,
+        beta_organizations: Enum.map(organizations, & &1.name)
+      )
+    )
+  end
+end

--- a/test/hexpm_web/controllers/sso_backchannel_logout_controller_test.exs
+++ b/test/hexpm_web/controllers/sso_backchannel_logout_controller_test.exs
@@ -27,10 +27,11 @@ defmodule HexpmWeb.SSOBackchannelLogoutControllerTest do
     %{organization: organization, user: user, connection: connection, identity: identity}
   end
 
-  test "a sid-scoped token ends the sessions from that provider session and no other",
+  test "a sid-scoped token ends that provider session's access and any of unknown origin",
        context do
     {_session, revoked} = establish_session(context, "sid-1")
     {survivor_session, _survivor} = establish_session(context, "sid-2")
+    {_unknown_session, unknown_origin} = establish_session(context, nil)
     copy = grant_copy(context, revoked)
 
     expect_logout_token(context.connection, ok_claims(sid: "sid-1"))
@@ -42,13 +43,14 @@ defmodule HexpmWeb.SSOBackchannelLogoutControllerTest do
 
     assert Repo.get!(OrgSession, revoked.id).revoked_at
     assert Repo.get!(OrgSession, copy.id).revoked_at
+    assert Repo.get!(OrgSession, unknown_origin.id).revoked_at
     assert SSO.current_org_session(survivor_session.id, context.organization.id)
 
     assert [audit] = audit_entries("sso.backchannel_logout")
     assert audit.params["organization"]["id"] == context.organization.id
     assert audit.params["user_id"] == context.user.id
     assert audit.params["sid_scoped"] == true
-    assert audit.params["revoked_count"] == 2
+    assert audit.params["revoked_count"] == 3
   end
 
   test "a token with no sid ends everything the identity holds, sessions without a sid included",
@@ -77,7 +79,9 @@ defmodule HexpmWeb.SSOBackchannelLogoutControllerTest do
   test "a replayed token succeeds and changes nothing further", context do
     {session, org_session} = establish_session(context, "sid-1")
 
-    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, 2, fn _connection, _token ->
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, 2, fn _connection,
+                                                                       _token,
+                                                                       _opts ->
       ok_claims(sid: "sid-1")
     end)
 
@@ -90,16 +94,37 @@ defmodule HexpmWeb.SSOBackchannelLogoutControllerTest do
     refute SSO.current_org_session(session.id, context.organization.id)
   end
 
-  test "an invalid token is refused and recorded for the administrator", context do
-    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn _connection, _token ->
+  test "an invalid token is refused and recorded once for the administrator", context do
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, 3, fn _connection,
+                                                                       _token,
+                                                                       _opts ->
       {:error, %Error{stage: :logout_token, code: :nonce_present}}
     end)
 
+    assert response(post_logout(context.organization), 400)
+    assert response(post_logout(context.organization), 400)
     assert response(post_logout(context.organization), 400)
 
     assert [failure] = SSO.failures(context.connection)
     assert failure.stage == "logout_token"
     assert failure.code == "nonce_present"
+  end
+
+  test "an unknown signing key stops triggering fetches while rejections are recent",
+       context do
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn _connection, _token, opts ->
+      assert opts[:refresh_jwks] == true
+      {:error, %Error{stage: :logout_token, code: :signature_invalid}}
+    end)
+
+    assert response(post_logout(context.organization), 400)
+
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn _connection, _token, opts ->
+      assert opts[:refresh_jwks] == false
+      {:error, %Error{stage: :logout_token, code: :signature_invalid}}
+    end)
+
+    assert response(post_logout(context.organization), 400)
   end
 
   test "a refreshed signing-key document is persisted", context do
@@ -172,9 +197,10 @@ defmodule HexpmWeb.SSOBackchannelLogoutControllerTest do
   end
 
   defp expect_logout_token(connection, result) do
-    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn received, token ->
+    expect(Hexpm.Accounts.SSO.OIDC.Mock, :validate_logout_token, fn received, token, opts ->
       assert received.id == connection.id
       assert token == "logout-token"
+      assert opts[:refresh_jwks] == true
       result
     end)
   end


### PR DESCRIPTION
Implements OIDC Back-Channel Logout 1.0 as the pre-SCIM offboarding signal. The provider POSTs a signed logout token to a per-organization endpoint (`/sso/backchannel-logout/:organization`); the token is validated against the connection's stored metadata and JWKS, and the identity's organization access sessions are revoked, scoped to the token's `sid` when it carries one. The `sid` claim is captured at authentication and carried across link consent, so granted OAuth-session copies revoke together with the browser session. Delivery is best-effort, so the session lifetime stays the guaranteed offboarding bound.

Logout tokens must carry `sub`; sid-only tokens are rejected. Invalid tokens land in the connection's failure log with a `logout_token` stage and show on the SSO tab, which also displays the endpoint URI to paste into the provider. Sid-scoped revocation also revokes the identity's sessions with no recorded sid, replay is idempotent, JWKS refresh is withheld for a cooldown after rejected tokens, and revocation runs under the connection lock and cancels pending link consents. Everything sits behind the existing SSO feature flag; with it off the endpoint 404s.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
