### PR TITLE
Track Sentry releases by image git sha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -200,6 +200,7 @@ jobs:
       PROJECT_ID: "hexpm-prod"
       SERVICE_ACCOUNT: ${{ secrets.GCLOUD_SERVICE_ACCOUNT }}
       WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCLOUD_WORKFLOW_IDENTITY_POOL_PROVIDER }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -237,3 +238,22 @@ jobs:
           push: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      # The release version is the image tag; the app sends the same value
+      # from the baked GIT_SHA, and the hexpm-ops deploy registers when it
+      # reaches an environment. The refs association needs the repository
+      # linked to the Sentry GitHub integration; fall back to a bare release
+      # so a missing link degrades commit tracking, not CI.
+      - name: Create Sentry release
+        if: ${{ github.event_name != 'pull_request' && env.SERVICE_ACCOUNT != '' && env.SENTRY_AUTH_TOKEN != '' }}
+        run: |
+          api="https://sentry.io/api/0/organizations/hexpm/releases/"
+          refs_payload=$(printf '{"version": "%s", "projects": ["hexpm"], "refs": [{"repository": "hexpm/hexpm", "commit": "%s"}]}' "$COMMIT_SHORT_SHA" "$GITHUB_SHA")
+          bare_payload=$(printf '{"version": "%s", "projects": ["hexpm"]}' "$COMMIT_SHORT_SHA")
+          curl -sf -X POST "$api" \
+            -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$refs_payload" ||
+            curl -sf -X POST "$api" \
+              -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$bare_payload"

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -87,9 +87,19 @@ if config_env() == :prod do
     access_key_id: System.fetch_env!("HEXPM_AWS_ACCESS_KEY_ID"),
     secret_access_key: System.fetch_env!("HEXPM_AWS_ACCESS_KEY_SECRET")
 
+  # GIT_SHA is baked into the image (see the Dockerfile) and matches the
+  # release CI creates in Sentry, so issues resolved via commits auto-resolve
+  # when the deploy carrying the fix is registered.
+  sentry_release =
+    case System.get_env("GIT_SHA") do
+      sha when sha in [nil, "", "unknown"] -> nil
+      sha -> sha
+    end
+
   config :sentry,
     dsn: System.fetch_env!("HEXPM_SENTRY_DSN"),
-    environment_name: System.fetch_env!("HEXPM_ENV")
+    environment_name: System.fetch_env!("HEXPM_ENV"),
+    release: sentry_release
 
   config :hexpm,
     email_base_url: "https://#{System.fetch_env!("HEXPM_HOST")}",


### PR DESCRIPTION
The SDK sends the baked GIT_SHA as the Sentry release (skipped when it holds the unknown default, so dev and test are unaffected), and the docker CI job creates the matching release with a commit ref when it pushes the image. Together with the deploy registration in hexpm-ops, issues resolved via commits get version-scoped resolution: events from older releases no longer count as regressions, and issues gain seen-in-release data and suspect commits.

The refs association needs hexpm/hexpm linked to the Sentry GitHub integration; the step falls back to a bare release if it isn't. The step skips itself until the SENTRY_AUTH_TOKEN secret from hexpm-ops#292 exists.