### PR TITLE
Add a test endpoint for creating users

### DIFF
--- a/lib/hexpm_web/controllers/test_controller.ex
+++ b/lib/hexpm_web/controllers/test_controller.ex
@@ -43,6 +43,22 @@ defmodule HexpmWeb.TestController do
     |> send_object(conn)
   end
 
+  def user(conn, params) do
+    params = Map.put(params, "emails", [%{"email" => params["email"]}])
+
+    case Users.add(params, audit: audit_data(conn)) do
+      {:ok, _user} ->
+        send_resp(conn, 201, "")
+
+      {:error, changeset} ->
+        conn
+        |> put_status(400)
+        |> render(:error,
+          error: %{error: "Failed to create user", details: inspect(changeset.errors)}
+        )
+    end
+  end
+
   def repo(conn, params) do
     {:ok, organization} =
       Organizations.create(conn.assigns.current_user, params,

--- a/lib/hexpm_web/router.ex
+++ b/lib/hexpm_web/router.ex
@@ -531,6 +531,7 @@ defmodule HexpmWeb.Router do
     scope "/api", HexpmWeb do
       pipe_through :api
 
+      post "/user", TestController, :user
       post "/repo", TestController, :repo
       post "/oauth_client", TestController, :oauth_client
       post "/oauth_token", TestController, :oauth_token

--- a/test/hexpm_web/controllers/test_controller_test.exs
+++ b/test/hexpm_web/controllers/test_controller_test.exs
@@ -53,6 +53,28 @@ defmodule HexpmWeb.TestControllerTest do
     assert response(conn, 404) == ""
   end
 
+  test "POST /api/user creates a user and returns 201" do
+    username = "user_" <> Fake.sequence(:package)
+
+    conn =
+      json_post(build_conn(), "/api/user", %{
+        "username" => username,
+        "email" => "#{username}@example.com",
+        "password" => "hunter42"
+      })
+
+    assert conn.status == 201
+    user = Hexpm.Accounts.Users.get(username, [:emails])
+    assert [%{email: email}] = user.emails
+    assert email == "#{username}@example.com"
+  end
+
+  test "POST /api/user returns 400 on invalid params" do
+    conn = json_post(build_conn(), "/api/user", %{"username" => "x", "password" => "hunter42"})
+
+    assert json_response(conn, 400)["error"] == "Failed to create user"
+  end
+
   test "POST /api/repo creates organization and returns 204" do
     user = insert(:user)
     org_name = "org_" <> Fake.sequence(:package)


### PR DESCRIPTION
The Hex client integration suite creates its users through `POST /api/users`, which https://github.com/hexpm/hexpm/pull/1885 removes. This adds `POST /api/user` to the test controller, available in the dev, test and hex environments like the other test endpoints, so the suite has a registration path that doesn't depend on the public API. The existing endpoint stays until https://github.com/hexpm/hex/pull/1234 and the v2.3 to v2.5 branches of Hex switch to the new one.
