### PR TITLE
Decide the latest docs version under a per-package lock

### DIFF
--- a/lib/hexpm/hexdocs/bucket.ex
+++ b/lib/hexpm/hexdocs/bucket.ex
@@ -42,38 +42,62 @@ defmodule Hexpm.Hexdocs.Bucket do
 
   # Every docs upload, on any pod, writes these objects, so the render, the
   # write number and the put run under a lock on the object: the number is
-  # then in write order and the content is the newest render.
+  # then in write order and the content is the newest render. Under the
+  # package lock of `Hexpm.Hexdocs` the object lock joins that transaction
+  # rather than nesting one, so a failure here reaches that lock's handling
+  # and the purge jobs of the pages already written still commit.
   defp upload_content(key, path, content_type, render, url) do
-    {:ok, :ok} =
-      Hexpm.Repo.transaction(
-        fn ->
-          Hexpm.Repo.advisory_xact_lock(:hexdocs,
-            sub_key: :erlang.phash2(path),
-            timeout: @lock_timeout
-          )
+    locked_on(path, fn ->
+      write = Hexpm.CDN.next_write()
 
-          write = Hexpm.CDN.next_write()
+      opts = [
+        content_type: content_type,
+        cache_control: "public, max-age=3600",
+        meta: [{"surrogate-key", key}, {"write", Integer.to_string(write)}]
+      ]
 
-          opts = [
-            content_type: content_type,
-            cache_control: "public, max-age=3600",
-            meta: [{"surrogate-key", key}, {"write", Integer.to_string(write)}]
-          ]
+      {:ok, %{etag: etag}} = Hexpm.Store.put(:docs_bucket, path, render.(), opts)
+      purge("hexpm", [key], [%{url: url, etag: etag, write: write}])
+    end)
+  end
 
-          {:ok, %{etag: etag}} = Hexpm.Store.put(:docs_bucket, path, render.(), opts)
-          purge("hexpm", [key], [%{url: url, etag: etag, write: write}])
-        end,
+  defp locked_on(path, fun) do
+    locked = fn ->
+      Hexpm.Repo.advisory_xact_lock(:hexdocs,
+        sub_key: :erlang.phash2(path),
         timeout: @lock_timeout
       )
 
-    :ok
+      fun.()
+    end
+
+    if Hexpm.Repo.in_transaction?() do
+      locked.()
+    else
+      {:ok, result} = Hexpm.Repo.transaction(locked, timeout: @lock_timeout)
+      result
+    end
   end
 
-  def upload(repository, package, version, all_versions, retired_versions, dir, files) do
-    upload_type =
-      if Utils.latest_version?(package, version, all_versions), do: :both, else: :versioned
+  @doc "Writes the pages of `version` under its own prefix and removes its files no longer in it."
+  def upload_versioned(repository, package, version, dir, files) do
+    uploads = list_upload_files(repository, package, version, dir, files, :versioned)
+    paths = MapSet.new(uploads, &elem(&1, 0))
+    write = Hexpm.CDN.next_write()
+    uploaded = upload_new_files(uploads, write)
+    delete_old_docs(repository, package, [version], paths, :versioned)
+    targets = page_targets(repository, uploaded, write)
+    purge_hexdocs_cache(repository, package, [version], :versioned, targets)
+  end
 
-    upload_files = list_upload_files(repository, package, version, dir, files, upload_type)
+  @doc """
+  Writes the pages of `version` as the package's unversioned pages and
+  removes the unversioned files no longer in it. `version` must be the
+  latest, decided under the package's lock in `Hexpm.Hexdocs`, where this
+  runs.
+  """
+  def upload_unversioned(repository, package, version, dir, files) do
+    uploads = list_upload_files(repository, package, version, dir, files, :unversioned)
 
     # docs_config.js, and on the public site the sitemap, are rewritten by
     # this same upload, so they stay in place rather than being missing
@@ -82,14 +106,19 @@ defmodule Hexpm.Hexdocs.Bucket do
       if repository == "hexpm", do: ["docs_config.js", "sitemap.xml"], else: ["docs_config.js"]
 
     paths =
-      Enum.reduce(rewritten, MapSet.new(upload_files, &elem(&1, 0)), fn file, paths ->
+      Enum.reduce(rewritten, MapSet.new(uploads, &elem(&1, 0)), fn file, paths ->
         MapSet.put(paths, repository_path(repository, Path.join(package, file)))
       end)
 
     write = Hexpm.CDN.next_write()
-    uploaded = upload_new_files(upload_files, write)
-    delete_old_docs(repository, package, [version], paths, upload_type)
+    uploaded = upload_new_files(uploads, write)
+    delete_old_docs(repository, package, [], paths, :unversioned)
+    targets = page_targets(repository, uploaded, write)
+    purge_hexdocs_cache(repository, package, [], :unversioned, targets)
+  end
 
+  @doc "Writes the package's docs_config.js, the version list every page loads, debounced."
+  def upload_docs_config(repository, package, version, all_versions, retired_versions, dir, files) do
     Debouncer.debounce(Debouncer, {:docs_config, repository, package}, @gcs_put_debounce, fn ->
       config =
         build_docs_config(
@@ -104,14 +133,6 @@ defmodule Hexpm.Hexdocs.Bucket do
 
       upload_new_files([config], Hexpm.CDN.next_write())
     end)
-
-    purge_hexdocs_cache(
-      repository,
-      package,
-      [version],
-      upload_type,
-      page_targets(repository, uploaded, write)
-    )
 
     purge(repository, [docs_config_cdn_key(repository, package)])
   end
@@ -285,11 +306,11 @@ defmodule Hexpm.Hexdocs.Bucket do
 
     existing =
       case {upload_type, versions} do
-        {:both, _} ->
-          Hexpm.Store.list(bucket, repository_path(repository, "#{package}/"))
-
         {:versioned, [version]} ->
           Hexpm.Store.list(bucket, repository_path(repository, "#{package}/#{version}/"))
+
+        {_both_or_unversioned, _} ->
+          Hexpm.Store.list(bucket, repository_path(repository, "#{package}/"))
       end
 
     keys =
@@ -339,6 +360,10 @@ defmodule Hexpm.Hexdocs.Bucket do
 
   defp purge_hexdocs_cache(repository, package, versions, :versioned, targets) do
     purge(repository, Enum.map(versions, &versioned_cdn_key(repository, package, &1)), targets)
+  end
+
+  defp purge_hexdocs_cache(repository, package, [], :unversioned, targets) do
+    purge(repository, [unversioned_cdn_key(repository, package)], targets)
   end
 
   defp versioned_cdn_key(repository, package, version),

--- a/lib/hexpm/hexdocs/hexdocs.ex
+++ b/lib/hexpm/hexdocs/hexdocs.ex
@@ -7,6 +7,7 @@ defmodule Hexpm.Hexdocs do
   @special_packages Application.compile_env!(:hexpm, :hexdocs_special_packages)
   @special_package_names Map.keys(@special_packages)
   @gcs_put_debounce Application.compile_env!(:hexpm, :hexdocs_gcs_put_debounce)
+  @lock_timeout :timer.minutes(4)
 
   # ExDoc marks these `noindex`, so listing them asks a crawler to fetch a page
   # it has been told not to keep.
@@ -24,20 +25,57 @@ defmodule Hexpm.Hexdocs do
     start = System.monotonic_time(:millisecond)
     Logger.info("UPLOAD #{key}")
 
-    {version, all_versions, retired_versions} = versions(repository, package, version)
+    version = parse_version(package, version)
     {dir, files, checksum} = download_and_unpack!(key, repository, package, version)
     FileRewriter.rewrite_files(dir, files)
-    Bucket.upload(repository, package, version, all_versions, retired_versions, dir, files)
-    ensure_archive_current!(key, checksum)
 
-    if Utils.latest_version?(package, version, all_versions) do
-      update_index_sitemap(repository, key)
-      update_package_sitemap(repository, key, package, files)
-      update_package_names_csv(repository)
+    outcome =
+      locked(repository, package, fn ->
+        case archive_state(key, checksum) do
+          :current ->
+            {all_versions, retired_versions} = versions(repository, package)
+            latest? = Utils.latest_version?(package, version, all_versions)
+            Bucket.upload_versioned(repository, package, version, dir, files)
+
+            if latest? do
+              Bucket.upload_unversioned(repository, package, version, dir, files)
+              update_package_sitemap(repository, key, package, files)
+            end
+
+            Bucket.upload_docs_config(
+              repository,
+              package,
+              version,
+              all_versions,
+              retired_versions,
+              dir,
+              files
+            )
+
+            {:uploaded, latest?}
+
+          :changed ->
+            raise StaleArchiveError, key: key
+
+          :missing ->
+            :removed
+        end
+      end)
+
+    case outcome do
+      {:uploaded, latest?} ->
+        if latest? do
+          update_index_sitemap(repository, key)
+          update_package_names_csv(repository)
+        end
+
+        elapsed = System.monotonic_time(:millisecond) - start
+        Logger.info("FINISHED UPLOADING DOCS #{key} #{elapsed}ms")
+
+      :removed ->
+        Logger.info("SKIPPING UPLOAD #{key} (archive removed)")
     end
 
-    elapsed = System.monotonic_time(:millisecond) - start
-    Logger.info("FINISHED UPLOADING DOCS #{key} #{elapsed}ms")
     :ok
   end
 
@@ -83,20 +121,31 @@ defmodule Hexpm.Hexdocs do
   def delete(key) do
     {repository, package, version} = key_components!(key)
 
-    cond do
-      package in @special_package_names ->
-        :ok
+    if package in @special_package_names do
+      :ok
+    else
+      parsed = Version.parse!(version)
 
-      Releases.docs_exist?(repository, package, version) ->
-        upload(key)
+      outcome =
+        locked(repository, package, fn ->
+          if Releases.docs_exist?(repository, package, version) do
+            :published
+          else
+            {all_versions, _retired_versions} = Releases.docs_versions(repository, package)
+            delete_docs(repository, package, parsed, all_versions)
+            update_index_sitemap(repository, key)
+            :deleted
+          end
+        end)
 
-      true ->
-        version = Version.parse!(version)
-        {all_versions, _retired_versions} = Releases.docs_versions(repository, package)
-        delete_docs(repository, package, version, all_versions)
-        update_index_sitemap(repository, key)
-        if repository == "hexpm", do: Search.delete(package, version)
-        :ok
+      case outcome do
+        :published ->
+          upload(key)
+
+        :deleted ->
+          if repository == "hexpm", do: Search.delete(package, parsed)
+          :ok
+      end
     end
   end
 
@@ -124,7 +173,17 @@ defmodule Hexpm.Hexdocs do
     {repository, package, version} = key_components!(key)
     {_dir, files, _checksum} = download_and_unpack!(key, repository, package, version)
     update_index_sitemap(repository, key)
-    update_package_sitemap(repository, key, package, files)
+
+    locked(repository, package, fn ->
+      {all_versions, _retired_versions} = versions(repository, package)
+
+      if Utils.latest_version?(package, parse_version(package, version), all_versions) do
+        update_package_sitemap(repository, key, package, files)
+      else
+        Logger.info("SKIPPING PACKAGE SITEMAP #{key} (not the latest version)")
+      end
+    end)
+
     :ok
   end
 
@@ -157,19 +216,51 @@ defmodule Hexpm.Hexdocs do
     end
   end
 
-  defp versions(_repository, package, version) when package in @special_package_names do
-    version =
-      case Version.parse(version) do
-        {:ok, parsed} -> parsed
-        :error -> version
-      end
-
-    {version, SourceRepo.versions!(Map.fetch!(@special_packages, package)), MapSet.new()}
+  defp parse_version(package, version) when package in @special_package_names do
+    case Version.parse(version) do
+      {:ok, parsed} -> parsed
+      :error -> version
+    end
   end
 
-  defp versions(repository, package, version) do
-    {all_versions, retired_versions} = Releases.docs_versions(repository, package)
-    {Version.parse!(version), all_versions, retired_versions}
+  defp parse_version(_package, version), do: Version.parse!(version)
+
+  defp versions(_repository, package) when package in @special_package_names do
+    {SourceRepo.versions!(Map.fetch!(@special_packages, package)), MapSet.new()}
+  end
+
+  defp versions(repository, package), do: Releases.docs_versions(repository, package)
+
+  # Uploads and deletions of one package's docs write the same objects, and
+  # which version is the latest, and whether the archive a job unpacked is
+  # still the one in the store, is decided under the lock, so the last
+  # writer is the version that is the latest at that moment and a job never
+  # writes from an archive that has been replaced or removed. The download
+  # and unpack and the site-wide files stay outside it. A failure after some
+  # of the writes still has to purge what was written, so the transaction
+  # commits their purge jobs before the error goes on.
+  defp locked(repository, package, fun) do
+    {:ok, result} =
+      Hexpm.Repo.transaction(
+        fn ->
+          Hexpm.Repo.advisory_xact_lock(:hexdocs,
+            sub_key: :erlang.phash2({repository, package}),
+            timeout: @lock_timeout
+          )
+
+          try do
+            {:ok, fun.()}
+          catch
+            kind, reason -> {:raised, kind, reason, __STACKTRACE__}
+          end
+        end,
+        timeout: @lock_timeout
+      )
+
+    case result do
+      {:ok, value} -> value
+      {:raised, kind, reason, stacktrace} -> :erlang.raise(kind, reason, stacktrace)
+    end
   end
 
   defp download_and_unpack!(key, repository, package, version) do
@@ -192,13 +283,19 @@ defmodule Hexpm.Hexdocs do
   end
 
   defp ensure_archive_current!(key, checksum) do
-    path = Hexpm.TmpDir.tmp_file("docs-tarball")
-
-    if Hexpm.Store.get_to_file(:repo_bucket, key, path) == :ok and
-         Assets.file_checksum(path) == checksum do
+    if archive_state(key, checksum) == :current do
       :ok
     else
       raise StaleArchiveError, key: key
+    end
+  end
+
+  defp archive_state(key, checksum) do
+    path = Hexpm.TmpDir.tmp_file("docs-tarball")
+
+    case Hexpm.Store.get_to_file(:repo_bucket, key, path) do
+      :ok -> if Assets.file_checksum(path) == checksum, do: :current, else: :changed
+      nil -> :missing
     end
   end
 

--- a/test/hexpm/hexdocs/bucket_test.exs
+++ b/test/hexpm/hexdocs/bucket_test.exs
@@ -7,7 +7,8 @@ defmodule Hexpm.Hexdocs.BucketTest do
     version = Version.parse!("1.0.0")
     {dir, files} = create_files([{"index.html", "1.0.0"}])
 
-    assert :ok = Bucket.upload("acme", "package", version, [], MapSet.new(), dir, files)
+    assert :ok = Bucket.upload_versioned("acme", "package", version, dir, files)
+    assert :ok = Bucket.upload_unversioned("acme", "package", version, dir, files)
 
     assert Hexpm.Store.get(:docs_private_bucket, "acme/package/1.0.0/index.html") == "1.0.0"
     assert Hexpm.Store.get(:docs_private_bucket, "acme/package/index.html") == "1.0.0"
@@ -19,11 +20,25 @@ defmodule Hexpm.Hexdocs.BucketTest do
     {latest_dir, latest_files} = create_files([{"index.html", "latest"}])
     {older_dir, older_files} = create_files([{"index.html", "older"}])
 
-    Bucket.upload("acme", "package", latest, [], MapSet.new(), latest_dir, latest_files)
-    Bucket.upload("acme", "package", older, [latest], MapSet.new(), older_dir, older_files)
+    Bucket.upload_versioned("acme", "package", latest, latest_dir, latest_files)
+    Bucket.upload_unversioned("acme", "package", latest, latest_dir, latest_files)
+    Bucket.upload_versioned("acme", "package", older, older_dir, older_files)
 
     assert Hexpm.Store.get(:docs_private_bucket, "acme/package/index.html") == "latest"
     assert Hexpm.Store.get(:docs_private_bucket, "acme/package/1.0.0/index.html") == "older"
+  end
+
+  test "the unversioned pages replace only unversioned files" do
+    version = Version.parse!("1.0.0")
+    Hexpm.Store.put(:docs_private_bucket, "acme/package/0.9.0/index.html", "0.9.0", [])
+    Hexpm.Store.put(:docs_private_bucket, "acme/package/removed.html", "removed", [])
+    {dir, files} = create_files([{"index.html", "1.0.0"}])
+
+    Bucket.upload_unversioned("acme", "package", version, dir, files)
+
+    assert Hexpm.Store.get(:docs_private_bucket, "acme/package/index.html") == "1.0.0"
+    assert Hexpm.Store.get(:docs_private_bucket, "acme/package/0.9.0/index.html") == "0.9.0"
+    refute Hexpm.Store.get(:docs_private_bucket, "acme/package/removed.html")
   end
 
   test "replacing docs removes stale files without affecting prefix-matching packages" do
@@ -35,9 +50,14 @@ defmodule Hexpm.Hexdocs.BucketTest do
     {prefix_dir, prefix_files} = create_files([{"index.html", "prefix"}])
     {second_dir, second_files} = create_files([{"index.html", "second"}])
 
-    Bucket.upload("acme", "package_extra", version, [], MapSet.new(), prefix_dir, prefix_files)
-    Bucket.upload("acme", "package", version, [], MapSet.new(), first_dir, first_files)
-    Bucket.upload("acme", "package", version, [], MapSet.new(), second_dir, second_files)
+    upload = fn package, dir, files ->
+      Bucket.upload_versioned("acme", package, version, dir, files)
+      Bucket.upload_unversioned("acme", package, version, dir, files)
+    end
+
+    upload.("package_extra", prefix_dir, prefix_files)
+    upload.("package", first_dir, first_files)
+    upload.("package", second_dir, second_files)
 
     assert Hexpm.Store.get(:docs_private_bucket, "acme/package/index.html") == "second"
     refute Hexpm.Store.get(:docs_private_bucket, "acme/package/removed.html")
@@ -51,7 +71,9 @@ defmodule Hexpm.Hexdocs.BucketTest do
     Hexpm.Store.put(:docs_bucket, "package/removed.html", "removed", [])
     {dir, files} = create_files([{"index.html", "new"}])
 
-    Bucket.upload("hexpm", "package", version, [], MapSet.new(), dir, files)
+    Bucket.upload_versioned("hexpm", "package", version, dir, files)
+    Bucket.upload_unversioned("hexpm", "package", version, dir, files)
+    Bucket.upload_docs_config("hexpm", "package", version, [], MapSet.new(), dir, files)
 
     assert Hexpm.Store.get(:docs_bucket, "package/sitemap.xml") == "old sitemap"
     assert IO.iodata_to_binary(Hexpm.Store.get(:docs_bucket, "package/docs_config.js")) =~ "1.0.0"
@@ -64,7 +86,9 @@ defmodule Hexpm.Hexdocs.BucketTest do
     Hexpm.Store.put(:docs_private_bucket, "acme/package/docs_config.js", "old config", [])
     {dir, files} = create_files([{"index.html", "new"}])
 
-    Bucket.upload("acme", "package", version, [], MapSet.new(), dir, files)
+    Bucket.upload_versioned("acme", "package", version, dir, files)
+    Bucket.upload_unversioned("acme", "package", version, dir, files)
+    Bucket.upload_docs_config("acme", "package", version, [], MapSet.new(), dir, files)
 
     refute Hexpm.Store.get(:docs_private_bucket, "acme/package/sitemap.xml")
 
@@ -77,7 +101,9 @@ defmodule Hexpm.Hexdocs.BucketTest do
     version = Version.parse!("1.0.0")
     {dir, files} = create_files([{"index.html", "public"}])
 
-    Bucket.upload("hexpm", "package", version, [], MapSet.new(), dir, files)
+    Bucket.upload_versioned("hexpm", "package", version, dir, files)
+    Bucket.upload_unversioned("hexpm", "package", version, dir, files)
+    Bucket.upload_docs_config("hexpm", "package", version, [], MapSet.new(), dir, files)
 
     assert Hexpm.Store.get(:docs_bucket, "package/index.html") == "public"
 

--- a/test/hexpm/hexdocs/workers_test.exs
+++ b/test/hexpm/hexdocs/workers_test.exs
@@ -38,6 +38,140 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     def clear, do: :persistent_term.erase(@replacement_key)
   end
 
+  defmodule PublishingStore do
+    @behaviour Hexpm.Store.Behaviour
+    @hook_key {__MODULE__, :after_read}
+
+    defdelegate list(bucket, prefix), to: Hexpm.Store.Memory
+    defdelegate get(bucket, key, opts), to: Hexpm.Store.Memory
+    defdelegate size(bucket, key), to: Hexpm.Store.Memory
+    defdelegate stream(bucket, key), to: Hexpm.Store.Memory
+    defdelegate put(bucket, key, body, opts), to: Hexpm.Store.Memory
+    defdelegate put_file(bucket, key, path, opts), to: Hexpm.Store.Memory
+    defdelegate delete(bucket, key), to: Hexpm.Store.Memory
+    defdelegate delete_many(bucket, keys), to: Hexpm.Store.Memory
+
+    # Runs a hook once after the archive is read, standing in for another
+    # release being published while the job is unpacking.
+    def get_to_file(bucket, key, path, opts) do
+      result = Hexpm.Store.Memory.get_to_file(bucket, key, path, opts)
+
+      case :persistent_term.get(@hook_key, nil) do
+        {^key, hook} ->
+          :persistent_term.erase(@hook_key)
+          hook.()
+
+        _other ->
+          :ok
+      end
+
+      result
+    end
+
+    def after_read(key, hook), do: :persistent_term.put(@hook_key, {key, hook})
+    def clear, do: :persistent_term.erase(@hook_key)
+  end
+
+  defmodule FailingStore do
+    @behaviour Hexpm.Store.Behaviour
+    @failing_key {__MODULE__, :failing}
+
+    defdelegate list(bucket, prefix), to: Hexpm.Store.Memory
+    defdelegate get(bucket, key, opts), to: Hexpm.Store.Memory
+    defdelegate size(bucket, key), to: Hexpm.Store.Memory
+    defdelegate stream(bucket, key), to: Hexpm.Store.Memory
+    defdelegate get_to_file(bucket, key, path, opts), to: Hexpm.Store.Memory
+    defdelegate put_file(bucket, key, path, opts), to: Hexpm.Store.Memory
+    defdelegate delete(bucket, key), to: Hexpm.Store.Memory
+    defdelegate delete_many(bucket, keys), to: Hexpm.Store.Memory
+
+    def put(bucket, key, body, opts) do
+      if key == :persistent_term.get(@failing_key, nil), do: raise("store down")
+      Hexpm.Store.Memory.put(bucket, key, body, opts)
+    end
+
+    def fail_on(key), do: :persistent_term.put(@failing_key, key)
+    def clear, do: :persistent_term.erase(@failing_key)
+  end
+
+  test "decides which version is the latest when it writes, not when it starts" do
+    package = insert(:package, name: "racing_docs", docs_updated_at: DateTime.utc_now())
+    insert(:release, package: package, version: "1.0.0", has_docs: true)
+    key = "docs/#{package.name}-1.0.0.tar.gz"
+    Hexpm.Store.put(:repo_bucket, key, create_docs_tar([{"index.html", "1.0.0"}]))
+
+    app_env(:hexpm, :repo_bucket, {PublishingStore, "repo_bucket"})
+    on_exit(&PublishingStore.clear/0)
+
+    PublishingStore.after_read(key, fn ->
+      insert(:release, package: package, version: "2.0.0", has_docs: true)
+    end)
+
+    assert :ok = perform_job(Workers.Upload, %{key: key})
+
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/index.html") =~ "1.0.0"
+    refute Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html")
+  end
+
+  test "a docs revert during an upload leaves nothing behind" do
+    package = insert(:package, name: "reverted_docs", docs_updated_at: DateTime.utc_now())
+    release = insert(:release, package: package, version: "1.0.0", has_docs: true)
+    key = "docs/#{package.name}-1.0.0.tar.gz"
+    Hexpm.Store.put(:repo_bucket, key, create_docs_tar([{"index.html", "1.0.0"}]))
+
+    app_env(:hexpm, :repo_bucket, {PublishingStore, "repo_bucket"})
+    on_exit(&PublishingStore.clear/0)
+
+    PublishingStore.after_read(key, fn ->
+      Ecto.Changeset.change(release, has_docs: false) |> Repo.update!()
+      Hexpm.Store.delete(:repo_bucket, key)
+    end)
+
+    assert :ok = perform_job(Workers.Upload, %{key: key})
+
+    refute Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/index.html")
+    refute Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html")
+    assert all_enqueued(worker: Hexpm.CDN.PurgeWorker) == []
+  end
+
+  test "the purges of finished writes survive a failure later in the upload" do
+    package = insert(:package, name: "half_uploaded_docs", docs_updated_at: DateTime.utc_now())
+    insert(:release, package: package, version: "1.0.0", has_docs: true)
+    key = "docs/#{package.name}-1.0.0.tar.gz"
+    Hexpm.Store.put(:repo_bucket, key, create_docs_tar([{"index.html", "1.0.0"}]))
+
+    app_env(:hexpm, :docs_bucket, {FailingStore, "docs_bucket"})
+    on_exit(&FailingStore.clear/0)
+    FailingStore.fail_on("#{package.name}/sitemap.xml")
+
+    assert_raise RuntimeError, "store down", fn -> perform_job(Workers.Upload, %{key: key}) end
+
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/index.html") =~ "1.0.0"
+
+    assert_enqueued(
+      worker: Hexpm.CDN.PurgeWorker,
+      args: %{"keys" => ["docspage/#{package.name}/1.0.0"]}
+    )
+
+    assert_enqueued(
+      worker: Hexpm.CDN.PurgeWorker,
+      args: %{"keys" => ["docspage/#{package.name}"]}
+    )
+  end
+
+  test "a sitemap job for an older version leaves the latest sitemap alone" do
+    package = insert(:package, name: "sitemap_older_docs", docs_updated_at: DateTime.utc_now())
+    insert(:release, package: package, version: "1.0.0", has_docs: true)
+    insert(:release, package: package, version: "2.0.0", has_docs: true)
+    key = "docs/#{package.name}-1.0.0.tar.gz"
+    Hexpm.Store.put(:repo_bucket, key, create_docs_tar([{"index.html", "1.0.0"}]))
+    Hexpm.Store.put(:docs_bucket, "#{package.name}/sitemap.xml", "latest sitemap", [])
+
+    assert :ok = perform_job(Workers.Sitemap, %{key: key})
+
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/sitemap.xml") == "latest sitemap"
+  end
+
   test "upload and delete are repeatable for public documentation" do
     package = insert(:package, name: "worker_docs", docs_updated_at: DateTime.utc_now())
     release = insert(:release, package: package, version: "1.0.0", has_docs: true)
@@ -92,16 +226,23 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     index = Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/index.html")
     etag = ~s("#{Base.encode16(:crypto.hash(:md5, index), case: :lower)}")
 
-    keys = ["docspage/verified_docs", "docspage/verified_docs/1.0.0"]
-
-    assert purge_args(keys) == %{
+    assert purge_args(["docspage/verified_docs/1.0.0"]) == %{
              "service" => "fastly_hexdocs",
-             "keys" => keys,
+             "keys" => ["docspage/verified_docs/1.0.0"],
              "verify" => [
-               %{"url" => "http://verified-docs.localhost:5002/1.0.0/index.html", "etag" => etag},
+               %{"url" => "http://verified-docs.localhost:5002/1.0.0/index.html", "etag" => etag}
+             ]
+           }
+
+    assert purge_args(["docspage/verified_docs"]) == %{
+             "service" => "fastly_hexdocs",
+             "keys" => ["docspage/verified_docs"],
+             "verify" => [
                %{"url" => "http://verified-docs.localhost:5002/index.html", "etag" => etag}
              ]
            }
+
+    keys = ["docspage/verified_docs", "docspage/verified_docs/1.0.0"]
 
     Ecto.Changeset.change(release, has_docs: false) |> Repo.update!()
     assert :ok = perform_job(Workers.Delete, %{key: key})
@@ -276,7 +417,8 @@ defmodule Hexpm.Hexdocs.WorkersTest do
     use_replacing_store(key, create_docs_tar([{"index.html", index}, {"new.html", "new"}]))
 
     assert {:snooze, 15} = perform_job(Workers.Upload, %{key: key, generation: "0001"})
-    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/old.html") =~ "old"
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/old.html") == nil
+    assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/index.html") == nil
 
     assert :ok = perform_job(Workers.Upload, %{key: key, generation: "0002"})
     assert Hexpm.Store.get(:docs_bucket, "#{package.name}/1.0.0/old.html") == nil


### PR DESCRIPTION
A docs upload reads the package's versions once at the start, decides from that list whether it is the latest, and only then downloads, unpacks and writes the versioned and unversioned pages. Two versions of one package can run at once (the heavy queue is 10 per pod on 3 pods and Oban uniqueness is per tarball key), so a version published after that read, whose own job finishes first, gets its unversioned pages overwritten by the older version's job, and `<package>.hexdocs.pm/` serves the older docs until the next publish. Nothing re-checks the decision and nothing serialises the two. In the week to 2026-09-02 none of the 1,246 docs uploads overlapped with another version of the same package (uploads take a median 1.2 s, p90 3 s, max 59 s), so it needs two versions published seconds apart, which a release script can do.

Uploads and deletions now take a `:hexdocs` advisory transaction lock keyed on the package and decide under it, so the last writer of the shared objects is the version that is the latest at that moment. The download and unpack, the second tarball download of the archive check that used to follow the writes, and the site-wide sitemap index and `package_names.csv` stay outside the lock. Under it, in order: the archive is checked against what the job unpacked (a replaced archive snoozes before anything is written, a removed one skips the upload rather than restoring reverted docs), the version list is read, the versioned pages are written, and when the version is the latest the unversioned pages and the package sitemap follow; `docs_config.js` is written either way. `Bucket.upload/7` becomes `upload_versioned/5`, `upload_unversioned/5` and `upload_docs_config/7`, and an upload enqueues one purge per step. The delete job decides under the same lock whether the docs were re-published in the meantime, the standalone sitemap job takes it and skips a version that is no longer the latest, and a failure after some of the writes commits their purge jobs before the error propagates instead of rolling them back with the transaction (the per-object lock of the sitemaps and `package_names.csv` from #1897 joins that transaction rather than nesting one, which would roll it back).

Tests cover the second version published during the first's download, a revert during an upload, a store failure after the pages are written, an older version's sitemap job, and the replaced-archive snooze now writing nothing.

Found while working on https://github.com/hexpm/hexpm/pull/1897; rebased onto it after it merged.
