### PR TITLE
Count API authentication by scheme and result

### DIFF
--- a/lib/hexpm/prom_ex/plugins/hexpm.ex
+++ b/lib/hexpm/prom_ex/plugins/hexpm.ex
@@ -2,9 +2,9 @@ defmodule Hexpm.PromEx.Plugins.Hexpm do
   @moduledoc """
   PromEx plugin for hex.pm business metrics: the domain events emitted from
   the contexts (see `Hexpm.Repository.Releases` and `Hexpm.Accounts.Users`),
-  registry builds (`Hexpm.Repository.RegistryWorker`) and CDN purges
-  (`Hexpm.CDN.PurgeWorker`, `Hexpm.CDN.Fastly`), and the number of Erlang
-  nodes this node is connected to.
+  API authentication (`HexpmWeb.AuthHelpers`), registry builds
+  (`Hexpm.Repository.RegistryWorker`) and CDN purges (`Hexpm.CDN.PurgeWorker`,
+  `Hexpm.CDN.Fastly`), and the number of Erlang nodes this node is connected to.
   """
 
   use PromEx.Plugin
@@ -42,6 +42,13 @@ defmodule Hexpm.PromEx.Plugins.Hexpm do
           unit: {:native, :millisecond},
           reporter_options: [buckets: [10, 50, 100, 500, 1000, 5000, 30_000]],
           description: "Time spent matching a release's files."
+        )
+      ]),
+      Event.build(:hexpm_api_event_metrics, [
+        counter("hexpm.api.authenticate.total",
+          event_name: [:hexpm, :api, :authenticate],
+          description: "API requests that carried an Authorization header, by scheme and result.",
+          tags: [:scheme, :result]
         )
       ]),
       Event.build(:hexpm_registry_builder_event_metrics, [

--- a/lib/hexpm_web/auth_helpers.ex
+++ b/lib/hexpm_web/auth_helpers.ex
@@ -223,21 +223,31 @@ defmodule HexpmWeb.AuthHelpers do
 
   def authenticate_at(conn, now) do
     case get_req_header(conn, "authorization") do
-      ["Basic " <> credentials] ->
-        if BasicAuth.disabled?(now) do
-          {:error, :basic_auth_disabled}
-        else
-          basic_auth(credentials)
-        end
+      ["Basic " <> credentials] -> credentials |> basic_auth(now) |> report(:basic)
+      ["Bearer " <> token] -> token |> oauth_token_auth(conn) |> report(:bearer)
+      [key] -> key |> key_auth(conn) |> report(:key)
+      _ -> {:error, :missing}
+    end
+  end
 
-      ["Bearer " <> token] ->
-        oauth_token_auth(token, conn)
+  defp report(result, scheme) do
+    :telemetry.execute(
+      [:hexpm, :api, :authenticate],
+      %{count: 1},
+      %{scheme: scheme, result: result_tag(result)}
+    )
 
-      [key] ->
-        key_auth(key, conn)
+    result
+  end
 
-      _ ->
-        {:error, :missing}
+  defp result_tag({:ok, _}), do: :ok
+  defp result_tag({:error, reason}), do: reason
+
+  defp basic_auth(credentials, now) do
+    if BasicAuth.disabled?(now) do
+      {:error, :basic_auth_disabled}
+    else
+      basic_auth(credentials)
     end
   end
 

--- a/test/hexpm/prom_ex/plugins/hexpm_test.exs
+++ b/test/hexpm/prom_ex/plugins/hexpm_test.exs
@@ -3,6 +3,16 @@ defmodule Hexpm.PromEx.Plugins.HexpmTest do
 
   alias Hexpm.PromEx.Plugins.Hexpm, as: Plugin
 
+  test "counts API authentication by scheme and result" do
+    [counter] =
+      [otp_app: :hexpm]
+      |> Plugin.event_metrics()
+      |> Enum.flat_map(& &1.metrics)
+      |> Enum.filter(&(&1.event_name == [:hexpm, :api, :authenticate]))
+
+    assert %Telemetry.Metrics.Counter{tags: [:scheme, :result]} = counter
+  end
+
   test "measures the number of connected nodes" do
     ref = make_ref()
     parent = self()

--- a/test/hexpm_web/auth_helpers_test.exs
+++ b/test/hexpm_web/auth_helpers_test.exs
@@ -65,6 +65,56 @@ defmodule HexpmWeb.AuthHelpersTest do
     assert oauth_user.id == user.id
   end
 
+  test "counts every request carrying credentials by scheme and result", %{user: user} do
+    ref = make_ref()
+
+    :telemetry.attach(
+      {__MODULE__, ref},
+      [:hexpm, :api, :authenticate],
+      &__MODULE__.forward_event/4,
+      %{pid: self(), ref: ref}
+    )
+
+    on_exit(fn -> :telemetry.detach({__MODULE__, ref}) end)
+
+    now = ~U[2026-09-30 23:59:59Z]
+    basic = "Basic " <> Base.encode64("#{user.username}:password")
+
+    user |> auth_conn(basic) |> AuthHelpers.authenticate_at(now)
+    assert_receive {^ref, %{count: 1}, %{scheme: :basic, result: :ok}}
+
+    user |> auth_conn(basic) |> AuthHelpers.authenticate_at(~U[2026-10-01 00:00:00Z])
+    assert_receive {^ref, %{count: 1}, %{scheme: :basic, result: :basic_auth_disabled}}
+
+    user
+    |> auth_conn("Basic " <> Base.encode64("#{user.username}:wrong"))
+    |> AuthHelpers.authenticate_at(now)
+
+    assert_receive {^ref, %{count: 1}, %{scheme: :basic, result: :password}}
+
+    user |> auth_conn("Basic not-base64") |> AuthHelpers.authenticate_at(now)
+    assert_receive {^ref, %{count: 1}, %{scheme: :basic, result: :invalid}}
+
+    key = Key.build(user, %{name: "api-key"}) |> Repo.insert!()
+    user |> auth_conn(key.user_secret) |> AuthHelpers.authenticate_at(now)
+    assert_receive {^ref, %{count: 1}, %{scheme: :key, result: :ok}}
+
+    user |> auth_conn("no-such-key") |> AuthHelpers.authenticate_at(now)
+    assert_receive {^ref, %{count: 1}, %{scheme: :key, result: :key}}
+
+    user |> auth_conn("Bearer no-such-token") |> AuthHelpers.authenticate_at(now)
+    assert_receive {^ref, %{count: 1}, %{scheme: :bearer, result: :key}}
+
+    assert {:error, :missing} = AuthHelpers.authenticate_at(build_conn(), now)
+    refute_received {^ref, _, _}
+  end
+
+  # Only events the test process itself executes are forwarded, so key and
+  # token authentication in concurrently running tests never reach the mailbox.
+  def forward_event(_event, measurements, metadata, %{pid: pid, ref: ref}) do
+    if self() == pid, do: send(pid, {ref, measurements, metadata})
+  end
+
   defp auth_conn(user, authorization) do
     build_conn()
     |> fetch_query_params()


### PR DESCRIPTION
The Basic authentication brownouts start on 1 October 2026 and nothing counts Basic auth requests or their rejections. This emits `[:hexpm, :api, :authenticate]` from `HexpmWeb.AuthHelpers.authenticate_at/2` for every request that carries an Authorization header, tagged with the scheme (`basic`, `bearer`, `key`) and the result (`ok` or the refusal reason: `basic_auth_disabled`, `password`, `invalid`, `key`, `revoked_key`), and exposes it as the `hexpm_api_authenticate_total` counter through PromEx. Requests without an Authorization header emit nothing.

The `basic`/`ok` series is the baseline before the brownouts and `basic`/`basic_auth_disabled` is what each window rejects. The dashboard panels are in hexpm-ops.
