### PR TITLE
Verify purges by write number, accept the org docs redirect and log cache headers in CDN verification

### DIFF
--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -207,8 +207,9 @@ defmodule Hexpm.Application do
   defp oban_child, do: {Oban, Application.fetch_env!(:hexpm, Oban)}
 
   defp finch_pools() do
+    cdn_url = Application.fetch_env!(:hexpm, :cdn_url)
     gcs_url = Application.get_env(:hexpm, :gcs_url, "https://storage.googleapis.com")
-    %{gcs_url => [size: 50, count: 8]}
+    %{cdn_url => [conn_max_idle_time: 5_000], gcs_url => [size: 50, count: 8]}
   end
 
   defp web_children do

--- a/lib/hexpm/cdn/cdn.ex
+++ b/lib/hexpm/cdn/cdn.ex
@@ -15,16 +15,21 @@ defmodule Hexpm.CDN do
   @type mask :: 0..32
 
   @typedoc """
-  An object to check after purging: the CDN must serve `url` with `etag`,
-  or, when `etag` is `nil`, answer 404 or redirect to the organization docs
-  host, which is what a removed page under an organization's name gets.
-  `repository` names the organization
-  whose private repository the object belongs to; the check then carries a
-  short-lived token the edge accepts for that repository.
+  An object to check after purging. `write` is the number the store write
+  carried (see `next_write/0`) and the CDN must serve `url` with a copy
+  whose number is at least that; `etag` is what the store returned for the
+  write and is compared instead when a copy predates numbered writes. When
+  `etag` is `nil` the object was deleted and the CDN must answer 404,
+  redirect to the organization docs host (what a removed page under an
+  organization's name gets), or serve a copy written after the deletion.
+  `repository` names the organization whose private repository the object
+  belongs to; the check then carries a short-lived token the edge accepts
+  for that repository.
   """
   @type target :: %{
           required(:url) => String.t(),
           required(:etag) => String.t() | nil,
+          required(:write) => pos_integer,
           optional(:repository) => String.t() | nil
         }
 
@@ -61,5 +66,19 @@ defmodule Hexpm.CDN do
     %{"service" => Atom.to_string(service), "keys" => keys, "verify" => verify}
     |> Hexpm.CDN.PurgeWorker.new()
     |> Oban.insert!()
+  end
+
+  @doc """
+  Takes the next write number.
+
+  Every write the check verifies stores it as the object's `write`
+  metadata, which the edge serves as `x-cache-write`, so a later write of
+  the same object always carries a higher number than an earlier one.
+  Taken before a write and after a deletion.
+  """
+  @spec next_write() :: pos_integer
+  def next_write() do
+    %{rows: [[write]]} = Hexpm.Repo.query!("SELECT nextval('cdn_writes')")
+    write
   end
 end

--- a/lib/hexpm/cdn/cdn.ex
+++ b/lib/hexpm/cdn/cdn.ex
@@ -16,7 +16,9 @@ defmodule Hexpm.CDN do
 
   @typedoc """
   An object to check after purging: the CDN must serve `url` with `etag`,
-  or with a 404 when `etag` is `nil`. `repository` names the organization
+  or, when `etag` is `nil`, answer 404 or redirect to the organization docs
+  host, which is what a removed page under an organization's name gets.
+  `repository` names the organization
   whose private repository the object belongs to; the check then carries a
   short-lived token the edge accepts for that repository.
   """

--- a/lib/hexpm/cdn/fastly.ex
+++ b/lib/hexpm/cdn/fastly.ex
@@ -15,10 +15,11 @@ defmodule Hexpm.CDN.Fastly do
   from that POP's cache, tunnelled over Fastly's shield network. The CDN
   turns the HEAD into a GET on a miss, so a probe also pulls the object
   into that POP's cache, which a client there would have done anyway. Every
-  answer carries `x-cache-served-by` (shield first, then edge), so a stale
-  result names the caches that kept the old copy. A probe that fails to
-  answer is reported in telemetry and the log but does not fail the check;
-  a stale answer from any POP does.
+  answer carries `x-cache-served-by`, `x-cache`, `x-cache-age` and
+  `x-cache-hits` (shield first, then edge), so a stale result names the
+  caches that kept the old copy and how long they had it. A probe that
+  fails to answer is reported in telemetry and the log but does not fail
+  the check; a stale answer from any POP does.
 
   Objects in a private repository are fetched with a token minted for the
   check: two minutes, scoped to that repository, verified by the edge
@@ -35,6 +36,7 @@ defmodule Hexpm.CDN.Fastly do
   @retry_opts [attempts: 5, base_delay: 200, statuses: [429, 500..599]]
   @probe_timeout 15_000
   @verify_concurrency 10
+  @cache_headers ~w(x-cache-served-by x-cache x-cache-age x-cache-hits)
 
   @impl true
   def purge_key(service, keys) do
@@ -94,8 +96,8 @@ defmodule Hexpm.CDN.Fastly do
   # nearest fetch decides, since a failed probe is no evidence of staleness.
   defp verdict(results) do
     stale =
-      for {_target, pop, {:error, {:stale, served, served_by}}} <- results,
-          do: %{pop: pop, etag: served, served_by: served_by}
+      for {_target, pop, {:error, {:stale, served, cache}}} <- results,
+          do: %{pop: pop, etag: served, cache: cache}
 
     if stale == [] do
       [nearest] = for {_target, :nearest, result} <- results, do: result
@@ -153,14 +155,20 @@ defmodule Hexpm.CDN.Fastly do
     if normalize_etag(served) == normalize_etag(etag) do
       :ok
     else
-      {:error, {:stale, served, header(headers, "x-cache-served-by")}}
+      {:error, {:stale, served, cache(headers)}}
     end
   end
 
   defp compare(404, _headers, nil), do: :ok
 
-  defp compare(status, headers, _etag),
-    do: {:error, {:status, status, header(headers, "x-cache-served-by")}}
+  defp compare(status, headers, _etag), do: {:error, {:status, status, cache(headers)}}
+
+  defp cache(headers) do
+    case for(name <- @cache_headers, value = header(headers, name), do: "#{name}: #{value}") do
+      [] -> nil
+      pairs -> Enum.join(pairs, "; ")
+    end
+  end
 
   @impl true
   def public_ips() do

--- a/lib/hexpm/cdn/fastly.ex
+++ b/lib/hexpm/cdn/fastly.ex
@@ -124,11 +124,11 @@ defmodule Hexpm.CDN.Fastly do
 
   defp probes(_service, _target), do: []
 
-  defp check(%{url: url, etag: etag}, pop, headers) do
+  defp check(%{url: url} = target, pop, headers) do
     :telemetry.span([:hexpm, :cdn, :verify], %{url: url, pop: pop}, fn ->
       result =
         case HTTP.impl().head(url, headers, decode_body: false, request_timeout: @probe_timeout) do
-          {:ok, status, headers, _body} -> compare(status, headers, etag)
+          {:ok, status, headers, _body} -> compare(target, status, headers)
           {:error, reason} -> {:error, reason}
         end
 
@@ -149,7 +149,7 @@ defmodule Hexpm.CDN.Fastly do
     token
   end
 
-  defp compare(200, headers, etag) when is_binary(etag) do
+  defp compare(%{etag: etag}, 200, headers) when is_binary(etag) do
     served = header(headers, "etag")
 
     if normalize_etag(served) == normalize_etag(etag) do
@@ -159,9 +159,26 @@ defmodule Hexpm.CDN.Fastly do
     end
   end
 
-  defp compare(404, _headers, nil), do: :ok
+  defp compare(%{etag: nil}, 404, _headers), do: :ok
 
-  defp compare(status, headers, _etag), do: {:error, {:status, status, cache(headers)}}
+  # A page removed from a subdomain that names an organization is redirected
+  # to the organization's docs host instead of answering 404.
+  defp compare(%{etag: nil, url: url}, 301, headers) do
+    if header(headers, "location") == organization_docs_url(url) do
+      :ok
+    else
+      {:error, {:status, 301, cache(headers)}}
+    end
+  end
+
+  defp compare(_target, status, headers), do: {:error, {:status, status, cache(headers)}}
+
+  defp organization_docs_url(url) do
+    target = URI.parse(url)
+    [subdomain | _] = String.split(target.host, ".")
+    docs = URI.parse(Application.fetch_env!(:hexpm, :private_docs_url))
+    URI.to_string(%{docs | host: "#{subdomain}.#{docs.host}", path: target.path})
+  end
 
   defp cache(headers) do
     case for(name <- @cache_headers, value = header(headers, name), do: "#{name}: #{value}") do

--- a/lib/hexpm/cdn/fastly.ex
+++ b/lib/hexpm/cdn/fastly.ex
@@ -103,6 +103,12 @@ defmodule Hexpm.CDN.Fastly do
       for {_target, pop, {:error, {:stale, served, cache}}} <- results,
           do: %{pop: pop, served: served, cache: cache}
 
+    stale =
+      Enum.sort_by(stale, fn
+        %{pop: :nearest} -> {0, ""}
+        %{pop: pop} -> {1, pop}
+      end)
+
     if stale == [] do
       [nearest] = for {_target, :nearest, result} <- results, do: result
       nearest

--- a/lib/hexpm/cdn/fastly.ex
+++ b/lib/hexpm/cdn/fastly.ex
@@ -159,10 +159,15 @@ defmodule Hexpm.CDN.Fastly do
     token
   end
 
+  # A target without a number was written before writes were numbered, so
+  # any numbered copy is a later write.
   defp compare(%{etag: etag} = target, 200, headers) when is_binary(etag) do
     case {target[:write], served_write(headers)} do
       {write, served} when is_integer(write) and is_integer(served) ->
         if served >= write, do: :ok, else: {:error, {:stale, {:write, served}, cache(headers)}}
+
+      {nil, served} when is_integer(served) ->
+        :ok
 
       _ ->
         served = header(headers, "etag")
@@ -181,9 +186,12 @@ defmodule Hexpm.CDN.Fastly do
   defp compare(%{etag: nil} = target, 200, headers) do
     served = served_write(headers)
 
-    if is_integer(target[:write]) and is_integer(served) and served > target[:write],
-      do: :ok,
-      else: {:error, {:stale, {:write, served}, cache(headers)}}
+    cond do
+      not is_integer(served) -> {:error, {:stale, {:write, served}, cache(headers)}}
+      is_nil(target[:write]) -> :ok
+      served > target[:write] -> :ok
+      true -> {:error, {:stale, {:write, served}, cache(headers)}}
+    end
   end
 
   # A page removed from a subdomain that names an organization is redirected

--- a/lib/hexpm/cdn/fastly.ex
+++ b/lib/hexpm/cdn/fastly.ex
@@ -3,23 +3,27 @@ defmodule Hexpm.CDN.Fastly do
   Fastly purging and post-purge verification.
 
   `verify/2` fetches every target the way a client would and compares the
-  served ETag with the one the store returned for the write. The checks of
-  all targets and POPs run in one task stream, so `@verify_concurrency`
-  bounds the requests in flight for the whole batch. Fastly routes
-  by anycast, so a plain request cannot pick its POP; the workers run in
+  write number the edge serves (`x-cache-write`, the object's `write`
+  metadata) with the target's: a copy at or past it is current, since a
+  later write of the object only raises the number, so a check that runs
+  after the next write of the same object still passes. Copies cached before
+  writes were numbered carry no number and are compared by ETag. The checks
+  of all targets and POPs run in one task stream, so `@verify_concurrency`
+  bounds the requests in flight for the whole batch. Fastly routes by
+  anycast, so a plain request cannot pick its POP; the workers run in
   us-east4, next to the IAD shield every other POP fetches through, so the
   direct fetch checks the shield, which is where the purges of August 2026
   went missing. For the repository service the check also asks the POPs in
   `:fastly_probe_pops`, one per continent: the Compute code accepts
   `hex-cache-probe: <shield code>` with a valid `fastly-key` and answers
   from that POP's cache, tunnelled over Fastly's shield network. The CDN
-  turns the HEAD into a GET on a miss, so a probe also pulls the object
-  into that POP's cache, which a client there would have done anyway. Every
+  turns the HEAD into a GET on a miss, so a probe also pulls the object into
+  that POP's cache, which a client there would have done anyway. Every
   answer carries `x-cache-served-by`, `x-cache`, `x-cache-age` and
   `x-cache-hits` (shield first, then edge), so a stale result names the
-  caches that kept the old copy and how long they had it. A probe that
-  fails to answer is reported in telemetry and the log but does not fail
-  the check; a stale answer from any POP does.
+  caches that kept the old copy and how long they had it. A probe that fails
+  to answer is reported in telemetry and the log but does not fail the
+  check; a stale answer from any POP does.
 
   Objects in a private repository are fetched with a token minted for the
   check: two minutes, scoped to that repository, verified by the edge
@@ -97,7 +101,7 @@ defmodule Hexpm.CDN.Fastly do
   defp verdict(results) do
     stale =
       for {_target, pop, {:error, {:stale, served, cache}}} <- results,
-          do: %{pop: pop, etag: served, cache: cache}
+          do: %{pop: pop, served: served, cache: cache}
 
     if stale == [] do
       [nearest] = for {_target, :nearest, result} <- results, do: result
@@ -149,17 +153,32 @@ defmodule Hexpm.CDN.Fastly do
     token
   end
 
-  defp compare(%{etag: etag}, 200, headers) when is_binary(etag) do
-    served = header(headers, "etag")
+  defp compare(%{etag: etag} = target, 200, headers) when is_binary(etag) do
+    case {target[:write], served_write(headers)} do
+      {write, served} when is_integer(write) and is_integer(served) ->
+        if served >= write, do: :ok, else: {:error, {:stale, {:write, served}, cache(headers)}}
 
-    if normalize_etag(served) == normalize_etag(etag) do
-      :ok
-    else
-      {:error, {:stale, served, cache(headers)}}
+      _ ->
+        served = header(headers, "etag")
+
+        if normalize_etag(served) == normalize_etag(etag),
+          do: :ok,
+          else: {:error, {:stale, {:etag, served}, cache(headers)}}
     end
   end
 
   defp compare(%{etag: nil}, 404, _headers), do: :ok
+
+  # A deleted object answered with a copy written after the deletion has
+  # been re-created since; anything else is the copy the deletion should
+  # have removed.
+  defp compare(%{etag: nil} = target, 200, headers) do
+    served = served_write(headers)
+
+    if is_integer(target[:write]) and is_integer(served) and served > target[:write],
+      do: :ok,
+      else: {:error, {:stale, {:write, served}, cache(headers)}}
+  end
 
   # A page removed from a subdomain that names an organization is redirected
   # to the organization's docs host instead of answering 404.
@@ -172,6 +191,13 @@ defmodule Hexpm.CDN.Fastly do
   end
 
   defp compare(_target, status, headers), do: {:error, {:status, status, cache(headers)}}
+
+  defp served_write(headers) do
+    case header(headers, "x-cache-write") do
+      nil -> nil
+      value -> with {write, ""} <- Integer.parse(value), do: write, else: (_ -> nil)
+    end
+  end
 
   defp organization_docs_url(url) do
     target = URI.parse(url)

--- a/lib/hexpm/cdn/purge_worker.ex
+++ b/lib/hexpm/cdn/purge_worker.ex
@@ -226,8 +226,8 @@ defmodule Hexpm.CDN.PurgeVerificationError do
 
   defp describe({target, {:stale, pops}}) do
     pops =
-      Enum.map_join(pops, ", ", fn %{pop: pop, etag: etag, served_by: served_by} ->
-        "#{pop} serves #{inspect(etag)} (#{served_by})"
+      Enum.map_join(pops, ", ", fn %{pop: pop, etag: etag, cache: cache} ->
+        "#{pop} serves #{inspect(etag)} (#{cache})"
       end)
 
     "  #{target.url} expected #{inspect(target.etag)}: #{pops}"

--- a/lib/hexpm/cdn/purge_worker.ex
+++ b/lib/hexpm/cdn/purge_worker.ex
@@ -7,9 +7,9 @@ defmodule Hexpm.CDN.PurgeWorker do
   the shield saw the purge). It then waits for propagation and checks every
   target the caller supplied against the CDN (`Hexpm.CDN.verify/2`: the
   nearest POP plus one probed POP per continent for the repository
-  service). Targets still serving the old ETag anywhere mean the purge did
-  not apply, so the keys are purged again and the targets rechecked, up to
-  `:purge_verify_rounds` times, after which the job raises
+  service). A target whose copy anywhere is older than the write means the
+  purge did not apply, so the keys are purged again and the targets
+  rechecked, up to `:purge_verify_rounds` times, after which the job raises
   `Hexpm.CDN.PurgeVerificationError` and Oban retries it later.
 
   Purges queue up faster than they run during publish bursts, so on start a
@@ -18,13 +18,13 @@ defmodule Hexpm.CDN.PurgeWorker do
   them) and the absorbed jobs are cancelled. Fastly accepts up to 256 keys
   per purge request, so a job never carries more than that, and it looks at
   no more than 256 candidates, since each brings at least one key. Two
-  targets for the same URL keep the later one's ETag, since that is the
-  object the store holds now.
+  targets for the same URL keep the one with the higher write number, since
+  that is the object the store holds now.
 
   The same object can also be written again after this job was enqueued,
-  by a job this one did not absorb. That job's ETag is the one the CDN
-  will serve, so a target that comes back stale is dropped, not re-purged,
-  when a newer job for its URL exists.
+  by a job this one did not absorb. The check compares write numbers, so
+  the CDN serving that later write passes this job's target too, and the
+  later job verifies its own.
   """
 
   use Oban.Worker, queue: :purge, max_attempts: 5
@@ -33,6 +33,7 @@ defmodule Hexpm.CDN.PurgeWorker do
   import Ecto.Changeset, only: [change: 2]
 
   alias Hexpm.CDN
+  alias Hexpm.CDN.PurgeVerificationError
   alias Hexpm.Repo
 
   require Logger
@@ -51,7 +52,9 @@ defmodule Hexpm.CDN.PurgeWorker do
     targets =
       targets
       |> dedupe_targets()
-      |> Enum.map(&%{url: &1["url"], etag: &1["etag"], repository: &1["repository"]})
+      |> Enum.map(
+        &%{url: &1["url"], etag: &1["etag"], write: &1["write"], repository: &1["repository"]}
+      )
 
     metadata = %{
       service: service,
@@ -91,20 +94,13 @@ defmodule Hexpm.CDN.PurgeWorker do
       for {target, {:error, reason}} <- CDN.verify(service, targets),
           do: {target, reason}
 
-    {superseded, stale} = Enum.split_with(stale, fn {target, _} -> superseded?(job, target) end)
-
-    for {target, reason} <- superseded do
-      Logger.info("CDN_PURGE_SUPERSEDED #{target.url} #{inspect(reason)} job=#{job.id}")
-    end
-
     for {target, reason} <- stale do
       Logger.warning(
-        "CDN_PURGE_STALE round=#{round} #{target.url} expected=#{inspect(target.etag)} " <>
-          "#{inspect(reason)} keys=#{Enum.join(keys, " ")} job=#{job.id}"
+        "CDN_PURGE_STALE round=#{round} #{target.url} " <>
+          "expected=#{PurgeVerificationError.expected(target)} #{inspect(reason)} " <>
+          "keys=#{Enum.join(keys, " ")} job=#{job.id}"
       )
     end
-
-    targets = targets -- Enum.map(superseded, &elem(&1, 0))
 
     cond do
       stale == [] ->
@@ -116,7 +112,7 @@ defmodule Hexpm.CDN.PurgeWorker do
         end
 
       true ->
-        raise Hexpm.CDN.PurgeVerificationError,
+        raise PurgeVerificationError,
           service: service,
           keys: keys,
           stale: stale,
@@ -124,30 +120,15 @@ defmodule Hexpm.CDN.PurgeWorker do
     end
   end
 
-  # A later job for the same URL, whether queued, running or done, carries
-  # the ETag the store holds now; this job's expectation is out of date.
-  defp superseded?(%Oban.Job{id: nil}, _target), do: false
-
-  defp superseded?(%Oban.Job{id: id}, %{url: url}) do
-    worker = Oban.Worker.to_string(__MODULE__)
-    match = %{"verify" => [%{"url" => url}]}
-
-    Repo.exists?(
-      from(j in Oban.Job,
-        where: j.worker == ^worker and j.id > ^id,
-        where: j.state in ["scheduled", "available", "executing", "retryable", "completed"],
-        where: fragment("? @> ?", j.args, ^match)
-      )
-    )
-  end
-
-  # Later targets replace earlier ones for the same URL: the running job's
-  # own targets come first, absorbed jobs follow in id order.
+  # One target per URL, the one with the highest write number; between
+  # equals (or targets without one) the later wins.
   defp dedupe_targets(targets) do
     targets
-    |> Enum.reverse()
-    |> Enum.uniq_by(& &1["url"])
-    |> Enum.reverse()
+    |> Enum.with_index()
+    |> Enum.sort_by(fn {target, index} -> {target["write"] || 0, index} end, :desc)
+    |> Enum.uniq_by(fn {target, _index} -> target["url"] end)
+    |> Enum.sort_by(fn {_target, index} -> index end)
+    |> Enum.map(fn {target, _index} -> target end)
   end
 
   defp purge_twice(service, keys) do
@@ -224,16 +205,25 @@ defmodule Hexpm.CDN.PurgeVerificationError do
     "purge of #{inspect(keys)} on #{service} not visible after #{rounds} rounds:\n#{stale}"
   end
 
+  @doc "Describes what the check wanted for `target`, for logs and this message."
+  def expected(%{etag: nil}), do: "404"
+  def expected(%{etag: _etag, write: write}) when is_integer(write), do: "write #{write}"
+  def expected(%{etag: etag}), do: inspect(etag)
+
   defp describe({target, {:stale, pops}}) do
     pops =
-      Enum.map_join(pops, ", ", fn %{pop: pop, etag: etag, cache: cache} ->
-        "#{pop} serves #{inspect(etag)} (#{cache})"
+      Enum.map_join(pops, ", ", fn %{pop: pop, served: served, cache: cache} ->
+        "#{pop} serves #{served(served)} (#{cache})"
       end)
 
-    "  #{target.url} expected #{inspect(target.etag)}: #{pops}"
+    "  #{target.url} expected #{expected(target)}: #{pops}"
   end
 
   defp describe({target, reason}) do
-    "  #{target.url} expected #{inspect(target.etag)}: #{inspect(reason)}"
+    "  #{target.url} expected #{expected(target)}: #{inspect(reason)}"
   end
+
+  defp served({:write, nil}), do: "no write number"
+  defp served({:write, write}), do: "write #{write}"
+  defp served({:etag, etag}), do: inspect(etag)
 end

--- a/lib/hexpm/cdn/purge_worker.ex
+++ b/lib/hexpm/cdn/purge_worker.ex
@@ -24,7 +24,10 @@ defmodule Hexpm.CDN.PurgeWorker do
   The same object can also be written again after this job was enqueued,
   by a job this one did not absorb. The check compares write numbers, so
   the CDN serving that later write passes this job's target too, and the
-  later job verifies its own.
+  later job verifies its own. When the number cannot decide, because the
+  copy served carries none or the object has been deleted since, a newer
+  job for the URL settles it: the target is dropped and that job's check
+  covers the URL.
   """
 
   use Oban.Worker, queue: :purge, max_attempts: 5
@@ -94,6 +97,17 @@ defmodule Hexpm.CDN.PurgeWorker do
       for {target, {:error, reason}} <- CDN.verify(service, targets),
           do: {target, reason}
 
+    {superseded, stale} =
+      Enum.split_with(stale, fn {target, reason} ->
+        undecided?(target, reason) and superseded?(job, target)
+      end)
+
+    for {target, reason} <- superseded do
+      Logger.info("CDN_PURGE_SUPERSEDED #{target.url} #{inspect(reason)} job=#{job.id}")
+    end
+
+    targets = targets -- Enum.map(superseded, &elem(&1, 0))
+
     for {target, reason} <- stale do
       Logger.warning(
         "CDN_PURGE_STALE round=#{round} #{target.url} " <>
@@ -118,6 +132,36 @@ defmodule Hexpm.CDN.PurgeWorker do
           stale: stale,
           rounds: round
     end
+  end
+
+  # The write number decides when the copy carries one. A copy without one
+  # is judged by ETag, and a 404 or redirect for a target that expected
+  # content may be a deletion since the write; neither tells whether a
+  # later write explains it.
+  defp undecided?(_target, {:stale, pops}),
+    do: Enum.all?(pops, &match?(%{served: {:etag, _}}, &1))
+
+  defp undecided?(%{etag: etag}, {:status, status, _cache})
+       when is_binary(etag) and status in [301, 404],
+       do: true
+
+  defp undecided?(_target, _reason), do: false
+
+  # A later job for the same URL, whether queued, running or done, carries
+  # what the store holds now; its check covers the URL.
+  defp superseded?(%Oban.Job{id: nil}, _target), do: false
+
+  defp superseded?(%Oban.Job{id: id}, %{url: url}) do
+    worker = Oban.Worker.to_string(__MODULE__)
+    match = %{"verify" => [%{"url" => url}]}
+
+    Repo.exists?(
+      from(j in Oban.Job,
+        where: j.worker == ^worker and j.id > ^id,
+        where: j.state in ["scheduled", "available", "executing", "retryable", "completed"],
+        where: fragment("? @> ?", j.args, ^match)
+      )
+    )
   end
 
   # One target per URL, the one with the highest write number; between

--- a/lib/hexpm/hexdocs/bucket.ex
+++ b/lib/hexpm/hexdocs/bucket.ex
@@ -37,14 +37,16 @@ defmodule Hexpm.Hexdocs.Bucket do
   end
 
   defp upload_content(key, path, content_type, content, url) do
+    write = Hexpm.CDN.next_write()
+
     opts = [
       content_type: content_type,
       cache_control: "public, max-age=3600",
-      meta: [{"surrogate-key", key}]
+      meta: [{"surrogate-key", key}, {"write", Integer.to_string(write)}]
     ]
 
     {:ok, %{etag: etag}} = Hexpm.Store.put(:docs_bucket, path, content, opts)
-    purge("hexpm", [key], [%{url: url, etag: etag}])
+    purge("hexpm", [key], [%{url: url, etag: etag, write: write}])
   end
 
   def upload(repository, package, version, all_versions, retired_versions, dir, files) do
@@ -54,7 +56,8 @@ defmodule Hexpm.Hexdocs.Bucket do
     upload_files = list_upload_files(repository, package, version, dir, files, upload_type)
     paths = MapSet.new(upload_files, &elem(&1, 0))
 
-    uploaded = upload_new_files(upload_files)
+    write = Hexpm.CDN.next_write()
+    uploaded = upload_new_files(upload_files, write)
     delete_old_docs(repository, package, [version], paths, upload_type)
 
     Debouncer.debounce(Debouncer, {:docs_config, repository, package}, @gcs_put_debounce, fn ->
@@ -69,7 +72,7 @@ defmodule Hexpm.Hexdocs.Bucket do
           files
         )
 
-      upload_new_files([config])
+      upload_new_files([config], Hexpm.CDN.next_write())
     end)
 
     purge_hexdocs_cache(
@@ -77,7 +80,7 @@ defmodule Hexpm.Hexdocs.Bucket do
       package,
       [version],
       upload_type,
-      page_targets(repository, uploaded)
+      page_targets(repository, uploaded, write)
     )
 
     purge(repository, [docs_config_cdn_key(repository, package)])
@@ -126,13 +129,13 @@ defmodule Hexpm.Hexdocs.Bucket do
 
   def delete(repository, package, version, :both) do
     delete_old_docs(repository, package, [version], [], :both)
-    targets = deleted_page_targets(repository, package, [version, nil])
+    targets = deleted_page_targets(repository, package, [version, nil], Hexpm.CDN.next_write())
     purge_hexdocs_cache(repository, package, [version], :both, targets)
   end
 
   def delete(repository, package, version, :versioned) do
     delete_old_docs(repository, package, [version], [], :versioned)
-    targets = deleted_page_targets(repository, package, [version])
+    targets = deleted_page_targets(repository, package, [version], Hexpm.CDN.next_write())
     purge_hexdocs_cache(repository, package, [version], :versioned, targets)
   end
 
@@ -141,12 +144,13 @@ defmodule Hexpm.Hexdocs.Bucket do
     uploads = list_upload_files(repository, package, new_latest, dir, files, :both)
     paths = MapSet.new(uploads, &elem(&1, 0))
     versions = [version, new_latest]
-    uploaded = upload_new_files(uploads)
+    write = Hexpm.CDN.next_write()
+    uploaded = upload_new_files(uploads, write)
     delete_old_docs(repository, package, versions, paths, :both)
 
     targets =
-      page_targets(repository, uploaded) ++
-        deleted_page_targets(repository, package, [version])
+      page_targets(repository, uploaded, write) ++
+        deleted_page_targets(repository, package, [version], write)
 
     purge_hexdocs_cache(repository, package, versions, :both, targets)
   end
@@ -186,7 +190,7 @@ defmodule Hexpm.Hexdocs.Bucket do
     end)
   end
 
-  defp upload_new_files(files) do
+  defp upload_new_files(files, write) do
     files
     |> Enum.map(fn {store_key, cdn_key, data, public?} ->
       opts =
@@ -197,7 +201,8 @@ defmodule Hexpm.Hexdocs.Bucket do
         )
         |> Keyword.put(:meta, [
           {"surrogate-key", cdn_key},
-          {"surrogate-control", "public, max-age=604800"}
+          {"surrogate-control", "public, max-age=604800"},
+          {"write", Integer.to_string(write)}
         ])
 
       {bucket(public?), store_key, data, opts}
@@ -222,23 +227,23 @@ defmodule Hexpm.Hexdocs.Bucket do
   # Each uploaded page set is checked through its index.html, versioned and
   # unversioned. Private docs sit behind a browser session the check cannot
   # carry, so only the public site is verified.
-  defp page_targets("hexpm", uploaded) do
+  defp page_targets("hexpm", uploaded, write) do
     for %{key: key, etag: etag} <- uploaded, Path.basename(key) == "index.html" do
-      %{url: page_url(key), etag: etag}
+      %{url: page_url(key), etag: etag, write: write}
     end
   end
 
-  defp page_targets(_repository, _uploaded), do: []
+  defp page_targets(_repository, _uploaded, _write), do: []
 
   # `nil` stands for the unversioned pages.
-  defp deleted_page_targets("hexpm", package, versions) do
+  defp deleted_page_targets("hexpm", package, versions, write) do
     Enum.map(versions, fn
-      nil -> %{url: page_url("#{package}/index.html"), etag: nil}
-      version -> %{url: page_url("#{package}/#{version}/index.html"), etag: nil}
+      nil -> %{url: page_url("#{package}/index.html"), etag: nil, write: write}
+      version -> %{url: page_url("#{package}/#{version}/index.html"), etag: nil, write: write}
     end)
   end
 
-  defp deleted_page_targets(_repository, _package, _versions), do: []
+  defp deleted_page_targets(_repository, _package, _versions, _write), do: []
 
   defp page_url(key) do
     [package | rest] = Path.split(key)

--- a/lib/hexpm/hexdocs/bucket.ex
+++ b/lib/hexpm/hexdocs/bucket.ex
@@ -3,50 +3,70 @@ defmodule Hexpm.Hexdocs.Bucket do
 
   @special_package_names Map.keys(Application.compile_env!(:hexpm, :hexdocs_special_packages))
   @gcs_put_debounce Application.compile_env!(:hexpm, :hexdocs_gcs_put_debounce)
+  @lock_timeout :timer.minutes(1)
 
-  def upload_index_sitemap(sitemap) do
+  @doc "Writes the sitemap index `render` produces."
+  def upload_index_sitemap(render) do
     upload_content(
       "sitemap",
       "sitemap.xml",
       "text/xml",
-      sitemap,
+      render,
       Hexpm.Utils.docs_url("sitemap.xml")
     )
   end
 
   # The CDN redirects hexdocs.pm/<package>/... to the package subdomain, so
   # the check has to fetch the sitemap where it is served.
-  def upload_package_sitemap(package, sitemap) do
+  @doc "Writes the sitemap of `package` that `render` produces."
+  def upload_package_sitemap(package, render) do
     upload_content(
       "sitemap/#{package}",
       "#{package}/sitemap.xml",
       "text/xml",
-      sitemap,
+      render,
       Hexpm.Utils.docs_html_url("hexpm", package, "/sitemap.xml")
     )
   end
 
-  def upload_package_names_csv(contents) do
+  @doc "Writes the package name list `render` produces."
+  def upload_package_names_csv(render) do
     upload_content(
       "package_names.csv",
       "package_names.csv",
       "text/csv",
-      contents,
+      render,
       Hexpm.Utils.docs_url("package_names.csv")
     )
   end
 
-  defp upload_content(key, path, content_type, content, url) do
-    write = Hexpm.CDN.next_write()
+  # Every docs upload, on any pod, writes these objects, so the render, the
+  # write number and the put run under a lock on the object: the number is
+  # then in write order and the content is the newest render.
+  defp upload_content(key, path, content_type, render, url) do
+    {:ok, :ok} =
+      Hexpm.Repo.transaction(
+        fn ->
+          Hexpm.Repo.advisory_xact_lock(:hexdocs,
+            sub_key: :erlang.phash2(path),
+            timeout: @lock_timeout
+          )
 
-    opts = [
-      content_type: content_type,
-      cache_control: "public, max-age=3600",
-      meta: [{"surrogate-key", key}, {"write", Integer.to_string(write)}]
-    ]
+          write = Hexpm.CDN.next_write()
 
-    {:ok, %{etag: etag}} = Hexpm.Store.put(:docs_bucket, path, content, opts)
-    purge("hexpm", [key], [%{url: url, etag: etag, write: write}])
+          opts = [
+            content_type: content_type,
+            cache_control: "public, max-age=3600",
+            meta: [{"surrogate-key", key}, {"write", Integer.to_string(write)}]
+          ]
+
+          {:ok, %{etag: etag}} = Hexpm.Store.put(:docs_bucket, path, render.(), opts)
+          purge("hexpm", [key], [%{url: url, etag: etag, write: write}])
+        end,
+        timeout: @lock_timeout
+      )
+
+    :ok
   end
 
   def upload(repository, package, version, all_versions, retired_versions, dir, files) do

--- a/lib/hexpm/hexdocs/bucket.ex
+++ b/lib/hexpm/hexdocs/bucket.ex
@@ -75,13 +75,16 @@ defmodule Hexpm.Hexdocs.Bucket do
 
     upload_files = list_upload_files(repository, package, version, dir, files, upload_type)
 
-    # The sitemap and docs_config.js are rewritten by this same upload, so
-    # they stay in place rather than being missing until then.
+    # docs_config.js, and on the public site the sitemap, are rewritten by
+    # this same upload, so they stay in place rather than being missing
+    # until then.
+    rewritten =
+      if repository == "hexpm", do: ["docs_config.js", "sitemap.xml"], else: ["docs_config.js"]
+
     paths =
-      upload_files
-      |> MapSet.new(&elem(&1, 0))
-      |> MapSet.put(repository_path(repository, Path.join(package, "sitemap.xml")))
-      |> MapSet.put(repository_path(repository, Path.join(package, "docs_config.js")))
+      Enum.reduce(rewritten, MapSet.new(upload_files, &elem(&1, 0)), fn file, paths ->
+        MapSet.put(paths, repository_path(repository, Path.join(package, file)))
+      end)
 
     write = Hexpm.CDN.next_write()
     uploaded = upload_new_files(upload_files, write)

--- a/lib/hexpm/hexdocs/bucket.ex
+++ b/lib/hexpm/hexdocs/bucket.ex
@@ -54,7 +54,14 @@ defmodule Hexpm.Hexdocs.Bucket do
       if Utils.latest_version?(package, version, all_versions), do: :both, else: :versioned
 
     upload_files = list_upload_files(repository, package, version, dir, files, upload_type)
-    paths = MapSet.new(upload_files, &elem(&1, 0))
+
+    # The sitemap and docs_config.js are rewritten by this same upload, so
+    # they stay in place rather than being missing until then.
+    paths =
+      upload_files
+      |> MapSet.new(&elem(&1, 0))
+      |> MapSet.put(repository_path(repository, Path.join(package, "sitemap.xml")))
+      |> MapSet.put(repository_path(repository, Path.join(package, "docs_config.js")))
 
     write = Hexpm.CDN.next_write()
     uploaded = upload_new_files(upload_files, write)

--- a/lib/hexpm/hexdocs/hexdocs.ex
+++ b/lib/hexpm/hexdocs/hexdocs.ex
@@ -209,7 +209,11 @@ defmodule Hexpm.Hexdocs do
       Hexpm.Hexdocs.Debouncer,
       :sitemap_index,
       @gcs_put_debounce,
-      fn -> Bucket.upload_index_sitemap(Sitemaps.render_docs(Sitemaps.packages_with_docs())) end
+      fn ->
+        Bucket.upload_index_sitemap(fn ->
+          Sitemaps.render_docs(Sitemaps.packages_with_docs())
+        end)
+      end
     )
   end
 
@@ -222,17 +226,18 @@ defmodule Hexpm.Hexdocs do
           path not in @noindex_pages,
           do: path
 
-    Bucket.upload_package_sitemap(
-      package,
+    Bucket.upload_package_sitemap(package, fn ->
       PackageSitemap.render(package, pages, DateTime.utc_now())
-    )
+    end)
   end
 
   defp update_package_sitemap(_repository, _key, _package, _files), do: :ok
 
   defp update_package_names_csv("hexpm") do
-    names = Enum.sort(@special_package_names) ++ Packages.public_names()
-    Bucket.upload_package_names_csv(for name <- names, do: [name, "\n"])
+    Bucket.upload_package_names_csv(fn ->
+      names = Enum.sort(@special_package_names) ++ Packages.public_names()
+      for name <- names, do: [name, "\n"]
+    end)
   end
 
   defp update_package_names_csv(_repository), do: :ok

--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -116,7 +116,8 @@ defmodule Hexpm.RepoBase do
     email_outbox: 5,
     migrate: 6,
     secret_scan: 7,
-    registry_object: 8
+    registry_object: 8,
+    hexdocs: 9
   }
 
   def advisory_lock_key(key), do: Map.fetch!(@advisory_locks, key)

--- a/lib/hexpm/repository/assets.ex
+++ b/lib/hexpm/repository/assets.ex
@@ -4,17 +4,13 @@ defmodule Hexpm.Repository.Assets do
   def push_release(release, body_path) do
     Hexpm.Repo.write_mode!()
 
-    meta = [
-      {"surrogate-key", tarball_cdn_key(release)},
-      {"surrogate-control", "public, max-age=604800"}
-    ]
-
+    write = Hexpm.CDN.next_write()
     cache_control = tarball_cache_control(release.package.repository)
-    opts = [cache_control: cache_control, meta: meta]
+    opts = [cache_control: cache_control, meta: meta(tarball_cdn_key(release), write)]
     key = tarball_store_key(release)
 
     {:ok, %{etag: etag}} = Hexpm.Store.put_file(:repo_bucket, key, body_path, opts)
-    purge(release, tarball_cdn_key(release), key, etag)
+    purge(release, tarball_cdn_key(release), key, etag, write)
   end
 
   def revert_release(release) do
@@ -22,24 +18,20 @@ defmodule Hexpm.Repository.Assets do
 
     key = tarball_store_key(release)
     Hexpm.Store.delete(:repo_bucket, key)
-    purge(release, tarball_cdn_key(release), key, nil)
+    purge(release, tarball_cdn_key(release), key, nil, Hexpm.CDN.next_write())
     revert_docs(release)
   end
 
   def push_docs(release, body_path) do
     Hexpm.Repo.write_mode!()
 
-    meta = [
-      {"surrogate-key", docs_cdn_key(release)},
-      {"surrogate-control", "public, max-age=604800"}
-    ]
-
+    write = Hexpm.CDN.next_write()
     cache_control = docs_cache_control(release.package.repository)
-    opts = [cache_control: cache_control, meta: meta]
+    opts = [cache_control: cache_control, meta: meta(docs_cdn_key(release), write)]
     key = docs_store_key(release)
 
     {:ok, %{etag: etag}} = Hexpm.Store.put_file(:repo_bucket, key, body_path, opts)
-    purge(release, docs_cdn_key(release), key, etag)
+    purge(release, docs_cdn_key(release), key, etag, write)
   end
 
   def revert_docs(release) do
@@ -48,13 +40,21 @@ defmodule Hexpm.Repository.Assets do
     if release.has_docs do
       key = docs_store_key(release)
       Hexpm.Store.delete(:repo_bucket, key)
-      purge(release, docs_cdn_key(release), key, nil)
+      purge(release, docs_cdn_key(release), key, nil, Hexpm.CDN.next_write())
     end
   end
 
-  defp purge(release, cdn_key, store_key, etag) do
+  defp meta(cdn_key, write) do
+    [
+      {"surrogate-key", cdn_key},
+      {"surrogate-control", "public, max-age=604800"},
+      {"write", Integer.to_string(write)}
+    ]
+  end
+
+  defp purge(release, cdn_key, store_key, etag, write) do
     repository = release.package.repository
-    target = %{url: Hexpm.Utils.cdn_url(store_key), etag: etag}
+    target = %{url: Hexpm.Utils.cdn_url(store_key), etag: etag, write: write}
 
     target =
       if repository.id == 1, do: target, else: Map.put(target, :repository, repository.name)

--- a/lib/hexpm/repository/policy_builder.ex
+++ b/lib/hexpm/repository/policy_builder.ex
@@ -38,8 +38,12 @@ defmodule Hexpm.Repository.PolicyBuilder do
         Hexpm.Repo.advisory_xact_lock(:policy, sub_key: policy.id)
         contents = build(policy)
         cdn_key = cdn_key(policy)
-        etag = Storage.put_object(store_key(policy), contents, [cdn_key], cache_control(policy))
-        Hexpm.CDN.purge(:fastly_hexrepo, cdn_key, verify: verify_targets(policy, etag))
+        write = Hexpm.CDN.next_write()
+
+        etag =
+          Storage.put_object(store_key(policy), contents, [cdn_key], cache_control(policy), write)
+
+        Hexpm.CDN.purge(:fastly_hexrepo, cdn_key, verify: verify_targets(policy, etag, write))
         :ok
       end)
 
@@ -54,19 +58,21 @@ defmodule Hexpm.Repository.PolicyBuilder do
   def delete(%Policy{} = policy) do
     policy = Hexpm.Repo.preload(policy, :organization)
     Storage.delete_object(store_key(policy))
-    Hexpm.CDN.purge(:fastly_hexrepo, cdn_key(policy), verify: verify_targets(policy, nil))
+    targets = verify_targets(policy, nil, Hexpm.CDN.next_write())
+    Hexpm.CDN.purge(:fastly_hexrepo, cdn_key(policy), verify: targets)
     :ok
   end
 
-  defp verify_targets(%{visibility: "public"} = policy, etag) do
-    [%{url: Hexpm.Utils.cdn_url(store_key(policy)), etag: etag}]
+  defp verify_targets(%{visibility: "public"} = policy, etag, write) do
+    [%{url: Hexpm.Utils.cdn_url(store_key(policy)), etag: etag, write: write}]
   end
 
-  defp verify_targets(policy, etag) do
+  defp verify_targets(policy, etag, write) do
     [
       %{
         url: Hexpm.Utils.cdn_url(store_key(policy)),
         etag: etag,
+        write: write,
         repository: policy.organization.name
       }
     ]

--- a/lib/hexpm/repository/registry_builder.ex
+++ b/lib/hexpm/repository/registry_builder.ex
@@ -109,7 +109,7 @@ defmodule Hexpm.Repository.RegistryBuilder do
         "registry-package-#{name}",
         repository_cdn_key(repository, "registry-package", name)
       ],
-      verify: verify_targets(repository, [%{key: key, etag: nil}])
+      verify: verify_targets(repository, [%{key: key, etag: nil, write: Hexpm.CDN.next_write()}])
     }
   end
 
@@ -117,14 +117,14 @@ defmodule Hexpm.Repository.RegistryBuilder do
   # `repos/<name>/` prefix of a private one; the check fetches the latter
   # with a token for that repository.
   defp verify_targets(%Repository{id: 1}, uploads) do
-    Enum.map(uploads, fn %{key: key, etag: etag} ->
-      %{url: Hexpm.Utils.cdn_url(key), etag: etag}
+    Enum.map(uploads, fn %{key: key, etag: etag, write: write} ->
+      %{url: Hexpm.Utils.cdn_url(key), etag: etag, write: write}
     end)
   end
 
   defp verify_targets(%Repository{name: name}, uploads) do
-    Enum.map(uploads, fn %{key: key, etag: etag} ->
-      %{url: Hexpm.Utils.cdn_url(key), etag: etag, repository: name}
+    Enum.map(uploads, fn %{key: key, etag: etag, write: write} ->
+      %{url: Hexpm.Utils.cdn_url(key), etag: etag, write: write, repository: name}
     end)
   end
 
@@ -307,11 +307,13 @@ defmodule Hexpm.Repository.RegistryBuilder do
   defp retirement_reason("renamed"), do: :RETIRED_RENAMED
 
   defp upload_files(repository, objects) do
+    write = Hexpm.CDN.next_write()
+
     Task.async_stream(
       objects(objects, repository),
       fn {kind, key, data, surrogate_keys} ->
-        etag = Storage.put_object(key, data, surrogate_keys, cache_control(repository))
-        %{kind: kind, key: key, etag: etag}
+        etag = Storage.put_object(key, data, surrogate_keys, cache_control(repository), write)
+        %{kind: kind, key: key, etag: etag, write: write}
       end,
       max_concurrency: 32,
       timeout: 60_000

--- a/lib/hexpm/repository/storage.ex
+++ b/lib/hexpm/repository/storage.ex
@@ -21,16 +21,18 @@ defmodule Hexpm.Repository.Storage do
 
   @doc """
   Writes `contents` to `key` in the repo bucket along with the standard
-  surrogate-key/surrogate-control metadata and the supplied
-  `cache_control` value. Returns the object's ETag as the store reports it.
+  surrogate-key/surrogate-control metadata, the write number the purge
+  check compares against and the supplied `cache_control` value. Returns
+  the object's ETag as the store reports it.
   """
-  @spec put_object(String.t(), iodata(), [String.t()], String.t()) :: String.t()
-  def put_object(key, contents, surrogate_keys, cache_control) do
+  @spec put_object(String.t(), iodata(), [String.t()], String.t(), pos_integer()) :: String.t()
+  def put_object(key, contents, surrogate_keys, cache_control, write) do
     Repo.write_mode!()
 
     meta = [
       {"surrogate-key", Enum.join(surrogate_keys, " ")},
-      {"surrogate-control", "public, max-age=604800"}
+      {"surrogate-control", "public, max-age=604800"},
+      {"write", Integer.to_string(write)}
     ]
 
     opts = [cache_control: cache_control, meta: meta]

--- a/priv/repo/migrations/20260902170000_create_cdn_writes_sequence.exs
+++ b/priv/repo/migrations/20260902170000_create_cdn_writes_sequence.exs
@@ -1,0 +1,11 @@
+defmodule Hexpm.Repo.Migrations.CreateCdnWritesSequence do
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE SEQUENCE cdn_writes")
+  end
+
+  def down do
+    execute("DROP SEQUENCE cdn_writes")
+  end
+end

--- a/test/hexpm/cdn/fastly_test.exs
+++ b/test/hexpm/cdn/fastly_test.exs
@@ -122,7 +122,13 @@ defmodule Hexpm.CDN.FastlyTest do
 
           {_, "nrt-tokyo-jp"} ->
             {:ok, 200,
-             [{"etag", ~s("old")}, {"x-cache-served-by", "cache-iad-2-IAD, cache-nrt-1-NRT"}], ""}
+             [
+               {"etag", ~s("old")},
+               {"x-cache-served-by", "cache-iad-2-IAD, cache-nrt-1-NRT"},
+               {"x-cache", "HIT, HIT"},
+               {"x-cache-age", "120, 3"},
+               {"x-cache-hits", "5, 1"}
+             ], ""}
         end
       end)
 
@@ -137,7 +143,9 @@ defmodule Hexpm.CDN.FastlyTest do
                       %{
                         pop: "nrt-tokyo-jp",
                         etag: ~s("old"),
-                        served_by: "cache-iad-2-IAD, cache-nrt-1-NRT"
+                        cache:
+                          "x-cache-served-by: cache-iad-2-IAD, cache-nrt-1-NRT; " <>
+                            "x-cache: HIT, HIT; x-cache-age: 120, 3; x-cache-hits: 5, 1"
                       }
                     ]}}}
                ]
@@ -173,7 +181,7 @@ defmodule Hexpm.CDN.FastlyTest do
       target = %{url: "https://repo.example/packages/foo", etag: "abc"}
 
       assert Fastly.verify(:fastly_hexrepo, [target]) ==
-               [{target, {:error, {:status, 503, "cache-bma-1-BMA"}}}]
+               [{target, {:error, {:status, 503, "x-cache-served-by: cache-bma-1-BMA"}}}]
     end
 
     test "emits telemetry per POP with the result" do

--- a/test/hexpm/cdn/fastly_test.exs
+++ b/test/hexpm/cdn/fastly_test.exs
@@ -142,11 +142,89 @@ defmodule Hexpm.CDN.FastlyTest do
                     [
                       %{
                         pop: "nrt-tokyo-jp",
-                        etag: ~s("old"),
+                        served: {:etag, ~s("old")},
                         cache:
                           "x-cache-served-by: cache-iad-2-IAD, cache-nrt-1-NRT; " <>
                             "x-cache: HIT, HIT; x-cache-age: 120, 3; x-cache-hits: 5, 1"
                       }
+                    ]}}}
+               ]
+    end
+
+    test "passes a copy whose write number is at or past the target's" do
+      expect(Hexpm.HTTP.Mock, :head, 2, fn _url, headers, _opts ->
+        case List.keyfind(headers, "hex-cache-probe", 0) do
+          nil -> {:ok, 200, [{"etag", ~s("later")}, {"x-cache-write", "8"}], ""}
+          _probe -> {:ok, 200, [{"etag", ~s("abc")}, {"x-cache-write", "7"}], ""}
+        end
+      end)
+
+      target = %{url: "https://repo.example/packages/foo", etag: ~s("abc"), write: 7}
+      assert Fastly.verify(:fastly_hexrepo, [target]) == [{target, :ok}]
+    end
+
+    test "reports a copy with a lower write number as stale whatever its ETag" do
+      expect(Hexpm.HTTP.Mock, :head, 2, fn _url, headers, _opts ->
+        case List.keyfind(headers, "hex-cache-probe", 0) do
+          nil -> {:ok, 200, [{"etag", ~s("abc")}, {"x-cache-write", "7"}], ""}
+          _probe -> {:ok, 200, [{"etag", ~s("abc")}, {"x-cache-write", "6"}], ""}
+        end
+      end)
+
+      target = %{url: "https://repo.example/packages/foo", etag: ~s("abc"), write: 7}
+
+      assert Fastly.verify(:fastly_hexrepo, [target]) ==
+               [
+                 {target,
+                  {:error, {:stale, [%{pop: "nrt-tokyo-jp", served: {:write, 6}, cache: nil}]}}}
+               ]
+    end
+
+    test "compares the ETag when the copy carries no write number" do
+      expect(Hexpm.HTTP.Mock, :head, 2, fn _url, headers, _opts ->
+        case List.keyfind(headers, "hex-cache-probe", 0) do
+          nil -> {:ok, 200, [{"etag", ~s("abc")}], ""}
+          _probe -> {:ok, 200, [{"etag", ~s("old")}], ""}
+        end
+      end)
+
+      target = %{url: "https://repo.example/packages/foo", etag: ~s("abc"), write: 7}
+
+      assert Fastly.verify(:fastly_hexrepo, [target]) ==
+               [
+                 {target,
+                  {:error,
+                   {:stale, [%{pop: "nrt-tokyo-jp", served: {:etag, ~s("old")}, cache: nil}]}}}
+               ]
+    end
+
+    test "accepts a deleted object re-created by a later write" do
+      expect(Hexpm.HTTP.Mock, :head, 2, fn _url, _headers, _opts ->
+        {:ok, 200, [{"etag", ~s("new")}, {"x-cache-write", "10"}], ""}
+      end)
+
+      target = %{url: "https://repo.example/tarballs/foo-1.0.0.tar", etag: nil, write: 9}
+      assert Fastly.verify(:fastly_hexrepo, [target]) == [{target, :ok}]
+    end
+
+    test "reports a deleted object still served as stale" do
+      expect(Hexpm.HTTP.Mock, :head, 2, fn _url, headers, _opts ->
+        case List.keyfind(headers, "hex-cache-probe", 0) do
+          nil -> {:ok, 200, [{"etag", ~s("old")}, {"x-cache-write", "9"}], ""}
+          _probe -> {:ok, 200, [{"etag", ~s("old")}], ""}
+        end
+      end)
+
+      target = %{url: "https://repo.example/tarballs/foo-1.0.0.tar", etag: nil, write: 9}
+
+      assert Fastly.verify(:fastly_hexrepo, [target]) ==
+               [
+                 {target,
+                  {:error,
+                   {:stale,
+                    [
+                      %{pop: :nearest, served: {:write, 9}, cache: nil},
+                      %{pop: "nrt-tokyo-jp", served: {:write, nil}, cache: nil}
                     ]}}}
                ]
     end

--- a/test/hexpm/cdn/fastly_test.exs
+++ b/test/hexpm/cdn/fastly_test.exs
@@ -170,6 +170,28 @@ defmodule Hexpm.CDN.FastlyTest do
       assert Fastly.verify(:fastly_hexrepo, [target]) == [{target, :ok}]
     end
 
+    test "accepts the organization docs redirect for a deleted page" do
+      expect(Hexpm.HTTP.Mock, :head, fn "https://foo.hexdocs.example/1.0.0/index.html",
+                                        [],
+                                        _opts ->
+        {:ok, 301, [{"location", "http://foo.localhost:5002/1.0.0/index.html"}], ""}
+      end)
+
+      target = %{url: "https://foo.hexdocs.example/1.0.0/index.html", etag: nil}
+      assert Fastly.verify(:fastly_hexdocs, [target]) == [{target, :ok}]
+    end
+
+    test "rejects any other redirect for a deleted page" do
+      expect(Hexpm.HTTP.Mock, :head, fn _url, _headers, _opts ->
+        {:ok, 301, [{"location", "https://foo.hexdocs.example/"}], ""}
+      end)
+
+      target = %{url: "https://foo.hexdocs.example/1.0.0/index.html", etag: nil}
+
+      assert Fastly.verify(:fastly_hexdocs, [target]) ==
+               [{target, {:error, {:status, 301, nil}}}]
+    end
+
     test "returns the status when the nearest POP does not serve the object" do
       expect(Hexpm.HTTP.Mock, :head, 2, fn _url, headers, _opts ->
         case List.keyfind(headers, "hex-cache-probe", 0) do

--- a/test/hexpm/cdn/fastly_test.exs
+++ b/test/hexpm/cdn/fastly_test.exs
@@ -198,6 +198,22 @@ defmodule Hexpm.CDN.FastlyTest do
                ]
     end
 
+    test "accepts a numbered copy for a target from before writes were numbered" do
+      expect(Hexpm.HTTP.Mock, :head, 2, fn _url, _headers, _opts ->
+        {:ok, 200, [{"etag", ~s("later")}, {"x-cache-write", "5"}], ""}
+      end)
+
+      target = %{url: "https://repo.example/packages/foo", etag: ~s("abc")}
+      assert Fastly.verify(:fastly_hexrepo, [target]) == [{target, :ok}]
+
+      expect(Hexpm.HTTP.Mock, :head, 2, fn _url, _headers, _opts ->
+        {:ok, 200, [{"etag", ~s("later")}, {"x-cache-write", "5"}], ""}
+      end)
+
+      deleted = %{url: "https://repo.example/tarballs/foo-1.0.0.tar", etag: nil}
+      assert Fastly.verify(:fastly_hexrepo, [deleted]) == [{deleted, :ok}]
+    end
+
     test "accepts a deleted object re-created by a later write" do
       expect(Hexpm.HTTP.Mock, :head, 2, fn _url, _headers, _opts ->
         {:ok, 200, [{"etag", ~s("new")}, {"x-cache-write", "10"}], ""}

--- a/test/hexpm/cdn/purge_worker_test.exs
+++ b/test/hexpm/cdn/purge_worker_test.exs
@@ -15,7 +15,8 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
     :ok
   end
 
-  defp target(url, etag \\ "abc"), do: %{"url" => url, "etag" => etag}
+  defp target(url, etag \\ "abc", write \\ 1),
+    do: %{"url" => url, "etag" => etag, "write" => write}
 
   describe "purge/3" do
     test "enqueues a purge job with the keys and verification targets" do
@@ -58,7 +59,7 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
       expect(Hexpm.CDN.Mock, :purge_key, 4, fn :fastly_hexrepo, ["k"] -> :ok end)
 
       expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a"} = a] ->
-        [{a, {:error, {:stale, [%{pop: :nearest, etag: "old", cache: "x-cache: HIT"}]}}}]
+        [{a, {:error, {:stale, [%{pop: :nearest, served: {:write, 0}, cache: "x-cache: HIT"}]}}}]
       end)
 
       expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a"} = a] -> [{a, :ok}] end)
@@ -76,7 +77,7 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
       expect(Hexpm.CDN.Mock, :purge_key, 6, fn :fastly_hexrepo, ["k"] -> :ok end)
 
       expect(Hexpm.CDN.Mock, :verify, 3, fn _service, [%{url: "https://r/a"} = a] ->
-        [{a, {:error, {:stale, [%{pop: :nearest, etag: "old", cache: "x-cache: HIT"}]}}}]
+        [{a, {:error, {:stale, [%{pop: :nearest, served: {:write, 0}, cache: "x-cache: HIT"}]}}}]
       end)
 
       args = %{
@@ -86,7 +87,7 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
       }
 
       assert_raise Hexpm.CDN.PurgeVerificationError,
-                   ~r/https:\/\/r\/a expected "abc": nearest serves "old" \(x-cache: HIT\)/,
+                   ~r/https:\/\/r\/a expected write 1: nearest serves write 0 \(x-cache: HIT\)/,
                    fn -> perform_job(PurgeWorker, args) end
     end
 
@@ -125,41 +126,58 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
                jobs("completed")
     end
 
-    test "keeps the later ETag when absorbed jobs wrote the same object" do
-      CDN.purge(:fastly_hexrepo, ["a"], verify: [%{url: "https://r/a", etag: "1"}])
-      CDN.purge(:fastly_hexrepo, ["a"], verify: [%{url: "https://r/a", etag: "2"}])
+    test "keeps the latest write when absorbed jobs wrote the same object" do
+      CDN.purge(:fastly_hexrepo, ["a"], verify: [%{url: "https://r/a", etag: "1", write: 1}])
+      CDN.purge(:fastly_hexrepo, ["a"], verify: [%{url: "https://r/a", etag: "2", write: 2}])
 
       expect(Hexpm.CDN.Mock, :purge_key, 2, fn :fastly_hexrepo, ["a"] -> :ok end)
 
-      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a", etag: "2"} = a] ->
+      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a", write: 2} = a] ->
         [{a, :ok}]
       end)
 
       assert %{success: 1, failure: 0} =
                Oban.drain_queue(queue: :purge, with_limit: 1, with_recursion: true)
 
-      assert [%{args: %{"verify" => [%{"url" => "https://r/a", "etag" => "2"}]}}] =
+      assert [%{args: %{"verify" => [%{"url" => "https://r/a", "etag" => "2", "write" => 2}]}}] =
                jobs("completed")
     end
 
-    test "drops a stale target when a newer job for its URL exists" do
+    test "keeps its own target over an absorbed older write of the same object" do
+      # A retried job comes back available behind newer ones, so the newer
+      # job absorbs it although its write is older.
+      CDN.purge(:fastly_hexrepo, ["a"], verify: [%{url: "https://r/a", etag: "2", write: 2}])
+      CDN.purge(:fastly_hexrepo, ["a"], verify: [%{url: "https://r/a", etag: "1", write: 1}])
+
+      expect(Hexpm.CDN.Mock, :purge_key, 2, fn :fastly_hexrepo, ["a"] -> :ok end)
+
+      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a", write: 2} = a] ->
+        [{a, :ok}]
+      end)
+
+      assert %{success: 1, failure: 0} =
+               Oban.drain_queue(queue: :purge, with_limit: 1, with_recursion: true)
+
+      assert [%{args: %{"verify" => [%{"url" => "https://r/a", "etag" => "2", "write" => 2}]}}] =
+               jobs("completed")
+    end
+
+    test "checks its target even when a newer job for the same URL is queued" do
       {:ok, older} =
         Repo.insert(
           PurgeWorker.new(%{
             "service" => "fastly_hexrepo",
             "keys" => ["a"],
-            "verify" => [target("https://r/a", "1")]
+            "verify" => [target("https://r/a", "1", 1)]
           })
         )
 
-      # The later write of the same object; scheduled, so the older job
-      # cannot absorb it and has to notice it instead.
       Oban.insert!(
         PurgeWorker.new(
           %{
             "service" => "fastly_hexrepo",
             "keys" => ["a"],
-            "verify" => [target("https://r/a", "2")]
+            "verify" => [target("https://r/a", "2", 2)]
           },
           schedule_in: 60
         )
@@ -167,11 +185,19 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
 
       expect(Hexpm.CDN.Mock, :purge_key, 2, fn :fastly_hexrepo, ["a"] -> :ok end)
 
-      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a", etag: "1"} = a] ->
-        [{a, {:error, {:stale, [%{pop: :nearest, etag: "2", served_by: "cache-iad-1-IAD"}]}}}]
+      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a", write: 1} = a] ->
+        [{a, :ok}]
       end)
 
       assert :ok = PurgeWorker.perform(older)
+    end
+  end
+
+  describe "next_write/0" do
+    test "increases with every call" do
+      first = CDN.next_write()
+      assert is_integer(first)
+      assert CDN.next_write() > first
     end
   end
 

--- a/test/hexpm/cdn/purge_worker_test.exs
+++ b/test/hexpm/cdn/purge_worker_test.exs
@@ -162,6 +162,84 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
                jobs("completed")
     end
 
+    test "drops a content target answered 404 when a newer deletion job exists" do
+      {:ok, older} =
+        Repo.insert(
+          PurgeWorker.new(%{
+            "service" => "fastly_hexrepo",
+            "keys" => ["a"],
+            "verify" => [target("https://r/a", "abc", 1)]
+          })
+        )
+
+      Oban.insert!(
+        PurgeWorker.new(
+          %{
+            "service" => "fastly_hexrepo",
+            "keys" => ["a"],
+            "verify" => [target("https://r/a", nil, 2)]
+          },
+          schedule_in: 60
+        )
+      )
+
+      expect(Hexpm.CDN.Mock, :purge_key, 2, fn :fastly_hexrepo, ["a"] -> :ok end)
+
+      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a", write: 1} = a] ->
+        [{a, {:error, {:status, 404, nil}}}]
+      end)
+
+      assert :ok = PurgeWorker.perform(older)
+    end
+
+    test "drops a stale target judged by ETag when a newer job for its URL exists" do
+      {:ok, older} =
+        Repo.insert(
+          PurgeWorker.new(%{
+            "service" => "fastly_hexrepo",
+            "keys" => ["a"],
+            "verify" => [target("https://r/a", "1", 1)]
+          })
+        )
+
+      Oban.insert!(
+        PurgeWorker.new(
+          %{
+            "service" => "fastly_hexrepo",
+            "keys" => ["a"],
+            "verify" => [target("https://r/a", "2", 2)]
+          },
+          schedule_in: 60
+        )
+      )
+
+      expect(Hexpm.CDN.Mock, :purge_key, 2, fn :fastly_hexrepo, ["a"] -> :ok end)
+
+      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a", write: 1} = a] ->
+        [{a, {:error, {:stale, [%{pop: :nearest, served: {:etag, "2"}, cache: nil}]}}}]
+      end)
+
+      assert :ok = PurgeWorker.perform(older)
+    end
+
+    test "purges again on a 404 that no newer job explains" do
+      expect(Hexpm.CDN.Mock, :purge_key, 4, fn :fastly_hexrepo, ["k"] -> :ok end)
+
+      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a"} = a] ->
+        [{a, {:error, {:status, 404, "x-cache: HIT"}}}]
+      end)
+
+      expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a"} = a] -> [{a, :ok}] end)
+
+      args = %{
+        "service" => "fastly_hexrepo",
+        "keys" => ["k"],
+        "verify" => [target("https://r/a")]
+      }
+
+      assert :ok = perform_job(PurgeWorker, args)
+    end
+
     test "checks its target even when a newer job for the same URL is queued" do
       {:ok, older} =
         Repo.insert(

--- a/test/hexpm/cdn/purge_worker_test.exs
+++ b/test/hexpm/cdn/purge_worker_test.exs
@@ -58,7 +58,7 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
       expect(Hexpm.CDN.Mock, :purge_key, 4, fn :fastly_hexrepo, ["k"] -> :ok end)
 
       expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a"} = a] ->
-        [{a, {:error, {:stale, [%{pop: :nearest, etag: "old", served_by: "cache-iad-1-IAD"}]}}}]
+        [{a, {:error, {:stale, [%{pop: :nearest, etag: "old", cache: "x-cache: HIT"}]}}}]
       end)
 
       expect(Hexpm.CDN.Mock, :verify, fn _service, [%{url: "https://r/a"} = a] -> [{a, :ok}] end)
@@ -76,7 +76,7 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
       expect(Hexpm.CDN.Mock, :purge_key, 6, fn :fastly_hexrepo, ["k"] -> :ok end)
 
       expect(Hexpm.CDN.Mock, :verify, 3, fn _service, [%{url: "https://r/a"} = a] ->
-        [{a, {:error, {:stale, [%{pop: :nearest, etag: "old", served_by: "cache-iad-1-IAD"}]}}}]
+        [{a, {:error, {:stale, [%{pop: :nearest, etag: "old", cache: "x-cache: HIT"}]}}}]
       end)
 
       args = %{
@@ -85,9 +85,9 @@ defmodule Hexpm.CDN.PurgeWorkerTest do
         "verify" => [target("https://r/a")]
       }
 
-      assert_raise Hexpm.CDN.PurgeVerificationError, ~r/https:\/\/r\/a expected "abc"/, fn ->
-        perform_job(PurgeWorker, args)
-      end
+      assert_raise Hexpm.CDN.PurgeVerificationError,
+                   ~r/https:\/\/r\/a expected "abc": nearest serves "old" \(x-cache: HIT\)/,
+                   fn -> perform_job(PurgeWorker, args) end
     end
 
     test "returns the purge error so the job retries" do

--- a/test/hexpm/hexdocs/bucket_test.exs
+++ b/test/hexpm/hexdocs/bucket_test.exs
@@ -58,6 +58,21 @@ defmodule Hexpm.Hexdocs.BucketTest do
     refute Hexpm.Store.get(:docs_bucket, "package/removed.html")
   end
 
+  test "removes an old sitemap from private docs, which nothing rewrites" do
+    version = Version.parse!("1.0.0")
+    Hexpm.Store.put(:docs_private_bucket, "acme/package/sitemap.xml", "old sitemap", [])
+    Hexpm.Store.put(:docs_private_bucket, "acme/package/docs_config.js", "old config", [])
+    {dir, files} = create_files([{"index.html", "new"}])
+
+    Bucket.upload("acme", "package", version, [], MapSet.new(), dir, files)
+
+    refute Hexpm.Store.get(:docs_private_bucket, "acme/package/sitemap.xml")
+
+    assert IO.iodata_to_binary(
+             Hexpm.Store.get(:docs_private_bucket, "acme/package/docs_config.js")
+           ) =~ "1.0.0"
+  end
+
   test "writes public docs to the existing docs bucket" do
     version = Version.parse!("1.0.0")
     {dir, files} = create_files([{"index.html", "public"}])

--- a/test/hexpm/hexdocs/bucket_test.exs
+++ b/test/hexpm/hexdocs/bucket_test.exs
@@ -44,6 +44,20 @@ defmodule Hexpm.Hexdocs.BucketTest do
     assert Hexpm.Store.get(:docs_private_bucket, "acme/package_extra/index.html") == "prefix"
   end
 
+  test "keeps the sitemap and docs_config.js the upload rewrites, and drops other old files" do
+    version = Version.parse!("1.0.0")
+    Hexpm.Store.put(:docs_bucket, "package/sitemap.xml", "old sitemap", [])
+    Hexpm.Store.put(:docs_bucket, "package/docs_config.js", "old config", [])
+    Hexpm.Store.put(:docs_bucket, "package/removed.html", "removed", [])
+    {dir, files} = create_files([{"index.html", "new"}])
+
+    Bucket.upload("hexpm", "package", version, [], MapSet.new(), dir, files)
+
+    assert Hexpm.Store.get(:docs_bucket, "package/sitemap.xml") == "old sitemap"
+    assert IO.iodata_to_binary(Hexpm.Store.get(:docs_bucket, "package/docs_config.js")) =~ "1.0.0"
+    refute Hexpm.Store.get(:docs_bucket, "package/removed.html")
+  end
+
   test "writes public docs to the existing docs bucket" do
     version = Version.parse!("1.0.0")
     {dir, files} = create_files([{"index.html", "public"}])

--- a/test/hexpm/hexdocs/workers_test.exs
+++ b/test/hexpm/hexdocs/workers_test.exs
@@ -92,32 +92,28 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     index = Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/index.html")
     etag = ~s("#{Base.encode16(:crypto.hash(:md5, index), case: :lower)}")
 
-    assert_enqueued(
-      worker: Hexpm.CDN.PurgeWorker,
-      args: %{
-        "service" => "fastly_hexdocs",
-        "keys" => ["docspage/verified_docs", "docspage/verified_docs/1.0.0"],
-        "verify" => [
-          %{"url" => "http://verified-docs.localhost:5002/1.0.0/index.html", "etag" => etag},
-          %{"url" => "http://verified-docs.localhost:5002/index.html", "etag" => etag}
-        ]
-      }
-    )
+    keys = ["docspage/verified_docs", "docspage/verified_docs/1.0.0"]
+
+    assert purge_args(keys) == %{
+             "service" => "fastly_hexdocs",
+             "keys" => keys,
+             "verify" => [
+               %{"url" => "http://verified-docs.localhost:5002/1.0.0/index.html", "etag" => etag},
+               %{"url" => "http://verified-docs.localhost:5002/index.html", "etag" => etag}
+             ]
+           }
 
     Ecto.Changeset.change(release, has_docs: false) |> Repo.update!()
     assert :ok = perform_job(Workers.Delete, %{key: key})
 
-    assert_enqueued(
-      worker: Hexpm.CDN.PurgeWorker,
-      args: %{
-        "service" => "fastly_hexdocs",
-        "keys" => ["docspage/verified_docs", "docspage/verified_docs/1.0.0"],
-        "verify" => [
-          %{"url" => "http://verified-docs.localhost:5002/1.0.0/index.html", "etag" => nil},
-          %{"url" => "http://verified-docs.localhost:5002/index.html", "etag" => nil}
-        ]
-      }
-    )
+    assert purge_args(keys) == %{
+             "service" => "fastly_hexdocs",
+             "keys" => keys,
+             "verify" => [
+               %{"url" => "http://verified-docs.localhost:5002/1.0.0/index.html", "etag" => nil},
+               %{"url" => "http://verified-docs.localhost:5002/index.html", "etag" => nil}
+             ]
+           }
   end
 
   test "upload succeeds for archives with write-protected file modes" do
@@ -247,14 +243,13 @@ defmodule Hexpm.Hexdocs.WorkersTest do
 
     etag = ~s("#{Base.encode16(:crypto.hash(:md5, sitemap), case: :lower)}")
 
-    assert_enqueued(
-      worker: Hexpm.CDN.PurgeWorker,
-      args: %{
-        "service" => "fastly_hexdocs",
-        "keys" => ["sitemap/#{package.name}"],
-        "verify" => [%{"url" => "http://sitemap-docs.localhost:5002/sitemap.xml", "etag" => etag}]
-      }
-    )
+    assert purge_args(["sitemap/#{package.name}"]) == %{
+             "service" => "fastly_hexdocs",
+             "keys" => ["sitemap/#{package.name}"],
+             "verify" => [
+               %{"url" => "http://sitemap-docs.localhost:5002/sitemap.xml", "etag" => etag}
+             ]
+           }
   end
 
   test "malformed archives fail so Oban can retry" do

--- a/test/hexpm/repository/policy_builder_test.exs
+++ b/test/hexpm/repository/policy_builder_test.exs
@@ -137,20 +137,17 @@ defmodule Hexpm.Repository.PolicyBuilderTest do
 
       etag = ~s("#{Base.encode16(:crypto.hash(:md5, stored), case: :lower)}")
 
-      assert_enqueued(
-        worker: Hexpm.CDN.PurgeWorker,
-        args: %{
-          "service" => "fastly_hexrepo",
-          "keys" => ["policy/#{org.name}/strict-prod"],
-          "verify" => [
-            %{
-              "url" => "http://localhost:5000/repos/#{org.name}/policies/strict-prod",
-              "etag" => etag,
-              "repository" => org.name
-            }
-          ]
-        }
-      )
+      assert purge_args(["policy/#{org.name}/strict-prod"]) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => ["policy/#{org.name}/strict-prod"],
+               "verify" => [
+                 %{
+                   "url" => "http://localhost:5000/repos/#{org.name}/policies/strict-prod",
+                   "etag" => etag,
+                   "repository" => org.name
+                 }
+               ]
+             }
     end
 
     test "verifies the purge of a public policy", %{organization: org, audit_data: audit_data} do
@@ -160,18 +157,16 @@ defmodule Hexpm.Repository.PolicyBuilderTest do
       stored = Hexpm.Store.get(:repo_bucket, "repos/#{org.name}/policies/open-pol", [])
       etag = ~s("#{Base.encode16(:crypto.hash(:md5, stored), case: :lower)}")
 
-      assert_enqueued(
-        worker: Hexpm.CDN.PurgeWorker,
-        args: %{
-          "keys" => ["policy/#{org.name}/open-pol"],
-          "verify" => [
-            %{
-              "url" => "http://localhost:5000/repos/#{org.name}/policies/open-pol",
-              "etag" => etag
-            }
-          ]
-        }
-      )
+      assert purge_args(["policy/#{org.name}/open-pol"]) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => ["policy/#{org.name}/open-pol"],
+               "verify" => [
+                 %{
+                   "url" => "http://localhost:5000/repos/#{org.name}/policies/open-pol",
+                   "etag" => etag
+                 }
+               ]
+             }
     end
 
     test "republishes a tab without the overrides an update removed",

--- a/test/hexpm/repository/registry_worker_test.exs
+++ b/test/hexpm/repository/registry_worker_test.exs
@@ -41,19 +41,18 @@ defmodule Hexpm.Repository.RegistryWorkerTest do
 
       assert [%{version: "0.0.1"}] = decoded.releases
 
-      assert_enqueued(
-        worker: PurgeWorker,
-        args: %{
-          "service" => "fastly_hexrepo",
-          "keys" => ["registry-package-#{package.name}", "registry-package/#{package.name}"],
-          "verify" => [
-            %{
-              "url" => "http://localhost:5000/packages/#{package.name}",
-              "etag" => etag("packages/#{package.name}")
-            }
-          ]
-        }
-      )
+      keys = ["registry-package-#{package.name}", "registry-package/#{package.name}"]
+
+      assert purge_args(keys) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => keys,
+               "verify" => [
+                 %{
+                   "url" => "http://localhost:5000/packages/#{package.name}",
+                   "etag" => etag("packages/#{package.name}")
+                 }
+               ]
+             }
     end
 
     test "verifies a private repository's object with its repository named" do
@@ -67,22 +66,22 @@ defmodule Hexpm.Repository.RegistryWorkerTest do
       key = "repos/#{repository.name}/packages/#{package.name}"
       assert registry(key)
 
-      assert_enqueued(
-        worker: PurgeWorker,
-        args: %{
-          "keys" => [
-            "registry-package-#{package.name}",
-            "registry-package/#{repository.name}/#{package.name}"
-          ],
-          "verify" => [
-            %{
-              "url" => "http://localhost:5000/#{key}",
-              "etag" => etag(key),
-              "repository" => repository.name
-            }
-          ]
-        }
-      )
+      keys = [
+        "registry-package-#{package.name}",
+        "registry-package/#{repository.name}/#{package.name}"
+      ]
+
+      assert purge_args(keys) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => keys,
+               "verify" => [
+                 %{
+                   "url" => "http://localhost:5000/#{key}",
+                   "etag" => etag(key),
+                   "repository" => repository.name
+                 }
+               ]
+             }
     end
 
     test "discards the job when the package is gone", %{package: package} do
@@ -269,15 +268,15 @@ defmodule Hexpm.Repository.RegistryWorkerTest do
 
       refute Hexpm.Store.get(:repo_bucket, "packages/#{package.name}", [])
 
-      assert_enqueued(
-        worker: PurgeWorker,
-        args: %{
-          "keys" => ["registry-package-#{package.name}", "registry-package/#{package.name}"],
-          "verify" => [
-            %{"url" => "http://localhost:5000/packages/#{package.name}", "etag" => nil}
-          ]
-        }
-      )
+      keys = ["registry-package-#{package.name}", "registry-package/#{package.name}"]
+
+      assert purge_args(keys) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => keys,
+               "verify" => [
+                 %{"url" => "http://localhost:5000/packages/#{package.name}", "etag" => nil}
+               ]
+             }
     end
   end
 
@@ -289,16 +288,17 @@ defmodule Hexpm.Repository.RegistryWorkerTest do
       {:ok, names} = :hex_registry.decode_names(registry("names"), "hexpm")
       assert Enum.any?(names.packages, &(&1.name == package.name))
 
-      assert_enqueued(
-        worker: PurgeWorker,
-        args: %{
-          "keys" => ["registry-index"],
-          "verify" => [
-            %{"url" => "http://localhost:5000/names", "etag" => etag("names")},
-            %{"url" => "http://localhost:5000/versions", "etag" => etag("versions")}
-          ]
-        }
-      )
+      assert purge_args(["registry-index"]) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => ["registry-index"],
+               "verify" => [
+                 %{"url" => "http://localhost:5000/names", "etag" => etag("names")},
+                 %{"url" => "http://localhost:5000/versions", "etag" => etag("versions")}
+               ]
+             }
+
+      assert [%{args: %{"verify" => [%{"write" => write}, %{"write" => write}]}}] =
+               all_enqueued(worker: PurgeWorker)
     end
   end
 
@@ -309,16 +309,14 @@ defmodule Hexpm.Repository.RegistryWorkerTest do
 
       assert registry("packages/#{package.name}")
 
-      assert_enqueued(
-        worker: PurgeWorker,
-        args: %{
-          "keys" => ["registry"],
-          "verify" => [
-            %{"url" => "http://localhost:5000/names", "etag" => etag("names")},
-            %{"url" => "http://localhost:5000/versions", "etag" => etag("versions")}
-          ]
-        }
-      )
+      assert purge_args(["registry"]) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => ["registry"],
+               "verify" => [
+                 %{"url" => "http://localhost:5000/names", "etag" => etag("names")},
+                 %{"url" => "http://localhost:5000/versions", "etag" => etag("versions")}
+               ]
+             }
     end
   end
 

--- a/test/hexpm/repository/releases_test.exs
+++ b/test/hexpm/repository/releases_test.exs
@@ -253,19 +253,16 @@ defmodule Hexpm.Repository.ReleasesTest do
                &match?(%{version: "0.1.0"}, &1)
              )
 
-      assert_enqueued(
-        worker: Hexpm.CDN.PurgeWorker,
-        args: %{
-          "service" => "fastly_hexrepo",
-          "keys" => ["tarballs/#{name}-0.1.0"],
-          "verify" => [
-            %{
-              "url" => "http://localhost:5000/tarballs/#{name}-0.1.0.tar",
-              "etag" => ~s("#{Base.encode16(:crypto.hash(:md5, tarball), case: :lower)}")
-            }
-          ]
-        }
-      )
+      assert purge_args(["tarballs/#{name}-0.1.0"]) == %{
+               "service" => "fastly_hexrepo",
+               "keys" => ["tarballs/#{name}-0.1.0"],
+               "verify" => [
+                 %{
+                   "url" => "http://localhost:5000/tarballs/#{name}-0.1.0.tar",
+                   "etag" => ~s("#{Base.encode16(:crypto.hash(:md5, tarball), case: :lower)}")
+                 }
+               ]
+             }
     end
 
     test "publish private package with public dependency", %{

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -2,6 +2,23 @@ defmodule Hexpm.TestHelpers do
   @tmp Application.compile_env(:hexpm, :tmp_dir)
 
   @doc """
+  The arguments of the newest purge job enqueued for `keys`, with the write
+  number every target must carry taken out, so a test can compare the rest
+  against a literal.
+  """
+  def purge_args(keys) do
+    jobs =
+      Oban.Testing.all_enqueued(Hexpm.RepoBase,
+        worker: Hexpm.CDN.PurgeWorker,
+        args: %{"keys" => keys}
+      )
+
+    %{args: args} = Enum.max_by(jobs, & &1.id)
+    true = Enum.all?(args["verify"], &is_integer(&1["write"]))
+    update_in(args["verify"], &Enum.map(&1, fn target -> Map.delete(target, "write") end))
+  end
+
+  @doc """
   Captures logs down to debug, including Ecto's query log.
 
   `capture_log/2`'s `:level` option filters what it keeps; it does not lower


### PR DESCRIPTION
In the week to 2026-09-02 `hexpm_cdn_verify_total` on prod showed 923 stale probes and 77 errors. None of the stale results was a purge that failed to apply: every one was a target whose URL a newer purge job already covered (the next publish 0.2 to 4.5 s later had rewritten `/names`, `/versions`, `/packages/<name>` or the docs sitemap) and the ETag the CDN served was that newer write's. The errors were one hexdocs job that could never pass, one sitemap served as 404 for 54 s after it was written, and `Mint.TransportError{reason: :closed}` on pooled connections. One commit per change.

The check no longer compares ETags. Every write that enqueues a purge takes the next value of a `cdn_writes` sequence, stores it as the object's `write` metadata and puts it on the verification target; the Compute services forward the metadata as `x-cache-write` (hexpm/hexpm-ops#307, which has to ship first, though until it does the header is missing and the check falls back to the ETag rule). A POP passes when the number it serves is at or past the target's and is stale when it is lower or missing. A later write of the same object only raises the number, so a check that runs after the next write sees a current copy rather than a false stale, whatever the timing between the two jobs; the superseded-job query and its dependence on job ids matching write order go away, and `result=stale` in the metric means a POP served something older than the write. A deleted target passes on 404, on the organization docs redirect, or on a copy numbered after the deletion. Absorbed jobs keep the higher number per URL rather than the later position, so a retried older job absorbed by a newer one no longer overwrites the newer expectation.

Where the number cannot decide, a newer purge job for the URL settles it, as the superseded check did before: a copy without a number (cached before the deploy, or written by a worker still on the previous release during the rollout) is judged by ETag, and a target that expected content but gets a 404 or the organization redirect may be looking at a deletion made after its write. In both cases the target is dropped when a newer job for the URL exists and that job's check covers it; a 404 no newer job explains is still re-purged, since it may be a cached negative entry. The site-wide docs objects (the sitemap index, `package_names.csv`) and each package sitemap are written by any pod, so their render, number and put now run under an advisory lock on the object, keeping the number in write order and the content the newest render.

A deleted-page target passes on a 301 whose Location is the same path on the organization docs host. That is what the hexdocs Compute service answers when the subdomain names an organization that is no longer a public package; job 542327 (docs removed for `riddler` and `asimov`, both organization names) raised through five attempts on it and was discarded.

The stale and status reasons carry `x-cache-served-by`, `x-cache`, `x-cache-age` and `x-cache-hits` instead of the served-by header alone, in the `CDN_PURGE_STALE` line and the `PurgeVerificationError` message, so a cached negative entry can be told from a fresh origin 404 next time.

`delete_old_docs/5` deleted `docs_config.js`, and on the public site the sitemap, a second before the same upload rewrote them; both stay in place now (a private package's sitemap comes from its archive and is still removed with the other old files). A request in that second, the purge check of an earlier docs job included, got a 404 that the CDN then cached for 60 s.

The Finch pool for repo.hex.pm closes a connection that has been idle for more than 5 s at checkout. The `:closed` errors (34 on repo.hex.pm in the week, 10 of them on the nearest fetch, each of which costs a purge round) all followed a gap of 64 s or more since the pod last talked to that host, none followed a gap under 60 s, and some came in pairs at the same millisecond for the same URL. The other hosts keep Finch's defaults: api.fastly.com made 30k requests from the same pods in the same week with no closed connection, and the rest show none either (`hexpm_prom_ex_outbound_http_request_total` by host and status). This is the known Finch race in sneako/finch#272, for which `conn_max_idle_time` is the upstream-recommended setting.

Two things this does not cover. Two docs publishes of the same package on two pods can write the unversioned pages in either order, and the check would then report the origin holding the earlier write; serialising those needs a lock that doesn't hold a transaction for the whole upload. And `promote/6` still deletes `docs_config.js` without rewriting it.
