### PR TITLE
Batch the announcement outbox inserts

### DIFF
--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -913,8 +913,7 @@ defmodule Hexpm.AdminTasks do
 
         pending
         |> Enum.flat_map(&prepare_announcement(&1, subject, body, group_key))
-        |> Enum.map(&Outbox.insert!/1)
-        |> length()
+        |> Outbox.insert_all!()
       end,
       timeout: :infinity
     )

--- a/lib/hexpm/emails/outbox.ex
+++ b/lib/hexpm/emails/outbox.ex
@@ -7,6 +7,8 @@ defmodule Hexpm.Emails.Outbox do
   @allowed_options [:category, :group_key, :scope_key, :expires_at, :priority]
   @cancel_options [:group_key, :scope_key, :categories]
   @retention_seconds 30 * 24 * 60 * 60
+  @insert_chunk_size 1_000
+  @entry_fields ~w(category type group_key scope_key recipients subject email expires_at priority)a
 
   def enqueue!(%Swoosh.Email{} = email, opts) do
     email
@@ -54,6 +56,47 @@ defmodule Hexpm.Emails.Outbox do
       end)
 
     entry
+  end
+
+  @doc """
+  Inserts prepared entries and their delivery jobs in chunks, one statement per
+  table and chunk. Returns the number of entries inserted.
+  """
+  def insert_all!(attrs_list) do
+    {:ok, count} =
+      Repo.transaction(fn ->
+        attrs_list
+        |> Enum.map(& &1[:group_key])
+        |> Enum.uniq()
+        |> Enum.sort()
+        |> Enum.each(&OutboxLock.acquire!/1)
+
+        attrs_list
+        |> Enum.chunk_every(@insert_chunk_size)
+        |> Enum.map(&insert_chunk!/1)
+        |> Enum.sum()
+      end)
+
+    count
+  end
+
+  defp insert_chunk!(attrs_list) do
+    inserted_at = DateTime.utc_now()
+
+    rows =
+      Enum.map(attrs_list, fn attrs ->
+        %OutboxEntry{}
+        |> OutboxEntry.changeset(attrs)
+        |> Ecto.Changeset.apply_action!(:insert)
+        |> Map.take(@entry_fields)
+        |> Map.put(:inserted_at, inserted_at)
+      end)
+
+    {count, entries} =
+      Repo.insert_all(OutboxEntry, rows, returning: [:id, :priority], log: false)
+
+    OutboxWorker.enqueue_all!(entries)
+    count
   end
 
   @doc """

--- a/lib/hexpm/emails/outbox_worker.ex
+++ b/lib/hexpm/emails/outbox_worker.ex
@@ -16,6 +16,12 @@ defmodule Hexpm.Emails.OutboxWorker do
     |> Oban.insert!()
   end
 
+  def enqueue_all!(entries) do
+    entries
+    |> Enum.map(&new(%{outbox_entry_id: &1.id}, priority: &1.priority))
+    |> Oban.insert_all()
+  end
+
   def discard!(outbox_entry_id), do: discard_entry(outbox_entry_id)
 
   @impl Oban.Worker

--- a/test/hexpm/emails/outbox_test.exs
+++ b/test/hexpm/emails/outbox_test.exs
@@ -1,7 +1,79 @@
 defmodule Hexpm.Emails.OutboxTest do
   use Hexpm.DataCase
+  use Oban.Testing, repo: Hexpm.RepoBase
 
-  alias Hexpm.Emails.{Outbox, OutboxEntry}
+  import Swoosh.Email, except: [from: 2]
+
+  alias Hexpm.Emails.{Outbox, OutboxEntry, OutboxWorker}
+
+  describe "insert_all!/1" do
+    test "inserts the entries and one delivery job per entry" do
+      attrs =
+        for n <- 1..3 do
+          prepared_entry("Bulk #{n}", category: "test.bulk", group_key: "bulk:1", priority: 3)
+        end
+
+      assert Outbox.insert_all!(attrs) == 3
+
+      entries = Repo.all(from(entry in OutboxEntry, order_by: entry.id))
+      assert Enum.map(entries, & &1.subject) == ["Bulk 1", "Bulk 2", "Bulk 3"]
+      assert Enum.map(entries, & &1.category) == ["test.bulk", "test.bulk", "test.bulk"]
+      assert Enum.map(entries, & &1.recipients) == List.duplicate(["bob@example.com"], 3)
+      assert Enum.all?(entries, & &1.inserted_at)
+
+      jobs = all_enqueued(worker: OutboxWorker)
+
+      assert Enum.sort(Enum.map(jobs, & &1.args["outbox_entry_id"])) ==
+               Enum.map(entries, & &1.id)
+
+      assert Enum.map(jobs, & &1.priority) == [3, 3, 3]
+    end
+
+    test "inserts more entries than one chunk holds" do
+      attrs = List.duplicate(prepared_entry("Bulk", category: "test.bulk"), 1_001)
+
+      assert Outbox.insert_all!(attrs) == 1_001
+      assert Repo.aggregate(OutboxEntry, :count) == 1_001
+      assert length(all_enqueued(worker: OutboxWorker)) == 1_001
+    end
+
+    test "inserts nothing when an entry is invalid" do
+      attrs = [
+        prepared_entry("Valid", category: "test.bulk"),
+        prepared_entry("Invalid", category: "Not A Category")
+      ]
+
+      assert_raise Ecto.InvalidChangesetError, fn -> Outbox.insert_all!(attrs) end
+      assert Repo.all(OutboxEntry) == []
+      assert all_enqueued(worker: OutboxWorker) == []
+    end
+
+    test "inserts nothing for an empty list" do
+      assert Outbox.insert_all!([]) == 0
+      assert Repo.all(OutboxEntry) == []
+    end
+  end
+
+  describe "insert_all!/1 locking" do
+    setup do
+      skip = Application.fetch_env!(:hexpm, :skip_advisory_locks)
+      Application.put_env(:hexpm, :skip_advisory_locks, false)
+      on_exit(fn -> Application.put_env(:hexpm, :skip_advisory_locks, skip) end)
+      :ok
+    end
+
+    test "takes one advisory lock per group" do
+      attrs = [
+        prepared_entry("One", category: "test.bulk", group_key: "bulk:1"),
+        prepared_entry("Two", category: "test.bulk", group_key: "bulk:1"),
+        prepared_entry("Three", category: "test.bulk", group_key: "bulk:2")
+      ]
+
+      assert held_outbox_locks() == 0
+      Outbox.insert_all!(attrs)
+      assert held_outbox_locks() == 2
+    end
+  end
 
   describe "cancel!/1 by group key" do
     test "deletes only the named categories in that group" do
@@ -230,5 +302,14 @@ defmodule Hexpm.Emails.OutboxTest do
 
       assert Repo.get(OutboxEntry, entry.id)
     end
+  end
+
+  defp prepared_entry(subject, opts) do
+    new()
+    |> Swoosh.Email.from({"Hex.pm", "noreply@hex.pm"})
+    |> to("bob@example.com")
+    |> subject(subject)
+    |> text_body("Body")
+    |> Outbox.prepare!(opts)
   end
 end


### PR DESCRIPTION
`AdminTasks.send_email/3` inserted each recipient's outbox entry and delivery job one at a time: the group lock, the entry insert, then `Oban.insert!` with its unique check (a try-lock, a select and the job insert). Five statements per recipient on one connection inside one transaction. The terms-of-service announcement to 18,428 addresses held the console for 2 min 21 s, with the per-row cost growing from 5.5 ms to 9.2 ms over the loop. Rendering measures 0.06 ms per email, so the time was the round trips.

`Outbox.insert_all!/1` takes the prepared attrs, acquires each distinct group lock once, and inserts in chunks of 1,000 with one `Repo.insert_all` for the entries and one `Oban.insert_all` for their jobs through `OutboxWorker.enqueue_all!/1`. Each row still goes through the entry changeset, so an invalid entry raises before anything is written. Oban's `insert_all` skips the unique check, which only matters for the reconciler's requeue since the args carry the entry id. `send_email/3` uses it in place of the per-recipient `insert!/1`, which stays for the SSO, package report and secret-scan callers.
