### PR TITLE
Count refused checkouts and connection churn as metrics

### DIFF
--- a/lib/hexpm/application.ex
+++ b/lib/hexpm/application.ex
@@ -183,6 +183,7 @@ defmodule Hexpm.Application do
   defp common_children(write_mode?) do
     [
       Hexpm.PromEx,
+      {DBConnection.TelemetryListener, name: Hexpm.RepoBase.TelemetryListener},
       Hexpm.RepoBase,
       {Finch, name: Hexpm.Finch, pools: finch_pools()},
       Hexpm.TmpDir,

--- a/lib/hexpm/prom_ex.ex
+++ b/lib/hexpm/prom_ex.ex
@@ -12,6 +12,7 @@ defmodule Hexpm.PromEx do
       {Plugins.Ecto, repos: [Hexpm.RepoBase]},
       Hexpm.PromEx.Plugins.Hexpm,
       Hexpm.PromEx.Plugins.EctoLatency,
+      Hexpm.PromEx.Plugins.DbConnection,
       Hexpm.PromEx.Plugins.OutboundHttp,
       Hexpm.PromEx.Plugins.Email
     ] ++ oban_plugins()

--- a/lib/hexpm/prom_ex/plugins/db_connection.ex
+++ b/lib/hexpm/prom_ex/plugins/db_connection.ex
@@ -1,0 +1,45 @@
+defmodule Hexpm.PromEx.Plugins.DbConnection do
+  @moduledoc """
+  PromEx plugin for the database connection pool: refused checkouts and
+  connection churn.
+
+  `[:db_connection, :connection_error]` fires where the pool gives up on a
+  checkout. The reason is `:queue_timeout` when the caller waited out the queue
+  and `:error` when there was no connection to wait for. Connects and
+  disconnects come from the `DBConnection.TelemetryListener` the repo is
+  started with.
+  """
+
+  use PromEx.Plugin
+
+  @impl true
+  def event_metrics(opts) do
+    otp_app = Keyword.fetch!(opts, :otp_app)
+
+    metric_prefix =
+      Keyword.get(opts, :metric_prefix, PromEx.metric_prefix(otp_app, :db_connection))
+
+    Event.build(:hexpm_db_connection_event_metrics, [
+      counter(
+        metric_prefix ++ [:connection_error, :total],
+        event_name: [:db_connection, :connection_error],
+        description: "Connection checkouts the pool refused, by reason.",
+        tags: [:reason],
+        tag_values: &__MODULE__.error_tags/1
+      ),
+      counter(
+        metric_prefix ++ [:connected, :total],
+        event_name: [:db_connection, :connected],
+        description: "Database connections established."
+      ),
+      counter(
+        metric_prefix ++ [:disconnected, :total],
+        event_name: [:db_connection, :disconnected],
+        description: "Database connections lost or closed."
+      )
+    ])
+  end
+
+  def error_tags(%{error: %DBConnection.ConnectionError{reason: reason}}), do: %{reason: reason}
+  def error_tags(_metadata), do: %{reason: :unknown}
+end

--- a/lib/hexpm/repo.ex
+++ b/lib/hexpm/repo.ex
@@ -122,6 +122,8 @@ defmodule Hexpm.RepoBase do
   def advisory_lock_key(key), do: Map.fetch!(@advisory_locks, key)
 
   def init(_reason, opts) do
+    opts = put_connection_listener(opts)
+
     if url = System.get_env("HEXPM_DATABASE_URL") do
       pool_size_env = System.get_env("HEXPM_DATABASE_POOL_SIZE")
       pool_size = if pool_size_env, do: String.to_integer(pool_size_env), else: opts[:pool_size]
@@ -134,6 +136,17 @@ defmodule Hexpm.RepoBase do
       {:ok, opts}
     else
       {:ok, opts}
+    end
+  end
+
+  # The listener runs in the application tree. A repo started on its own, as
+  # the release tasks do, has nobody to notify, and a name that is not
+  # registered would crash every connection that tries.
+  defp put_connection_listener(opts) do
+    if Process.whereis(__MODULE__.TelemetryListener) do
+      Keyword.put(opts, :connection_listeners, {[__MODULE__.TelemetryListener], __MODULE__})
+    else
+      opts
     end
   end
 

--- a/test/hexpm/prom_ex/plugins/db_connection_test.exs
+++ b/test/hexpm/prom_ex/plugins/db_connection_test.exs
@@ -1,0 +1,54 @@
+defmodule Hexpm.PromEx.Plugins.DbConnectionTest do
+  use ExUnit.Case, async: true
+
+  alias Hexpm.PromEx.Plugins.DbConnection
+
+  test "tags a refused checkout by its reason" do
+    error = DBConnection.ConnectionError.exception("connection not available", :queue_timeout)
+
+    assert DbConnection.error_tags(%{error: error}) == %{reason: :queue_timeout}
+  end
+
+  test "counts an error without a reason rather than dropping it" do
+    assert DbConnection.error_tags(%{error: :closed}) == %{reason: :unknown}
+  end
+
+  test "attaches to the pool and listener events" do
+    events =
+      [otp_app: :hexpm]
+      |> DbConnection.event_metrics()
+      |> List.wrap()
+      |> Enum.flat_map(& &1.metrics)
+      |> Enum.map(& &1.event_name)
+      |> Enum.uniq()
+
+    assert [:db_connection, :connection_error] in events
+    assert [:db_connection, :connected] in events
+    assert [:db_connection, :disconnected] in events
+  end
+
+  test "the repo notifies the listener the application started" do
+    assert Hexpm.RepoBase.config()[:connection_listeners] ==
+             {[Hexpm.RepoBase.TelemetryListener], Hexpm.RepoBase}
+  end
+
+  test "the listener reports connections the repo opens and closes" do
+    ref = make_ref()
+    parent = self()
+
+    :telemetry.attach_many(
+      {__MODULE__, ref},
+      [[:db_connection, :connected], [:db_connection, :disconnected]],
+      fn event, _measurements, metadata, _config -> send(parent, {ref, event, metadata.tag}) end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+    {:ok, repo} = Hexpm.RepoBase.start_link(name: __MODULE__.Repo, pool_size: 1)
+    assert_receive {^ref, [:db_connection, :connected], Hexpm.RepoBase}, 5_000
+
+    Supervisor.stop(repo)
+    assert_receive {^ref, [:db_connection, :disconnected], Hexpm.RepoBase}, 5_000
+  end
+end


### PR DESCRIPTION
DBConnection emits `[:db_connection, :connection_error]` where the pool gives up on a checkout, with the reason (`:queue_timeout` or `:error`), and `DBConnection.TelemetryListener` emits `connected` and `disconnected` for every connection process. A PromEx plugin turns them into three counters (connection errors by reason, connections established, connections lost) so a saturated pool or a connection storm can be alerted on from Prometheus instead of from the log-line policies in Cloud Monitoring.

The listener runs in the application supervision tree and the repo only registers it when the listener process is running: a repo started on its own, as the release tasks do, would otherwise crash every connection on `send/2` to an unregistered name.

The Prometheus rules that read these counters are in hexpm/hexpm-ops#300.
