### PR TITLE
Count infrastructure noise as a metric instead of Sentry issues

### DIFF
--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -59,10 +59,21 @@ defmodule Hexpm.Application do
 
   def sentry_before_send(%Sentry.Event{original_exception: exception} = event) do
     cond do
-      websocket_protocol_error?(event) -> nil
-      Plug.Exception.status(exception) < 500 -> nil
-      Sentry.DefaultEventFilter.exclude_exception?(exception, event.source) -> nil
-      true -> event
+      websocket_protocol_error?(event) ->
+        nil
+
+      Plug.Exception.status(exception) < 500 ->
+        nil
+
+      class = metric_only_class(event) ->
+        :telemetry.execute([:hexpm, :sentry, :filtered], %{}, %{class: class})
+        nil
+
+      Sentry.DefaultEventFilter.exclude_exception?(exception, event.source) ->
+        nil
+
+      true ->
+        event
     end
   end
 
@@ -73,6 +84,43 @@ defmodule Hexpm.Application do
     do: true
 
   defp websocket_protocol_error?(%Sentry.Event{}), do: false
+
+  # Saturation and transport failures carry no per-event signal, so they are
+  # counted in the hexpm.sentry.filtered.total metric instead of reported as
+  # issues. Query-level failures arrive as Postgrex.Error and stay reported,
+  # except the two saturation symptoms.
+  defp metric_only_class(%Sentry.Event{
+         original_exception: %DBConnection.ConnectionError{} = error
+       }) do
+    case error do
+      %{reason: :queue_timeout} -> :pool_timeout
+      %{message: "tcp connect" <> _} -> :db_connect
+      _other -> :db_disconnect
+    end
+  end
+
+  defp metric_only_class(%Sentry.Event{
+         original_exception: %Postgrex.Error{postgres: %{code: code}}
+       })
+       when code in [:too_many_connections, :query_canceled] do
+    code
+  end
+
+  defp metric_only_class(%Sentry.Event{original_exception: %Bandit.TransportError{}}) do
+    :client_transport
+  end
+
+  defp metric_only_class(%Sentry.Event{original_exception: %Plug.Conn.NotSentError{}}) do
+    :response_not_sent
+  end
+
+  defp metric_only_class(%Sentry.Event{
+         extra: %{crash_reason: "{%DBConnection.ConnectionError{" <> _}
+       }) do
+    :db_connection_exit
+  end
+
+  defp metric_only_class(%Sentry.Event{}), do: nil
 
   # Make sure we exit after hex client tests are finished running
   if Mix.env() == :hex do

--- a/lib/hexpm/prom_ex/plugins/hexpm.ex
+++ b/lib/hexpm/prom_ex/plugins/hexpm.ex
@@ -66,6 +66,14 @@ defmodule Hexpm.PromEx.Plugins.Hexpm do
           tags: [:type]
         )
       ]),
+      Event.build(:hexpm_sentry_event_metrics, [
+        counter("hexpm.sentry.filtered.total",
+          event_name: [:hexpm, :sentry, :filtered],
+          description:
+            "Sentry events dropped by the before_send filter and counted here instead, by class.",
+          tags: [:class]
+        )
+      ]),
       Event.build(:hexpm_cdn_event_metrics, [
         counter("hexpm.cdn.purge_request.total",
           event_name: [:hexpm, :cdn, :purge_request, :stop],

--- a/test/hexpm/application_test.exs
+++ b/test/hexpm/application_test.exs
@@ -44,6 +44,92 @@ defmodule Hexpm.ApplicationTest do
 
       assert Hexpm.Application.sentry_before_send(event) == event
     end
+
+    test "counts and drops pool checkout timeouts" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:hexpm, :sentry, :filtered]])
+
+      exception =
+        DBConnection.ConnectionError.exception(
+          "connection not available and request was dropped from queue after 101ms",
+          :queue_timeout
+        )
+
+      event = Sentry.Event.create_event(exception: exception)
+
+      assert Hexpm.Application.sentry_before_send(event) == nil
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :pool_timeout}}
+    end
+
+    test "counts and drops connection failures by shape" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:hexpm, :sentry, :filtered]])
+
+      connect = DBConnection.ConnectionError.exception("tcp connect (127.0.0.1:5432): refused")
+      disconnect = DBConnection.ConnectionError.exception("tcp recv (idle): closed")
+
+      assert Hexpm.Application.sentry_before_send(Sentry.Event.create_event(exception: connect)) ==
+               nil
+
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :db_connect}}
+
+      assert Hexpm.Application.sentry_before_send(
+               Sentry.Event.create_event(exception: disconnect)
+             ) == nil
+
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :db_disconnect}}
+    end
+
+    test "counts and drops crash reports wrapping connection errors" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:hexpm, :sentry, :filtered]])
+
+      event =
+        Sentry.Event.create_event(
+          message: "Uncaught exit",
+          extra: %{
+            crash_reason: "{%DBConnection.ConnectionError{message: \"tcp recv: closed\"}, []}"
+          }
+        )
+
+      assert Hexpm.Application.sentry_before_send(event) == nil
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :db_connection_exit}}
+    end
+
+    test "counts and drops saturation-level postgres errors, keeps the rest" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:hexpm, :sentry, :filtered]])
+
+      canceled = %Postgrex.Error{postgres: %{code: :query_canceled}}
+      saturated = %Postgrex.Error{postgres: %{code: :too_many_connections}}
+      query_bug = %Postgrex.Error{postgres: %{code: :object_not_in_prerequisite_state}}
+
+      assert Hexpm.Application.sentry_before_send(Sentry.Event.create_event(exception: canceled)) ==
+               nil
+
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :query_canceled}}
+
+      assert Hexpm.Application.sentry_before_send(Sentry.Event.create_event(exception: saturated)) ==
+               nil
+
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :too_many_connections}}
+
+      event = Sentry.Event.create_event(exception: query_bug)
+      assert Hexpm.Application.sentry_before_send(event) == event
+    end
+
+    test "counts and drops client transport errors" do
+      ref = :telemetry_test.attach_event_handlers(self(), [[:hexpm, :sentry, :filtered]])
+
+      transport = %Bandit.TransportError{message: "Unrecoverable error: closed", error: :closed}
+      not_sent = %Plug.Conn.NotSentError{}
+
+      assert Hexpm.Application.sentry_before_send(Sentry.Event.create_event(exception: transport)) ==
+               nil
+
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :client_transport}}
+
+      assert Hexpm.Application.sentry_before_send(Sentry.Event.create_event(exception: not_sent)) ==
+               nil
+
+      assert_received {[:hexpm, :sentry, :filtered], ^ref, %{}, %{class: :response_not_sent}}
+    end
   end
 
   describe "mode supervision" do


### PR DESCRIPTION
Saturation and transport failures (pool checkout timeouts, dead sockets, connect refused, query_canceled, too_many_connections, client aborts, unsent responses) produced hundreds of Sentry issues per incident day while carrying no per-event signal: the pool-timeout family alone was ~1,900 events across ~21 issues in the last 90 days, fingerprinted apart by the queue-wait milliseconds in the message. Client aborts like HEXPM-8A regress on every fresh event now that the backlog is resolved.

before_send drops these classes and counts each one in a new hexpm.sentry.filtered.total PromEx counter tagged by class. Query-level failures still arrive as Postgrex.Error and stay reported, except the two saturation symptoms (query_canceled, too_many_connections).

Merge hexpm-ops#295 before or together with this so the saturation signal is never dark: its log-based alerts replace the Sentry issues as the overload signal.