### PR TITLE
Add blog post on the private package authorization vulnerabilities

### DIFF
--- a/lib/hexpm/accounts/organization.ex
+++ b/lib/hexpm/accounts/organization.ex
@@ -71,6 +71,28 @@ defmodule Hexpm.Accounts.Organization do
     )
   end
 
+  # Admins are the members an organization notice is written to, and an
+  # unverified address is one we never confirmed reaches anyone.
+  def all_admin_notifiable_emails(opts) do
+    query =
+      from(
+        o in Hexpm.Accounts.Organization,
+        join: ou in assoc(o, :organization_users),
+        join: u in assoc(ou, :user),
+        join: e in assoc(u, :emails),
+        where: ou.role == "admin",
+        where: e.verified and e.primary,
+        where: is_nil(u.deactivated_at),
+        distinct: true,
+        select: e.email
+      )
+
+    case Keyword.fetch(opts, :billing_active) do
+      {:ok, billing_active} -> from(o in query, where: o.billing_active == ^billing_active)
+      :error -> query
+    end
+  end
+
   def role_or_higher("read"), do: ["read", "write", "admin"]
   def role_or_higher("write"), do: ["write", "admin"]
   def role_or_higher("admin"), do: ["admin"]

--- a/lib/hexpm/accounts/organizations.ex
+++ b/lib/hexpm/accounts/organizations.ex
@@ -19,6 +19,11 @@ defmodule Hexpm.Accounts.Organizations do
     |> Repo.preload(preload)
   end
 
+  def all_admin_notifiable_emails(opts \\ []) do
+    Organization.all_admin_notifiable_emails(opts)
+    |> Repo.all()
+  end
+
   def get(name, preload \\ []) do
     Repo.get_by(Organization, name: name)
     |> Repo.preload(preload)

--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -883,6 +883,7 @@ defmodule Hexpm.AdminTasks do
   ## Arguments
 
   - `recipients` - Email addresses to send to, see `Hexpm.Accounts.Users.all_notifiable_emails/0`
+    and `Hexpm.Accounts.Organizations.all_admin_notifiable_emails/1`
   - `subject` - Subject line, a leading `"Hex.pm - "` is dropped from the heading
   - `body` - Plain text body, blank lines separate paragraphs, single newlines
     are kept as line breaks and bare URLs become links in the HTML part

--- a/lib/hexpm_web/templates/blog/026-private-package-authorization-vulnerabilities.html.md
+++ b/lib/hexpm_web/templates/blog/026-private-package-authorization-vulnerabilities.html.md
@@ -1,0 +1,118 @@
+## Private package authorization vulnerabilities
+
+<div class="subtitle"><time datetime="2026-09-01T00:00:00Z">1 September, 2026</time> · by Eric Meadows-Jönsson</div>
+
+On 24 August 2026 we found and fixed two vulnerabilities in how hex.pm issues
+OAuth tokens. Both could give an account read access to private packages of an
+organization it was not entitled to. Neither was being exploited when we found
+them: no active token carried a scope for an organization its holder could not
+access. Whether either had been used earlier we cannot say, because the
+records that would settle that had been deleted by routine cleanup. This post
+describes both vulnerabilities, what we could and could not establish, and
+what we changed in authorization and in logging. Organization admins are also
+being notified by email.
+
+### CVE-2026-75542: token exchange for organizations the key holder could not access
+
+Any hex.pm account can create an API key with the `repositories` permission,
+which means "every repository this account has access to". Since 18 October
+2025 such a key could be exchanged, through the OAuth `client_credentials`
+grant, for an access token. The exchange admitted a requested scope if the
+key held `repositories` and the scope string began with `repository:`. The
+organization name after the colon was never resolved against the account's
+memberships, so the key could be exchanged for a token scoped to any
+organization on hex.pm.
+
+Our CDN authorizes private package downloads from the signed token alone,
+without a database lookup. A token created this way was therefore working read
+access to the named organization's private packages for its 30-minute
+lifetime, and it could be created again at will. No request reached the
+application, so nothing there could have refused or recorded it. From
+15 March 2026 the same was true of organization keys.
+
+The advisory is
+[GHSA-rfx8-w654-8cpr](https://github.com/hexpm/hexpm/security/advisories/GHSA-rfx8-w654-8cpr).
+
+### CVE-2026-75554: organization scopes surviving removal from the organization
+
+When a token is created with the plain `repositories` scope, which is what the
+Hex client requests, hex.pm expands it into one scope per organization the
+account is currently a member of, and expands it again on every refresh. A
+session granted an explicit `repository:<org>` or `docs:<org>` scope instead,
+which is how the authorization screen stores a selection, was not expanded
+again: every refresh reproduced the scope as granted. Since 10 October 2025
+a user removed from an organization could keep downloading its private
+packages and private docs for as long as they kept refreshing, up to the
+30-day refresh token lifetime, instead of losing access within the 30-minute
+access token lifetime.
+
+The advisory is
+[GHSA-24ww-j3f4-p49c](https://github.com/hexpm/hexpm/security/advisories/GHSA-24ww-j3f4-p49c).
+
+### What we could establish
+
+We found both vulnerabilities on 24 August 2026 and deployed the fixes the
+same day, shortly after 13:46 UTC. The advisories were published that
+evening.
+
+When we found the vulnerabilities we checked every active token against its
+holder's access. No token carried a scope for an organization its holder
+could not access, so neither vulnerability was being exploited at the time.
+Since the fix, every token issued is checked the same way at the
+moment it is created. Of the 92,968 tokens on record as of 30 August 2026,
+none carried a scope its holder was not entitled to.
+
+For the period before the fix we cannot say. The database rows recording
+which token was issued to whom, with which scopes, were deleted by a nightly
+cleanup job once the token could no longer be used, which for a
+`client_credentials` token is within a day of its issue. The CDN access logs
+for repo.hex.pm cover the whole period and record the client IP, time,
+path, status and user agent of every download, but not the account behind
+it. Between 18 October 2025 and 24 August 2026 we can neither confirm nor
+exclude that an account outside an organization downloaded its private
+packages.
+
+### What we changed in authorization
+
+Requested organization scopes are now resolved against the requesting
+principal's actual access every time a token is created, including refreshes.
+A user's scopes are held against current memberships and an organization key's
+against its own organization. Scopes the principal is not entitled to are
+dropped, and every grant type goes through one token builder, so no grant can
+skip the check. The public repository stays available to everyone.
+
+### What we changed in logging
+
+The token records were deleted by the nightly cleanup job, and the access
+logs did not record which account made a request. We made four changes:
+
+1. **Authorization records are archived before deletion.** The cleanup job
+   now writes every row it deletes, including OAuth tokens, API keys and
+   sessions, to write-once storage with a ten-year retention policy, with
+   the secret material removed. The archive records who was granted which
+   scopes, when, and through which key or session.
+2. **A standing entitlement check.** A query over the archive and the live
+   records lists every token whose organization scopes were not covered by
+   membership at the time it was created, judged against the membership
+   history in the organization audit log. It is the check reported above,
+   and it can be run again under a different rule later.
+3. **Identity in the CDN access log.** Each repo.hex.pm access-log line now
+   ends with the token or API key that authorized the request, so a private
+   package download can be attributed to the account behind it.
+4. **Origin and application logs.** Requests to the storage bucket behind
+   repo.hex.pm are logged again, which they had not been since 2018,
+   application logs are kept for ten years, and every audit-log entry
+   written from a request carries the id of that request, so it can be
+   matched to the request log.
+
+### For organization admins
+
+The fix needs no change on your side. If you want to assess the period
+before the fix for your organization, we can extract from the CDN logs the
+client IPs, times and user agents of every download of your organization's
+private packages between 18 October 2025 and 24 August 2026, for you to
+compare against your own team. Email [security@hex.pm](mailto:security@hex.pm)
+from an admin account of the organization.
+
+We apologize to the organizations that trust hex.pm with their private
+packages.

--- a/lib/hexpm_web/templates/blog/026-private-package-authorization-vulnerabilities.html.md
+++ b/lib/hexpm_web/templates/blog/026-private-package-authorization-vulnerabilities.html.md
@@ -97,8 +97,9 @@ logs did not record which account made a request. We made four changes:
    history in the organization audit log. It is the check reported above,
    and it can be run again under a different rule later.
 3. **Identity in the CDN access log.** Each repo.hex.pm access-log line now
-   ends with the token or API key that authorized the request, so a private
-   package download can be attributed to the account behind it.
+   ends with the id of the token or API key that authorized the request,
+   never the credential itself, so a private package download can be
+   attributed to the account behind it.
 4. **Origin and application logs.** Requests to the storage bucket behind
    repo.hex.pm are logged again, which they had not been since 2018,
    application logs are kept for ten years, and every audit-log entry
@@ -114,5 +115,6 @@ private packages between 18 October 2025 and 24 August 2026, for you to
 compare against your own team. Email [security@hex.pm](mailto:security@hex.pm)
 from an admin account of the organization.
 
-We apologize to the organizations that trust hex.pm with their private
-packages.
+We take the trust organizations place in hex.pm seriously. When
+vulnerabilities are found, we will fix them quickly, investigate their
+impact, and be transparent about what we know and what we cannot establish.

--- a/test/hexpm/accounts/organizations_test.exs
+++ b/test/hexpm/accounts/organizations_test.exs
@@ -4,6 +4,45 @@ defmodule Hexpm.Accounts.OrganizationsTest do
   alias Hexpm.Accounts.Organizations
   alias Hexpm.Repository.PackageOwner
 
+  describe "all_admin_notifiable_emails/1" do
+    test "returns the verified primary address of each admin once" do
+      admin = insert(:user)
+      member = insert(:user)
+      organization = insert(:organization)
+      other = insert(:organization)
+      insert(:organization_user, organization: organization, user: admin, role: "admin")
+      insert(:organization_user, organization: other, user: admin, role: "admin")
+      insert(:organization_user, organization: organization, user: member, role: "write")
+
+      assert Organizations.all_admin_notifiable_emails() == [hd(admin.emails).email]
+    end
+
+    test "skips unverified addresses and deactivated admins" do
+      organization = insert(:organization)
+      unverified = insert(:user, emails: [build(:email, verified: false)])
+      deactivated = insert(:user, deactivated_at: DateTime.utc_now())
+      insert(:organization_user, organization: organization, user: unverified, role: "admin")
+      insert(:organization_user, organization: organization, user: deactivated, role: "admin")
+
+      assert Organizations.all_admin_notifiable_emails() == []
+    end
+
+    test "filters on billing_active" do
+      billed = insert(:user)
+      unbilled = insert(:user)
+      billed_org = insert(:organization, billing_active: true)
+      unbilled_org = insert(:organization, billing_active: false)
+      insert(:organization_user, organization: billed_org, user: billed, role: "admin")
+      insert(:organization_user, organization: unbilled_org, user: unbilled, role: "admin")
+
+      assert Organizations.all_admin_notifiable_emails(billing_active: true) ==
+               [hd(billed.emails).email]
+
+      assert Organizations.all_admin_notifiable_emails(billing_active: false) ==
+               [hd(unbilled.emails).email]
+    end
+  end
+
   describe "create/3" do
     test "publishes org_names.csv to the docs bucket" do
       user = insert(:user)


### PR DESCRIPTION
Blog post disclosing CVE-2026-75542 and CVE-2026-75554 (GHSA-rfx8-w654-8cpr and GHSA-24ww-j3f4-p49c), fixed on 2026-08-24 in bf0fb9d, 50cffd2 and a8bb81d: what each vulnerability was, that neither was being exploited when found and that earlier use can't be established from the deleted token records, the authorization fix, and the four logging changes (audit archive, entitlement query, identity in the CDN access log, origin and application logs). Organization admins get an email pointing at the post. The second commit adds `Organizations.all_admin_notifiable_emails/1`, the admin counterpart of `Users.all_notifiable_emails/0`, with a `billing_active:` option for the recipient list.

Before merging, set the post date from 2026-09-01 to the publish date; it drives the feed order.

Rendered at http://localhost:4000/blog/private-package-authorization-vulnerabilities:

![Rendered blog post](<https://github.com/hexpm/hexpm/blob/a7128ae404400c6305f5ffb008159748928ac7b2/2026-09-02%2014.14.40%20localhost%2073f760b55109.png?raw=true>)

## Announcement email

Once the post is live, send the email from a production iex session. The recipients are the verified primary addresses of every admin of an organization with active billing, each address once:

```elixir
subject = "Hex.pm - Security notice: private package authorization vulnerabilities"

body = """
You're receiving this because you administer an organization on hex.pm.

On 24 August 2026 we found and fixed two vulnerabilities in how hex.pm issues OAuth tokens. The more serious one, CVE-2026-75542, let any hex.pm account exchange an ordinary API key for a token scoped to any organization, including yours, and download that organization's private packages from our CDN. It existed from 18 October 2025 until the fix. The second, CVE-2026-75554, let a user removed from an organization keep downloading its private packages and docs for up to 30 days after removal instead of 30 minutes.

When we found the vulnerabilities, no active token carried a scope for an organization its holder could not access, so neither was being exploited at the time. We can't rule out earlier use: the token records that would show it were deleted by routine cleanup, and our CDN access logs from that period record the client IP, time and path of every download but not the account behind it. For 18 October 2025 to 24 August 2026 we can neither confirm nor exclude that someone outside your organization downloaded its private packages.

The fix needs no change on your side. If you want to assess that period for your organization, we can extract from the CDN logs the client IPs, times and user agents of every download of your organization's private packages, for you to compare against your own team. Reply to this email to request it.

The full account, including what we changed so this question can be answered next time (authorization records archived before deletion, a standing check of every token against membership, and the authorizing token or key recorded on every CDN access-log line), is at https://hex.pm/blog/private-package-authorization-vulnerabilities

Questions to security@hex.pm.

The hex.pm team
"""

Hexpm.Accounts.Organizations.all_admin_notifiable_emails(billing_active: true)
|> Hexpm.AdminTasks.send_email(subject, body)
```

`send_email/3` returns `{:ok, count}` with the number queued, not delivered; delivery goes through the email outbox with Oban retries, and a rerun with the same subject skips the addresses already queued.
