### PR TITLE
Refuse owners and organization members without a verified primary email

### DIFF
--- a/lib/hexpm/accounts/organizations.ex
+++ b/lib/hexpm/accounts/organizations.ex
@@ -117,6 +117,14 @@ defmodule Hexpm.Accounts.Organizations do
   end
 
   def add_member(organization, %User{organization_id: nil} = user, params, audit: audit_data) do
+    if User.verified_primary_email?(user) do
+      insert_member(organization, user, params, audit_data)
+    else
+      {:error, :unverified_primary_email}
+    end
+  end
+
+  defp insert_member(organization, user, params, audit_data) do
     multi =
       Multi.new()
       |> Seats.claim(:seats, organization)

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -158,6 +158,9 @@ defmodule Hexpm.Accounts.User do
     Enum.any?(emails, &(&1.primary and &1.verified))
   end
 
+  def public_profile?(%User{organization_id: id}) when not is_nil(id), do: true
+  def public_profile?(%User{} = user), do: verified_primary_email?(user)
+
   def get(username_or_email, preload \\ []) do
     if email?(username_or_email) do
       from(

--- a/lib/hexpm/accounts/user.ex
+++ b/lib/hexpm/accounts/user.ex
@@ -154,6 +154,10 @@ defmodule Hexpm.Accounts.User do
   defp email(nil), do: nil
   defp email(email), do: email.email
 
+  def verified_primary_email?(%User{emails: emails}) do
+    Enum.any?(emails, &(&1.primary and &1.verified))
+  end
+
   def get(username_or_email, preload \\ []) do
     if email?(username_or_email) do
       from(

--- a/lib/hexpm/repository/owners.ex
+++ b/lib/hexpm/repository/owners.ex
@@ -38,6 +38,9 @@ defmodule Hexpm.Repository.Owners do
       repository.id != 1 and not repository_access ->
         {:error, :not_member}
 
+      not User.organization?(user) and not User.verified_primary_email?(user) ->
+        {:error, :unverified_primary_email}
+
       User.organization?(user) and Map.get(params, "transfer", false) != true ->
         {:error, :not_organization_transfer}
 

--- a/lib/hexpm_web/controllers/api/organization_user_controller.ex
+++ b/lib/hexpm_web/controllers/api/organization_user_controller.ex
@@ -61,6 +61,12 @@ defmodule HexpmWeb.API.OrganizationUserController do
         {:error, :organization_user} ->
           validation_failed(conn, "cannot add an organization as member to an organization")
 
+        {:error, :unverified_primary_email} ->
+          validation_failed(
+            conn,
+            "cannot add member until the user has verified their primary email"
+          )
+
         {:error, changeset} ->
           validation_failed(conn, changeset)
       end

--- a/lib/hexpm_web/controllers/api/owner_controller.ex
+++ b/lib/hexpm_web/controllers/api/owner_controller.ex
@@ -68,6 +68,11 @@ defmodule HexpmWeb.API.OwnerController do
                 "cannot add owner to private package when the user is not a member of the organization"
             })
 
+          {:error, :unverified_primary_email} ->
+            validation_failed(conn, %{
+              "username" => "cannot add owner until the user has verified their primary email"
+            })
+
           {:error, :not_organization_transfer} ->
             validation_failed(conn, %{
               "username" =>

--- a/lib/hexpm_web/controllers/api/user_controller.ex
+++ b/lib/hexpm_web/controllers/api/user_controller.ex
@@ -58,12 +58,15 @@ defmodule HexpmWeb.API.UserController do
   def show(conn, %{"name" => name}) do
     user = Users.public_get(name, [:emails, owned_packages: :repository])
 
-    accessible_packages =
-      Packages.accessible_user_owned_packages(user, SSOEnforcement.reachable_organizations(conn))
+    if user && User.public_profile?(user) do
+      accessible_packages =
+        Packages.accessible_user_owned_packages(
+          user,
+          SSOEnforcement.reachable_organizations(conn)
+        )
 
-    user = user && %{user | owned_packages: accessible_packages}
+      user = %{user | owned_packages: accessible_packages}
 
-    if user do
       when_stale(conn, user, fn conn ->
         conn
         |> api_cache(:private)

--- a/lib/hexpm_web/controllers/dashboard/organization_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/organization_controller.ex
@@ -135,6 +135,12 @@ defmodule HexpmWeb.Dashboard.OrganizationController do
             |> put_flash(:error, "Not enough seats in organization to add member.")
             |> render_index(organization, tab: :members)
 
+          {:error, :unverified_primary_email} ->
+            conn
+            |> put_status(400)
+            |> put_flash(:error, "User #{username} has not verified their primary email.")
+            |> render_index(organization, tab: :members)
+
           {:error, changeset} ->
             conn
             |> put_status(400)

--- a/lib/hexpm_web/controllers/dashboard/profile_controller.ex
+++ b/lib/hexpm_web/controllers/dashboard/profile_controller.ex
@@ -2,6 +2,7 @@ defmodule HexpmWeb.Dashboard.ProfileController do
   use HexpmWeb, :controller
 
   plug :requires_login
+  plug :requires_verified_primary_email
 
   def index(conn, _params) do
     user = conn.assigns.current_user
@@ -32,5 +33,16 @@ defmodule HexpmWeb.Dashboard.ProfileController do
       container: "flex-1 flex flex-col",
       changeset: changeset
     )
+  end
+
+  defp requires_verified_primary_email(conn, _opts) do
+    if User.verified_primary_email?(conn.assigns.current_user) do
+      conn
+    else
+      conn
+      |> put_flash(:error, "Verify your primary email before editing your public profile.")
+      |> redirect(to: ~p"/dashboard/email")
+      |> halt()
+    end
   end
 end

--- a/lib/hexpm_web/controllers/package_owner_controller.ex
+++ b/lib/hexpm_web/controllers/package_owner_controller.ex
@@ -41,6 +41,11 @@ defmodule HexpmWeb.PackageOwnerController do
           |> put_flash(:error, "#{username} is not a member of this repository.")
           |> redirect(to: ViewHelpers.path_for_owners(package))
 
+        {:error, :unverified_primary_email} ->
+          conn
+          |> put_flash(:error, "#{username} has not verified their primary email.")
+          |> redirect(to: ViewHelpers.path_for_owners(package))
+
         {:error, :not_organization_transfer} ->
           conn
           |> put_flash(:error, "#{username} is an organization — use a transfer to add it.")

--- a/lib/hexpm_web/controllers/user_controller.ex
+++ b/lib/hexpm_web/controllers/user_controller.ex
@@ -15,7 +15,7 @@ defmodule HexpmWeb.UserController do
         owned_packages: [:repository]
       ])
 
-    if user do
+    if user && User.public_profile?(user) do
       organization = user.organization
 
       case conn.path_info do
@@ -85,7 +85,8 @@ defmodule HexpmWeb.UserController do
              :emails,
              :organization,
              owned_packages: [:repository]
-           ]) do
+           ]),
+         true <- User.public_profile?(user) do
       all_packages =
         user
         |> Packages.accessible_user_owned_packages(SSOEnforcement.reachable_organizations(conn))

--- a/lib/hexpm_web/live/package_owner_live/add_owner.ex
+++ b/lib/hexpm_web/live/package_owner_live/add_owner.ex
@@ -39,8 +39,14 @@ defmodule HexpmWeb.PackageOwnerLive.AddOwner do
 
         true ->
           case Users.get_by_username(username, [:emails, :organization]) do
-            nil -> :not_found
-            user -> user
+            nil ->
+              :not_found
+
+            %User{organization_id: nil} = user ->
+              if User.verified_primary_email?(user), do: user, else: :unverified
+
+            user ->
+              user
           end
       end
 
@@ -145,6 +151,15 @@ defmodule HexpmWeb.PackageOwnerLive.AddOwner do
     ~H"""
     <p class="text-sm text-red-600 dark:text-red-400">
       No user found with username <span class="font-medium">"{@username}"</span>.
+    </p>
+    """
+  end
+
+  defp render_preview(%{looked_up_user: :unverified} = assigns) do
+    ~H"""
+    <p class="text-sm text-red-600 dark:text-red-400">
+      <span class="font-medium">{@username}</span>
+      has not verified their primary email and cannot be added as an owner.
     </p>
     """
   end

--- a/test/hexpm/accounts/organizations_test.exs
+++ b/test/hexpm/accounts/organizations_test.exs
@@ -43,6 +43,59 @@ defmodule Hexpm.Accounts.OrganizationsTest do
     end
   end
 
+  describe "add_member/4" do
+    setup do
+      organization = insert(:organization)
+      admin = insert(:user)
+      insert(:organization_user, organization: organization, user: admin, role: "admin")
+      %{organization: organization, admin: admin}
+    end
+
+    test "adds a user with a verified primary email", %{organization: organization, admin: admin} do
+      user = insert(:user)
+
+      assert {:ok, organization_user} =
+               Organizations.add_member(organization, user, %{"role" => "write"},
+                 audit: audit_data(admin)
+               )
+
+      assert organization_user.role == "write"
+      assert Organizations.get_role(organization, user) == "write"
+    end
+
+    test "refuses a user whose primary email is unverified", %{
+      organization: organization,
+      admin: admin
+    } do
+      user = insert(:user, emails: [build(:email, verified: false)])
+
+      assert {:error, :unverified_primary_email} =
+               Organizations.add_member(organization, user, %{"role" => "write"},
+                 audit: audit_data(admin)
+               )
+
+      refute Organizations.get_role(organization, user)
+    end
+
+    test "a verified secondary email does not stand in for the primary", %{
+      organization: organization,
+      admin: admin
+    } do
+      user =
+        insert(:user,
+          emails: [
+            build(:email, verified: false),
+            build(:email, primary: false, public: false, gravatar: false)
+          ]
+        )
+
+      assert {:error, :unverified_primary_email} =
+               Organizations.add_member(organization, user, %{"role" => "read"},
+                 audit: audit_data(admin)
+               )
+    end
+  end
+
   describe "remove_member/3" do
     test "cannot remove last member" do
       user = insert(:user)

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -6,7 +6,7 @@ defmodule Hexpm.AdminTasksTest do
   alias Hexpm.AdminTasks
   alias Hexpm.Accounts.{Organization, OrganizationUser, User}
   alias Hexpm.Emails.{OutboxEntry, OutboxWorker}
-  alias Hexpm.Repository.{Package, Release}
+  alias Hexpm.Repository.{Package, PackageOwner, Release}
 
   describe "change_password/3" do
     test "changes password by username" do
@@ -872,6 +872,18 @@ defmodule Hexpm.AdminTasksTest do
       assert {:ok, package_owner} = AdminTasks.add_owner(package.name, email)
 
       assert package_owner.user_id == new_owner.id
+    end
+
+    test "refuses a user whose primary email is unverified" do
+      package = insert(:package)
+      owner = insert(:user)
+      insert(:package_owner, package: package, user: owner)
+      new_owner = insert(:user, emails: [build(:email, verified: false)])
+
+      assert {:error, :unverified_primary_email} =
+               AdminTasks.add_owner(package.name, new_owner.username)
+
+      refute Repo.get_by(PackageOwner, package_id: package.id, user_id: new_owner.id)
     end
   end
 

--- a/test/hexpm/repository/owners_test.exs
+++ b/test/hexpm/repository/owners_test.exs
@@ -1,0 +1,84 @@
+defmodule Hexpm.Repository.OwnersTest do
+  use Hexpm.DataCase, async: true
+
+  alias Hexpm.Repository.Owners
+
+  setup do
+    owner = insert(:user)
+
+    package =
+      insert(:package, package_owners: [build(:package_owner, user: owner, level: "full")])
+      |> Repo.preload(repository: :organization)
+
+    %{owner: owner, package: package}
+  end
+
+  describe "add/4" do
+    test "adds a user with a verified primary email", %{owner: owner, package: package} do
+      user = insert(:user)
+
+      assert {:ok, package_owner} = Owners.add(package, user, %{}, audit: audit_data(owner))
+      assert package_owner.user_id == user.id
+      assert Owners.get(package, user).level == "full"
+    end
+
+    test "refuses a user whose primary email is unverified", %{owner: owner, package: package} do
+      user = insert(:user, emails: [build(:email, verified: false)])
+
+      assert {:error, :unverified_primary_email} =
+               Owners.add(package, user, %{}, audit: audit_data(owner))
+
+      refute Owners.get(package, user)
+    end
+
+    test "refuses a transfer to a user whose primary email is unverified", %{
+      owner: owner,
+      package: package
+    } do
+      user = insert(:user, emails: [build(:email, verified: false)])
+
+      assert {:error, :unverified_primary_email} =
+               Owners.add(package, user, %{"transfer" => true}, audit: audit_data(owner))
+
+      assert [%{user_id: owner_id}] = Owners.all(package)
+      assert owner_id == owner.id
+    end
+
+    test "a verified secondary email does not stand in for the primary", %{
+      owner: owner,
+      package: package
+    } do
+      user =
+        insert(:user,
+          emails: [
+            build(:email, verified: false),
+            build(:email, primary: false, public: false, gravatar: false)
+          ]
+        )
+
+      assert {:error, :unverified_primary_email} =
+               Owners.add(package, user, %{}, audit: audit_data(owner))
+    end
+
+    test "transfers to an organization without consulting its emails", %{
+      owner: owner,
+      package: package
+    } do
+      name = Fake.sequence(:package)
+
+      organization =
+        insert(:organization, name: name, user: build(:user, username: name, emails: []))
+
+      organization_user = Repo.preload(organization.user, [:emails, :organization])
+
+      assert {:ok, package_owner} =
+               Owners.add(package, organization_user, %{"transfer" => true},
+                 audit: audit_data(owner)
+               )
+
+      assert package_owner.user_id == organization.user.id
+      assert [%{user_id: user_id}] = Owners.all(package)
+      assert user_id == organization.user.id
+    end
+  end
+end

--- a/test/hexpm_web/controllers/api/organization_user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/organization_user_controller_test.exs
@@ -109,6 +109,27 @@ defmodule HexpmWeb.API.OrganizationUserControllerTest do
       refute Organizations.get_role(organization, organization2.user)
     end
 
+    test "new organization member validates primary email is verified", %{
+      user1: user1,
+      organization: organization
+    } do
+      insert(:organization_user, organization: organization, user: user1, role: "admin")
+      unverified = insert(:user, emails: [build(:email, verified: false)])
+      params = %{"name" => unverified.username, "role" => "read"}
+
+      conn =
+        build_conn()
+        |> put_req_header("authorization", key_for(user1))
+        |> post("/api/orgs/#{organization.name}/members", params)
+
+      result = json_response(conn, 422)
+
+      assert result["errors"] ==
+               "cannot add member until the user has verified their primary email"
+
+      refute Organizations.get_role(organization, unverified)
+    end
+
     test "new organization member validates number of seats", %{
       user1: user1,
       organization: organization

--- a/test/hexpm_web/controllers/api/owner_controller_test.exs
+++ b/test/hexpm_web/controllers/api/owner_controller_test.exs
@@ -266,6 +266,37 @@ defmodule HexpmWeb.API.OwnerControllerTest do
       assert Owners.get(package, user2).level == "maintainer"
     end
 
+    test "cannot add owner whose primary email is unverified", %{user1: user1, package: package} do
+      unverified = insert(:user, emails: [build(:email, verified: false)])
+
+      result =
+        build_conn()
+        |> put_req_header("authorization", key_for(user1))
+        |> put("/api/packages/#{package.name}/owners/#{unverified.username}")
+        |> json_response(422)
+
+      assert result["errors"]["username"] ==
+               "cannot add owner until the user has verified their primary email"
+
+      refute Owners.get(package, unverified)
+      refute Hexpm.Repo.exists?(AuditLog)
+    end
+
+    test "cannot transfer to owner whose primary email is unverified", %{
+      user1: user1,
+      package: package
+    } do
+      unverified = insert(:user, emails: [build(:email, verified: false)])
+
+      build_conn()
+      |> put_req_header("authorization", key_for(user1))
+      |> put("/api/packages/#{package.name}/owners/#{unverified.username}", %{"transfer" => true})
+      |> json_response(422)
+
+      assert [owner] = assoc(package, :owners) |> Hexpm.Repo.all()
+      assert owner.id == user1.id
+    end
+
     test "add owner with duplicate email (organization admin)", %{user1: user1} do
       # Create organization and make user2 an admin
       organization = insert(:organization)

--- a/test/hexpm_web/controllers/api/user_controller_test.exs
+++ b/test/hexpm_web/controllers/api/user_controller_test.exs
@@ -225,6 +225,27 @@ defmodule HexpmWeb.API.UserControllerTest do
       assert conn.status == 404
     end
 
+    test "returns 404 for a user whose primary email is unverified" do
+      user = insert(:user, emails: [build(:email, verified: false)])
+
+      conn = get(build_conn(), "/api/users/#{user.username}")
+      assert conn.status == 404
+      refute conn.resp_body =~ hd(user.emails).email
+    end
+
+    test "returns an organization account without any organization emails" do
+      name = Hexpm.Fake.sequence(:package)
+      insert(:organization, name: name, user: build(:user, username: name, emails: []))
+
+      body =
+        build_conn()
+        |> get("/api/users/#{name}")
+        |> json_response(200)
+
+      assert body["username"] == name
+      refute body["email"]
+    end
+
     test "show owned packages as owner", data do
       conn =
         build_conn()

--- a/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/organization_controller_test.exs
@@ -456,6 +456,33 @@ defmodule HexpmWeb.Dashboard.OrganizationControllerTest do
       assert_email_sent(Hexpm.Emails.organization_invite(organization, new_user))
     end
 
+    test "add member whose primary email is unverified", %{
+      user: user,
+      organization: organization
+    } do
+      mock_customer(organization)
+      insert(:organization_user, organization: organization, user: user, role: "admin")
+      unverified = insert(:user, emails: [build(:email, verified: false)])
+      params = %{"username" => unverified.username, role: "write"}
+
+      conn =
+        build_conn()
+        |> test_login(user)
+        |> post("/dashboard/orgs/#{organization.name}", %{
+          "action" => "add_member",
+          "organization_user" => params
+        })
+
+      html = html_response(conn, 400)
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+               "User #{unverified.username} has not verified their primary email."
+
+      assert active_org_tab(html) == "Members"
+      refute Repo.get_by(assoc(organization, :organization_users), user_id: unverified.id)
+      assert_no_email_sent()
+    end
+
     test "adding member does not send invite when user opts out", %{
       user: user,
       organization: organization

--- a/test/hexpm_web/controllers/dashboard/profile_controller_test.exs
+++ b/test/hexpm_web/controllers/dashboard/profile_controller_test.exs
@@ -37,6 +37,37 @@ defmodule HexpmWeb.Dashboard.ProfileControllerTest do
     assert redirected_to(conn) == "/login?return=%2Fdashboard%2Fprofile"
   end
 
+  test "sends a user with an unverified primary email to the email page" do
+    user = insert(:user, emails: [build(:email, verified: false)])
+
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> get("/dashboard/profile")
+
+    assert redirected_to(conn) == "/dashboard/email"
+
+    assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+             "Verify your primary email before editing your public profile."
+  end
+
+  test "does not update the profile of a user with an unverified primary email" do
+    user = insert(:user, emails: [build(:email, verified: false)])
+
+    conn =
+      build_conn()
+      |> test_login(user)
+      |> post("/dashboard/profile", %{
+        user: %{full_name: "New Name", handles: %{url: "https://example.com"}}
+      })
+
+    assert redirected_to(conn) == "/dashboard/email"
+
+    user = Hexpm.Repo.get!(User, user.id)
+    refute user.full_name == "New Name"
+    refute user.handles && user.handles.url
+  end
+
   test "update profile", c do
     conn =
       build_conn()
@@ -97,8 +128,8 @@ defmodule HexpmWeb.Dashboard.ProfileControllerTest do
     refute Users.get(c.user.username, [:emails]) |> User.email(:public)
   end
 
-  test "update profile with no emails", c do
-    Hexpm.Repo.delete_all(Hexpm.Accounts.Email)
+  test "update profile with no public email", c do
+    Hexpm.Repo.update_all(Hexpm.Accounts.Email, set: [public: false])
 
     conn =
       build_conn()

--- a/test/hexpm_web/controllers/package_owner_controller_test.exs
+++ b/test/hexpm_web/controllers/package_owner_controller_test.exs
@@ -160,6 +160,25 @@ defmodule HexpmWeb.PackageOwnerControllerTest do
       assert Phoenix.Flash.get(conn.assigns.flash, :error) =~ "not found"
     end
 
+    test "shows error flash for user whose primary email is unverified", %{
+      full_owner: full_owner,
+      package: package
+    } do
+      unverified = insert(:user, emails: [build(:email, verified: false)])
+
+      conn =
+        build_conn()
+        |> test_login(full_owner, sudo: true)
+        |> post("/packages/#{package.name}/owners", %{"username" => unverified.username})
+
+      assert redirected_to(conn) == "/packages/#{package.name}/owners"
+
+      assert Phoenix.Flash.get(conn.assigns.flash, :error) ==
+               "#{unverified.username} has not verified their primary email."
+
+      refute Owners.get(package, unverified)
+    end
+
     test "is forbidden for maintainer even with sudo", %{
       maintainer: maintainer,
       non_owner: non_owner,

--- a/test/hexpm_web/controllers/user_controller_test.exs
+++ b/test/hexpm_web/controllers/user_controller_test.exs
@@ -46,6 +46,25 @@ defmodule HexpmWeb.UserControllerTest do
     assert response(conn, 200) =~ c.user1.username
   end
 
+  test "returns 404 for a user whose primary email is unverified" do
+    user = insert(:user, full_name: "Unverified Person", emails: [build(:email, verified: false)])
+
+    conn = get(build_conn(), "/users/#{user.username}")
+    assert response(conn, 404)
+    refute conn.resp_body =~ "Unverified Person"
+
+    conn = get(build_conn(), "/users/#{user.username}/stats")
+    assert response(conn, 404)
+  end
+
+  test "shows an organization page without any organization emails" do
+    name = Hexpm.Fake.sequence(:package)
+    insert(:organization, name: name, user: build(:user, username: name, emails: []))
+
+    conn = get(build_conn(), "/orgs/#{name}")
+    assert response(conn, 200) =~ name
+  end
+
   test "show owned packages as owner", c do
     conn =
       build_conn()

--- a/test/hexpm_web/live/package_owner_live/add_owner_test.exs
+++ b/test/hexpm_web/live/package_owner_live/add_owner_test.exs
@@ -75,6 +75,27 @@ defmodule HexpmWeb.PackageOwnerLive.AddOwnerTest do
     refute submit_button_disabled?(after_lookup)
   end
 
+  test "refuses a user whose primary email is unverified", %{conn: conn, session: session} do
+    insert(:user,
+      username: "unverified_user",
+      full_name: "Unverified Person",
+      emails: [build(:email, verified: false)]
+    )
+
+    {:ok, view, _html} = live_isolated(conn, AddOwner, session: session)
+
+    html =
+      view
+      |> form("#add-owner-form", username: "unverified_user", level: "maintainer")
+      |> render_change()
+
+    assert html =~ "unverified_user"
+    assert html =~ "has not verified their primary email"
+    refute html =~ "Unverified Person"
+    refute html =~ ~s(href="/users/unverified_user")
+    assert submit_button_disabled?(html)
+  end
+
   defp submit_button_disabled?(html) do
     {:ok, doc} = Floki.parse_fragment(html)
 


### PR DESCRIPTION
`Owners.add/4` and `Organizations.add_member/4` accepted any user found by username, so an account that never verified its primary email could be made a package owner or an organization member. Both now return `{:error, :unverified_primary_email}` for a user without a verified primary email. That is the definition the API authentication gate uses: `verified_user?/3` in `HexpmWeb.AuthHelpers` checks the primary email for key and OAuth credentials. Organization accounts are exempt as before, since they carry no primary email and a transfer to one is decided by the organization's membership.

The four controllers that reach these functions map the error to a 422 (API) or a flash (web): `HexpmWeb.API.OwnerController.create/2`, `HexpmWeb.PackageOwnerController.create/2`, `HexpmWeb.API.OrganizationUserController.create/2` and the dashboard `add_member` action. `AdminTasks.add_owner/3` goes through `Owners.add/4` and returns the new error unchanged. The add-owner dialog previews such a user as not addable, without profile details, and keeps the submit disabled.

The public profile editor (`/dashboard/profile`) is also closed to a session whose primary email is unverified: both the page and the update redirect to `/dashboard/email` with a flash, so the account can't set a profile URL or handles before verifying. Organization profiles are edited from the organization dashboard and aren't affected.

The public profile itself is withheld until the primary email is verified. `/users/:username`, `/users/:username/stats` and `GET /api/users/:name` answer 404 for such an account, the same as for a username that doesn't exist. Before this, an account created through the signup form or `POST /api/users` had an indexable page and an API document carrying its `full_name` and a `mailto:` link to the unverified address without ever clicking the verification link. Organization accounts have no primary email and keep their pages.

Not changed, listed for a decision. `POST /api/keys` keeps `allow_unconfirmed` so `mix hex.user auth` works before the confirmation link is clicked, and the client credentials grant on `POST /api/oauth/token` exchanges such a key for a token with no email check; both the key and the token are refused on use. `HexpmWeb.AuthController.handle_existing_user_login/2` (GitHub login for an account with the provider already linked) starts a session without the verified-email check that password login has. The application doesn't produce an account with the provider linked and the primary unverified, because linking needs a session and the first session of an account needs a verified primary, so the check is missing rather than reachable. No other browser route has a verified-email gate of its own, so accepting an organization invitation, creating an organization, approving an OAuth or device authorization, creating keys and linking GitHub all rest on that login decision.
