### PR TITLE
Reject control characters in return paths

### DIFF
--- a/lib/hexpm_web/controllers/controller_helpers.ex
+++ b/lib/hexpm_web/controllers/controller_helpers.ex
@@ -599,9 +599,14 @@ defmodule HexpmWeb.ControllerHelpers do
   #   * tab, LF and CR are stripped while parsing a URL, so `/<TAB>/evil.com`
   #     resolves as `//evil.com` (the bypass behind CVE-2026-64941). LF and CR
   #     would also split a Location header.
-  #   * `%2f` and `%5c` are the encoded spellings, rejected so that a later
-  #     decoding step downstream cannot reintroduce the leading `//`.
-  @invalid_return_path_chars ["\\", "\t", "\n", "\r", "%09", "%2f", "%2F", "%5c", "%5C"]
+  #   * `%2f`, `%5c` and `%09` are the encoded spellings, rejected so that a
+  #     later decoding step downstream cannot reintroduce the leading `//`.
+  #
+  # The whole C0 range and DEL go with them: none belong in a path, and
+  # `Plug.Conn.put_resp_header/3` raises on NUL, LF and CR rather than
+  # redirecting, which surfaces as a 500.
+  @control_chars Enum.map(Enum.to_list(0x00..0x1F) ++ [0x7F], &<<&1>>)
+  @invalid_return_path_chars ["\\", "%09", "%2f", "%2F", "%5c", "%5C"] ++ @control_chars
 
   @doc """
   Returns the value if it is a local path, otherwise returns nil.

--- a/test/hexpm_web/controllers/login_controller_test.exs
+++ b/test/hexpm_web/controllers/login_controller_test.exs
@@ -77,7 +77,11 @@ defmodule HexpmWeb.LoginControllerTest do
         {"line feed", "/\n/evil.com"},
         {"carriage return", "/\r/evil.com"},
         {"CRLF", "/\r\n/evil.com"},
-        {"header injection", "/dashboard\r\nSet-Cookie: x=1"}
+        {"header injection", "/dashboard\r\nSet-Cookie: x=1"},
+        {"null byte", "/dashboard\0"},
+        {"vertical tab", "/dashboard\v"},
+        {"form feed", "/dashboard\f"},
+        {"delete", "/dashboard\d"}
       ] do
     test "log in refuses to redirect off-site via a #{label} return path", c do
       conn =

--- a/test/hexpm_web/controllers/tfa_auth_controller_test.exs
+++ b/test/hexpm_web/controllers/tfa_auth_controller_test.exs
@@ -75,36 +75,35 @@ defmodule HexpmWeb.TFAAuthControllerTest do
       assert redirected_to(conn) == "/"
     end
 
-    test "with valid token and non-path return falls back to user profile", c do
-      token = Hexpm.Accounts.TFA.time_based_token(c.user.tfa.secret)
+    # The return value reaches the session from the login form, so the same
+    # unsafe spellings rejected in HexpmWeb.LoginControllerTest have to be
+    # rejected again here, on the way out of the TFA step.
+    for {label, return} <- [
+          {"absolute URL", "https%3A%2F%2Fhex.pm%2Foauth%2Fauthorize%3Fclient_id%3Dabc"},
+          {"protocol-relative", "//evil.com"},
+          {"backslash", "/\\evil.com"},
+          {"encoded slash", "/%2fevil.com"},
+          {"tab", "/\t/evil.com"},
+          {"encoded tab", "/%09/evil.com"},
+          {"CRLF", "/\r\n/evil.com"},
+          {"null byte", "/dashboard\0"},
+          {"delete", "/dashboard\d"}
+        ] do
+      test "with valid token and #{label} return falls back to user profile", c do
+        token = Hexpm.Accounts.TFA.time_based_token(c.user.tfa.secret)
 
-      conn =
-        build_conn()
-        |> test_login(c.user)
-        |> put_session("tfa_user_id", %{
-          "uid" => c.user.id,
-          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
-          "return" => "https%3A%2F%2Fhex.pm%2Foauth%2Fauthorize%3Fclient_id%3Dabc"
-        })
-        |> post("/tfa", %{"code" => token})
+        conn =
+          build_conn()
+          |> test_login(c.user)
+          |> put_session("tfa_user_id", %{
+            "uid" => c.user.id,
+            "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now()),
+            "return" => unquote(return)
+          })
+          |> post("/tfa", %{"code" => token})
 
-      assert redirected_to(conn) == "/users/#{c.user.username}"
-    end
-
-    test "with valid token and protocol-relative return falls back to user profile", c do
-      token = Hexpm.Accounts.TFA.time_based_token(c.user.tfa.secret)
-
-      conn =
-        build_conn()
-        |> test_login(c.user)
-        |> put_session("tfa_user_id", %{
-          "uid" => c.user.id,
-          "return" => "//evil.com",
-          "at" => NaiveDateTime.to_iso8601(NaiveDateTime.utc_now())
-        })
-        |> post("/tfa", %{"code" => token})
-
-      assert redirected_to(conn) == "/users/#{c.user.username}"
+        assert redirected_to(conn) == "/users/#{c.user.username}"
+      end
     end
 
     test "redirects to login after too many failed attempts", c do


### PR DESCRIPTION
`safe_return_path/1` rejected tab, LF and CR but not NUL. Plug's `put_resp_header/3` raises `Plug.Conn.InvalidHeaderError` on NUL, LF and CR, and Phoenix's `validate_local_url` only catches `\`, `/%09` and `/\t`, so a return path ending in a null byte passed both checks and then raised while setting the Location header, which renders as a 500. Rejects the whole C0 range and DEL instead.

The two standalone TFA return path tests are folded into a table matching the one in `LoginControllerTest`, covering the control characters at both the login and TFA consume sites.
