### PR TITLE
Block new email addresses on listed domains

### DIFF
--- a/lib/hexpm/accounts/blocked_email_domain.ex
+++ b/lib/hexpm/accounts/blocked_email_domain.ex
@@ -1,0 +1,49 @@
+defmodule Hexpm.Accounts.BlockedEmailDomain do
+  use Hexpm.Schema
+
+  @moduledoc """
+  A domain whose addresses cannot be added to an account.
+
+  A block covers the domain and everything under it, so blocking `example.com`
+  also blocks `mail.example.com`. Addresses that already exist are untouched.
+  """
+
+  schema "blocked_email_domains" do
+    field :domain, :string
+    field :comment, :string
+
+    timestamps(updated_at: false)
+  end
+
+  def changeset(blocked_domain, params) do
+    cast(blocked_domain, params, ~w(domain comment)a)
+    |> validate_required(~w(domain)a)
+    |> update_change(:domain, &normalize/1)
+    |> validate_format(:domain, ~r/^[^\s@]+\.[^\s@.]+$/)
+    |> unique_constraint(:domain)
+  end
+
+  @doc "Every blocked domain an address falls under."
+  def by_email(email) do
+    domains =
+      email
+      |> String.split("@")
+      |> List.last()
+      |> normalize()
+      |> suffixes()
+
+    from(b in __MODULE__, where: b.domain in ^domains)
+  end
+
+  def by_domain(domain) do
+    from(b in __MODULE__, where: b.domain == ^normalize(domain))
+  end
+
+  defp normalize(domain), do: domain |> String.trim() |> String.downcase()
+
+  defp suffixes(domain) do
+    labels = String.split(domain, ".")
+
+    for n <- 2..length(labels)//1, do: labels |> Enum.take(-n) |> Enum.join(".")
+  end
+end

--- a/lib/hexpm/accounts/email.ex
+++ b/lib/hexpm/accounts/email.ex
@@ -85,7 +85,20 @@ defmodule Hexpm.Accounts.Email do
     |> validate_required(~w(email)a)
     |> update_change(:email, &String.downcase/1)
     |> validate_format(:email, @email_regex)
+    |> validate_domain_not_blocked()
     |> unique_constraint(:email, name: "emails_email_key")
     |> unique_constraint(:email, name: "emails_email_user_key")
+  end
+
+  defp validate_domain_not_blocked(changeset) do
+    prepare_changes(changeset, fn changeset ->
+      email = get_change(changeset, :email)
+
+      if email && changeset.repo.exists?(BlockedEmailDomain.by_email(email)) do
+        add_error(changeset, :email, "uses a blocked domain")
+      else
+        changeset
+      end
+    end)
   end
 end

--- a/lib/hexpm/admin_tasks.ex
+++ b/lib/hexpm/admin_tasks.ex
@@ -309,6 +309,60 @@ defmodule Hexpm.AdminTasks do
   end
 
   @doc """
+  Blocks new email addresses on a domain and everything under it.
+
+  Existing addresses stay; only adding an address on the domain fails, at
+  signup and in the account settings alike.
+
+  ## Examples
+
+      iex> AdminTasks.block_email_domain("example.com", comment: "signup farm")
+      :ok
+  """
+  @spec block_email_domain(String.t(), keyword()) :: :ok | {:error, Ecto.Changeset.t()}
+  def block_email_domain(domain, opts \\ []) do
+    params = %{domain: domain, comment: Keyword.get(opts, :comment)}
+
+    case Repo.insert(BlockedEmailDomain.changeset(%BlockedEmailDomain{}, params)) do
+      {:ok, _blocked} -> :ok
+      {:error, changeset} -> {:error, changeset}
+    end
+  end
+
+  @doc """
+  Removes a domain from the email block list.
+
+  ## Examples
+
+      iex> AdminTasks.unblock_email_domain("example.com")
+      :ok
+  """
+  @spec unblock_email_domain(String.t()) :: :ok | {:error, :not_found}
+  def unblock_email_domain(domain) do
+    case Repo.delete_all(BlockedEmailDomain.by_domain(domain)) do
+      {0, _} -> {:error, :not_found}
+      {_count, _} -> :ok
+    end
+  end
+
+  @doc """
+  Lists the blocked email domains with their comments.
+
+  ## Examples
+
+      iex> AdminTasks.blocked_email_domains()
+      [%{domain: "example.com", comment: "signup farm"}]
+  """
+  @spec blocked_email_domains() :: [%{domain: String.t(), comment: String.t() | nil}]
+  def blocked_email_domains() do
+    from(b in BlockedEmailDomain,
+      order_by: b.domain,
+      select: %{domain: b.domain, comment: b.comment}
+    )
+    |> Repo.all()
+  end
+
+  @doc """
   Allows republishing a release by resetting its inserted_at timestamp.
 
   ## Arguments

--- a/lib/hexpm/shared.ex
+++ b/lib/hexpm/shared.ex
@@ -6,6 +6,7 @@ defmodule Hexpm.Shared do
         Accounts.AuditLog,
         Accounts.AuditLogs,
         Accounts.Auth,
+        Accounts.BlockedEmailDomain,
         Accounts.Email,
         Accounts.Key,
         Accounts.KeyPermission,

--- a/priv/repo/migrations/20260902120000_add_blocked_email_domains.exs
+++ b/priv/repo/migrations/20260902120000_add_blocked_email_domains.exs
@@ -1,0 +1,13 @@
+defmodule Hexpm.Repo.Migrations.AddBlockedEmailDomains do
+  use Ecto.Migration
+
+  def change do
+    create table(:blocked_email_domains) do
+      add :domain, :string, null: false
+      add :comment, :string
+      timestamps(updated_at: false)
+    end
+
+    create unique_index(:blocked_email_domains, [:domain])
+  end
+end

--- a/test/hexpm/accounts/user_test.exs
+++ b/test/hexpm/accounts/user_test.exs
@@ -1,7 +1,7 @@
 defmodule Hexpm.Accounts.UserTest do
   use Hexpm.DataCase, async: true
 
-  alias Hexpm.Accounts.{Auth, User, OptionalEmails}
+  alias Hexpm.Accounts.{Auth, BlockedEmailDomain, User, OptionalEmails}
 
   setup do
     user = insert(:user, password: Auth.gen_password("password"))
@@ -61,6 +61,34 @@ defmodule Hexpm.Accounts.UserTest do
                |> Hexpm.Repo.insert()
 
       assert errors_on(changeset)[:emails][:email] == "already in use"
+    end
+
+    test "rejects an email on a blocked domain or under it" do
+      Repo.insert!(
+        BlockedEmailDomain.changeset(%BlockedEmailDomain{}, %{domain: "Blocked.example"})
+      )
+
+      for email <- ["someone@blocked.example", "someone@mail.BLOCKED.example"] do
+        assert {:error, changeset} =
+                 User.build(
+                   %{username: "blockeduser", emails: [%{email: email}], password: "password"},
+                   true
+                 )
+                 |> Hexpm.Repo.insert()
+
+        assert errors_on(changeset)[:emails][:email] == "uses a blocked domain"
+      end
+
+      assert {:ok, _user} =
+               User.build(
+                 %{
+                   username: "blockeduser",
+                   emails: [%{email: "someone@notblocked.example"}],
+                   password: "password"
+                 },
+                 true
+               )
+               |> Hexpm.Repo.insert()
     end
   end
 

--- a/test/hexpm/admin_tasks_test.exs
+++ b/test/hexpm/admin_tasks_test.exs
@@ -400,6 +400,45 @@ defmodule Hexpm.AdminTasksTest do
     end
   end
 
+  describe "block_email_domain/2" do
+    test "blocks new addresses on the domain and leaves existing ones" do
+      user = insert(:user, emails: [build(:email, email: "old@farm.example")])
+
+      assert :ok = AdminTasks.block_email_domain("farm.example", comment: "signup farm")
+
+      assert [%{domain: "farm.example", comment: "signup farm"}] =
+               AdminTasks.blocked_email_domains()
+
+      assert {:error, changeset} =
+               Hexpm.Accounts.Users.add_email(user, %{email: "new@farm.example"},
+                 audit: audit_data(user)
+               )
+
+      assert errors_on(changeset)[:email] == "uses a blocked domain"
+
+      assert Repo.get!(User, user.id) |> Repo.preload(:emails) |> Map.fetch!(:emails) |> length() ==
+               1
+    end
+
+    test "rejects a domain that is already blocked or malformed" do
+      assert :ok = AdminTasks.block_email_domain("farm.example")
+      assert {:error, changeset} = AdminTasks.block_email_domain("FARM.example")
+      assert errors_on(changeset)[:domain] == "has already been taken"
+
+      assert {:error, changeset} = AdminTasks.block_email_domain("not a domain")
+      assert errors_on(changeset)[:domain] == "has invalid format"
+    end
+  end
+
+  describe "unblock_email_domain/1" do
+    test "removes the block" do
+      assert :ok = AdminTasks.block_email_domain("farm.example")
+      assert :ok = AdminTasks.unblock_email_domain("farm.example")
+      assert AdminTasks.blocked_email_domains() == []
+      assert {:error, :not_found} = AdminTasks.unblock_email_domain("farm.example")
+    end
+  end
+
   describe "rename_user/2" do
     test "renames user" do
       user = insert(:user, username: "oldname")


### PR DESCRIPTION
A signup farm has created about 1,250 accounts since 2026-08-13 on a handful of domains that exist only as mail-forwarding MX records, and nothing refused the addresses. This adds a `blocked_email_domains` table and checks it in the email changeset at insert time, the way usernames are checked against `reserved_usernames`, so it applies wherever an address is added: signup, the account settings page and organization emails. A block covers the domain and everything under it. Existing addresses are untouched; the rejected form shows "Email uses a blocked domain".

`AdminTasks.block_email_domain/2`, `unblock_email_domain/1` and `blocked_email_domains/0` manage the list. The table starts empty; the domains are added from the remote shell after deploy.